### PR TITLE
Add scene flow visualization to scenario graph

### DIFF
--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -69,7 +69,8 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             "npc":      self.load_icon("assets/npc_icon.png",      32, 0.6),
             "place":    self.load_icon("assets/places_icon.png",    32, 0.6),
             "scenario": self.load_icon("assets/gm_screen_icon.png", 32, 0.6),
-            "creature": self.load_icon("assets/creature_icon.png", 32, 0.6)
+            "creature": self.load_icon("assets/creature_icon.png", 32, 0.6),
+            "scene":    self.load_icon("assets/scenario_icon.png", 32, 0.6)
         }
         
         # Graph structure.
@@ -196,11 +197,26 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         toolbar = ctk.CTkFrame(self)
         toolbar.pack(fill="x", padx=5, pady=5)
         ctk.CTkButton(toolbar, text="Select Scenario", command=self.select_scenario).pack(side="left", padx=5)
+        ctk.CTkButton(toolbar, text="Scenes Flow View", command=self.show_scene_flow).pack(side="left", padx=5)
+        ctk.CTkButton(toolbar, text="Entity Overview", command=self.show_entity_view).pack(side="left", padx=5)
         ctk.CTkButton(toolbar, text="Save Graph", command=self.save_graph).pack(side="left", padx=5)
         ctk.CTkButton(toolbar, text="Load Graph", command=self.load_graph).pack(side="left", padx=5)
         ctk.CTkButton(toolbar, text="Reset Zoom", command=self.reset_zoom).pack(side="left", padx=5)
 
-    
+
+    def show_scene_flow(self):
+        if not self.scenario:
+            messagebox.showinfo("Select Scenario", "Please select a scenario first to build the scene flow view.")
+            return
+        self.load_scenario_scene_flow(self.scenario)
+
+    def show_entity_view(self):
+        if not self.scenario:
+            messagebox.showinfo("Select Scenario", "Please select a scenario first to display its entity overview.")
+            return
+        self.load_scenario(self.scenario)
+
+
     def select_scenario(self):
         def on_scenario_selected(scenario_name):
             # Lookup the full pc dictionary using the pc wrapper.
@@ -425,6 +441,604 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             self.canvas.xview_moveto(scroll_x_frac)
             self.canvas.yview_moveto(scroll_y_frac)
 
