### PR TITLE
Fix lingering map marker overlays

### DIFF
--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -47,6 +47,13 @@ def _build_canvas(self):
     if hasattr(self, "_on_canvas_pointer_leave"):
         self.canvas.bind("<Leave>", self._on_canvas_pointer_leave)
 
+    if hasattr(self, "_on_canvas_focus_out"):
+        self.canvas.bind("<FocusOut>", self._on_canvas_focus_out)
+
+    if hasattr(self, "_on_application_focus_out") and not getattr(self, "_focus_bindings_registered", False):
+        root.bind("<FocusOut>", lambda e: self._on_application_focus_out(), add="+")
+        self._focus_bindings_registered = True
+
 
 def _on_delete_key(self, event=None):
     """Delete the hovered marker or the currently selected item when Delete is pressed."""


### PR DESCRIPTION
## Summary
- shrink the collapsed marker entry width so the caption matches its text
- dismiss marker description popups and hover panels whenever the canvas or app loses focus
- register focus-out bindings to hide overlays and avoid leaving ghost tooltips on screen

## Testing
- python -m compileall modules/maps/controllers/display_map_controller.py modules/maps/views/canvas_view.py

------
https://chatgpt.com/codex/tasks/task_e_68d52d98fb4c832b928bbb9726c53189