### PR TITLE
Add hover font size support to map schema

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -20,6 +20,7 @@ _SQLITE_TYPE = {
     "list":     "TEXT",  # we’ll store lists as JSON strings
     "file":     "TEXT",
     "float":    "REAL",
+    "int":      "INTEGER",
     "audio":    "TEXT",
 }
 

--- a/modules/maps/maps_template.json
+++ b/modules/maps/maps_template.json
@@ -8,6 +8,7 @@
       { "name": "token_size",  "type": "int"},
       { "name": "pan_x",      "type": "float"},
       { "name": "pan_y",      "type": "float"},
-      { "name": "zoom",       "type": "float"}
+      { "name": "zoom",       "type": "float"},
+      { "name": "hover_font_size", "type": "int" }
   ]
 }


### PR DESCRIPTION
## Summary
- map templates now declare the hover_font_size field so it is stored in SQLite
- map schema migration recognizes integer types via the shared type map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7735300c0832b94b37ca88ecf82b0