+    def load_scenario_scene_flow(self, scenario=None):
+        if scenario is not None:
+            self.scenario = scenario
+        scenario_data = self.scenario
+        if not scenario_data:
+            messagebox.showinfo("Select Scenario", "Please select a scenario first to build the scene flow view.")
+            return
+
+        scenes_raw = scenario_data.get("Scenes")
+        scenes_list = self._coerce_scene_list(scenes_raw)
+        if not scenes_list:
+            messagebox.showinfo("Scene Flow", "This scenario does not contain any scenes to display.")
+            return
+
+        scenario_npcs = self._dedupe_preserve_order(self._to_list(scenario_data.get("NPCs")))
+        scenario_creatures = self._dedupe_preserve_order(self._to_list(scenario_data.get("Creatures")))
+        scenario_places = self._dedupe_preserve_order(self._to_list(scenario_data.get("Places")))
+
+        normalized_scenes = []
+        for idx, entry in enumerate(scenes_list):
+            normalized = self._normalize_scene_entry(
+                entry,
+                idx,
+                scenario_npcs,
+                scenario_creatures,
+                scenario_places
+            )
+            if normalized:
+                normalized_scenes.append(normalized)
+
+        if not normalized_scenes:
+            messagebox.showinfo("Scene Flow", "No readable scenes were found for this scenario.")
+            return
+
+        self.graph = {"nodes": [], "links": []}
+        self.node_positions.clear()
+
+        count = len(normalized_scenes)
+        cols = min(4, max(1, int(math.ceil(math.sqrt(count)))))
+        x_spacing = 360
+        y_spacing = 320
+        origin_x = 400
+        origin_y = 260
+
+        for idx, scene in enumerate(normalized_scenes):
+            row = idx // cols
+            col = idx % cols
+            x = origin_x + (col - (cols - 1) / 2) * x_spacing
+            y = origin_y + row * y_spacing
+
+            display_name = scene.get("display_name") or f"Scene {idx + 1}"
+            node_tag = f"scene_{display_name.replace(' ', '_')}"
+            scene["tag"] = node_tag
+            node_data = {
+                "type": "scene",
+                "name": display_name,
+                "x": x,
+                "y": y,
+                "color": scene.get("color", "#d1a86d"),
+                "data": {
+                    "Text": scene.get("text", ""),
+                    "Entities": scene.get("entities", [])
+                }
+            }
+            self.graph["nodes"].append(node_data)
+            self.node_positions[node_tag] = (x, y)
+
+        lookup, index_lookup = self._build_scene_lookup(normalized_scenes)
+
+        existing_links = set()
+        for scene in normalized_scenes:
+            from_tag = scene.get("tag")
+            if not from_tag:
+                continue
+            links = list(scene.get("links", []))
+            if not links and scene.get("index", 0) < count - 1:
+                next_scene = normalized_scenes[scene["index"] + 1]
+                if next_scene.get("tag"):
+                    links.append({"target_tag": next_scene["tag"], "text": "Continue"})
+
+            for link in links:
+                text = (link.get("text") or "").strip()
+                if not text:
+                    text = "Continue"
+
+                target_tag = link.get("target_tag")
+                if not target_tag:
+                    target_index = link.get("target_index")
+                    if isinstance(target_index, int):
+                        target_tag = index_lookup.get(target_index)
+                if not target_tag:
+                    target_tag = self._resolve_scene_reference(link.get("target_key"), lookup, index_lookup)
+                if not target_tag:
+                    target_tag = self._resolve_scene_reference(link.get("target"), lookup, index_lookup)
+
+                if not target_tag or target_tag == from_tag:
+                    continue
+
+                key = (from_tag, target_tag, text)
+                if key in existing_links:
+                    continue
+                existing_links.add(key)
+                self.graph["links"].append({
+                    "from": from_tag,
+                    "to": target_tag,
+                    "text": text
+                })
+
+        self.original_positions = dict(self.node_positions)
+        self.canvas_scale = 1.0
+        self.draw_graph()
+        self.canvas.update_idletasks()
+
+        bbox_all = self.canvas.bbox("all")
+        if bbox_all:
+            x0, y0, x1, y1 = bbox_all
+            canvas_width = self.canvas.winfo_width() or 1
+            canvas_height = self.canvas.winfo_height() or 1
+            center_x = (x0 + x1) / 2
+            center_y = (y0 + y1) / 2
+            span_x = max(1, x1 - x0)
+            span_y = max(1, y1 - y0)
+            self.canvas.xview_moveto(max(0.0, min(1.0, (center_x - canvas_width / 2 - x0) / span_x)))
+            self.canvas.yview_moveto(max(0.0, min(1.0, (center_y - canvas_height / 2 - y0) / span_y)))
+
+    def _coerce_scene_list(self, scenes_raw):
+        if not scenes_raw:
+            return []
+        if isinstance(scenes_raw, list):
+            return scenes_raw
+        if isinstance(scenes_raw, dict):
+            if isinstance(scenes_raw.get("Scenes"), list):
+                return scenes_raw["Scenes"]
+            return [scenes_raw]
+        if isinstance(scenes_raw, str):
+            text = scenes_raw.strip()
+            if not text:
+                return []
+            try:
+                parsed = json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                parsed = None
+            if isinstance(parsed, list):
+                return parsed
+            if isinstance(parsed, dict):
+                if isinstance(parsed.get("Scenes"), list):
+                    return parsed["Scenes"]
+                return [parsed]
+            blocks = [block.strip() for block in re.split(r"\n{2,}", text) if block.strip()]
+            return blocks or [text]
+        return [scenes_raw]
+
+    def _normalize_scene_entry(self, entry, index, scenario_npcs, scenario_creatures, scenario_places):
+        raw_text = ""
+        if isinstance(entry, dict):
+            text_fragments = []
+            for key in ("Text", "text", "Description", "Summary", "Body", "Details", "Notes", "Gist", "Content"):
+                value = entry.get(key)
+                if isinstance(value, str):
+                    text_fragments.append(value)
+                elif isinstance(value, list):
+                    text_fragments.extend(str(v) for v in value if v)
+            raw_text = "\n\n".join(fragment for fragment in text_fragments if str(fragment).strip())
+            if not raw_text and isinstance(entry.get("text"), str):
+                raw_text = entry.get("text")
+        elif isinstance(entry, str):
+            raw_text = entry
+        else:
+            raw_text = str(entry)
+
+        cleaned_text = clean_longtext(raw_text, max_length=1600).strip()
+        lines = [line.strip() for line in cleaned_text.splitlines() if line.strip()]
+
+        title_text = ""
+        if isinstance(entry, dict):
+            for key in ("Title", "Scene", "Heading", "Name", "Label"):
+                val = entry.get(key)
+                if isinstance(val, str) and val.strip():
+                    title_text = val.strip()
+                    break
+
+        if not title_text and lines:
+            title_text = lines[0]
+            lines = lines[1:]
+        title_text = self._clean_scene_title(title_text) if title_text else ""
+
+        if lines:
+            body_text = "\n".join(lines).strip()
+        else:
+            body_text = cleaned_text
+
+        if len(body_text) > 1200:
+            trimmed = body_text[:1200]
+            cut = trimmed.rfind(" ")
+            if cut > 900:
+                trimmed = trimmed[:cut]
+            body_text = trimmed.rstrip() + "..."
+
+        if not title_text:
+            title_text = f"Scene {index + 1}"
+
+        npc_names = []
+        creature_names = []
+        place_names = []
+        if isinstance(entry, dict):
+            for field in ("NPCs", "InvolvedNPCs", "Participants", "Allies", "Characters"):
+                npc_names.extend(self._to_list(entry.get(field)))
+            for field in ("Creatures", "Monsters", "Enemies", "Foes", "Opponents", "Threats"):
+                creature_names.extend(self._to_list(entry.get(field)))
+            for field in ("Places", "Locations", "Site", "Setting", "Where", "Venue"):
+                place_names.extend(self._to_list(entry.get(field)))
+
+            entity_blob = entry.get("Entities") or entry.get("EntityRefs") or entry.get("Actors")
+            if isinstance(entity_blob, list):
+                for ent in entity_blob:
+                    if isinstance(ent, dict):
+                        ent_type = (ent.get("type") or ent.get("Type") or ent.get("category") or "").lower()
+                        ent_name = ent.get("name") or ent.get("Name") or ent.get("title")
+                        if ent_name:
+                            if ent_type in ("npc", "character", "ally"):
+                                npc_names.append(ent_name)
+                            elif ent_type in ("creature", "monster", "enemy", "foe"):
+                                creature_names.append(ent_name)
+                            elif ent_type in ("place", "location", "site"):
+                                place_names.append(ent_name)
+                            else:
+                                npc_names.append(ent_name)
+                    elif isinstance(ent, str):
+                        npc_names.append(ent)
+
+        npc_names = self._dedupe_preserve_order(npc_names)
+        creature_names = self._dedupe_preserve_order(creature_names)
+        place_names = self._dedupe_preserve_order(place_names)
+
+        search_text = f"{title_text}\n{body_text}".lower()
+        if not npc_names:
+            npc_names.extend(self._find_mentions(search_text, scenario_npcs))
+        if not creature_names:
+            creature_names.extend(self._find_mentions(search_text, scenario_creatures))
+        if not place_names:
+            place_names.extend(self._find_mentions(search_text, scenario_places))
+
+        npc_names = self._dedupe_preserve_order(npc_names)
+        creature_names = self._dedupe_preserve_order(creature_names)
+        place_names = self._dedupe_preserve_order(place_names)
+
+        entities = []
+        seen_pairs = set()
+
+        def add_entities(names, ent_type):
+            for name in names:
+                cleaned = str(name).strip()
+                if not cleaned:
+                    continue
+                key = (ent_type, cleaned.lower())
+                if key in seen_pairs:
+                    continue
+                seen_pairs.add(key)
+                record = self._lookup_entity_by_name(ent_type, cleaned)
+                portrait = ""
+                if record:
+                    portrait = record.get("Portrait") or record.get("portrait") or ""
+                entities.append({
+                    "type": ent_type,
+                    "name": cleaned,
+                    "portrait": portrait
+                })
+
+        add_entities(npc_names, "npc")
+        add_entities(creature_names, "creature")
+        add_entities(place_names, "place")
+
+        raw_links = []
+        if isinstance(entry, dict):
+            for field in ("Links", "Transitions", "Choices", "Branches", "Paths", "Outcomes"):
+                raw_links.extend(self._coerce_scene_links(entry.get(field)))
+            for field in ("Next", "NextScene", "NextScenes", "LeadsTo", "OnSuccess", "OnFailure", "IfSuccess", "IfFailure"):
+                raw_links.extend(self._coerce_scene_links(entry.get(field)))
+
+        normalised_links = []
+        seen_links = set()
+        for item in raw_links:
+            if not isinstance(item, dict):
+                continue
+            target_value = item.get("target")
+            text_value = item.get("text")
+            if isinstance(target_value, dict):
+                target_value = target_value.get("target") or target_value.get("Scene") or target_value.get("Next")
+            text_clean = clean_longtext(str(text_value), max_length=160).strip() if text_value else ""
+            target_index = None
+            if isinstance(target_value, (int, float)):
+                target_index = int(target_value)
+            elif isinstance(target_value, str):
+                stripped = target_value.strip()
+                if stripped.isdigit():
+                    target_index = int(stripped)
+                else:
+                    match = re.search(r"(scene|scène)\s*(\d+)", stripped, re.IGNORECASE)
+                    if match:
+                        target_index = int(match.group(2))
+            key = (repr(target_value), text_clean)
+            if key in seen_links:
+                continue
+            seen_links.add(key)
+            normalised_links.append({
+                "target": target_value,
+                "target_key": target_value,
+                "target_index": target_index,
+                "text": text_clean
+            })
+
+        base_title = title_text.strip()
+        if len(base_title) > 80:
+            base_title = base_title[:77].rstrip() + "..."
+        display_title = base_title or f"Scene {index + 1}"
+        display_name = f"{index + 1}. {display_title}"
+        if len(display_name) > 60:
+            display_name = display_name[:57].rstrip() + "..."
+
+        identifiers = set()
+        identifiers.add(str(index + 1))
+        identifiers.add(display_title)
+        identifiers.add(display_name)
+        identifiers.add(self._normalize_scene_identifier_key(display_title))
+        identifiers.add(self._slugify_scene_identifier(display_title))
+        if isinstance(entry, dict):
+            for key_name in ("Id", "ID", "SceneId", "Key", "Slug", "Tag", "Reference"):
+                value = entry.get(key_name)
+                if value:
+                    identifiers.add(str(value))
+                    norm = self._normalize_scene_identifier_key(value)
+                    if norm:
+                        identifiers.add(norm)
+                    slug = self._slugify_scene_identifier(value)
+                    if slug:
+                        identifiers.add(slug)
+
+        identifiers = {ident for ident in identifiers if ident}
+
+        return {
+            "index": index,
+            "display_name": display_name,
+            "title": display_title,
+            "text": body_text,
+            "entities": entities,
+            "links": normalised_links,
+            "color": self._scene_color_from_entry(entry),
+            "identifiers": identifiers
+        }
+
+    def _scene_color_from_entry(self, entry):
+        if not isinstance(entry, dict):
+            return "#d1a86d"
+        type_value = entry.get("Type") or entry.get("type") or entry.get("Category") or entry.get("SceneType") or entry.get("Mood")
+        if isinstance(type_value, str):
+            lowered = type_value.lower()
+            if any(token in lowered for token in ("combat", "battle", "fight", "skirmish")):
+                return "#b96a55"
+            if any(token in lowered for token in ("social", "role", "parley", "diplom")):
+                return "#4f6fb5"
+            if any(token in lowered for token in ("invest", "myster", "clue", "explor")):
+                return "#c3973a"
+            if any(token in lowered for token in ("travel", "chase", "journey", "pursuit")):
+                return "#5e8f6b"
+            if any(token in lowered for token in ("downtime", "rest", "interlude")):
+                return "#8d7ac0"
+        return "#d1a86d"
+
+    def _clean_scene_title(self, text):
+        if not text:
+            return ""
+        cleaned = str(text).strip()
+        cleaned = re.sub(r"^[\u2022\-\*\s\t]+", "", cleaned)
+        cleaned = re.sub(r"^(?:scene|scène|acte)\s*\d+\s*[:.\-]*\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"^[^\w]+", "", cleaned)
+        return cleaned.strip()
+
+    def _to_list(self, value):
+        if value is None:
+            return []
+        if isinstance(value, list):
+            result = []
+            for item in value:
+                if isinstance(item, dict):
+                    name = item.get("Name") or item.get("Title") or item.get("name") or item.get("text")
+                    if name:
+                        result.append(str(name).strip())
+                else:
+                    item_str = str(item).strip()
+                    if item_str:
+                        result.append(item_str)
+            return result
+        if isinstance(value, (set, tuple)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, dict):
+            collected = []
+            for sub in value.values():
+                collected.extend(self._to_list(sub))
+            return collected
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return []
+            try:
+                parsed = json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                parsed = None
+            if parsed is not None:
+                return self._to_list(parsed)
+            parts = [part.strip() for part in re.split(r"[,;\n]", text) if part.strip()]
+            return parts or [text]
+        return [str(value)]
+
+    def _dedupe_preserve_order(self, values):
+        result = []
+        seen = set()
+        for value in values or []:
+            if value is None:
+                continue
+            text = str(value).strip()
+            if not text:
+                continue
+            key = text.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(text)
+        return result
+
+    def _lookup_entity_by_name(self, entity_type, name):
+        if not name:
+            return None
+        name_text = str(name).strip()
+        if not name_text:
+            return None
+        pools = {
+            "npc": self.npcs,
+            "creature": self.creatures,
+            "place": self.places,
+        }
+        collection = pools.get(entity_type)
+        if not isinstance(collection, dict):
+            return None
+        if name_text in collection:
+            return collection[name_text]
+        lower = name_text.lower()
+        for key, value in collection.items():
+            if key.lower() == lower:
+                return value
+        return None
+
+    def _find_mentions(self, text, candidates):
+        if not text or not candidates:
+            return []
+        lower_text = text.lower()
+        matches = []
+        for candidate in candidates:
+            if not candidate:
+                continue
+            candidate_text = str(candidate).strip()
+            if not candidate_text:
+                continue
+            if candidate_text.lower() in lower_text:
+                matches.append(candidate_text)
+        return matches
+
+    def _coerce_scene_links(self, value):
+        links = []
+        if value is None:
+            return links
+        if isinstance(value, list):
+            for item in value:
+                links.extend(self._coerce_scene_links(item))
+            return links
+        if isinstance(value, dict):
+            target = None
+            text = None
+            for key in ("target", "Target", "to", "To", "scene", "Scene", "next", "Next", "id", "Id", "goto", "GoTo"):
+                if key in value:
+                    target = value[key]
+                    break
+            for key in ("text", "Text", "label", "Label", "description", "Description", "summary", "Summary", "choice", "Choice", "result", "Result", "outcome", "Outcome", "condition", "Condition"):
+                if key in value:
+                    text = value[key]
+                    break
+            if target is not None or text is not None:
+                links.append({"target": target, "text": text})
+            else:
+                for key, sub in value.items():
+                    sub_links = self._coerce_scene_links(sub)
+                    if sub_links:
+                        for link in sub_links:
+                            if not link.get("text") and isinstance(key, str):
+                                link["text"] = key
+                        links.extend(sub_links)
+                    else:
+                        links.append({"target": sub, "text": key})
+            return links
+        if isinstance(value, (int, float)):
+            links.append({"target": int(value), "text": ""})
+            return links
+        if isinstance(value, str):
+            text_value = value.strip()
+            if not text_value:
+                return links
+            links.append({"target": text_value, "text": text_value})
+            return links
+        return links
+
+    def _build_scene_lookup(self, scenes):
+        lookup = {}
+        index_lookup = {}
+        for scene in scenes:
+            tag = scene.get("tag")
+            index = scene.get("index", 0)
+            if tag:
+                index_lookup[index] = tag
+                index_lookup[index + 1] = tag
+            for ident in scene.get("identifiers", []) or []:
+                norm = self._normalize_scene_identifier_key(ident)
+                if norm and norm not in lookup:
+                    lookup[norm] = tag
+                slug = self._slugify_scene_identifier(ident)
+                if slug and slug not in lookup:
+                    lookup[slug] = tag
+        return lookup, index_lookup
+
+    def _resolve_scene_reference(self, reference, lookup, index_lookup):
+        if reference is None:
+            return None
+        if isinstance(reference, dict):
+            for key in ("target", "Target", "Scene", "scene", "Next", "next", "Id", "id"):
+                if key in reference:
+                    resolved = self._resolve_scene_reference(reference[key], lookup, index_lookup)
+                    if resolved:
+                        return resolved
+            return None
+        if isinstance(reference, list):
+            for item in reference:
+                resolved = self._resolve_scene_reference(item, lookup, index_lookup)
+                if resolved:
+                    return resolved
+            return None
+        if isinstance(reference, (int, float)):
+            return index_lookup.get(int(reference))
+        if isinstance(reference, str):
+            ref = reference.strip()
+            if not ref:
+                return None
+            if ref.isdigit():
+                target = index_lookup.get(int(ref))
+                if target:
+                    return target
+            lowered = ref.lower()
+            match = re.search(r"(scene|scène|acte)\s*(\d+)", lowered)
+            if match:
+                num = int(match.group(2))
+                target = index_lookup.get(num)
+                if target:
+                    return target
+            candidates = [ref, lowered]
+            cleaned = re.sub(r"^(scene|scène|acte)\s*", "", lowered, flags=re.IGNORECASE).strip()
+            if cleaned and cleaned != lowered:
+                candidates.append(cleaned)
+            if ":" in ref:
+                prefix = ref.split(":", 1)[0].strip()
+                if prefix:
+                    candidates.append(prefix)
+            for candidate in candidates:
+                norm = self._normalize_scene_identifier_key(candidate)
+                if norm and norm in lookup:
+                    return lookup[norm]
+                slug = self._slugify_scene_identifier(candidate)
+                if slug and slug in lookup:
+                    return lookup[slug]
+        return None
+
+    def _normalize_scene_identifier_key(self, value):
+        if value is None:
+            return ""
+        if isinstance(value, (int, float)):
+            return str(int(value))
+        text = str(value).strip().lower()
+        if not text:
+            return ""
+        text = text.replace("’", "'")
+        text = re.sub(r"[\s_/]+", " ", text)
+        return text
+
+    def _slugify_scene_identifier(self, value):
+        if value is None:
+            return ""
+        if isinstance(value, (int, float)):
+            return str(int(value))
+        text = str(value).lower().replace("’", "")
+        slug = re.sub(r"[^a-z0-9]+", "-", text)
+        return slug.strip('-')
+
     def draw_graph(self):
         self.canvas.delete("node")
         self.canvas.delete("link")
@@ -474,6 +1088,31 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         except Exception as e:
             print(f"Error loading portrait for {node_tag}: {e}")
             return None, (0, 0)
+
+    def load_thumbnail(self, portrait_path, cache_key, size):
+        if not portrait_path or not os.path.exists(portrait_path):
+            return None
+        try:
+            img = Image.open(portrait_path)
+            resample_method = getattr(Image, "Resampling", Image).LANCZOS
+            img.thumbnail(size, resample_method)
+            thumb = ImageTk.PhotoImage(img, master=self.canvas)
+            self.node_images[cache_key] = thumb
+            return thumb
+        except Exception as exc:
+            print(f"Error loading portrait thumbnail '{portrait_path}': {exc}")
+            return None
+
+    def _entity_placeholder_color(self, entity_type):
+        base = (entity_type or "").lower()
+        color_map = {
+            "npc": "#3f6fb5",
+            "creature": "#b85a4a",
+            "monster": "#b85a4a",
+            "place": "#4f8750",
+            "location": "#4f8750",
+        }
+        return color_map.get(base, "#666666")
     
     def draw_nodes(self):
 
@@ -505,14 +1144,32 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             node_name = node["name"]
             node_tag = f"{node_type}_{node_name.replace(' ', '_')}"
             x, y = node["x"], node["y"]
-            data = node.get("data", {})
+            data = node.get("data", {}) or {}
             title_text = node_name
 
-            # Determine body text
+            entity_entries = []
+
             if node_type == "scenario":
                 summary = data.get("Summary", "")
                 secret  = data.get("Secret", "")
                 body_text = f"{summary}\nSecrets: {secret}" if secret else summary
+            elif node_type == "scene":
+                raw_text = data.get("Text") or data.get("text") or ""
+                body_text = clean_longtext(raw_text, max_length=1200)
+                body_text = body_text.strip()
+                if len(body_text) > 700:
+                    trimmed = body_text[:700]
+                    cut = trimmed.rfind(" ")
+                    if cut > 400:
+                        trimmed = trimmed[:cut]
+                    body_text = trimmed.rstrip() + "..."
+                if not body_text:
+                    body_text = "No scene notes provided."
+                entities_raw = data.get("Entities") or data.get("entities") or []
+                if isinstance(entities_raw, list):
+                    entity_entries = [ent for ent in entities_raw if isinstance(ent, dict)]
+                else:
+                    entity_entries = []
             elif node_type == "place":
                 desc   = data.get("Description", "")
                 secret = data.get("Secret", "")
@@ -527,6 +1184,13 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                 secret = data.get("Secret", "")
                 body_text = f"{traits}\nSecret: {secret}" if secret else traits
 
+            if node_type == "scene" and entity_entries:
+                max_entities = 8
+                if len(entity_entries) > max_entities:
+                    entity_entries = entity_entries[:max_entities]
+            else:
+                entity_entries = entity_entries or []
+
             # Load portrait if applicable
             portrait = None
             p_w = p_h = 0
@@ -538,7 +1202,7 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                 )
 
             # Compute wrap width
