### PR TITLE
Add shared dice engine and integrate dice bar UI

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -50,6 +50,7 @@ from modules.generic.custom_fields_editor import CustomFieldsEditor
 
 
 from modules.dice.dice_roller_window import DiceRollerWindow
+from modules.dice.dice_bar_window import DiceBarWindow
 from modules.audio.audio_bar_window import AudioBarWindow
 from modules.audio.audio_controller import get_audio_controller
 from modules.audio.sound_manager_window import SoundManagerWindow
@@ -93,6 +94,7 @@ class MainWindow(ctk.CTk):
         self.init_wrappers()
         self.current_gm_view = None
         self.dice_roller_window = None
+        self.dice_bar_window = None
         self.audio_controller = get_audio_controller()
         self.sound_manager_window = None
         self.audio_bar_window = None
@@ -395,6 +397,7 @@ class MainWindow(ctk.CTk):
             ("map_tool", "Map Tool", self.map_tool),
             ("sound_manager", "Sound & Music Manager", self.open_sound_manager),
             ("audio_controls", "Audio Controls Bar", self.open_audio_bar),
+            ("dice_bar", "Dice Bar", self.open_dice_bar),
             ("dice_roller", "Open Dice Roller", self.open_dice_roller),
         ]
 
@@ -1574,6 +1577,27 @@ class MainWindow(ctk.CTk):
     def _on_audio_bar_destroyed(self, event=None):
         if event is None or event.widget is self.audio_bar_window:
             self.audio_bar_window = None
