### PR TITLE
Improve card title styling and add lazy loading for card views

### DIFF
--- a/modules/pcs/display_pcs.py
+++ b/modules/pcs/display_pcs.py
@@ -89,13 +89,19 @@ def display_pcs_in_banner(banner_frame, pcs_items):
         label_content.pack(fill="x")
 
     def add_large_label(parent, title, content):
-        frame = ctk.CTkFrame(parent, fg_color="transparent")
+        frame = ctk.CTkFrame(
+            parent,
+            fg_color="#555555",
+            border_width=1,
+            border_color="#777777",
+            corner_radius=4,
+        )
         frame.pack(fill="x", pady=2, padx=3)
         label_content = ctk.CTkLabel(
             frame, text=content, font=("Segoe UI", 15, "bold"),
             anchor="w", justify="left", wraplength=card_width - 20
         )
-        label_content.pack(fill="x")
+        label_content.pack(fill="x", padx=4, pady=4)
 
     # Populate all PCs
     for pc_name, pc_data in pcs_items.items():


### PR DESCRIPTION
## Summary
- Style card titles with bordered header for clearer separation
- Add lazy loading to card views, initially displaying 10 cards and loading more on scroll
- Apply bordered title styling to PC banner cards

## Testing
- `python -m py_compile modules/generic/generic_list_view.py modules/pcs/display_pcs.py`
- `python auto-tests/autotest.py` *(fails: ModuleNotFoundError: No module named 'pywinauto')*


------
https://chatgpt.com/codex/tasks/task_e_68a397806838832b8c07e16c54d74e5b