### PR TITLE
Add configurable logging support and instrumentation

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2,6 +2,12 @@
 models_path = E:\SwarmUI\SwarmUI\Models\Stable-diffusion
 swarmui_path = E:/SwarmUI/SwarmUI
 
+[Logging]
+enabled = false
+directory = logs
+filename = gmcampaigndesigner.log
+level = INFO
+
 [Size]
 max_text_width = 500
 

--- a/modules/helpers/config_helper.py
+++ b/modules/helpers/config_helper.py
@@ -38,6 +38,15 @@ class ConfigHelper:
             print(f"Config error: [{section}] {key} â€” {e}")
             return fallback
 
+    @classmethod
+    def getboolean(cls, section, key, fallback=False):
+        cls.load_config()
+        try:
+            return cls._config.getboolean(section, key, fallback=fallback)
+        except Exception as e:
+            print(f"Config error: [{section}] {key} â€” {e}")
+            return fallback
+
     def set(section, key, value, file_path="config/config.ini"):
         config = configparser.ConfigParser()
         if os.path.exists(file_path):

--- a/modules/helpers/logging_helper.py
+++ b/modules/helpers/logging_helper.py
@@ -1,0 +1,215 @@
+import logging
+import os
+import inspect
+from functools import wraps
+from typing import Any, Callable, TypeVar, cast, Optional
+
+from modules.helpers.config_helper import ConfigHelper
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_LOGGER: Optional[logging.Logger] = None
+_LAST_CONFIG: Optional[tuple[Any, ...]] = None
+_LOGGER_ENABLED: bool = False
+_ACTIVE_LOG_PATH: Optional[str] = None
+
+
+def _resolve_directory(directory: str) -> str:
+    directory = directory or "logs"
+    if os.path.isabs(directory):
+        return directory
+    return os.path.join(PROJECT_ROOT, directory)
+
+
+def _refresh_logger() -> logging.Logger:
+    global _LOGGER, _LAST_CONFIG, _LOGGER_ENABLED, _ACTIVE_LOG_PATH
+
+    enabled = ConfigHelper.getboolean("Logging", "enabled", fallback=False)
+    directory = ConfigHelper.get("Logging", "directory", fallback="logs") or "logs"
+    filename = ConfigHelper.get("Logging", "filename", fallback="gmcampaigndesigner.log") or "gmcampaigndesigner.log"
+    level_name = ConfigHelper.get("Logging", "level", fallback="INFO") or "INFO"
+
+    config_signature = (enabled, directory, filename, level_name)
+
+    if _LOGGER is None:
+        _LOGGER = logging.getLogger("GMCampaignDesigner")
+        _LOGGER.propagate = False
+
+    if config_signature != _LAST_CONFIG:
+        _LAST_CONFIG = config_signature
+
+        for handler in list(_LOGGER.handlers):
+            if getattr(handler, "_gmc_handler", False):
+                _LOGGER.removeHandler(handler)
+
+        _ACTIVE_LOG_PATH = None
+
+        if enabled:
+            resolved_dir = _resolve_directory(directory)
+            os.makedirs(resolved_dir, exist_ok=True)
+
+            if os.path.isabs(filename):
+                log_path = filename
+            else:
+                log_path = os.path.join(resolved_dir, filename)
+
+            level = getattr(logging, str(level_name).upper(), logging.INFO)
+
+            file_handler = logging.FileHandler(log_path, encoding="utf-8")
+            file_handler.setLevel(level)
+            file_handler.setFormatter(
+                logging.Formatter("%(asctime)s | %(levelname)s | %(message)s", "%Y-%m-%d %H:%M:%S")
+            )
+            file_handler._gmc_handler = True  # type: ignore[attr-defined]
+            file_handler._gmc_path = log_path  # type: ignore[attr-defined]
+            _LOGGER.addHandler(file_handler)
+            _LOGGER.setLevel(level)
+            _ACTIVE_LOG_PATH = log_path
+
+            _LOGGER.info("logging_helper.configure - Logging enabled. Writing to %s", log_path)
+        else:
+            null_handler = logging.NullHandler()
+            null_handler._gmc_handler = True  # type: ignore[attr-defined]
+            _LOGGER.addHandler(null_handler)
+            _LOGGER.setLevel(logging.CRITICAL)
+
+    _LOGGER_ENABLED = enabled
+    return _LOGGER
+
+
+def ensure_logger() -> tuple[logging.Logger, bool]:
+    logger = _refresh_logger()
+    return logger, _LOGGER_ENABLED
+
+
+def is_logging_enabled() -> bool:
+    _, enabled = ensure_logger()
+    return enabled
+
+
+def get_active_log_path() -> Optional[str]:
+    return _ACTIVE_LOG_PATH
+
+
+def _determine_caller(extra_depth: int = 0) -> str:
+    frame = inspect.currentframe()
+    target = frame
+    try:
+        depth = 2 + max(extra_depth, 0)
+        for _ in range(depth):
+            if target is None:
+                break
+            target = target.f_back
+
+        if target is None:
+            return "unknown"
+
+        module = target.f_globals.get("__name__", "")
+        name = target.f_code.co_name
+        return f"{module}.{name}" if module else name
+    finally:
+        del frame
+        del target
+
+
+def _log(level: int, message: str, *, func_name: Optional[str] = None, extra_depth: int = 0, exc_info: bool = False) -> None:
+    logger, enabled = ensure_logger()
+    if not enabled:
+        return
+
+    name = func_name or _determine_caller(extra_depth)
+    if exc_info:
+        logger.log(level, "%s - %s", name, message, exc_info=True)
+    else:
+        logger.log(level, "%s - %s", name, message)
+
+
+def log_debug(message: str, *, func_name: Optional[str] = None) -> None:
+    _log(logging.DEBUG, message, func_name=func_name)
+
+
+def log_info(message: str, *, func_name: Optional[str] = None) -> None:
+    _log(logging.INFO, message, func_name=func_name)
+
+
+def log_warning(message: str, *, func_name: Optional[str] = None) -> None:
+    _log(logging.WARNING, message, func_name=func_name)
+
+
+def log_error(message: str, *, func_name: Optional[str] = None) -> None:
+    _log(logging.ERROR, message, func_name=func_name)
+
+
+def log_exception(message: str, *, func_name: Optional[str] = None) -> None:
+    logger, enabled = ensure_logger()
+    if not enabled:
+        return
+    name = func_name or _determine_caller()
+    logger.exception("%s - %s", name, message)
+
+
+def log_function(func: F) -> F:
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        logger, enabled = ensure_logger()
+        if not enabled:
+            return func(*args, **kwargs)
+
+        func_name = func.__qualname__
+        _log(logging.INFO, "started", func_name=func_name)
+        try:
+            result = func(*args, **kwargs)
+            _log(logging.DEBUG, "completed", func_name=func_name)
+            return result
+        except Exception as exc:
+            logger.exception("%s - failed: %s", func_name, exc)
+            raise
+
+    return cast(F, wrapper)
+
+
+def log_methods(cls: type) -> type:
+    for name, attr in list(cls.__dict__.items()):
+        if name.startswith("__"):
+            continue
+
+        if isinstance(attr, staticmethod):
+            original = attr.__func__
+            setattr(cls, name, staticmethod(log_function(original)))
+        elif isinstance(attr, classmethod):
+            original = attr.__func__
+            setattr(cls, name, classmethod(log_function(original)))
+        elif callable(attr):
+            setattr(cls, name, log_function(attr))
+
+    return cls
+
+
+def initialize_logging() -> bool:
+    logger, enabled = ensure_logger()
+    if not enabled:
+        return False
+    if _ACTIVE_LOG_PATH:
+        logger.info("logging_helper.initialize - Logging ready at %s", _ACTIVE_LOG_PATH)
+    else:
+        logger.info("logging_helper.initialize - Logging ready")
+    return True
+
+
+__all__ = [
+    "ensure_logger",
+    "get_active_log_path",
+    "initialize_logging",
+    "is_logging_enabled",
+    "log_debug",
+    "log_error",
+    "log_exception",
+    "log_function",
+    "log_info",
+    "log_methods",
+    "log_warning",
+]
+

