### PR TITLE
Add hover font size selector for map hover popups

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -288,6 +288,13 @@ def _persist_tokens(self):
     """Quickly capture token state, then hand off the heavy write to a daemon thread."""
     # 1) Build the JSON in–memory (cheap)
     data = []
+    try:
+        if isinstance(getattr(self, "current_map", None), dict):
+            hover_size = int(getattr(self, "hover_font_size", 12))
+            if hover_size > 0:
+                self.current_map["hover_font_size"] = hover_size
+    except Exception:
+        pass
     for t in self.tokens:
         try:
             x, y = t["position"]

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -3,6 +3,7 @@ import ast
 import json
 import os
 import tkinter as tk
+import customtkinter as ctk
 from PIL import Image, ImageTk, ImageDraw
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.template_loader import load_template
@@ -38,6 +39,18 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
     size = item.get("token_size")
     if isinstance(size, int):
         self.token_size = size
+
+    # Restore hover font size if persisted
+    hover_size = item.get("hover_font_size")
+    if isinstance(hover_size, int) and hover_size > 0:
+        self.hover_font_size = hover_size
+        if hover_size not in getattr(self, "hover_font_size_options", []):
+            self.hover_font_size_options.append(hover_size)
+            self.hover_font_size_options = sorted(set(self.hover_font_size_options))
+        try:
+            self.hover_font.configure(size=self.hover_font_size)
+        except Exception:
+            self.hover_font = ctk.CTkFont(size=self.hover_font_size)
 
     # 2) Tear down any existing UI & build toolbar + canvas
     for w in self.parent.winfo_children():

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -95,6 +95,24 @@ def _build_toolbar(self):
     )
     self.token_size_value_label.pack(side="left", padx=(2,10), pady=8)
 
+    # Hover font size selector
+    hover_font_label = ctk.CTkLabel(toolbar, text="Hover Font Size:")
+    hover_font_label.pack(side="left", padx=(10,2), pady=8)
+
+    font_sizes = getattr(self, "hover_font_size_options", [10, 12, 14, 16, 18, 20, 24, 28, 32])
+    current_hover_size = getattr(self, "hover_font_size", 12)
+    if current_hover_size not in font_sizes:
+        font_sizes = sorted(set(list(font_sizes) + [current_hover_size]))
+    self.hover_font_size_options = list(font_sizes)
+    font_size_values = [str(size) for size in self.hover_font_size_options]
+    self.hover_font_size_menu = ctk.CTkOptionMenu(
+        toolbar,
+        values=font_size_values,
+        command=self._on_hover_font_size_change
+    )
+    self.hover_font_size_menu.set(str(current_hover_size))
+    self.hover_font_size_menu.pack(side="left", padx=5, pady=8)
+
     # --- Drawing Tool Selector ---
     tool_label = ctk.CTkLabel(toolbar, text="Active Tool:")
     tool_label.pack(side="left", padx=(20,2), pady=8)


### PR DESCRIPTION
## Summary
- add a hover font size dropdown to the map toolbar and persist the selection per map
- apply the selected font to token and marker hover popups so they resize immediately

## Testing
- python -m compileall modules/maps

------
https://chatgpt.com/codex/tasks/task_e_68d572b8bb48832bb9026cbb32a3940c