### PR TITLE
Improve map tool marker interactions and tooltip

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -298,15 +298,10 @@ def _persist_tokens(self):
                 entry_widget = t.get("entry_widget")
                 if entry_widget and entry_widget.winfo_exists():
                     t["text"] = entry_widget.get()
-                desc_widget = t.get("description_widget")
-                if desc_widget and desc_widget.winfo_exists() and hasattr(desc_widget, "_textbox"):
-                    t["description"] = desc_widget._textbox.get("1.0", "end").rstrip()
                 item_data.update({
                     "text": t.get("text", ""),
                     "description": t.get("description", ""),
                     "entry_width": t.get("entry_width", 180),
-                    "description_width": t.get("description_width", 240),
-                    "description_height": t.get("description_height", 140),
                 })
             else:
                 # Silently skip unknown types for now

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -191,13 +191,12 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "text": rec.get("text", "New Marker"),
                 "description": rec.get("description", "Marker description"),
                 "entry_width": rec.get("entry_width", 180),
-                "description_width": rec.get("description_width", 240),
-                "description_height": rec.get("description_height", 140),
                 "entry_widget": None,
-                "description_widget": None,
-                "description_window_id": None,
+                "description_popup": None,
+                "description_label": None,
                 "description_hide_job": None,
                 "description_visible": False,
+                "description_editor": None,
                 "focus_pending": False,
             })
         else:


### PR DESCRIPTION
## Summary
- make the map tool marker handle draggable and keep entry width aligned with the marker text
- replace the marker hover with a custom resizable popup that automatically fits the description text and offer a dedicated editor dialog
- update persistence to reflect the new marker data fields

## Testing
- python -m compileall modules/maps

------
https://chatgpt.com/codex/tasks/task_e_68d50395a5dc832b910aa9beaf787293