--- a/modules/helpers/swarmui_helper.py
+++ b/modules/helpers/swarmui_helper.py
@@ -1,14 +1,31 @@
 import os
 from modules.helpers.config_helper import ConfigHelper  # avoid circular import
-   
+from modules.helpers.logging_helper import log_function, log_info, log_warning
+
+
+@log_function
 def get_available_models():
-    models_path = ConfigHelper.get("Paths", "models_path", fallback=r"E:\SwarmUI\SwarmUI\Models\Stable-diffusion")
+    models_path = ConfigHelper.get(
+        "Paths",
+        "models_path",
+        fallback=r"E:\SwarmUI\SwarmUI\Models\Stable-diffusion",
+    )
     try:
-        return sorted([
-            os.path.splitext(f)[0]
-            for f in os.listdir(models_path)
-            if f.endswith(".safetensors")
-        ])
+        models = sorted(
+            [
+                os.path.splitext(f)[0]
+                for f in os.listdir(models_path)
+                if f.endswith(".safetensors")
+            ]
+        )
+        log_info(
+            f"Discovered {len(models)} SwarmUI models in {models_path}",
+            func_name="modules.helpers.swarmui_helper.get_available_models",
+        )
+        return models
     except Exception as e:
-        print(f"Failed to load models: {e}")
+        log_warning(
+            f"Failed to load models from {models_path}: {e}",
+            func_name="modules.helpers.swarmui_helper.get_available_models",
+        )
         return []

--- a/modules/helpers/window_helper.py
+++ b/modules/helpers/window_helper.py
@@ -1,3 +1,7 @@
+from modules.helpers.logging_helper import log_debug, log_function
+
+
+@log_function
 def position_window_at_top(window, width=None, height=None):
     """ Positionne une fenêtre au sommet de l'écran, centrée horizontalement.
 
@@ -19,4 +23,7 @@ def position_window_at_top(window, width=None, height=None):
     x = (screen_width - width) // 2
     y = 0  # Collé en haut de l'écran
 
-    window.geometry(f"{width}x{height}+{x}+{y}")
+    geometry = f"{width}x{height}+{x}+{y}"
+    log_debug(f"Applying geometry {geometry} on screen {screen_width}x{screen_height}",
+              func_name="modules.helpers.window_helper.position_window_at_top")
+    window.geometry(geometry)


### PR DESCRIPTION
## Summary
- add a `[Logging]` section in `config.ini` that controls whether logs are written and where they are stored
- introduce a reusable `logging_helper` module with helpers/decorators for consistent, contextual log output
- instrument the main window and helper modules to emit informative messages through the centralized logging utilities

## Testing
- python -m compileall main_window.py modules/helpers

------
https://chatgpt.com/codex/tasks/task_e_68cd1ac51b98832bb7057f81f28bc81a