### PR TITLE
Fix lingering token hover popups when leaving map canvas

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -574,6 +574,13 @@ class DisplayMapController:
             self.canvas.tag_bind(cid, "<Enter>", lambda e, t=token: self._on_token_hover_enter(t))
             self.canvas.tag_bind(cid, "<Leave>", lambda e, t=token: self._on_token_hover_leave(t))
 
+    def _on_canvas_pointer_leave(self, event=None):
+        for token in getattr(self, "tokens", []):
+            if not isinstance(token, dict):
+                continue
+            if token.get("hover_visible"):
+                self._schedule_hide_token_hover(token)
+
     def _open_marker_description_editor(self, marker):
         if not marker:
             return

--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -44,6 +44,9 @@ def _build_canvas(self):
     # Configure binding might be better on self.canvas if self.parent is not the direct container that resizes
     self.parent.bind("<Configure>",        lambda e: self._update_canvas_images() if self.base_img else None)
 
+    if hasattr(self, "_on_canvas_pointer_leave"):
+        self.canvas.bind("<Leave>", self._on_canvas_pointer_leave)
+
 
 def _on_delete_key(self, event=None):
     """If an item (token or shape) is selected, delete it on Delete key."""


### PR DESCRIPTION
## Summary
- hide any visible token hover popups whenever the pointer leaves the map canvas
- wire the canvas <Leave> event to the new controller hook so hover tooltips disappear reliably

## Testing
- python -m compileall modules/maps/controllers/display_map_controller.py modules/maps/views/canvas_view.py

------
https://chatgpt.com/codex/tasks/task_e_68d5174c7470832b8a4770ce2802de5a