### PR TITLE
Enhance portrait import workflow with interactive review

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -10,7 +10,16 @@ import re
 import unicodedata
 import tkinter as tk
 from difflib import SequenceMatcher
-from tkinter import filedialog, messagebox, Toplevel, Listbox, MULTIPLE, PhotoImage, simpledialog
+from tkinter import (
+    filedialog,
+    messagebox,
+    Toplevel,
+    Listbox,
+    MULTIPLE,
+    PhotoImage,
+    simpledialog,
+)
+from tkinter import ttk
 
 import customtkinter as ctk
 from PIL import Image, ImageTk
@@ -1438,7 +1447,17 @@ class MainWindow(ctk.CTk):
                 candidate = cleaned or normalized
                 if not candidate:
                     continue
-                image_candidates.append((candidate, os.path.join(root, file_name)))
+
+                path = os.path.join(root, file_name)
+                image_candidates.append(
+                    {
+                        "normalized": candidate,
+                        "compact": candidate.replace(" ", ""),
+                        "path": path,
+                        "display": file_name,
+                        "relative": os.path.relpath(path, directory),
+                    }
+                )
 
         if not image_candidates:
             log_info(
@@ -1476,24 +1495,41 @@ class MainWindow(ctk.CTk):
             "clues": "Clues",
         }
 
-        def best_image_match(normalized_name):
-            best_path = None
-            best_score = 0.0
+        def compute_matches(normalized_name):
+            matches = []
             if not normalized_name:
-                return best_path, best_score
+                return matches
+
             compact_name = normalized_name.replace(" ", "")
