### PR TITLE
Add audio playback support across entity tools

### DIFF
--- a/modules/audio/entity_audio.py
+++ b/modules/audio/entity_audio.py
@@ -1,0 +1,122 @@
+"""Utility helpers for playing entity-specific audio cues."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from modules.audio.audio_player import AudioPlayer
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.logging_helper import (
+    log_exception,
+    log_info,
+    log_module_import,
+    log_warning,
+)
+
+log_module_import(__name__)
+
+_ENTITY_PLAYER: Optional[AudioPlayer] = None
+
+
+def _get_player() -> AudioPlayer:
+    global _ENTITY_PLAYER
+    if _ENTITY_PLAYER is None:
+        _ENTITY_PLAYER = AudioPlayer()
+    return _ENTITY_PLAYER
+
+
+def resolve_audio_path(value: str | os.PathLike[str]) -> str:
+    """Return an absolute path for an audio reference stored in the campaign."""
+    if not value:
+        return ""
+    try:
+        candidate = Path(value)
+    except TypeError:
+        return ""
+    if candidate.is_absolute():
+        return str(candidate)
+    base = Path(ConfigHelper.get_campaign_dir())
+    return str((base / candidate).resolve())
+
+
+def play_entity_audio(value: str | os.PathLike[str], *, entity_label: str = "") -> bool:
+    """Play a single audio track associated with an entity.
+
+    Parameters
+    ----------
+    value:
+        Path (relative or absolute) to the audio file.
+    entity_label:
+        Friendly name used in log output and UI messages.
+    """
+    path = resolve_audio_path(value)
+    if not path:
+        log_warning(
+            "play_entity_audio - no audio path supplied",
+            func_name="play_entity_audio",
+        )
+        return False
+    if not os.path.exists(path):
+        log_warning(
+            f"play_entity_audio - file not found: {path}",
+            func_name="play_entity_audio",
+        )
+        return False
+
+    player = _get_player()
+    try:
+        player.stop()
+    except Exception as exc:  # pragma: no cover - defensive
+        log_warning(
+            f"play_entity_audio - stop failed before replay: {exc}",
+            func_name="play_entity_audio",
+        )
+
+    track = {
+        "id": path,
+        "name": entity_label or os.path.splitext(os.path.basename(path))[0],
+        "path": path,
+    }
+
+    try:
+        player.set_playlist([track])
+        success = player.play(start_index=0)
+    except Exception as exc:  # pragma: no cover - backend failure
+        log_exception(
+            f"play_entity_audio - playback raised exception: {exc}",
+            func_name="play_entity_audio",
+        )
+        return False
+
+    if success:
+        log_info(
+            f"play_entity_audio - playing '{track['name']}'",
+            func_name="play_entity_audio",
+        )
+    else:
+        log_warning(
+            f"play_entity_audio - failed to start playback: {player.last_error}",
+            func_name="play_entity_audio",
+        )
+    return success
+
+
+def stop_entity_audio() -> None:
+    """Stop the currently playing entity audio track, if any."""
+    if _ENTITY_PLAYER is None:
+        return
+    try:
+        _ENTITY_PLAYER.stop()
+    except Exception as exc:  # pragma: no cover - defensive
+        log_warning(
+            f"stop_entity_audio - stop failed: {exc}",
+            func_name="stop_entity_audio",
+        )
+
+__all__ = [
+    "play_entity_audio",
+    "resolve_audio_path",
+    "stop_entity_audio",
+]

--- a/modules/creatures/creatures_template.json
+++ b/modules/creatures/creatures_template.json
@@ -8,6 +8,7 @@
       {"name": "Stats", "type": "longtext"},
       {"name": "Background", "type": "longtext"},
       {"name": "Genre", "type": "text"},
-      {"name": "Portrait", "type": "text"}
+      {"name": "Portrait", "type": "text"},
+      {"name": "Audio", "type": "audio"}
   ]
 }

--- a/modules/npcs/npcs_template.json
+++ b/modules/npcs/npcs_template.json
@@ -57,6 +57,10 @@
     {
       "name": "Portrait",
       "type": "text"
+    },
+    {
+      "name": "Audio",
+      "type": "audio"
     }
   ]
 }

--- a/modules/pcs/pc_graph_editor.py
+++ b/modules/pcs/pc_graph_editor.py
@@ -19,6 +19,7 @@ import re
 from tkinter.font import Font  # add at top of file
 from modules.ui.image_viewer import show_portrait
 from modules.helpers.config_helper import ConfigHelper
+from modules.audio.entity_audio import play_entity_audio, stop_entity_audio
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -591,6 +592,19 @@ class PCGraphEditor(ctk.CTkFrame):
         node_menu.add_separator()
         node_menu.add_command(label="Change Color", command=lambda: self.show_color_menu(x, y))
         node_menu.add_command(label="Display Portrait Window", command=self.display_portrait_window)
+        record = None
+        entity_name = None
+        if self.selected_node and self.selected_node.startswith("pc_"):
+            entity_name = self.selected_node.replace("pc_", "").replace("_", " ")
+            record = self.pcs.get(entity_name, {})
+        audio_value = self._get_entity_audio(record)
+        if audio_value:
+            node_menu.add_separator()
+            node_menu.add_command(
+                label="Play Audio",
+                command=lambda n=entity_name, r=record: self._play_entity_audio(r, n),
+            )
+            node_menu.add_command(label="Stop Audio", command=stop_entity_audio)
         node_menu.post(int(x), int(y))
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -625,6 +639,24 @@ class PCGraphEditor(ctk.CTkFrame):
     def redraw_after_drag(self):
         self.draw_graph()
         self._redraw_scheduled = False
+
+
+    def _get_entity_audio(self, record):
+        if not isinstance(record, dict):
+            return ""
+        value = record.get("Audio") or ""
+        if isinstance(value, dict):
+            value = value.get("path") or value.get("text") or ""
+        return str(value).strip()
+
+    def _play_entity_audio(self, record, name):
+        audio_value = self._get_entity_audio(record)
+        if not audio_value:
+            messagebox.showinfo("Audio", "No audio file configured for this PC.")
+            return
+        label = name or "PC"
+        if not play_entity_audio(audio_value, entity_label=str(label)):
+            messagebox.showwarning("Audio", f"Unable to play audio for {label}.")
 
 
     # ─────────────────────────────────────────────────────────────────────────

--- a/modules/pcs/pcs_template.json
+++ b/modules/pcs/pcs_template.json
@@ -7,6 +7,7 @@
       {"name": "Traits", "type": "longtext"},
       {"name": "Factions", "type": "list", "linked_type": "Factions"},
       {"name": "Objects", "type": "list", "linked_type": "Objects"},
-      {"name": "Portrait", "type": "text"}
+      {"name": "Portrait", "type": "text"},
+      {"name": "Audio", "type": "audio"}
   ]
 }

--- a/modules/places/places_template.json
+++ b/modules/places/places_template.json
@@ -5,6 +5,7 @@
       {"name": "NPCs", "type": "list", "linked_type": "NPCs"},
       {"name": "PlayerDisplay", "type": "boolean"},
       {"name": "Secrets", "type": "longtext"},
-      {"name": "Portrait", "type": "text"}
+      {"name": "Portrait", "type": "text"},
+      {"name": "Audio", "type": "audio"}
   ]
 }


### PR DESCRIPTION
## Summary
- add an audio field to NPC, PC, creature and place templates with editor support for importing and previewing campaign audio assets
- introduce a shared entity audio helper and expose right-click playback in list views, GM detail panels, scenario graphs, and NPC/PC editors
- enable map tokens to trigger linked audio from their context menu

## Testing
- python -m compileall modules

------
https://chatgpt.com/codex/tasks/task_e_68d2d07073f4832b8ffc098ef36b21b8