### PR TITLE
Enable middle-click panning in graph editors

### DIFF
--- a/modules/factions/faction_graph_editor.py
+++ b/modules/factions/faction_graph_editor.py
@@ -37,6 +37,10 @@ class FactionGraphEditor(ctk.CTkFrame):
         self.canvas.bind("<B1-Motion>", self.do_drag)
         self.canvas.bind("<ButtonRelease-1>", self.end_drag)
         self.canvas.bind("<Button-3>", self.on_right_click)
+        self._is_panning = False
+        self.canvas.bind("<Button-2>", self._start_canvas_pan)
+        self.canvas.bind("<B2-Motion>", self._do_canvas_pan)
+        self.canvas.bind("<ButtonRelease-2>", self._end_canvas_pan)
 
         # toolbar
         self._dragging = None
@@ -167,6 +171,18 @@ class FactionGraphEditor(ctk.CTkFrame):
 
     def end_drag(self, evt):
         self._drag_tag=None
+
+    def _start_canvas_pan(self, event):
+        self._is_panning = True
+        self.canvas.scan_mark(event.x, event.y)
+
+    def _do_canvas_pan(self, event):
+        if not self._is_panning:
+            return
+        self.canvas.scan_dragto(event.x, event.y, gain=1)
+
+    def _end_canvas_pan(self, _event):
+        self._is_panning = False
 
     # --- right-click menu to delete ---
     def on_right_click(self, evt):

--- a/modules/npcs/npc_graph_editor.py
+++ b/modules/npcs/npc_graph_editor.py
@@ -128,6 +128,10 @@ class NPCGraphEditor(ctk.CTkFrame):
         self.canvas.bind("<Control-Button-5>", self._on_zoom)    # Linux scroll down
     # Bind double-click on any NPC element to open the editor window
         self.canvas.bind("<Double-Button-1>", self.open_npc_editor)
+        self._is_panning = False
+        self.canvas.bind("<Button-2>", self._start_canvas_pan)
+        self.canvas.bind("<B2-Motion>", self._do_canvas_pan)
+        self.canvas.bind("<ButtonRelease-2>", self._end_canvas_pan)
 
     def _on_zoom(self, event):
         if event.delta > 0 or event.num == 4:
@@ -253,6 +257,18 @@ class NPCGraphEditor(ctk.CTkFrame):
             self.canvas.xview_scroll(-1, "units")
         elif event.num == 5 or event.delta < 0:
             self.canvas.xview_scroll(1, "units")
+
+    def _start_canvas_pan(self, event):
+        self._is_panning = True
+        self.canvas.scan_mark(event.x, event.y)
+
+    def _do_canvas_pan(self, event):
+        if not self._is_panning:
+            return
+        self.canvas.scan_dragto(event.x, event.y, gain=1)
+
+    def _end_canvas_pan(self, _event):
+        self._is_panning = False
 
     # ─────────────────────────────────────────────────────────────────────────
     # FUNCTION: init_toolbar

--- a/modules/pcs/pc_graph_editor.py
+++ b/modules/pcs/pc_graph_editor.py
@@ -116,6 +116,10 @@ class PCGraphEditor(ctk.CTkFrame):
         self.canvas.bind("<Shift-Button-5>", self._on_mousewheel_x)
     # Bind double-click on any PC element to open the editor window
         self.canvas.bind("<Double-Button-1>", self.open_pc_editor)
+        self._is_panning = False
+        self.canvas.bind("<Button-2>", self._start_canvas_pan)
+        self.canvas.bind("<B2-Motion>", self._do_canvas_pan)
+        self.canvas.bind("<ButtonRelease-2>", self._end_canvas_pan)
 
  # ─────────────────────────────────────────────────────────────────────────
     # FUNCTION: open_pc_editor
@@ -201,6 +205,18 @@ class PCGraphEditor(ctk.CTkFrame):
             self.canvas.xview_scroll(-1, "units")
         elif event.num == 5 or event.delta < 0:
             self.canvas.xview_scroll(1, "units")
+
+    def _start_canvas_pan(self, event):
+        self._is_panning = True
+        self.canvas.scan_mark(event.x, event.y)
+
+    def _do_canvas_pan(self, event):
+        if not self._is_panning:
+            return
+        self.canvas.scan_dragto(event.x, event.y, gain=1)
+
+    def _end_canvas_pan(self, _event):
+        self._is_panning = False
 
     # ─────────────────────────────────────────────────────────────────────────
     # FUNCTION: init_toolbar

--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -152,6 +152,10 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         self.canvas.bind("<Control-Button-5>", self._on_zoom)    # Linux scroll down
         self.canvas.bind("<Shift-Button-4>", self._on_mousewheel_x)
         self.canvas.bind("<Shift-Button-5>", self._on_mousewheel_x)
+        self._is_panning = False
+        self.canvas.bind("<Button-2>", self._start_canvas_pan)
+        self.canvas.bind("<B2-Motion>", self._do_canvas_pan)
+        self.canvas.bind("<ButtonRelease-2>", self._end_canvas_pan)
     
     def _on_zoom(self, event):
         if event.delta > 0 or event.num == 4:
@@ -1974,6 +1978,18 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             self.canvas.xview_scroll(-1, "units")
         elif event.num == 5 or event.delta < 0:
             self.canvas.xview_scroll(1, "units")
+
+    def _start_canvas_pan(self, event):
+        self._is_panning = True
+        self.canvas.scan_mark(event.x, event.y)
+
+    def _do_canvas_pan(self, event):
+        if not self._is_panning:
+            return
+        self.canvas.scan_dragto(event.x, event.y, gain=1)
+
+    def _end_canvas_pan(self, _event):
+        self._is_panning = False
 
     def show_node_menu(self, x, y):
         node_menu = Menu(self.canvas, tearoff=0)


### PR DESCRIPTION
## Summary
- allow middle mouse button panning across the scenario, NPC, PC, and faction graph editors
- reuse Tk canvas scan behaviour to drag the viewport when the middle button is held

## Testing
- python -m compileall modules/factions/faction_graph_editor.py modules/npcs/npc_graph_editor.py modules/pcs/pc_graph_editor.py modules/scenarios/scenario_graph_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d173a201d8832bb4171a97f0ae1b15