### PR TITLE
Add Map Tool integration from world map

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -1,7 +1,7 @@
 import os
 import json
 from pathlib import Path
-from tkinter import colorchooser
+from tkinter import colorchooser, messagebox
 import tkinter as tk
 import customtkinter as ctk
 from modules.maps.views.map_selector import select_map, _on_display_map
@@ -109,6 +109,16 @@ class DisplayMapController:
         
         self._maps = {m["Name"]: m for m in maps_wrapper.load_items()}
         self.select_map()
+
+    def open_map_by_name(self, map_name):
+        target = (map_name or "").strip()
+        if not target:
+            return False
+        if target not in self._maps:
+            messagebox.showwarning("Not Found", f"Map '{target}' not found.")
+            return False
+        self._on_display_map("maps", target)
+        return True
 
     def open_global_search(self, event=None):
         if self.drawing_mode != "token":


### PR DESCRIPTION
## Summary
- add an "Open in Map Tool" action to the world map toolbar that opens the selected or current map in the Map Tool window
- allow the Map Tool window to be reused when already open and accept a requested map name
- provide a DisplayMapController helper for loading a map by name so nested maps can be shown directly

## Testing
- python -m compileall modules/maps/world_map_view.py modules/maps/controllers/display_map_controller.py main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c5bbbe58832bb6302bc89d4f8354