### PR TITLE
Fix GM screen creature portraits and add hover tooltips

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -9,6 +9,7 @@ from tkinter import Toplevel, messagebox
 from tkinter import ttk
 import tkinter.font as tkfont
 from modules.ui.image_viewer import show_portrait
+from modules.ui.tooltip import ToolTip
 from modules.generic.generic_editor_window import GenericEditorWindow
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.logging_helper import (
@@ -22,6 +23,54 @@ log_module_import(__name__)
 # Configure portrait size.
 PORTRAIT_SIZE = (200, 200)
 _open_entity_windows = {}
+
+TOOLTIP_FIELDS = {
+    "NPCs": ("Role", "Secret", "Traits", "Motivation"),
+    "Creatures": ("Type", "Stats", "Powers", "Weakness", "Background"),
+    "PCs": ("Role", "Traits", "Secret", "Background"),
+    "Places": ("Description", "Secrets"),
+    "Objects": ("Description", "Powers"),
+    "Factions": ("Description", "Secrets"),
+}
+
+
+def _format_tooltip_value(value, max_length=200):
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        joined = ", ".join(str(v).strip() for v in value if str(v).strip())
+        if not joined:
+            return ""
+        return format_longtext(joined, max_length=max_length)
+    return format_longtext(value, max_length=max_length)
+
+
+def build_entity_tooltip(entity_type, data):
+    """Build a compact tooltip string for an entity portrait."""
+    if not isinstance(data, dict):
+        return ""
+
+    name_field = "Title" if entity_type == "Scenarios" else "Name"
+    name_value = str(data.get(name_field, "")).strip()
+    lines = []
+    if name_value:
+        lines.append(name_value)
+
+    for field in TOOLTIP_FIELDS.get(entity_type, ()):  # type: ignore[arg-type]
+        if field == name_field:
+            continue
+        raw_value = data.get(field)
+        text = _format_tooltip_value(raw_value)
+        if text:
+            lines.append(f"{field}: {text}")
+
+    return "\n".join(lines)
+
+
+def _attach_portrait_tooltip(widget, entity_type, data):
+    tooltip_text = build_entity_tooltip(entity_type, data)
+    if tooltip_text:
+        widget.tooltip = ToolTip(widget, tooltip_text)
 wrappers = {
             "Scenarios": GenericModelWrapper("scenarios"),
             "Places": GenericModelWrapper("places"),
@@ -207,6 +256,7 @@ def insert_npc_table(parent, header, npc_names, open_entity_callback):
             photo = CTkImage(light_image=img, size=(40,40))
             widget = CTkLabel(table, image=photo, text="", anchor="center")
             widget.image = photo
+            _attach_portrait_tooltip(widget, "NPCs", data)
             # clicking the thumbnail pops up the full‑screen viewer
             widget.bind(
                 "<Button-1>",
@@ -298,6 +348,7 @@ def insert_creature_table(parent, header, creature_names, open_entity_callback):
             photo = CTkImage(light_image=img, size=(40,40))
             widget = CTkLabel(table, image=photo, text="", anchor="center")
             widget.image = photo
+            _attach_portrait_tooltip(widget, "Creatures", data)
             widget.bind(
                 "<Button-1>",
                 lambda e, p=portrait_path, n=name: show_portrait(p, n)
@@ -407,6 +458,7 @@ def insert_places_table(parent, header, place_names, open_entity_callback):
                     photo = CTkImage(light_image=img, size=(40, 40))
                     cell  = CTkLabel(table, image=photo, text="", anchor="center")
                     cell.image = photo
+                    _attach_portrait_tooltip(cell, "Places", data)
                     cell.bind(
                         "<Button-1>",
                         lambda e, p=portrait, n=name: show_portrait(p, n)
@@ -461,7 +513,7 @@ def insert_places_table(parent, header, place_names, open_entity_callback):
         table.grid_rowconfigure(r, weight=1)
         
 @log_function
-def insert_list_longtext(parent, header, items, open_entity_callback=None):
+def insert_list_longtext(parent, header, items, open_entity_callback=None, entity_collector=None):
     """Insert collapsible sections for long text lists such as scenario scenes."""
     ctk.CTkLabel(parent, text=f"{header}:", font=("Arial", 14, "bold")) \
         .pack(anchor="w", padx=10, pady=(10, 2))
@@ -530,6 +582,10 @@ def insert_list_longtext(parent, header, items, open_entity_callback=None):
         npc_names = _coerce_names(scene_dict.get("NPCs"))
         creature_names = _coerce_names(scene_dict.get("Creatures"))
         place_names = _coerce_names(scene_dict.get("Places"))
+        if entity_collector is not None:
+            entity_collector.setdefault("NPCs", set()).update(npc_names)
+            entity_collector.setdefault("Creatures", set()).update(creature_names)
+            entity_collector.setdefault("Places", set()).update(place_names)
         links = _coerce_links(scene_dict.get("Links"))
 
         outer = ctk.CTkFrame(parent, fg_color="transparent")
@@ -678,6 +734,7 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
 
     # ——— BODY — prepare fields in the custom order ———
     tpl = load_template(entity_type.lower())
+    scene_entity_tracker = {"NPCs": set(), "Creatures": set(), "Places": set()}
     # remove header fields
     body_fields = [
         f for f in tpl["fields"]
@@ -702,7 +759,13 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
         if ftype == "text":
             insert_text(frame, name, value)
         elif ftype == "list_longtext":
-            insert_list_longtext(frame, name, value, open_entity_callback)
+            insert_list_longtext(
+                frame,
+                name,
+                value,
+                open_entity_callback,
+                entity_collector=scene_entity_tracker,
+            )
         elif ftype == "longtext":
             insert_longtext(frame, name, value)
         elif ftype == "list":
@@ -711,7 +774,13 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
             if linked == "NPCs":
                 insert_npc_table(frame, "NPCs", items, open_entity_callback)
             elif linked == "Creatures":
-                insert_creature_table(frame, "Creatures", items, open_entity_callback)
+                filtered_creatures = [
+                    creature for creature in items
+                    if creature not in scene_entity_tracker.get("Creatures", set())
+                ]
+                if not filtered_creatures:
+                    continue
+                insert_creature_table(frame, "Creatures", filtered_creatures, open_entity_callback)
             elif linked == "Places":
                 insert_places_table(frame, "Places", items, open_entity_callback)
             else:
@@ -833,6 +902,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
                 portrait_label.entity_name = entity.get("Name", "")
                 portrait_label.is_portrait = True
                 content_frame.portrait_images[entity.get("Name", "")] = ctk_image
+                _attach_portrait_tooltip(portrait_label, entity_type, entity)
                 portrait_label.bind(
                     "<Button-1>",
                     lambda e, p=portrait_path, n=portrait_label.entity_name: show_portrait(p, n)

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -9,13 +9,14 @@ from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.template_loader import load_template as load_entity_template
 from modules.helpers.text_helpers import format_multiline_text
 from customtkinter import CTkLabel, CTkImage
-from modules.generic.entity_detail_factory import create_entity_detail_frame
+from modules.generic.entity_detail_factory import create_entity_detail_frame, build_entity_tooltip
 from modules.npcs.npc_graph_editor import NPCGraphEditor
 from modules.pcs.pc_graph_editor import PCGraphEditor
 from modules.scenarios.scenario_graph_editor import ScenarioGraphEditor
 from modules.generic.generic_list_selection_view import GenericListSelectionView
 from modules.helpers.config_helper import ConfigHelper
 import random
+from modules.ui.tooltip import ToolTip
 from modules.helpers.logging_helper import (
     log_function,
     log_info,
@@ -35,6 +36,7 @@ class GMScreenView(ctk.CTkFrame):
         super().__init__(master, *args, **kwargs)
         # Persistent cache for portrait images
         self.portrait_images = {}
+        self.portrait_tooltips = {}
         self.scenario = scenario_item
 
         # Load your detach and reattach icon files (adjust file paths and sizes as needed)
@@ -460,6 +462,9 @@ class GMScreenView(ctk.CTkFrame):
                     lab.image = self.portrait_images[key]
                     lab.entity_name = key
                     lab.is_portrait = True
+                    tooltip_text = self.portrait_tooltips.get(key)
+                    if tooltip_text:
+                        lab.tooltip = ToolTip(lab, tooltip_text)
                     lab.pack(pady=10)
                     self.tabs[name]["portrait_label"] = lab
 
@@ -736,6 +741,12 @@ class GMScreenView(ctk.CTkFrame):
             portrait_label.entity_name = entity["Name"]
             portrait_label.is_portrait = True
             self.portrait_images[entity["Name"]] = ctk_image
+            tooltip_text = build_entity_tooltip(entity_type, entity)
+            if tooltip_text:
+                portrait_label.tooltip = ToolTip(portrait_label, tooltip_text)
+                self.portrait_tooltips[entity["Name"]] = tooltip_text
+            else:
+                self.portrait_tooltips.pop(entity["Name"], None)
             portrait_label.pack(pady=10)
             print(f"[DEBUG] Created portrait label for {entity['Name']}: is_portrait={portrait_label.is_portrait}, entity_name={portrait_label.entity_name}")
             frame.portrait_label = portrait_label


### PR DESCRIPTION
## Summary
- prevent creature portraits assigned to other scenes from showing in the first scene's roster by filtering scene-linked creatures out of the scenario-wide list
- add a reusable tooltip builder and attach hover tooltips to portraits in detail views and roster tables
- keep portrait tooltips intact when tabs are detached and reattached in the GM screen

## Testing
- python -m compileall modules

------
https://chatgpt.com/codex/tasks/task_e_68d01f79dd50832ba66d7430945aadfd