### PR TITLE
Persist GM screen scene state and update checkbox layout

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -674,18 +674,18 @@ def insert_list_longtext(parent, header, items, open_entity_callback=None, entit
             check_var = ctk.BooleanVar(master=outer, value=initial_state)
             header_row = ctk.CTkFrame(outer, fg_color="transparent")
             header_row.pack(fill="x", expand=True)
-            checkbox = ctk.CTkCheckBox(
-                header_row,
-                text="Completed",
-                variable=check_var,
-            )
-            checkbox.pack(side="left", padx=(0, 8), pady=(2, 2))
             btn = ctk.CTkButton(
                 header_row,
                 text=button_text,
                 fg_color="transparent",
                 anchor="w",
             )
+            checkbox = ctk.CTkCheckBox(
+                header_row,
+                text="",
+                variable=check_var,
+            )
+            checkbox.pack(side="right", padx=(8, 0), pady=(2, 2))
         else:
             check_var = None
             checkbox = None


### PR DESCRIPTION
## Summary
- move GM scene checkboxes to the end of the header row and remove the "Completed" label for a cleaner look
- persist GM screen scene completion state and GM notes through the layout manager so returning to a scenario restores the previous state
- extend the layout manager to store and retrieve per-scenario scene states and notes alongside existing layout data

## Testing
- python -m compileall modules/scenarios/gm_screen_view.py modules/scenarios/gm_layout_manager.py modules/generic/entity_detail_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68d942a9d808832b85ddf22cd082f27f