### PR TITLE
Improve dice bar display and auto-launch

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -101,6 +101,7 @@ class MainWindow(ctk.CTk):
         root = self.winfo_toplevel()
         root.bind_all("<Control-f>", self._on_ctrl_f)
 
+        self.after(200, self.open_dice_bar)
         self.after(400, self.open_audio_bar)
 
     def open_ai_settings(self):


### PR DESCRIPTION
## Summary
- open the dice bar automatically shortly after startup
- refine dice bar layout and geometry to keep the bar slim
- show highlighted totals for rolls, including per-die breakdown when "Separate" is enabled

## Testing
- `python -m compileall modules/dice/dice_bar_window.py main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68cebea7ae74832b9e86c6ca5ef4c0e7