### PR TITLE
Require explicit fog brush selection in map tool

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -78,7 +78,7 @@ class DisplayMapController:
         self.hover_font_size = 14
         self.hover_font = ctk.CTkFont(size=self.hover_font_size)
         self.brush_shape = "rectangle"
-        self.fog_mode    = "add"
+        self.fog_mode    = None
         self.tokens      = [] # List of all items (tokens and shapes)
         
         self.drawing_mode = "token"

--- a/modules/maps/services/fog_manager.py
+++ b/modules/maps/services/fog_manager.py
@@ -4,7 +4,18 @@ from modules.helpers.logging_helper import log_module_import
 log_module_import(__name__)
 
 def _set_fog(self, mode):
-    self.fog_mode = mode
+    """Toggle the active fog brush mode between add/remove/none."""
+    if mode not in ("add", "rem"):
+        new_mode = None
+    else:
+        current = getattr(self, "fog_mode", None)
+        new_mode = None if current == mode else mode
+
+    self.fog_mode = new_mode
+
+    updater = getattr(self, "_update_fog_button_states", None)
+    if callable(updater):
+        updater()
 
 def clear_fog(self):
     self.mask_img = Image.new("RGBA", self.base_img.size, (0,0,0,0))
@@ -17,6 +28,8 @@ def reset_fog(self):
 def on_paint(self, event):
     """Paint or erase fog using a square brush of size self.brush_size,
        with semi-transparent black (alpha=128) for fog."""
+    if self.fog_mode not in ("add", "rem"):
+        return
     if any('drag_data' in t for t in self.tokens):
         return
     if not self.mask_img:

--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -87,6 +87,8 @@ def on_paint2(self, event):
     """Paint or erase fog using a square brush of size self.brush_size,
        with semi-transparent black (alpha=128) for fog."""
     # Prevent fog painting if a drag operation is in progress for any item
+    if self.fog_mode not in ("add", "rem"):
+        return
     if any(t.get('drag_data') for t in self.tokens):
         return
     if not self.mask_img:

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -32,8 +32,36 @@ def _build_toolbar(self):
     }
 
     # Fog controls
-    create_icon_button(toolbar, icons["add"],   "Add Fog",     command=lambda: self._set_fog("add")).pack(side="left")
-    create_icon_button(toolbar, icons["rem"],   "Remove Fog",  command=lambda: self._set_fog("rem")).pack(side="left")
+    self._fog_button_default_style = {
+        "fg_color": "#0077CC",
+        "hover_color": "#005fa3",
+        "border_color": "#005fa3",
+    }
+    self._fog_button_active_style = {
+        "fg_color": "#004c80",
+        "hover_color": "#004c80",
+        "border_color": "#33a8ff",
+    }
+    self._fog_buttons = {}
+
+    add_fog_container = create_icon_button(
+        toolbar,
+        icons["add"],
+        "Add Fog",
+        command=lambda: self._set_fog("add")
+    )
+    add_fog_container.pack(side="left")
+    self._fog_buttons["add"] = getattr(add_fog_container, "button", None)
+
+    rem_fog_container = create_icon_button(
+        toolbar,
+        icons["rem"],
+        "Remove Fog",
+        command=lambda: self._set_fog("rem")
+    )
+    rem_fog_container.pack(side="left")
+    self._fog_buttons["rem"] = getattr(rem_fog_container, "button", None)
+
     create_icon_button(toolbar, icons["clear"], "Clear Fog",   command=self.clear_fog).pack(side="left")
     create_icon_button(toolbar, icons["reset"], "Reset Fog",   command=self.reset_fog).pack(side="left")
     create_icon_button(toolbar, icons["save"],  "Save Map",    command=self.save_map).pack(side="left")
@@ -183,6 +211,8 @@ def _build_toolbar(self):
     if hasattr(self, '_update_shape_controls_visibility'):
         self._update_shape_controls_visibility()
 
+    self._update_fog_button_states()
+
 def _on_brush_size_change(self, val): # This is for FOG brush
     try:
         size = int(val)
@@ -242,6 +272,24 @@ def _on_token_size_change(self, val):
             self.token_size_value_label.configure(text=str(self.token_size))
         except tk.TclError:
             pass
+
+
+def _update_fog_button_states(self):
+    """Update fog button appearance to reflect the active fog tool."""
+    buttons = getattr(self, "_fog_buttons", {})
+    default_style = getattr(self, "_fog_button_default_style", {})
+    active_style = getattr(self, "_fog_button_active_style", {})
+    active_mode = getattr(self, "fog_mode", None)
+
+    for mode, button in buttons.items():
+        if not button:
+            continue
+        style = active_style if mode == active_mode else default_style
+        try:
+            button.configure(**style)
+        except tk.TclError:
+            # If the button has been destroyed, ignore the update.
+            continue
 
 # Placeholder for new callbacks in DisplayMapController - these will be defined there.
 # def _on_drawing_tool_change(self, selected_tool):

--- a/modules/ui/icon_button.py
+++ b/modules/ui/icon_button.py
@@ -36,6 +36,12 @@ def create_icon_button(parent, icon, tooltip_text, command):
         btn.configure(font=("Segoe UI", 14, "bold"))
 
     btn.pack(fill="both", expand=True)
+
+    # Expose the underlying button widget so callers can adjust its
+    # configuration after creation (for example, to reflect toggled states).
+    # This keeps backwards compatibility by still returning the container.
+    container.icon_button = btn
+    container.button = btn
     ToolTip(btn, tooltip_text)
     return container
 


### PR DESCRIPTION
## Summary
- start the map tool with no fog brush selected and skip fog painting until a mode is chosen
- add toggle behaviour and pressed styling for the Add/Remove Fog toolbar buttons while exposing the underlying button widget
- keep fog brush logic aligned with the toolbar selection, including deselection when the active button is clicked again

## Testing
- python -m compileall modules/maps modules/ui

------
https://chatgpt.com/codex/tasks/task_e_68d76f71a7f0832ba2aabfdc159c16a1