### PR TITLE
Add toolbar button to clear hover popups

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -395,6 +395,11 @@ class DisplayMapController:
         self._hide_all_marker_descriptions()
         self._hide_all_token_hovers()
 
+    def clear_hover_windows(self):
+        """Hide all hover-related popups such as token hovers and marker descriptions."""
+        self._hide_all_token_hovers()
+        self._hide_all_marker_descriptions()
+
     def _on_application_focus_out(self, event=None):
         self._hide_all_marker_descriptions()
         self._hide_all_token_hovers()

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -47,6 +47,8 @@ def _build_toolbar(self):
         .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["marker"], "Add Marker", command=self.add_marker)\
         .pack(side="left", padx=2)
+    create_icon_button(toolbar, None, "Close Hover Windows", command=self.clear_hover_windows)\
+        .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["fs"],    "Fullscreen",   command=self.open_fullscreen)\
         .pack(side="left", padx=2)
     create_icon_button(toolbar, icons["fs"],    "Web Display",   command=self.open_web_display)\


### PR DESCRIPTION
## Summary
- add a controller helper to hide all hover-related popups
- expose a toolbar button in the map tool that clears current hover windows

## Testing
- python -m compileall modules/maps/views/toolbar_view.py modules/maps/controllers/display_map_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68d539ae6ce4832b97576f0a9620bfcd