### PR TITLE
Ensure sound manager window opens in front

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1554,10 +1554,7 @@ class MainWindow(ctk.CTk):
             if window is None or not window.winfo_exists():
                 self.sound_manager_window = SoundManagerWindow(self)
                 self.sound_manager_window.bind("<Destroy>", self._on_sound_manager_destroyed)
-            else:
-                self.sound_manager_window.deiconify()
-                self.sound_manager_window.focus()
-                self.sound_manager_window.lift()
+            self.sound_manager_window.show()
         except Exception as exc:
             messagebox.showerror("Error", f"Failed to open Sound & Music Manager:\n{exc}")
 

--- a/modules/audio/sound_manager_window.py
+++ b/modules/audio/sound_manager_window.py
@@ -293,6 +293,16 @@ class SoundManagerWindow(ctk.CTkToplevel):
         for section, player in self.players.items():
             player.add_listener(lambda event, payload, s=section: self._dispatch_player_event(s, event, payload))
 
+    def show(self) -> None:
+        try:
+            self.deiconify()
+            self.lift()
+            self.focus_force()
+            self.attributes("-topmost", True)
+            self.after(400, lambda: self.attributes("-topmost", False))
+        except Exception:
+            pass
+
     def _dispatch_player_event(self, section: str, event: str, payload: dict[str, Any]) -> None:
         try:
             self.after(0, self._handle_player_event, section, event, payload)


### PR DESCRIPTION
## Summary
- add a `show` helper to `SoundManagerWindow` that brings the window to the front and briefly toggles the topmost flag
- ensure the main window always calls `show()` when opening the sound manager so it appears in front of other windows

## Testing
- python -m compileall modules/audio/sound_manager_window.py main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68ce6a8b3980832b882c0abe563a56d9