### PR TITLE
Add customizable borders to map markers

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -319,6 +319,7 @@ def _persist_tokens(self):
                     "text": t.get("text", ""),
                     "description": t.get("description", ""),
                     "entry_width": t.get("entry_width", 180),
+                    "border_color": t.get("border_color", "#00ff00"),
                 })
             else:
                 # Silently skip unknown types for now

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -190,6 +190,8 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "text": rec.get("text", "New Marker"),
                 "description": rec.get("description", "Marker description"),
                 "entry_width": rec.get("entry_width", 180),
+                "border_color": rec.get("border_color", "#00ff00"),
+                "border_canvas_id": None,
                 "entry_widget": None,
                 "description_popup": None,
                 "description_label": None,


### PR DESCRIPTION
## Summary
- draw a dedicated canvas border around map markers and default it to green
- add a context menu option to pick a marker border color and persist it across sessions
- include marker border color in clipboard, persistence, and map loading defaults

## Testing
- python -m compileall -f modules/maps/controllers/display_map_controller.py modules/maps/services/token_manager.py modules/maps/views/map_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68d56ab31994832bbf0f34960772b849