### PR TITLE
Add GM screen layout persistence and launcher integration

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -54,6 +54,7 @@ from modules.ui.portrait_importer import PortraitImporter
 from modules.generic.generic_list_view import GenericListView
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.scenarios.gm_screen_view import GMScreenView
+from modules.scenarios.gm_layout_manager import GMScreenLayoutManager
 from modules.npcs.npc_graph_editor import NPCGraphEditor
 from modules.pcs.pc_graph_editor import PCGraphEditor
 from modules.scenarios.scenario_graph_editor import ScenarioGraphEditor
@@ -807,6 +808,13 @@ class MainWindow(ctk.CTk):
             messagebox.showwarning("No Scenarios", "No scenarios available.")
             return
 
+        layout_manager = GMScreenLayoutManager()
+        layout_map = layout_manager.list_layouts()
+        default_label = "Use Scenario Default"
+        layout_options = [default_label]
+        layout_options.extend(sorted(layout_map.keys()))
+        selected_layout_var = tk.StringVar(value=default_label)
+
         # 3) Ensure the PC‐banner is shown and up to date
         if getattr(self, 'banner_frame', None) and self.banner_frame.winfo_exists():
             if not self.banner_frame.winfo_ismapped():
@@ -825,6 +833,12 @@ class MainWindow(ctk.CTk):
             w.destroy()
         parent = self.inner_content_frame
 
+        layout_bar = ctk.CTkFrame(parent)
+        layout_bar.pack(fill="x", padx=10, pady=(5, 0))
+        ctk.CTkLabel(layout_bar, text="Layout when opening scenario:").pack(side="left", padx=(0, 10), pady=5)
+        layout_menu = ctk.CTkOptionMenu(layout_bar, variable=selected_layout_var, values=layout_options)
+        layout_menu.pack(side="left", pady=5)
+
         # 5) Callback to open a selected scenario in detail
         def on_scenario_select(entity_type, entity_name):
             selected = next(
@@ -840,7 +854,14 @@ class MainWindow(ctk.CTk):
                 w.destroy()
             detail_container = ctk.CTkFrame(parent)
             detail_container.grid(row=0, column=0, sticky="nsew")
-            view = GMScreenView(detail_container, scenario_item=selected)
+            chosen_layout = selected_layout_var.get()
+            initial_layout = None if chosen_layout == default_label else chosen_layout
+            view = GMScreenView(
+                detail_container,
+                scenario_item=selected,
+                initial_layout=initial_layout,
+                layout_manager=layout_manager,
+            )
             view.pack(fill="both", expand=True)
             # track the active GM-screen view for our Ctrl+F handler
             self.current_gm_view = view

--- a/modules/scenarios/gm_layout_manager.py
+++ b/modules/scenarios/gm_layout_manager.py
@@ -1,0 +1,88 @@
+import json
+import os
+from typing import Dict, Any, Optional
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.logging_helper import log_info, log_warning, log_exception, log_module_import
+
+
+class GMScreenLayoutManager:
+    """Persist GM Screen tab layouts per campaign."""
+
+    FILE_NAME = "gm_layouts.json"
+
+    def __init__(self):
+        self.path = os.path.join(ConfigHelper.get_campaign_dir(), self.FILE_NAME)
+        self.data: Dict[str, Any] = {"layouts": {}, "scenario_defaults": {}}
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Basic persistence helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not os.path.exists(self.path):
+            log_info(f"No layout file found at {self.path}; starting fresh.", func_name="GMScreenLayoutManager._load")
+            return
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                raw = json.load(fh) or {}
+            layouts = raw.get("layouts") or {}
+            scenario_defaults = raw.get("scenario_defaults") or {}
+            if not isinstance(layouts, dict) or not isinstance(scenario_defaults, dict):
+                raise ValueError("Layout file malformed")
+            self.data["layouts"] = layouts
+            self.data["scenario_defaults"] = scenario_defaults
+        except Exception as exc:
+            log_exception(exc, func_name="GMScreenLayoutManager._load")
+            log_warning(
+                f"Failed to load GM layouts from {self.path}. Reinitializing empty store.",
+                func_name="GMScreenLayoutManager._load",
+            )
+            self.data = {"layouts": {}, "scenario_defaults": {}}
+
+    def _write(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(self.data, fh, indent=2)
+        log_info(
+            f"GM layouts saved to {self.path}",
+            func_name="GMScreenLayoutManager._write",
+        )
+
+    # ------------------------------------------------------------------
+    # Layout operations
+    # ------------------------------------------------------------------
+    def list_layouts(self) -> Dict[str, Any]:
+        return dict(self.data.get("layouts", {}))
+
+    def get_layout(self, name: str) -> Optional[Dict[str, Any]]:
+        layouts = self.data.get("layouts", {})
+        layout = layouts.get(name)
+        if layout is None:
+            return None
+        return json.loads(json.dumps(layout))  # deep copy to avoid accidental mutation
+
+    def save_layout(self, name: str, layout: Dict[str, Any]) -> None:
+        self.data.setdefault("layouts", {})[name] = layout
+        self._write()
+
+    # ------------------------------------------------------------------
+    # Scenario defaults
+    # ------------------------------------------------------------------
+    def get_scenario_default(self, scenario_title: str) -> Optional[str]:
+        if not scenario_title:
+            return None
+        return self.data.get("scenario_defaults", {}).get(scenario_title)
+
+    def set_scenario_default(self, scenario_title: str, layout_name: Optional[str]) -> None:
+        defaults = self.data.setdefault("scenario_defaults", {})
+        if not scenario_title:
+            return
+        if layout_name:
+            defaults[scenario_title] = layout_name
+        else:
+            defaults.pop(scenario_title, None)
+        self._write()
+
+
+log_module_import(__name__)


### PR DESCRIPTION
## Summary
- add a GM screen layout manager that stores layouts and scenario defaults per campaign
- extend GMScreenView with Save/Load layout controls, persistence logic, and status display
- update the GM screen launcher to let users pick or auto-apply saved layouts when opening scenarios

## Testing
- python -m compileall modules/scenarios/gm_layout_manager.py modules/scenarios/gm_screen_view.py main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d91a078004832b881f04f7641bda34