+
+    def open_dice_bar(self):
+        try:
+            window = self.dice_bar_window
+        except AttributeError:
+            window = None
+        try:
+            if window is None or not window.winfo_exists():
+                self.dice_bar_window = DiceBarWindow(self)
+                self.dice_bar_window.bind("<Destroy>", self._on_dice_bar_destroyed)
+                window = self.dice_bar_window
+            window.show()
+        except Exception as exc:
+            messagebox.showerror("Error", f"Failed to open Dice Bar:\n{exc}")
+
+    def _on_dice_bar_destroyed(self, event=None):
+        if event is None:
+            self.dice_bar_window = None
+            return
+        if event.widget is self.dice_bar_window:
+            self.dice_bar_window = None
 
     def open_sound_manager(self):
         try:

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -1,0 +1,229 @@
+"""Always-on-top dice bar that reuses the shared dice engine."""
+
+from __future__ import annotations
+
+import time
+import tkinter as tk
+from collections import deque
+from typing import Deque, List, Tuple
+
+import customtkinter as ctk
+
+from modules.dice import dice_engine
+from modules.helpers.logging_helper import log_module_import
+
+log_module_import(__name__)
+
+SUPPORTED_DICE_SIZES: Tuple[int, ...] = dice_engine.DEFAULT_DICE_SIZES
+
+
+class DiceBarWindow(ctk.CTkToplevel):
+    """Compact dice roller that mirrors the behaviour of the full window."""
+
+    HISTORY_LIMIT = 10
+
+    def __init__(self, master: tk.Misc | None = None) -> None:
+        super().__init__(master)
+        self.overrideredirect(True)
+        self.resizable(False, False)
+        self.attributes("-topmost", True)
+        self.configure(fg_color="#111c2a")
+
+        self._drag_offset: Tuple[int, int] | None = None
+        self._history: Deque[str] = deque(maxlen=self.HISTORY_LIMIT)
+
+        self.formula_var = tk.StringVar(value="1d20")
+        self.exploding_var = tk.BooleanVar(value=False)
+        self.result_var = tk.StringVar(value="Enter a dice formula and roll.")
+
+        self._history_box: ctk.CTkTextbox | None = None
+        self._result_label: ctk.CTkLabel | None = None
+        self._formula_entry: ctk.CTkEntry | None = None
+
+        self._build_ui()
+        self._apply_geometry()
+
+        self.bind("<Escape>", lambda _event: self._on_close())
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        container = ctk.CTkFrame(self, corner_radius=12, fg_color="#101a2a")
+        container.grid(row=0, column=0, padx=8, pady=8, sticky="nsew")
+        container.grid_columnconfigure(1, weight=1)
+        container.grid_columnconfigure(2, weight=0)
+        container.grid_columnconfigure(3, weight=0)
+        container.grid_columnconfigure(4, weight=0)
+
+        handle = ctk.CTkLabel(container, text="🎲", width=28, font=("Segoe UI", 18))
+        handle.grid(row=0, column=0, padx=(10, 4), pady=6, sticky="w")
+        handle.bind("<ButtonPress-1>", self._on_drag_start)
+        handle.bind("<B1-Motion>", self._on_drag_motion)
+        handle.bind("<ButtonRelease-1>", self._on_drag_end)
+
+        entry = ctk.CTkEntry(container, textvariable=self.formula_var, width=220)
+        entry.grid(row=0, column=1, padx=4, pady=6, sticky="ew")
+        entry.bind("<Return>", lambda _event: self.roll())
+        self._formula_entry = entry
+
+        explode_box = ctk.CTkCheckBox(
+            container,
+            text="Explode",
+            variable=self.exploding_var,
+        )
+        explode_box.grid(row=0, column=2, padx=4, pady=6, sticky="w")
+
+        roll_button = ctk.CTkButton(container, text="Roll", width=70, command=self.roll)
+        roll_button.grid(row=0, column=3, padx=4, pady=6, sticky="ew")
+
+        close_button = ctk.CTkButton(container, text="✕", width=32, command=self._on_close)
+        close_button.grid(row=0, column=4, padx=(4, 10), pady=6, sticky="e")
+
+        preset_frame = ctk.CTkFrame(container, fg_color="#0f1725")
+        preset_frame.grid(row=1, column=0, columnspan=5, padx=10, pady=(0, 6), sticky="ew")
+        for idx, faces in enumerate(SUPPORTED_DICE_SIZES):
+            button = ctk.CTkButton(
+                preset_frame,
+                text=f"d{faces}",
+                width=52,
+                command=lambda f=faces: self._append_die(f),
+            )
+            button.grid(row=0, column=idx, padx=3, pady=4)
+
+        result_label = ctk.CTkLabel(
+            container,
+            textvariable=self.result_var,
+            anchor="w",
+            wraplength=420,
+            font=("Segoe UI", 14, "bold"),
+        )
+        result_label.grid(row=2, column=0, columnspan=4, padx=(12, 4), pady=(4, 2), sticky="ew")
+        result_label.bind("<ButtonPress-1>", self._on_drag_start)
+        result_label.bind("<B1-Motion>", self._on_drag_motion)
+        result_label.bind("<ButtonRelease-1>", self._on_drag_end)
+        self._result_label = result_label
+
+        clear_button = ctk.CTkButton(container, text="Clear", width=60, command=self._clear_history)
+        clear_button.grid(row=2, column=4, padx=(4, 12), pady=(4, 2), sticky="e")
+
+        history_box = ctk.CTkTextbox(container, height=90, activate_scrollbars=False, wrap="word")
+        history_box.grid(row=3, column=0, columnspan=5, padx=12, pady=(0, 10), sticky="nsew")
+        history_box.configure(state="disabled")
+        history_box.bind("<ButtonPress-1>", self._on_drag_start)
+        history_box.bind("<B1-Motion>", self._on_drag_motion)
+        history_box.bind("<ButtonRelease-1>", self._on_drag_end)
+        self._history_box = history_box
+
+        if self._formula_entry is not None:
+            self.after(0, self._formula_entry.focus_set)
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def roll(self) -> None:
+        formula_text = self.formula_var.get()
+        try:
+            parsed = dice_engine.parse_formula(formula_text, supported_faces=SUPPORTED_DICE_SIZES)
+        except dice_engine.FormulaError as exc:
+            self._show_error(str(exc))
+            return
+
+        try:
+            result = dice_engine.roll_parsed_formula(parsed, explode=bool(self.exploding_var.get()))
+        except dice_engine.DiceEngineError as exc:
+            self._show_error(str(exc))
+            return
+
+        canonical = result.canonical()
+        self.formula_var.set(canonical)
+
+        summary_parts: List[str] = []
+        for summary in result.face_summaries:
+            values = summary.display_values
+            if not values:
+                continue
+            summary_parts.append(f"{summary.base_count}d{summary.faces}:[{', '.join(values)}]")
+        if result.modifier:
+            summary_parts.append(f"mod {result.modifier:+d}")
+        breakdown = " | ".join(summary_parts) if summary_parts else "0"
+
+        total = result.total
+        self.result_var.set(f"{canonical} = {total}")
+        self._append_history_entry(canonical, breakdown, total)
+
+    def _append_die(self, faces: int) -> None:
+        fragment = f"1d{faces}"
+        current = self.formula_var.get().strip()
+        combined = fragment if not current else f"{current} + {fragment}"
+        try:
+            parsed = dice_engine.parse_formula(combined, supported_faces=SUPPORTED_DICE_SIZES)
+        except dice_engine.FormulaError as exc:
+            self._show_error(str(exc))
+            return
+        self.formula_var.set(parsed.canonical())
+        self.result_var.set(f"Added {fragment} to formula.")
+
+    def _append_history_entry(self, canonical: str, breakdown: str, total: int) -> None:
+        timestamp = time.strftime("%H:%M:%S")
+        entry = f"[{timestamp}] {canonical} -> {breakdown} = {total}"
+        self._history.append(entry)
+        if self._history_box is None:
+            return
+        self._history_box.configure(state="normal")
+        self._history_box.delete("1.0", "end")
+        for line in self._history:
+            self._history_box.insert("end", line + "\n")
+        self._history_box.configure(state="disabled")
+        self._history_box.see("end")
+
+    def _clear_history(self) -> None:
+        self._history.clear()
+        if self._history_box is not None:
+            self._history_box.configure(state="normal")
+            self._history_box.delete("1.0", "end")
+            self._history_box.configure(state="disabled")
+        self.result_var.set("History cleared. Ready for new rolls.")
+
+    # ------------------------------------------------------------------
+    # Window helpers
+    # ------------------------------------------------------------------
+    def show(self) -> None:
+        try:
+            self.deiconify()
+            self._apply_geometry()
+            self.lift()
+            self.focus_force()
+            self.attributes("-topmost", True)
+        except Exception:
+            pass
+
+    def _apply_geometry(self) -> None:
+        width, height = 560, 180
+        screen_width = self.winfo_screenwidth()
+        x = max(screen_width - width - 60, 40)
+        y = 60
+        self.geometry(f"{width}x{height}+{x}+{y}")
+
+    def _show_error(self, message: str) -> None:
+        self.result_var.set(f"⚠️ {message}")
+
+    def _on_drag_start(self, event: tk.Event) -> None:
+        self._drag_offset = (event.x_root - self.winfo_x(), event.y_root - self.winfo_y())
+
+    def _on_drag_motion(self, event: tk.Event) -> None:
+        if self._drag_offset is None:
+            return
+        x = event.x_root - self._drag_offset[0]
+        y = event.y_root - self._drag_offset[1]
+        self.geometry(f"+{x}+{y}")
+
+    def _on_drag_end(self, _event: tk.Event) -> None:
+        self._drag_offset = None
+
+    def _on_close(self) -> None:
+        self.destroy()

