### PR TITLE
Center scene flow view on nodes

### DIFF
--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -955,9 +955,11 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         self.draw_graph()
         self.canvas.update_idletasks()
 
+        bbox_nodes = self.canvas.bbox("node")
         bbox_all = self.canvas.bbox("all")
-        if bbox_all:
-            x0, y0, x1, y1 = bbox_all
+        target_bbox = bbox_nodes or bbox_all
+        if target_bbox:
+            x0, y0, x1, y1 = target_bbox
             canvas_width = self.canvas.winfo_width() or 1
             canvas_height = self.canvas.winfo_height() or 1
             center_x = (x0 + x1) / 2


### PR DESCRIPTION
## Summary
- center the initial scene flow viewport on the rendered scene nodes instead of the entire canvas background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d18410b0a8832b9a979dd65113887c