### PR TITLE
Enable editing marker description via hover popup

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -346,6 +346,14 @@ class DisplayMapController:
         for widget in (toplevel, frame, text_label):
             widget.bind("<Enter>", lambda e, m=marker: self._cancel_marker_hide(m))
             widget.bind("<Leave>", lambda e, m=marker: self._schedule_hide_marker_description(m))
+
+        def _on_description_double_click(event, m=marker):
+            self._cancel_marker_hide(m)
+            self._open_marker_description_editor(m)
+            return "break"
+
+        text_label.bind("<Double-Button-1>", _on_description_double_click)
+        frame.bind("<Double-Button-1>", _on_description_double_click)
         marker["description_popup"] = toplevel
         marker["description_label"] = text_label
         return toplevel


### PR DESCRIPTION
## Summary
- allow double-clicking the marker description hover popup to open the editor
- keep the popup visible while invoking the editor so the description can be updated quickly

## Testing
- python -m compileall modules/maps/controllers/display_map_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68d508451b6c832b87cfc0ff18d5a870