### PR TITLE
Update map tool sizing controls and defaults

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -74,9 +74,11 @@ class DisplayMapController:
         self.clipboard_token = None # Copied item data (token or shape)
     
         self.brush_size  = DEFAULT_BRUSH_SIZE
+        self.brush_size_options = list(range(4, 129, 4))
         self.token_size  = 48
+        self.token_size_options = list(range(16, 129, 8))
         self.hover_font_size_options = [10, 12, 14, 16, 18, 20, 24, 28, 32]
-        self.hover_font_size = 12
+        self.hover_font_size = 14
         self.hover_font = ctk.CTkFont(size=self.hover_font_size)
         self.brush_shape = "rectangle"
         self.fog_mode    = "add"
@@ -2042,7 +2044,7 @@ class DisplayMapController:
             "pan_x": self.pan_x,
             "pan_y": self.pan_y,
             "zoom": self.zoom,
-            "hover_font_size": getattr(self, "hover_font_size", 12)
+            "hover_font_size": getattr(self, "hover_font_size", 14)
         })
         all_maps = list(self._maps.values()); self.maps.save_items(all_maps)
         try:

--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -290,7 +290,7 @@ def _persist_tokens(self):
     data = []
     try:
         if isinstance(getattr(self, "current_map", None), dict):
-            hover_size = int(getattr(self, "hover_font_size", 12))
+            hover_size = int(getattr(self, "hover_font_size", 14))
             if hover_size > 0:
                 self.current_map["hover_font_size"] = hover_size
     except Exception:


### PR DESCRIPTION
## Summary
- default map hover text font size to 14pt and persist the new default when saving maps
- convert fog brush and token size controls to dropdown menus backed by shared option lists
- update size change handlers to sync dropdown selections and keep displayed values accurate

## Testing
- python -m compileall modules/maps

------
https://chatgpt.com/codex/tasks/task_e_68d57750e8cc832b86914a88f51286be