### PR TITLE
Fix invalid tag bindings in scenario graph

### DIFF
--- a/modules/scenarios/scene_flow_viewer.py
+++ b/modules/scenarios/scene_flow_viewer.py
@@ -306,7 +306,7 @@ class SceneFlowViewerFrame(ScenarioGraphEditor):
         super()._draw_scene_card(node, scale)
 
         node_name = node.get("name", "Scene")
-        node_tag = f"scene_{node_name.replace(' ', '_')}"
+        node_tag = self._build_tag("scene", node_name)
         bbox = self.node_bboxes.get(node_tag)
         if not bbox:
             return


### PR DESCRIPTION
## Summary
- add a helper that sanitizes canvas tag components before building tag strings
- update all tag creation in the scenario graph editor and scene flow viewer to use the sanitized helper, avoiding invalid Tk tag expressions

## Testing
- python -m compileall modules/scenarios/scenario_graph_editor.py modules/scenarios/scene_flow_viewer.py

------
https://chatgpt.com/codex/tasks/task_e_68d300afaac8832b8ae14a3b52b16c05