-            desired_chars_per_line = 40
+            desired_chars_per_line = 45 if node_type == "scene" else 40
             avg_char_width = 7
             wrap_width = max(90, int(desired_chars_per_line * avg_char_width))
             if portrait and p_w > 0:
@@ -551,6 +1215,14 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             body_font = tkFont.Font(family="Arial",
                                     size=max(1, int(9 * scale)))
 
+            thumb_size = max(24, int(40 * scale))
+            thumb_gap = max(4, int(6 * scale))
+            icons_height = thumb_size if entity_entries else 0
+            icon_row_width = (
+                len(entity_entries) * thumb_size
+                + (len(entity_entries) - 1) * thumb_gap if entity_entries else 0
+            )
+
             # Measure text heights
             title_h = measure_text_height(title_text, title_font, wrap_width)
             body_h  = measure_text_height(body_text,  body_font,  wrap_width)
@@ -558,8 +1230,10 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             text_h  = title_h + gap + body_h
 
             # Node content size
-            content_width  = max(p_w, wrap_width)
+            content_width  = max(p_w, wrap_width, icon_row_width)
             content_height = p_h + (GAP if portrait else 0) + text_h
+            if entity_entries:
+                content_height += GAP + icons_height
             min_w = content_width + 2 * PAD
             min_h = content_height + 2 * PAD
 
