### PR TITLE
Limit scene editor auto-height

### DIFF
--- a/modules/generic/generic_editor_window.py
+++ b/modules/generic/generic_editor_window.py
@@ -296,12 +296,13 @@ class GenericEditorWindow(ctk.CTkToplevel):
         if self._ai_client is None:
             self._ai_client = LocalAIClient()
         return self._ai_client
-    def _make_richtext_editor(self, parent, initial_text, hide_toolbar=True):
+    def _make_richtext_editor(self, parent, initial_text, hide_toolbar=True, max_lines=None):
         """
         Shared initialization for any RichTextEditor-based field.
         Returns the editor instance.
         """
-        editor = RichTextEditor(parent)
+        line_limit = 100 if max_lines is None else max_lines
+        editor = RichTextEditor(parent, max_lines=line_limit)
         editor.text_widget.configure(
             bg="#2B2B2B", fg="white", insertbackground="white"
         )
@@ -575,7 +576,7 @@ class GenericEditorWindow(ctk.CTkToplevel):
             ).pack(side="right")
 
             text_data = data.get("Text") or data.get("text") or ""
-            rte = self._make_richtext_editor(row, text_data, hide_toolbar=True)
+            rte = self._make_richtext_editor(row, text_data, hide_toolbar=True, max_lines=12)
             rte.pack_configure(pady=4)
             scene_state["editor"] = rte
 

--- a/modules/helpers/rich_text_editor.py
+++ b/modules/helpers/rich_text_editor.py
@@ -7,8 +7,9 @@ from modules.helpers.logging_helper import log_module_import
 log_module_import(__name__)
 
 class RichTextEditor(ctk.CTkFrame):
-    def __init__(self, master, initial_text=""):
+    def __init__(self, master, initial_text="", max_lines=100):
         super().__init__(master)
+        self.max_lines = max_lines
         # Global toolbar at the top (exposed as self.toolbar)
         self.toolbar = ctk.CTkFrame(self)
         self.toolbar.pack(fill="x", padx=5, pady=5)
@@ -52,7 +53,7 @@ class RichTextEditor(ctk.CTkFrame):
     
     def update_text_height(self, event=None):
         lines = int(self.text_widget.count("1.0", "end", "displaylines")[0])
-        clamped = max(1, min(lines, 100))
+        clamped = max(1, min(lines, self.max_lines))
         self.text_widget.configure(height=clamped)
     # ----------------------
     # Formatting Functions


### PR DESCRIPTION
## Summary
- allow configuring a maximum line count for the rich text editor auto-resize logic
- cap scene editors to 12 lines so the section no longer expands with long text

## Testing
- python -m compileall modules/helpers/rich_text_editor.py modules/generic/generic_editor_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b658f270832b96bdf1244ac429cc