### PR TITLE
Add editable map markers with hover descriptions

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -294,6 +294,20 @@ def _persist_tokens(self):
                     "height":         t.get("height", 50),
                     "border_color":   t.get("border_color", "#000000"),
                 })
+            elif item_type == "marker":
+                entry_widget = t.get("entry_widget")
+                if entry_widget and entry_widget.winfo_exists():
+                    t["text"] = entry_widget.get()
+                desc_widget = t.get("description_widget")
+                if desc_widget and desc_widget.winfo_exists() and hasattr(desc_widget, "_textbox"):
+                    t["description"] = desc_widget._textbox.get("1.0", "end").rstrip()
+                item_data.update({
+                    "text": t.get("text", ""),
+                    "description": t.get("description", ""),
+                    "entry_width": t.get("entry_width", 180),
+                    "description_width": t.get("description_width", 240),
+                    "description_height": t.get("description_height", 140),
+                })
             else:
                 # Silently skip unknown types for now
                 continue

--- a/modules/maps/views/fullscreen_view.py
+++ b/modules/maps/views/fullscreen_view.py
@@ -75,6 +75,9 @@ def _update_fullscreen_map(self):
         sx = int(xw * self.zoom + self.pan_x)
         sy = int(yw * self.zoom + self.pan_y)
 
+        if item_type == "marker":
+            continue
+
         if item_type == "token":
             pil = item.get('pil_image')
             if not pil:

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -142,7 +142,7 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
         }
 
         if item_type_from_rec == "token":
-            
+
             campaign_dir = ConfigHelper.get_campaign_dir()
             portrait_path = rec.get("image_path")
             path = os.path.join(campaign_dir, portrait_path)
@@ -186,10 +186,24 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "height":       rec.get("height", 50),# Default height for shapes
                 "pil_image":    None, # Shapes don't use PIL image for drawing
             })
+        elif item_type_from_rec == "marker":
+            item_data.update({
+                "text": rec.get("text", "New Marker"),
+                "description": rec.get("description", "Marker description"),
+                "entry_width": rec.get("entry_width", 180),
+                "description_width": rec.get("description_width", 240),
+                "description_height": rec.get("description_height", 140),
+                "entry_widget": None,
+                "description_widget": None,
+                "description_window_id": None,
+                "description_hide_job": None,
+                "description_visible": False,
+                "focus_pending": False,
+            })
         else:
             print(f"[_on_display_map] Unknown item type '{item_type_from_rec}' in map data. Skipping: {rec}")
             continue
-        
+
         self.tokens.append(item_data)
 
     # 8) Hydrate info box (ONLY FOR TOKENS)

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -44,6 +44,8 @@ def _build_toolbar(self):
         .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["pc"], "Add PC", command=lambda: self.open_entity_picker("PC")) \
         .pack(side="left", padx=2)
+    create_icon_button(toolbar, None, "Add Marker", command=self.add_marker)\
+        .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["fs"],    "Fullscreen",   command=self.open_fullscreen)\
         .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["fs"],    "Web Display",   command=self.open_web_display)\

--- a/modules/maps/views/web_display_view.py
+++ b/modules/maps/views/web_display_view.py
@@ -89,6 +89,8 @@ def _render_map_image(self):
         xw, yw = item.get('position', (0, 0))
         sx = int(xw * self.zoom + self.pan_x - min_x)
         sy = int(yw * self.zoom + self.pan_y - min_y)
+        if item_type == 'marker':
+            continue
         if item_type == 'token':
             pil = item.get('pil_image')
             if pil:


### PR DESCRIPTION
## Summary
- add an "Add Marker" control to the map tool toolbar
- implement editable map markers with hover descriptions that persist with the map data
- ensure GM-only markers stay hidden from fullscreen and web displays

## Testing
- python -m compileall modules/maps

------
https://chatgpt.com/codex/tasks/task_e_68d4f5167b80832b8e2ebc60119ffd7a