--- a/modules/dice/dice_engine.py
+++ b/modules/dice/dice_engine.py
@@ -1,0 +1,265 @@
+"""Non-UI dice rolling engine with reusable parsing and roll helpers."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Iterable, Mapping, Tuple
+
+from modules.helpers.logging_helper import log_module_import
+
+log_module_import(__name__)
+
+DEFAULT_DICE_SIZES: Tuple[int, ...] = (4, 6, 8, 10, 12, 20)
+
+
+class DiceEngineError(Exception):
+    """Base class for dice engine related errors."""
+
+
+class FormulaError(ValueError, DiceEngineError):
+    """Raised when a dice formula cannot be parsed."""
+
+
+class RollError(DiceEngineError):
+    """Raised when a roll cannot be completed."""
+
+
+@dataclass(frozen=True)
+class ParsedFormula:
+    """Immutable representation of a parsed dice formula."""
+
+    dice: Mapping[int, int]
+    modifier: int = 0
+
+    def __post_init__(self) -> None:
+        normalized = {int(faces): int(count) for faces, count in dict(self.dice).items() if int(count) != 0}
+        object.__setattr__(self, "dice", MappingProxyType(normalized))
+
+    @property
+    def total_dice(self) -> int:
+        return sum(self.dice.values())
+
+    def canonical(self) -> str:
+        return format_formula(self.dice, self.modifier)
+
+
+@dataclass(frozen=True)
+class DieRoll:
+    """Represents the outcome of a single die throw."""
+
+    value: int
+    exploded: bool = False
+
+
+@dataclass(frozen=True)
+class DieRollChain:
+    """Represents the sequence of rolls for a single die, including explosions."""
+
+    faces: int
+    rolls: Tuple[DieRoll, ...]
+
+    @property
+    def total(self) -> int:
+        return sum(roll.value for roll in self.rolls)
+
+    @property
+    def display_values(self) -> Tuple[str, ...]:
+        return tuple(f"{roll.value}{'!' if roll.exploded else ''}" for roll in self.rolls)
+
+
+@dataclass(frozen=True)
+class FaceRollSummary:
+    """Aggregated results for all dice of the same size in a roll."""
+
+    faces: int
+    base_count: int
+    rolls: Tuple[DieRoll, ...]
+
+    @property
+    def total(self) -> int:
+        return sum(roll.value for roll in self.rolls)
+
+    @property
+    def display_values(self) -> Tuple[str, ...]:
+        return tuple(f"{roll.value}{'!' if roll.exploded else ''}" for roll in self.rolls)
+
+
+@dataclass(frozen=True)
+class RollResult:
+    """Structured outcome of evaluating a parsed dice formula."""
+
+    parsed: ParsedFormula
+    chains: Tuple[DieRollChain, ...]
+    face_summaries: Tuple[FaceRollSummary, ...]
+    subtotal: int
+    total: int
+
+    @property
+    def modifier(self) -> int:
+        return self.parsed.modifier
+
+    def canonical(self) -> str:
+        return self.parsed.canonical()
+
+    def totals_by_face(self) -> Mapping[int, int]:
+        return {summary.faces: summary.total for summary in self.face_summaries}
+
+    def display_values_by_face(self) -> Mapping[int, Tuple[str, ...]]:
+        return {summary.faces: summary.display_values for summary in self.face_summaries}
+
+
+def parse_formula(formula: str, *, supported_faces: Iterable[int] | None = None) -> ParsedFormula:
+    """Parse a textual dice formula into a :class:`ParsedFormula`."""
+
+    cleaned = formula.replace(" ", "").lower()
+    if not cleaned:
+        raise FormulaError("Please provide a dice formula.")
+
+    allowed_faces = set(int(face) for face in supported_faces) if supported_faces is not None else None
+
+    tokens: list[tuple[str, str]] = []
+    current = ""
+    sign = "+"
+    for char in cleaned:
+        if char in "+-":
+            if current:
+                tokens.append((sign, current))
+                current = ""
+            sign = char
+        else:
+            current += char
+    if current:
+        tokens.append((sign, current))
+
+    dice: dict[int, int] = {}
+    modifier = 0
+    seen_dice_segment = False
+
+    for sign, token in tokens:
+        if not token:
+            raise FormulaError("Formula contains an empty segment.")
+        if "d" in token:
+            count_str, _, faces_str = token.partition("d")
+            if not faces_str:
+                raise FormulaError("Missing die size in formula.")
+            try:
+                count = int(count_str) if count_str else 1
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise FormulaError(str(exc)) from None
+            try:
+                faces = int(faces_str)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise FormulaError(str(exc)) from None
+            if allowed_faces is not None and faces not in allowed_faces:
+                raise FormulaError(f"d{faces} is not supported.")
+            if count <= 0:
+                raise FormulaError("Dice count must be positive.")
+            sign_multiplier = -1 if sign == "-" else 1
+            dice[faces] = dice.get(faces, 0) + sign_multiplier * count
+            seen_dice_segment = True
+        else:
+            try:
+                value = int(token)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise FormulaError(str(exc)) from None
+            sign_multiplier = -1 if sign == "-" else 1
+            modifier += sign_multiplier * value
+
+    dice = {faces: count for faces, count in dice.items() if count != 0}
+    for faces, count in dice.items():
+        if count < 0:
+            raise FormulaError(f"Negative dice counts detected for d{faces}.")
+
+    if not dice and seen_dice_segment:
+        raise FormulaError("All dice cancelled out. Adjust the formula.")
+
+    return ParsedFormula(dice=dice, modifier=modifier)
+
+
+def format_formula(dice: Mapping[int, int], modifier: int) -> str:
+    """Return a canonical textual representation for a dice formula."""
+
+    parts: list[str] = []
+    for faces in sorted(dice):
+        count = dice[faces]
+        if count <= 0:
+            continue
+        token = f"{count}d{faces}" if count != 1 else f"1d{faces}"
+        parts.append(token)
+    if modifier:
+        sign = "+" if modifier > 0 else "-"
+        parts.append(f"{sign} {abs(modifier)}")
+    if not parts:
+        return "0"
+    formatted = " + ".join(parts)
+    return formatted.replace("+ -", "- ")
+
+
+def roll_parsed_formula(
+    parsed: ParsedFormula,
+    *,
+    explode: bool = False,
+    rng: random.Random | None = None,
+) -> RollResult:
+    """Roll an already parsed formula and return a :class:`RollResult`."""
+
+    if parsed.total_dice <= 0:
+        raise RollError("Please include at least one die in the formula.")
+
+    generator = rng or random
+    if not hasattr(generator, "randint"):
+        raise TypeError("rng must provide a randint method.")
+
+    chains: list[DieRollChain] = []
+    per_face_rolls: dict[int, list[DieRoll]] = defaultdict(list)
+
+    for faces in sorted(parsed.dice):
+        count = parsed.dice[faces]
+        for _ in range(count):
+            chain_rolls: list[DieRoll] = []
+            keep_rolling = True
+            while keep_rolling:
+                value = generator.randint(1, faces)
+                exploded = explode and faces > 1 and value == faces
+                die_roll = DieRoll(value=value, exploded=exploded)
+                chain_rolls.append(die_roll)
+                per_face_rolls[faces].append(die_roll)
+                keep_rolling = exploded
+            chains.append(DieRollChain(faces=faces, rolls=tuple(chain_rolls)))
+
+    subtotal = sum(chain.total for chain in chains)
+    face_summaries = []
+    for faces in sorted(parsed.dice):
+        rolls = tuple(per_face_rolls.get(faces, ()))
+        face_summaries.append(
+            FaceRollSummary(
+                faces=faces,
+                base_count=parsed.dice[faces],
+                rolls=rolls,
+            )
+        )
+
+    total = subtotal + parsed.modifier
+    return RollResult(
+        parsed=parsed,
+        chains=tuple(chains),
+        face_summaries=tuple(face_summaries),
+        subtotal=subtotal,
+        total=total,
+    )
+
+
+def roll_formula(
+    formula: str,
+    *,
+    explode: bool = False,
+    supported_faces: Iterable[int] | None = None,
+    rng: random.Random | None = None,
+) -> RollResult:
+    """Convenience helper that parses and rolls a formula in one go."""
+
+    parsed = parse_formula(formula, supported_faces=supported_faces)
+    return roll_parsed_formula(parsed, explode=explode, rng=rng)


### PR DESCRIPTION
## Summary
- add a reusable dice engine module with formula parsing, roll execution, and structured results
- refactor `DiceRollerWindow` to consume the shared engine and build render sequences from roll results
- implement a compact always-on-top `DiceBarWindow` using the engine and wire it into the main window utilities

## Testing
- python -m compileall modules/dice main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68ce90155c78832b99e6cfc13a2b49d0