### PR TITLE
Switch map info popups to click-to-pin cards

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -51,10 +51,8 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
         "hp_entry_id": None,
         "hover_popup": None,
         "hover_label": None,
-        "hover_hide_job": None,
         "hover_visible": False,
         "hover_bbox": None,
-        "_hover_bound": False,
     }
 
     self.tokens.append(token)
@@ -251,21 +249,13 @@ def _delete_token(self, token):
         del token["max_hp_entry_widget"], token["max_hp_entry_widget_id"]
 
     # 6) The info widget on the right
-    hide_job = token.get("hover_hide_job")
-    if hide_job:
-        try:
-            self.canvas.after_cancel(hide_job)
-        except ValueError:
-            pass
     popup = token.get("hover_popup")
     if popup and popup.winfo_exists():
         popup.destroy()
     token["hover_popup"] = None
     token["hover_label"] = None
-    token["hover_hide_job"] = None
     token["hover_visible"] = False
     token.pop("hover_bbox", None)
-    token.pop("_hover_bound", None)
 
     # 7) Fullscreen mirror items, if present
     if getattr(self, "fs_canvas", None):

--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -44,18 +44,12 @@ def _build_canvas(self):
     # Configure binding might be better on self.canvas if self.parent is not the direct container that resizes
     self.parent.bind("<Configure>",        lambda e: self._update_canvas_images() if self.base_img else None)
 
-    if hasattr(self, "_on_canvas_pointer_leave"):
-        self.canvas.bind("<Leave>", self._on_canvas_pointer_leave)
-
     if hasattr(self, "_on_canvas_focus_out"):
         self.canvas.bind("<FocusOut>", self._on_canvas_focus_out)
 
     if hasattr(self, "_on_application_focus_out") and not getattr(self, "_focus_bindings_registered", False):
         root.bind("<FocusOut>", lambda e: self._on_application_focus_out(), add="+")
         self._focus_bindings_registered = True
-
-    if hasattr(self, "_start_hover_cleanup_loop"):
-        self._start_hover_cleanup_loop()
 
 
 def _on_delete_key(self, event=None):

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -213,7 +213,6 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "entry_widget": None,
                 "description_popup": None,
                 "description_label": None,
-                "description_hide_job": None,
                 "description_visible": False,
                 "description_editor": None,
                 "focus_pending": False,
@@ -224,7 +223,7 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
 
         self.tokens.append(item_data)
 
-    # 8) Hydrate token metadata for hover display (ONLY FOR TOKENS)
+    # 8) Hydrate token metadata for info card display (ONLY FOR TOKENS)
     for current_item in self.tokens:
         if current_item.get("type", "token") == "token":
             token_entity_type = current_item.get("entity_type")
@@ -244,21 +243,13 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 else:
                     print(f"[_on_display_map] Unknown entity_type '{token_entity_type}' for token ID '{token_entity_id}'. Cannot hydrate info.")
                 current_item["entity_record"] = record
-
-            current_item["hover_popup"] = None
-            current_item["hover_label"] = None
-            current_item["hover_hide_job"] = None
-            current_item["hover_visible"] = False
-            current_item["hover_bbox"] = None
-            current_item["_hover_bound"] = False
         else:
             current_item["entity_record"] = {}
-            current_item["hover_popup"] = None
-            current_item["hover_label"] = None
-            current_item["hover_hide_job"] = None
-            current_item["hover_visible"] = False
-            current_item["hover_bbox"] = None
-            current_item["_hover_bound"] = False
+
+        current_item["hover_popup"] = None
+        current_item["hover_label"] = None
+        current_item["hover_visible"] = False
+        current_item["hover_bbox"] = None
 
     # 9) Finally draw everything onto the canvas
     self._update_canvas_images()

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -117,8 +117,8 @@ def _build_toolbar(self):
     )
     self.token_size_value_label.pack(side="left", padx=(2,10), pady=8)
 
-    # Hover font size selector
-    hover_font_label = ctk.CTkLabel(toolbar, text="Hover Font Size:")
+    # Info card font size selector
+    hover_font_label = ctk.CTkLabel(toolbar, text="Info Card Font Size:")
     hover_font_label.pack(side="left", padx=(10,2), pady=8)
 
     font_sizes = getattr(self, "hover_font_size_options", [10, 12, 14, 16, 18, 20, 24, 28, 32])


### PR DESCRIPTION
## Summary
- replace the hover-based token and marker popups with click-to-toggle info cards and ensure clicks on empty space dismiss them
- update the map selector, token manager, and toolbar label to drop legacy hover bookkeeping while preserving info card font sizing
- simplify the canvas setup now that hover cleanup bindings are no longer needed

## Testing
- python -m compileall modules/maps/controllers/display_map_controller.py modules/maps/views/canvas_view.py modules/maps/views/map_selector.py modules/maps/services/token_manager.py modules/maps/views/toolbar_view.py

------
https://chatgpt.com/codex/tasks/task_e_68d763d810a4832baefbfd763e32a8c7