### PR TITLE
Add periodic cleanup for stray map hover popups

### DIFF
--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -54,6 +54,9 @@ def _build_canvas(self):
         root.bind("<FocusOut>", lambda e: self._on_application_focus_out(), add="+")
         self._focus_bindings_registered = True
 
+    if hasattr(self, "_start_hover_cleanup_loop"):
+        self._start_hover_cleanup_loop()
+
 
 def _on_delete_key(self, event=None):
     """Delete the hovered marker or the currently selected item when Delete is pressed."""


### PR DESCRIPTION
## Summary
- add a recurring cleanup loop that hides stale token hover popups when the pointer moves away
- track the hover cleanup job on the display map controller and start it when the canvas is built

## Testing
- python -m compileall modules/maps/controllers/display_map_controller.py modules/maps/views/canvas_view.py

------
https://chatgpt.com/codex/tasks/task_e_68d5364357a4832b8fb8744f6ccf8550