### PR TITLE
Restore last played audio on audio bar

### DIFF
--- a/modules/audio/audio_library.py
+++ b/modules/audio/audio_library.py
@@ -29,6 +29,8 @@ def _default_state() -> Dict[str, Dict[str, Any]]:
                 "shuffle": False,
                 "loop": True,
                 "last_directory": "",
+                "last_category": "",
+                "last_track_id": "",
             },
         },
         "effects": {
@@ -38,6 +40,8 @@ def _default_state() -> Dict[str, Dict[str, Any]]:
                 "shuffle": False,
                 "loop": False,
                 "last_directory": "",
+                "last_category": "",
+                "last_track_id": "",
             },
         },
     }
@@ -147,7 +151,14 @@ class AudioLibrary:
             settings_raw = section_raw.get("settings", {})
             if isinstance(settings_raw, dict):
                 section_settings = state[section]["settings"]
-                for key in ("volume", "shuffle", "loop", "last_directory"):
+                for key in (
+                    "volume",
+                    "shuffle",
+                    "loop",
+                    "last_directory",
+                    "last_category",
+                    "last_track_id",
+                ):
                     if key in settings_raw:
                         section_settings[key] = settings_raw[key]
 


### PR DESCRIPTION
## Summary
- persist the last used category and track in the audio library settings
- restore playlists and last played track when the audio controller is created so the audio bar defaults to prior audio
- update the controller to record last played metadata when playback starts, keeping the play button enabled

## Testing
- python -m compileall modules/audio

------
https://chatgpt.com/codex/tasks/task_e_68ce8d385e78832b8a970d1b9111d7a8