### PR TITLE
Preserve transparency when pasting portraits

### DIFF
--- a/modules/generic/generic_editor_window.py
+++ b/modules/generic/generic_editor_window.py
@@ -1327,7 +1327,11 @@ class GenericEditorWindow(ctk.CTkToplevel):
                 dest_path = portrait_folder / dest_filename
 
                 img = data
-                if img.mode in ('P', 'RGBA'):
+                if img.mode == 'P':
+                    # Convert palette images to RGBA to preserve transparency information
+                    img = img.convert('RGBA')
+                elif img.mode not in ('RGB', 'RGBA'):
+                    # Fallback for other color modes that are not directly supported
                     img = img.convert('RGB')
 
                 img.save(dest_path, format='PNG')


### PR DESCRIPTION
## Summary
- preserve alpha channels when saving pasted portrait images
- convert palette images to RGBA while keeping other formats intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4ee4db894832b851431d885cf8a80