-            for img_name, img_path in image_candidates:
-                score_full = SequenceMatcher(None, normalized_name, img_name).ratio()
-                score_compact = SequenceMatcher(
+            for candidate in image_candidates:
+                score_full = SequenceMatcher(
                     None,
-                    compact_name,
-                    img_name.replace(" ", ""),
+                    normalized_name,
+                    candidate["normalized"],
                 ).ratio()
+                if compact_name:
+                    score_compact = SequenceMatcher(
+                        None,
+                        compact_name,
+                        candidate["compact"],
+                    ).ratio()
+                else:
+                    score_compact = score_full
                 score = max(score_full, score_compact)
-                if score > best_score:
-                    best_score = score
-                    best_path = img_path
-            return best_path, best_score
+                matches.append(
+                    {
+                        "score": score,
+                        "path": candidate["path"],
+                        "display": candidate["display"],
+                        "relative": candidate["relative"],
+                        "normalized": candidate["normalized"],
+                    }
+                )
+
+            matches.sort(key=lambda item: item["score"], reverse=True)
+            return matches[:20]
+
+        entity_review_data = []
 
         db_path = ConfigHelper.get("Database", "path", fallback="default_campaign.db")
         conn = sqlite3.connect(db_path)
@@ -1517,23 +1553,45 @@ class MainWindow(ctk.CTk):
                     if not name:
                         continue
                     existing_portrait = str(row["Portrait"] or "").strip()
+                    normalized_name = self.normalize_name(name)
+                    matches = compute_matches(normalized_name)
+                    best_match = matches[0] if matches else None
+                    best_score = best_match["score"] if best_match else 0.0
+
+                    entity_record = {
+                        "table": table,
+                        "key_field": key_field,
+                        "display_table": display_names.get(table, table.title()),
+                        "name": name,
+                        "existing_portrait": existing_portrait,
+                        "matches": matches,
+                        "best_score": best_score,
+                        "best_source": best_match["path"] if best_match else "",
+                        "status": "Ready to review" if matches else "No portrait suggestions",
+                    }
+                    entity_review_data.append(entity_record)
+
                     if existing_portrait and not replace_existing:
                         skipped_existing += 1
+                        entity_record["status"] = "Skipped (existing portrait)"
                         continue
 
-                    normalized_name = self.normalize_name(name)
-                    best_path, score = best_image_match(normalized_name)
-                    if not best_path or score < 0.85:
+                    if not best_match or best_score < 0.85:
                         skipped_low_score += 1
+                        if not matches:
+                            entity_record["status"] = "No portrait suggestions"
+                        else:
+                            entity_record["status"] = "No match ≥85%"
                         continue
 
                     try:
-                        new_path = self.copy_and_resize_portrait({"Name": name}, best_path)
+                        new_path = self.copy_and_resize_portrait({"Name": name}, best_match["path"])
                     except Exception as exc:
                         log_exception(
                             f"Failed to copy portrait for {name}: {exc}",
                             func_name="main_window.MainWindow.import_portraits_from_directory",
                         )
+                        entity_record["status"] = f"Error importing ({exc})"
                         continue
 
                     cursor.execute(
@@ -1542,8 +1600,12 @@ class MainWindow(ctk.CTk):
                     )
                     updated_here += 1
                     total_updates += 1
+                    entity_record["status"] = f"Imported automatically ({best_score * 100:.1f}%)"
+                    entity_record["applied_path"] = new_path
+                    entity_record["applied_source"] = best_match["path"]
+                    entity_record["applied_score"] = best_score
                     log_info(
-                        f"Imported portrait for {display_names.get(table, table.title())} '{name}' (score {score * 100:.1f}%)",
+                        f"Imported portrait for {display_names.get(table, table.title())} '{name}' (score {best_score * 100:.1f}%)",
                         func_name="main_window.MainWindow.import_portraits_from_directory",
                     )
 
@@ -1590,6 +1652,10 @@ class MainWindow(ctk.CTk):
                 summary_lines.append(
                     f"Skipped {skipped_low_score} entries without a ≥85% name match."
                 )
+            if image_candidates:
+                summary_lines.append(
+                    "Review and fine-tune matches in the portrait matcher window that opens next."
+                )
             messagebox.showinfo("Import Portraits", "\n".join(summary_lines))
         else:
             log_info(
@@ -1609,7 +1675,527 @@ class MainWindow(ctk.CTk):
                 details.append(
                     "Ensure image file names closely match entity names (≥85% similarity)."
                 )
+            elif image_candidates:
+                details.append(
+                    "Adjust matches manually in the review window that opens next."
+                )
             messagebox.showinfo("Import Portraits", "\n".join(details))
+
+        if image_candidates and entity_review_data:
+            self.show_portrait_import_review(entity_review_data, replace_existing)
+
+    def show_portrait_import_review(self, entity_review_data, replace_existing):
+        """Display an interactive window to review and fine-tune portrait matches."""
+
+        if not entity_review_data:
+            return
+
+        if not any(record.get("matches") for record in entity_review_data):
+            return
+
+        review_window = ctk.CTkToplevel(self)
+        review_window.title("Portrait Import Review")
+        review_window.geometry("1020x620")
+        review_window.minsize(900, 520)
+        position_window_at_top(review_window)
+
+        review_window.columnconfigure(0, weight=1)
+        review_window.rowconfigure(0, weight=1)
+
+        container = ctk.CTkFrame(review_window)
+        container.grid(row=0, column=0, sticky="nsew", padx=12, pady=12)
+        container.grid_columnconfigure(0, weight=1)
+        container.grid_columnconfigure(1, weight=1)
+        container.grid_rowconfigure(2, weight=1)
+
+        title_font = ctk.CTkFont(size=18, weight="bold")
+        subtitle_font = ctk.CTkFont(size=13)
+
+        header = ctk.CTkLabel(container, text="Review portrait matches", font=title_font, anchor="w")
+        header.grid(row=0, column=0, columnspan=2, sticky="w")
+
+        subheader = ctk.CTkLabel(
+            container,
+            text=(
+                "Double-click an entity to inspect potential portraits. Use the similarity slider to widen or narrow "
+                "the suggestions and double-click a portrait to assign it."
+            ),
+            font=subtitle_font,
+            justify="left",
+            wraplength=880,
+            anchor="w",
+        )
+        subheader.grid(row=1, column=0, columnspan=2, sticky="we", pady=(4, 12))
+
+        left_frame = ctk.CTkFrame(container)
+        left_frame.grid(row=2, column=0, sticky="nsew", padx=(0, 10))
+        left_frame.grid_columnconfigure(0, weight=1)
+        left_frame.grid_rowconfigure(1, weight=1)
+
+        left_label = ctk.CTkLabel(left_frame, text="Entities", anchor="w")
+        left_label.grid(row=0, column=0, sticky="we")
+
+        style = ttk.Style()
+        try:
+            style.theme_use("clam")
+        except tk.TclError:
+            # Fallback to default theme if clam is unavailable
+            pass
+        style.configure(
+            "PortraitReview.Treeview",
+            background="#1e1e1e",
+            fieldbackground="#1e1e1e",
+            foreground="#f2f2f2",
+            bordercolor="#2a2a2a",
+            rowheight=26,
+        )
+        style.configure(
+            "PortraitReview.Treeview.Heading",
+            background="#2a2a2a",
+            foreground="#f2f2f2",
+            relief="flat",
+        )
+        style.map(
+            "PortraitReview.Treeview",
+            background=[("selected", "#3a7ebf")],
+            foreground=[("selected", "#ffffff")],
+        )
+
+        columns = ("type", "name", "score", "status")
+        tree = ttk.Treeview(
+            left_frame,
+            columns=columns,
+            show="headings",
+            style="PortraitReview.Treeview",
+            selectmode="browse",
+        )
+        tree.heading("type", text="Type")
+        tree.heading("name", text="Entity")
+        tree.heading("score", text="Best match")
+        tree.heading("status", text="Status")
+        tree.column("type", width=110, anchor="w")
+        tree.column("name", width=200, anchor="w")
+        tree.column("score", width=110, anchor="center")
+        tree.column("status", width=240, anchor="w")
+
+        tree_scroll = ttk.Scrollbar(left_frame, orient="vertical", command=tree.yview)
+        tree.configure(yscrollcommand=tree_scroll.set)
+        tree.grid(row=1, column=0, sticky="nsew")
+        tree_scroll.grid(row=1, column=1, sticky="ns")
+
+        left_hint = ctk.CTkLabel(
+            left_frame,
+            text="Tip: double-click an entity to load suggested portraits.",
+            anchor="w",
+            wraplength=360,
+            justify="left",
+        )
+        left_hint.grid(row=2, column=0, columnspan=2, sticky="we", pady=(6, 0))
+
+        detail_frame = ctk.CTkFrame(container)
+        detail_frame.grid(row=2, column=1, sticky="nsew")
+        detail_frame.grid_columnconfigure(0, weight=1)
+        detail_frame.grid_rowconfigure(4, weight=1)
+
+        entity_title_label = ctk.CTkLabel(
+            detail_frame,
+            text="Select an entity to review matches.",
+            font=ctk.CTkFont(size=16, weight="bold"),
+            justify="left",
+            wraplength=360,
+            anchor="w",
+        )
+        entity_title_label.grid(row=0, column=0, sticky="we")
+
+        detail_status_label = ctk.CTkLabel(
+            detail_frame,
+            text="",
+            justify="left",
+            wraplength=360,
+            anchor="w",
+        )
+        detail_status_label.grid(row=1, column=0, sticky="we", pady=(4, 6))
+
+        similarity_frame = ctk.CTkFrame(detail_frame)
+        similarity_frame.grid(row=2, column=0, sticky="we")
+        similarity_frame.grid_columnconfigure(1, weight=1)
+
+        similarity_label = ctk.CTkLabel(similarity_frame, text="Similarity threshold:")
+        similarity_label.grid(row=0, column=0, padx=(0, 6), sticky="w")
+
+        threshold_var = tk.DoubleVar(value=85.0)
+
+        def update_threshold_label(value):
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError, tk.TclError):
+                numeric = threshold_var.get()
+            threshold_display.configure(text=f"{numeric:.0f}%")
+
+        def on_slider_change(value):
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                return
+            threshold_var.set(numeric)
+            update_threshold_label(numeric)
+            populate_match_list()
+
+        slider = ttk.Scale(
+            similarity_frame,
+            from_=50,
+            to=100,
+            orient="horizontal",
+            command=on_slider_change,
+        )
+        slider.set(85.0)
+        slider.grid(row=0, column=1, sticky="we")
+
+        def on_spin_change():
+            try:
+                numeric = float(threshold_var.get())
+            except (TypeError, ValueError, tk.TclError):
+                return
+            numeric = min(max(numeric, 50.0), 100.0)
+            threshold_var.set(numeric)
+            slider.set(numeric)
+            update_threshold_label(numeric)
+            populate_match_list()
+
+        threshold_spin = tk.Spinbox(
+            similarity_frame,
+            from_=50,
+            to=100,
+            textvariable=threshold_var,
+            width=5,
+            command=on_spin_change,
+        )
+        threshold_spin.grid(row=0, column=2, padx=(8, 6))
+        threshold_spin.bind("<Return>", lambda _event: on_spin_change())
+        threshold_spin.bind("<FocusOut>", lambda _event: on_spin_change())
+
+        threshold_display = ctk.CTkLabel(similarity_frame, text="85%")
+        threshold_display.grid(row=0, column=3, sticky="e")
+
+        matches_label = ctk.CTkLabel(detail_frame, text="Suggested portraits", anchor="w")
+        matches_label.grid(row=3, column=0, sticky="we", pady=(10, 4))
+
+        matches_frame = tk.Frame(detail_frame, bg="#1e1e1e", highlightthickness=1, highlightbackground="#2a2a2a")
+        matches_frame.grid(row=4, column=0, sticky="nsew")
+        matches_frame.grid_columnconfigure(0, weight=1)
+        matches_frame.grid_rowconfigure(0, weight=1)
+
+        match_listbox = tk.Listbox(
+            matches_frame,
+            activestyle="none",
+            selectmode="browse",
+            exportselection=False,
+            bg="#1e1e1e",
+            fg="#f2f2f2",
+            highlightthickness=0,
+            selectbackground="#3a7ebf",
+            selectforeground="#ffffff",
+        )
+        match_listbox.grid(row=0, column=0, sticky="nsew")
+
+        match_scroll = tk.Scrollbar(matches_frame, orient="vertical", command=match_listbox.yview)
+        match_scroll.grid(row=0, column=1, sticky="ns")
+        match_listbox.configure(yscrollcommand=match_scroll.set)
+
+        match_info_label = ctk.CTkLabel(
+            detail_frame,
+            text="Select a portrait to preview.",
+            justify="left",
+            wraplength=360,
+            anchor="w",
+        )
+        match_info_label.grid(row=5, column=0, sticky="we", pady=(8, 6))
+
+        preview_frame = ctk.CTkFrame(detail_frame)
+        preview_frame.grid(row=6, column=0, sticky="we")
+        preview_frame.grid_columnconfigure(0, weight=1)
+
+        preview_label = tk.Label(
+            preview_frame,
+            text="Portrait preview",
+            bg="#1e1e1e",
+            fg="#f2f2f2",
+            width=40,
+            height=18,
+            anchor="center",
+            justify="center",
+            wraplength=320,
+            relief="ridge",
+        )
+        preview_label.grid(row=0, column=0, sticky="we")
+
+        assign_button = ctk.CTkButton(
+            detail_frame,
+            text="Assign Selected Portrait",
+            command=lambda: assign_selected_portrait(),
+            state="disabled",
+        )
+        assign_button.grid(row=7, column=0, sticky="we", pady=(12, 6))
+
+        detail_hint_label = ctk.CTkLabel(
+            detail_frame,
+            text="Tip: double-click a portrait in the list to assign it instantly.",
+            wraplength=360,
+            justify="left",
+            anchor="w",
+        )
+        detail_hint_label.grid(row=8, column=0, sticky="we")
+
+        tree.tag_configure("auto", foreground="#7bcf8d")
+        tree.tag_configure("manual", foreground="#80caff")
+        tree.tag_configure("skipped", foreground="#f4c77f")
+        tree.tag_configure("error", foreground="#f28b82")
+
+        tree_records: dict[str, dict] = {}
+        current_entity: dict | None = None
+        match_index_map: list[dict] = []
+        preview_image = None
+
+        for record in entity_review_data:
+            score_text = (
+                f"{record.get('best_score', 0) * 100:.1f}%" if record.get("best_score") else "—"
+            )
+            status_text = record.get("status") or "Ready to review"
+            lowered = status_text.lower()
+            tags = []
+            if "error" in lowered:
+                tags.append("error")
+            elif "assigned manually" in lowered:
+                tags.append("manual")
+            elif "imported automatically" in lowered:
+                tags.append("auto")
+            elif "skipped" in lowered or "no match" in lowered:
+                tags.append("skipped")
+            tree_id = tree.insert(
+                "",
+                "end",
+                values=(record.get("display_table"), record.get("name"), score_text, status_text),
+                tags=tags if tags else ("default",),
+            )
+            record["tree_id"] = tree_id
+            tree_records[tree_id] = record
+
+        def populate_match_list():
+            nonlocal match_index_map, preview_image
+            match_listbox.delete(0, "end")
+            match_index_map = []
+            assign_button.configure(state="disabled")
+            preview_image = None
+            preview_label.configure(image="", text="Portrait preview")
+            preview_label.image = None
+
+            if current_entity is None:
+                match_info_label.configure(text="Select an entity to see suggested portraits.")
+                return
+
+            matches = current_entity.get("matches") or []
+            if not matches:
+                match_info_label.configure(text="No portrait suggestions are available for this entity.")
+                return
+
+            try:
+                threshold = float(threshold_var.get()) / 100.0
+            except (TypeError, ValueError, tk.TclError):
+                threshold = 0.85
+
+            filtered = [m for m in matches if m.get("score", 0) >= threshold]
+            if not filtered:
+                filtered = matches[:5]
+                if filtered:
+                    match_info_label.configure(
+                        text="No portraits meet the chosen threshold. Showing the closest matches instead."
+                    )
+                else:
+                    match_info_label.configure(
+                        text="No portrait suggestions are available for this entity."
+                    )
+            else:
+                match_info_label.configure(
+                    text=f"Showing {len(filtered)} portrait(s) with ≥{threshold_var.get():.0f}% similarity."
+                )
+
+            for match in filtered:
+                entry_text = f"{match.get('score', 0) * 100:.1f}% · {match.get('display')}"
+                match_listbox.insert("end", entry_text)
+                match_index_map.append(match)
+
+            if match_index_map:
+                match_listbox.selection_set(0)
+                on_match_select()
+
+        def on_match_select(event=None):
+            nonlocal preview_image
+            selection = match_listbox.curselection()
+            if not selection:
+                assign_button.configure(state="disabled")
+                preview_label.configure(image="", text="Portrait preview")
+                preview_label.image = None
+                return
+
+            match = match_index_map[selection[0]]
+            assign_button.configure(state="normal")
+            rel_path = match.get("relative") or os.path.basename(match.get("path", ""))
+            match_info_label.configure(
+                text=f"{match.get('score', 0) * 100:.1f}% similarity\n{rel_path}"
+            )
+
+            try:
+                with Image.open(match.get("path")) as img:
+                    img.thumbnail((340, 340))
+                    preview_image = ImageTk.PhotoImage(img)
+            except Exception as exc:
+                preview_image = None
+                preview_label.configure(
+                    text=f"Unable to load preview:\n{exc}",
+                    image="",
+                )
+                preview_label.image = None
+                assign_button.configure(state="disabled")
+                return
+
+            preview_label.configure(image=preview_image, text="")
+            preview_label.image = preview_image
+
+        match_listbox.bind("<<ListboxSelect>>", on_match_select)
+
+        def show_entity_details(record: dict | None):
+            nonlocal current_entity
+            current_entity = record
+            if not record:
+                entity_title_label.configure(text="Select an entity to review matches.")
+                detail_status_label.configure(text="")
+                match_info_label.configure(text="Select a portrait to preview.")
+                match_listbox.delete(0, "end")
+                assign_button.configure(state="disabled")
+                preview_label.configure(image="", text="Portrait preview")
+                preview_label.image = None
+                return
+
+            entity_title_label.configure(
+                text=f"{record.get('display_table')}: {record.get('name')}"
+            )
+            detail_status_label.configure(text=record.get("status") or "Ready to review")
+
+            default_threshold = 85.0
+            if record.get("best_score"):
+                default_threshold = min(100.0, max(50.0, round(record["best_score"] * 100)))
+
+            threshold_var.set(default_threshold)
+            slider.set(default_threshold)
+            update_threshold_label(default_threshold)
+
+            populate_match_list()
+
+        def on_tree_select(_event=None):
+            selection = tree.selection()
+            if not selection:
+                return
+            record = tree_records.get(selection[0])
+            show_entity_details(record)
+
+        def on_tree_double_click(event):
+            item_id = tree.identify_row(event.y)
+            if not item_id:
+                return
+            tree.selection_set(item_id)
+            tree.focus(item_id)
+            show_entity_details(tree_records.get(item_id))
+
+        tree.bind("<<TreeviewSelect>>", on_tree_select)
+        tree.bind("<Double-1>", on_tree_double_click)
+
+        def assign_selected_portrait(event=None):
+            nonlocal preview_image
+            if current_entity is None:
+                return
+            selection = match_listbox.curselection()
+            if not selection:
+                return
+
+            match = match_index_map[selection[0]]
+            target_path = match.get("path")
+            if not target_path:
+                return
+
+            if (
+                current_entity.get("existing_portrait")
+                and not replace_existing
+                and not current_entity.get("applied_path")
+            ):
+                confirm = messagebox.askyesno(
+                    "Replace Portrait?",
+                    (
+                        f"{current_entity.get('display_table')} '{current_entity.get('name')}' already has a portrait.\n"
+                        "Do you want to replace it with the selected one?"
+                    ),
+                )
+                if not confirm:
+                    return
+
+            try:
+                new_path = self.copy_and_resize_portrait(
+                    {"Name": current_entity.get("name", "Unnamed")},
+                    target_path,
+                )
+            except Exception as exc:
+                messagebox.showerror(
+                    "Import Portraits",
+                    f"Failed to copy portrait:\n{exc}",
+                )
+                return
+
+            try:
+                db_path = ConfigHelper.get("Database", "path", fallback="default_campaign.db")
+                with sqlite3.connect(db_path) as conn:
+                    conn.execute(
+                        f"UPDATE {current_entity['table']} SET Portrait = ? WHERE {current_entity['key_field']} = ?",
+                        (new_path, current_entity.get("name")),
+                    )
+                    conn.commit()
+            except Exception as exc:
+                messagebox.showerror(
+                    "Import Portraits",
+                    f"Failed to save portrait to the database:\n{exc}",
+                )
+                return
+
+            current_entity["status"] = f"Assigned manually ({match.get('score', 0) * 100:.1f}%)"
+            current_entity["applied_path"] = new_path
+            current_entity["applied_source"] = target_path
+            current_entity["applied_score"] = match.get("score", 0)
+            current_entity["existing_portrait"] = new_path
+
+            detail_status_label.configure(text=current_entity["status"])
+            rel_path = match.get("relative") or os.path.basename(target_path)
+            match_info_label.configure(
+                text=f"Assigned portrait ({match.get('score', 0) * 100:.1f}% match)\n{rel_path}"
+            )
+
+            tree.set(current_entity["tree_id"], "status", current_entity["status"])
+            tree.set(
+                current_entity["tree_id"],
+                "score",
+                f"{match.get('score', 0) * 100:.1f}%",
+            )
+            tree.item(current_entity["tree_id"], tags=("manual",))
+            assign_button.configure(state="disabled")
+
+        match_listbox.bind("<Double-Button-1>", assign_selected_portrait)
+
+        review_window.bind("<Escape>", lambda _event: review_window.destroy())
+
+        # Preselect the first entity that has matches to streamline the workflow.
+        for record in entity_review_data:
+            if record.get("matches"):
+                show_entity_details(record)
+                tree.selection_set(record["tree_id"])
+                tree.focus(record["tree_id"])
+                break
 
     def preview_and_export_scenarios(self):
         scenario_wrapper = GenericModelWrapper("scenarios")


### PR DESCRIPTION
## Summary
- collect normalized metadata for portrait candidates and retain match results for each entity during batch import
- open a post-import review window with adjustable similarity threshold, portrait previews, and manual assignment controls
- update import messaging to direct users toward the interactive review experience

## Testing
- python -m compileall main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d43e5e3794832b98811d4aeadc1e32