### PR TITLE
Preserve token source images for crisp zoom

### DIFF
--- a/modules/maps/views/fullscreen_view.py
+++ b/modules/maps/views/fullscreen_view.py
@@ -79,19 +79,39 @@ def _update_fullscreen_map(self):
             continue
 
         if item_type == "token":
+            source = item.get('source_image')
             pil = item.get('pil_image')
-            if not pil:
-                continue
+            size_px = item.get('size')
+            if size_px is None:
+                if source is not None:
+                    size_px = source.size[0]
+                elif pil is not None:
+                    size_px = pil.size[0]
+                else:
+                    size_px = getattr(self, 'token_size', 64)
+            try:
+                size_px = max(1, int(size_px))
+            except Exception:
+                size_px = max(1, int(getattr(self, 'token_size', 64)))
 
-            tw, th = pil.size
-            if tw <= 0 or th <= 0:
-                continue
-            
-            nw, nh = int(tw * self.zoom), int(th * self.zoom)
-            if nw <= 0 or nh <= 0:
-                continue
-            
-            img_r = pil.resize((nw, nh), resample=Image.LANCZOS)
+            if source is not None:
+                nw = nh = max(1, int(size_px * self.zoom))
+                if nw <= 0 or nh <= 0:
+                    continue
+                img_r = source.resize((nw, nh), resample=Image.LANCZOS)
+            else:
+                if not pil:
+                    continue
+
+                tw, th = pil.size
+                if tw <= 0 or th <= 0:
+                    continue
+
+                nw, nh = int(tw * self.zoom), int(th * self.zoom)
+                if nw <= 0 or nh <= 0:
+                    continue
+
+                img_r = pil.resize((nw, nh), resample=Image.LANCZOS)
             fsimg = ImageTk.PhotoImage(img_r)
             item['fs_tk'] = fsimg # Store the PhotoImage to prevent garbage collection
 

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -148,24 +148,29 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
             
             sz   = rec.get("size", self.token_size) # Use self.token_size as default
             pil_image = None
+            source_image = None
             try:
                 if path and os.path.exists(path): # Check if path exists
-                    pil_image = Image.open(path).convert("RGBA")
-                    pil_image = pil_image.resize((sz, sz), resample=Image.LANCZOS)
+                    source_image = Image.open(path).convert("RGBA")
+                    pil_image = source_image.resize((sz, sz), resample=Image.LANCZOS)
                 elif path: # Path provided but does not exist
                      print(f"[_on_display_map] Token image path not found: '{path}'. Creating placeholder.")
                      pil_image = Image.new("RGBA", (sz, sz), (255, 0, 0, 128)) # Red placeholder
+                     source_image = pil_image
                 else: # No path provided for a token
                     print(f"[_on_display_map] Token missing image_path. Creating placeholder for ID: {rec.get('entity_id')}.")
                     pil_image = Image.new("RGBA", (sz, sz), (255, 0, 0, 128)) # Red placeholder
+                    source_image = pil_image
             except Exception as e:
                 print(f"[_on_display_map] Failed to load token image '{path}': {e}. Creating placeholder.")
                 pil_image = Image.new("RGBA", (sz, sz), (255, 0, 0, 128)) # Red placeholder on any error
+                source_image = pil_image
 
             item_data.update({
                 "entity_type":  rec.get("entity_type"), # Must come from record for tokens
                 "entity_id":    rec.get("entity_id"),
                 "image_path":   path,
+                "source_image": source_image,
                 "pil_image":    pil_image,
                 "border_color": rec.get("border_color", "#0000ff"), # Default blue for tokens
                 "size":         sz,


### PR DESCRIPTION
## Summary
- retain each token's original image alongside its logical size so resizes always start from full resolution data
- update canvas, fullscreen, and web rendering paths to generate zoomed bitmaps directly from the stored source image
- hydrate loaded map tokens with their source images to keep previews and pasted tokens sharp

## Testing
- python -m compileall modules/maps/services/token_manager.py modules/maps/controllers/display_map_controller.py modules/maps/views/fullscreen_view.py modules/maps/views/web_display_view.py modules/maps/views/map_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68d56d8c3cf4832ba6ccab1a092a3364