### PR TITLE
Ensure world map entity picker overlays canvas

### DIFF
--- a/modules/generic/generic_list_selection_view.py
+++ b/modules/generic/generic_list_selection_view.py
@@ -43,19 +43,21 @@ class GenericListSelectionView(ctk.CTkFrame):
         # --- Create a local ttk style for the Treeview ---
         style = ttk.Style(self)
         style.theme_use("clam")
+        body_font = ("Segoe UI", 11)
+        heading_font = ("Segoe UI", 12, "bold")
         style.configure(
             "Custom.Treeview",
             background="#2B2B2B",
             fieldbackground="#2B2B2B",
             foreground="white",
-            rowheight=25,
-            font=("Segoe UI", 10),
+            rowheight=30,
+            font=body_font,
         )
         style.configure(
             "Custom.Treeview.Heading",
             background="#2B2B2B",
             foreground="white",
-            font=("Segoe UI", 10, "bold"),
+            font=heading_font,
         )
         style.map("Custom.Treeview", background=[("selected", "#2B2B2B")])
 
@@ -73,14 +75,14 @@ class GenericListSelectionView(ctk.CTkFrame):
             text=self.unique_field,
             command=lambda c=self.unique_field: self.sort_column(c),
         )
-        self.tree.column("#0", width=150, anchor="w")
+        self.tree.column("#0", width=240, minwidth=180, anchor="w", stretch=True)
         for col in self.columns:
             self.tree.heading(
                 col,
                 text=col,
                 command=lambda c=col: self.sort_column(c),
             )
-            self.tree.column(col, width=100, anchor="w")
+            self.tree.column(col, width=160, minwidth=120, anchor="w", stretch=True)
 
         # --- Add vertical and horizontal scrollbars ---
         vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)

--- a/modules/maps/world_map_view.py
+++ b/modules/maps/world_map_view.py
@@ -399,7 +399,13 @@ class WorldMapWindow(ctk.CTkToplevel):
 
         picker = ctk.CTkToplevel(self)
         picker.title(f"Select {entity_type}")
-        picker.geometry("900x600")
+        picker.geometry("960x640")
+        picker.minsize(720, 520)
+        picker.transient(self)
+        picker.lift()
+        picker.after(10, picker.lift)
+        picker.grab_set()
+        picker.focus_set()
 
         def on_select(_, name):
             picker.destroy()


### PR DESCRIPTION
## Summary
- ensure world map entity picker windows stay above the world map canvas and maintain a comfortable size
- improve the generic list selection view styling and column sizing for better readability across entity pickers

## Testing
- python -m compileall modules/maps/world_map_view.py modules/generic/generic_list_selection_view.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cb581c78832bb10651a08b5dc385