### PR TITLE
Collapse dice and audio bars by default

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -55,6 +55,7 @@ class AudioBarWindow(ctk.CTkToplevel):
         self._remembered_track_label: Optional[str] = None
         self._building_ui = False
         self._build_ui()
+        self._set_collapsed(True)
         self._register_controller_listener()
         self._refresh_from_state()
         self.after(0, self._apply_geometry)

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -57,6 +57,7 @@ class DiceBarWindow(ctk.CTkToplevel):
         self._result_emphasis_font = ctk.CTkFont(size=18, weight="bold")
 
         self._build_ui()
+        self._set_collapsed(True)
         self._apply_geometry()
 
         self.bind("<Escape>", lambda _event: self._on_close())


### PR DESCRIPTION
## Summary
- collapse the dice bar immediately after construction so it launches in its reduced form
- collapse the audio bar on initialization so it opens minimized alongside the dice bar

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d454793184832bba2df438e0f3f1b9