### PR TITLE
Place dice bar above audio bar and add separate checkbox

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1577,6 +1577,11 @@ class MainWindow(ctk.CTk):
     def _on_audio_bar_destroyed(self, event=None):
         if event is None or event.widget is self.audio_bar_window:
             self.audio_bar_window = None
+            try:
+                if self.dice_bar_window and self.dice_bar_window.winfo_exists():
+                    self.dice_bar_window._apply_geometry()
+            except Exception:
+                pass
 
     def open_dice_bar(self):
         try:

--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -452,6 +452,12 @@ class AudioBarWindow(ctk.CTkToplevel):
             height = max(36, int((height_source.winfo_reqheight() if height_source else 36) + 16))
             y = self.winfo_screenheight() - height
             self.geometry(f"{width}x{height}+0+{max(0, y)}")
+            dice_window = getattr(self.master, "dice_bar_window", None)
+            if dice_window is not None and dice_window.winfo_exists():
+                try:
+                    dice_window._apply_geometry()
+                except Exception:
+                    pass
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- add a Separate checkbox to the dice bar so per-die totals appear in the result history when requested
- keep the dice bar stacked above the audio bar with a small gap whenever both widgets are open
- refresh dice bar placement after the audio bar moves or is closed to prevent overlap

## Testing
- python -m compileall modules/dice/dice_bar_window.py modules/audio/audio_bar_window.py main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68cebbdd224c832b92632a335fbd7e08