@@ -648,7 +1322,7 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                 text_top = top + PAD
 
             # 2) Title text
-            self.canvas.create_text(
+            title_id = self.canvas.create_text(
                 x,
                 text_top + title_h/2 + 10,
                 text=title_text,
@@ -660,7 +1334,7 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             )
 
             # 3) Body text
-            self.canvas.create_text(
+            body_id = self.canvas.create_text(
                 x,
                 text_top + title_h + gap + body_h/2 + 10,
                 text=body_text,
@@ -670,6 +1344,53 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                 anchor="center",
                 tags=("node", node_tag)
             )
+
+            if entity_entries:
+                text_bottom = text_top + title_h + gap + body_h + 10
+                row_width = icon_row_width
+                row_left = x - row_width / 2
+                icons_y = text_bottom + GAP + icons_height / 2
+                for idx, entity in enumerate(entity_entries):
+                    name = entity.get("name") or entity.get("Name") or ""
+                    portrait_path = entity.get("portrait") or entity.get("Portrait") or ""
+                    thumb_key = f"{node_tag}_thumb_{idx}"
+                    icon = None
+                    if portrait_path:
+                        icon = self.load_thumbnail(portrait_path, thumb_key, (thumb_size, thumb_size))
+                    if icon is None:
+                        entity_type = (entity.get("type") or "").lower()
+                        icon = self.type_icons.get(entity_type)
+                    icon_x = row_left + idx * (thumb_size + thumb_gap) + thumb_size / 2
+                    if icon is not None:
+                        self.canvas.create_image(
+                            icon_x,
+                            icons_y,
+                            image=icon,
+                            anchor="center",
+                            tags=("node", node_tag)
+                        )
+                    else:
+                        color = self._entity_placeholder_color(entity.get("type"))
+                        radius = thumb_size / 2
+                        self.canvas.create_oval(
+                            icon_x - radius,
+                            icons_y - radius,
+                            icon_x + radius,
+                            icons_y + radius,
+                            fill=color,
+                            outline="",
+                            tags=("node", node_tag)
+                        )
+                        initial = (name or "?")[0].upper()
+                        marker_font = tkFont.Font(family="Arial", size=max(1, int(10 * scale)), weight="bold")
+                        self.canvas.create_text(
+                            icon_x,
+                            icons_y,
+                            text=initial,
+                            font=marker_font,
+                            fill="white",
+                            tags=("node", node_tag)
+                        )
 
             # Record bounding box for hit-testing
             self.node_bboxes[node_tag] = (
@@ -682,7 +1403,8 @@ class ScenarioGraphEditor(ctk.CTkFrame):
     def draw_links(self):
         for link in self.graph["links"]:
             self.draw_one_link(link)
-        self.canvas.tag_lower("link")
+        self.canvas.tag_lower("link_line")
+        self.canvas.tag_raise("link_label")
 
     def draw_one_link(self, link):
         tag_from = link["from"]
@@ -690,9 +1412,33 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         x1, y1 = self.node_positions.get(tag_from, (0, 0))
         x2, y2 = self.node_positions.get(tag_to, (0, 0))
         line_id = self.canvas.create_line(
-            x1, y1, x2, y2, fill="black", width=2, tags=("link",)
+            x1, y1, x2, y2, fill="black", width=2, tags=("link", "link_line")
         )
         self.canvas.tag_lower(line_id)
+
+        text = (link.get("text") or "").strip()
+        if text:
+            mid_x = (x1 + x2) / 2
+            mid_y = (y1 + y2) / 2
+            dx = x2 - x1
+            dy = y2 - y1
+            length = math.hypot(dx, dy) or 1
+            offset = 18
+            offset_x = -dy / length * offset
+            offset_y = dx / length * offset
+            label_x = mid_x + offset_x
+            label_y = mid_y + offset_y
+            label_font = tkFont.Font(family="Arial", size=max(8, int(9 * self.canvas_scale)))
+            self.canvas.create_text(
+                label_x,
+                label_y,
+                text=text,
+                font=label_font,
+                fill="#1f1f1f",
+                width=180,
+                justify="center",
+                tags=("link", "link_label")
+            )
 
     def start_drag(self, event):
         x = self.canvas.canvasx(event.x)
@@ -709,7 +1455,8 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         node_tag = next((t for t in tags if t.startswith("scenario_")
                         or t.startswith("npc_")
                         or t.startswith("creature_")
-                        or t.startswith("place_")), None)
+                        or t.startswith("place_")
+                        or t.startswith("scene_")), None)
         if node_tag:
             self.selected_node = node_tag
             self.selected_items = self.canvas.find_withtag(node_tag)
@@ -903,8 +1650,12 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                     node_tag = f"npc_{node['name'].replace(' ', '_')}"
                 elif node["type"] == "creature":
                     node_tag = f"creature_{node['name'].replace(' ', '_')}"
-                else:
+                elif node["type"] == "place":
                     node_tag = f"place_{node['name'].replace(' ', '_')}"
+                elif node["type"] == "scene":
+                    node_tag = f"scene_{node['name'].replace(' ', '_')}"
+                else:
+                    node_tag = f"{node['type']}_{node['name'].replace(' ', '_')}"
                 x, y = self.node_positions.get(node_tag, (node["x"], node["y"]))
                 node["x"], node["y"] = x, y
             with open(file_path, "w", encoding="utf-8") as f:
@@ -923,8 +1674,12 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                     node_tag = f"npc_{node['name'].replace(' ', '_')}"
                 elif node["type"] == "creature":
                     node_tag = f"creature_{node['name'].replace(' ', '_')}"
-                else:
+                elif node["type"] == "place":
                     node_tag = f"place_{node['name'].replace(' ', '_')}"
+                elif node["type"] == "scene":
+                    node_tag = f"scene_{node['name'].replace(' ', '_')}"
+                else:
+                    node_tag = f"{node['type']}_{node['name'].replace(' ', '_')}"
                 self.node_positions[node_tag] = (node["x"], node["y"])
             self.draw_graph()
         # Try to find the scenario node and set self.scenario


### PR DESCRIPTION
## Summary
- add toolbar actions to switch between the existing entity layout and a new scene flow view for scenarios
- build a scene graph that parses scene text, linked entities, and branching information to create nodes with portraits and labeled transitions on the corkboard canvas
- enhance canvas rendering and persistence helpers so scene nodes render thumbnail strips, drag correctly, and save/load alongside existing graph data

## Testing
- python -m compileall modules/scenarios

------
https://chatgpt.com/codex/tasks/task_e_68d008b8ed80832bbb93aff4ea170880