### PR TITLE
Fix background tag lowering error in scene flow viewer

### DIFF
--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -1680,8 +1680,12 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                 bbox[2] + padding, bbox[3] + padding
             ))
         # Ensure proper layering
-        if hasattr(self, "background_id"):
-            self.canvas.tag_lower(self.background_id)
+        if getattr(self, "background_id", None) is not None:
+            # Use the tag assigned during creation so Tk always receives
+            # a valid identifier. Passing a missing/empty identifier leads
+            # to a Tcl "wrong # args" error on some platforms when the
+            # image was not created successfully.
+            self.canvas.tag_lower("background")
 
         self.canvas.tag_raise("link")  # Put links behind everything
         self.canvas.tag_raise("node")  # Bring nodes to the top


### PR DESCRIPTION
## Summary
- guard the canvas background lowering call and use the background tag to avoid passing an empty identifier
- prevent the scene flow viewer from triggering a Tcl "wrong # args" exception when drawing the graph

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19a91e280832bbdf0b2dd847d984c