### PR TITLE
Add audio metadata support for NPC, creature, and PC entities

### DIFF
--- a/modules/audio/entity_audio.py
+++ b/modules/audio/entity_audio.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from modules.audio.audio_player import AudioPlayer
 from modules.helpers.config_helper import ConfigHelper
@@ -18,6 +19,34 @@ from modules.helpers.logging_helper import (
 log_module_import(__name__)
 
 _ENTITY_PLAYER: Optional[AudioPlayer] = None
+
+
+def normalize_audio_reference(value: Any) -> str:
+    """Normalize stored audio metadata into a plain string reference."""
+
+    if not value:
+        return ""
+    if isinstance(value, Mapping):
+        for key in ("path", "text", "value", "url"):
+            candidate = value.get(key)
+            if candidate:
+                try:
+                    return str(candidate).strip()
+                except Exception:
+                    continue
+        return ""
+    try:
+        return str(value).strip()
+    except Exception:
+        return ""
+
+
+def get_entity_audio_value(record: Any) -> str:
+    """Extract an audio reference from an entity record or value."""
+
+    if isinstance(record, Mapping):
+        return normalize_audio_reference(record.get("Audio"))
+    return normalize_audio_reference(record)
 
 
 def _get_player() -> AudioPlayer:
@@ -116,6 +145,8 @@ def stop_entity_audio() -> None:
         )
 
 __all__ = [
+    "get_entity_audio_value",
+    "normalize_audio_reference",
     "play_entity_audio",
     "resolve_audio_path",
     "stop_entity_audio",

--- a/modules/creatures/creatures_template.json
+++ b/modules/creatures/creatures_template.json
@@ -9,6 +9,6 @@
       {"name": "Background", "type": "longtext"},
       {"name": "Genre", "type": "text"},
       {"name": "Portrait", "type": "text"},
-      {"name": "Audio", "type": "text"}
+      {"name": "Audio", "type": "audio"}
   ]
 }

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -13,7 +13,12 @@ from modules.ui.image_viewer import show_portrait
 from modules.ui.tooltip import ToolTip
 from modules.generic.generic_editor_window import GenericEditorWindow
 from modules.helpers.config_helper import ConfigHelper
-from modules.audio.entity_audio import play_entity_audio, resolve_audio_path, stop_entity_audio
+from modules.audio.entity_audio import (
+    get_entity_audio_value,
+    play_entity_audio,
+    resolve_audio_path,
+    stop_entity_audio,
+)
 from modules.helpers.logging_helper import (
     log_function,
     log_info,
@@ -962,7 +967,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
     button_bar = ctk.CTkFrame(content_frame)
     button_bar.pack(fill="x", pady=(0, 10))
 
-    audio_value = entity.get("Audio") or ""
+    audio_value = get_entity_audio_value(entity)
     entity_label = entity.get("Name") or entity.get("Title") or entity_type[:-1]
 
     def _audio_display_name(value: str) -> str:

--- a/modules/generic/generic_editor_window.py
+++ b/modules/generic/generic_editor_window.py
@@ -231,12 +231,16 @@ class GenericEditorWindow(ctk.CTkToplevel):
         fields = self.template["fields"]
         portrait_field = None
         image_field = None
+        audio_field = None
         other_fields = []
         for field in fields:
-            if field["name"] == "Portrait":
+            name = field.get("name")
+            if name == "Portrait":
                 portrait_field = field
-            elif field["name"] == "Image":
+            elif name == "Image":
                 image_field = field
+            elif name == "Audio":
+                audio_field = field
             else:
                 other_fields.append(field)
         if portrait_field:
@@ -245,6 +249,9 @@ class GenericEditorWindow(ctk.CTkToplevel):
         if image_field:
             ctk.CTkLabel(self.scroll_frame, text=image_field["name"]).pack(pady=(5, 0), anchor="w")
             self.create_image_field(image_field)
+        if audio_field:
+            ctk.CTkLabel(self.scroll_frame, text=audio_field["name"]).pack(pady=(5, 0), anchor="w")
+            self.create_audio_field(audio_field)
 
         for field in other_fields:
             field_name = str(field.get("name", ""))

--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -10,7 +10,11 @@ from modules.generic.generic_editor_window import GenericEditorWindow
 from modules.ui.image_viewer import show_portrait
 from modules.ui.second_screen_display import show_entity_on_second_screen
 from modules.helpers.config_helper import ConfigHelper
-from modules.audio.entity_audio import play_entity_audio, stop_entity_audio
+from modules.audio.entity_audio import (
+    get_entity_audio_value,
+    play_entity_audio,
+    stop_entity_audio,
+)
 from modules.scenarios.gm_screen_view import GMScreenView
 from modules.ai.authoring_wizard import AuthoringWizardView
 import shutil
@@ -727,10 +731,7 @@ class GenericListView(ctk.CTkFrame):
     def _get_audio_value(self, item):
         if not item:
             return ""
-        value = item.get("Audio") or ""
-        if isinstance(value, dict):
-            return value.get("path") or value.get("text") or ""
-        return str(value).strip()
+        return get_entity_audio_value(item)
 
     def play_item_audio(self, item):
         audio_value = self._get_audio_value(item)

--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -31,7 +31,11 @@ from modules.helpers.text_helpers import format_longtext
 from modules.helpers.config_helper import ConfigHelper
 from modules.ui.image_viewer import show_portrait
 from modules.helpers.logging_helper import log_module_import
-from modules.audio.entity_audio import play_entity_audio, stop_entity_audio
+from modules.audio.entity_audio import (
+    get_entity_audio_value,
+    play_entity_audio,
+    stop_entity_audio,
+)
 
 log_module_import(__name__)
 
@@ -1515,11 +1519,7 @@ class DisplayMapController:
             print(f"Error displaying token menu: {e}")
 
     def _get_token_audio_value(self, token):
-        record = token.get("entity_record") or {}
-        value = record.get("Audio") or ""
-        if isinstance(value, dict):
-            value = value.get("path") or value.get("text") or ""
-        value = str(value).strip()
+        value = get_entity_audio_value(token.get("entity_record"))
         if value:
             return value
         entity_type = token.get("entity_type")
@@ -1530,10 +1530,9 @@ class DisplayMapController:
         try:
             for item in wrapper.load_items():
                 if item.get("Name") == entity_id:
-                    raw = item.get("Audio") or ""
-                    if isinstance(raw, dict):
-                        raw = raw.get("path") or raw.get("text") or ""
-                    return str(raw).strip()
+                    raw_value = get_entity_audio_value(item)
+                    if raw_value:
+                        return raw_value
         except Exception:
             return ""
         return ""

--- a/modules/npcs/npc_graph_editor.py
+++ b/modules/npcs/npc_graph_editor.py
@@ -17,7 +17,11 @@ import os
 import textwrap
 from modules.ui.image_viewer import show_portrait
 from modules.helpers.config_helper import ConfigHelper
-from modules.audio.entity_audio import play_entity_audio, stop_entity_audio
+from modules.audio.entity_audio import (
+    get_entity_audio_value,
+    play_entity_audio,
+    stop_entity_audio,
+)
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -734,12 +738,7 @@ class NPCGraphEditor(ctk.CTkFrame):
         self.draw_graph()
 
     def _get_entity_audio(self, record):
-        if not isinstance(record, dict):
-            return ""
-        value = record.get("Audio") or ""
-        if isinstance(value, dict):
-            value = value.get("path") or value.get("text") or ""
-        return str(value).strip()
+        return get_entity_audio_value(record)
 
     def _play_entity_audio(self, record, name):
         audio_value = self._get_entity_audio(record)

--- a/modules/npcs/npcs_template.json
+++ b/modules/npcs/npcs_template.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "Audio",
-      "type": "text"
+      "type": "audio"
     }
   ]
 }

--- a/modules/pcs/pc_graph_editor.py
+++ b/modules/pcs/pc_graph_editor.py
@@ -19,7 +19,11 @@ import re
 from tkinter.font import Font  # add at top of file
 from modules.ui.image_viewer import show_portrait
 from modules.helpers.config_helper import ConfigHelper
-from modules.audio.entity_audio import play_entity_audio, stop_entity_audio
+from modules.audio.entity_audio import (
+    get_entity_audio_value,
+    play_entity_audio,
+    stop_entity_audio,
+)
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -642,12 +646,7 @@ class PCGraphEditor(ctk.CTkFrame):
 
 
     def _get_entity_audio(self, record):
-        if not isinstance(record, dict):
-            return ""
-        value = record.get("Audio") or ""
-        if isinstance(value, dict):
-            value = value.get("path") or value.get("text") or ""
-        return str(value).strip()
+        return get_entity_audio_value(record)
 
     def _play_entity_audio(self, record, name):
         audio_value = self._get_entity_audio(record)

--- a/modules/pcs/pcs_template.json
+++ b/modules/pcs/pcs_template.json
@@ -8,6 +8,6 @@
       {"name": "Factions", "type": "list", "linked_type": "Factions"},
       {"name": "Objects", "type": "list", "linked_type": "Objects"},
       {"name": "Portrait", "type": "text"},
-      {"name": "Audio", "type": "text"}
+      {"name": "Audio", "type": "audio"}
   ]
 }

--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -20,7 +20,11 @@ from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.text_helpers import format_longtext
 from modules.ui.image_viewer import show_portrait
 from modules.helpers.template_loader import load_template
-from modules.audio.entity_audio import play_entity_audio, stop_entity_audio
+from modules.audio.entity_audio import (
+    get_entity_audio_value,
+    play_entity_audio,
+    stop_entity_audio,
+)
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -2814,12 +2818,7 @@ class ScenarioGraphEditor(ctk.CTkFrame):
         node_menu.post(int(x), int(y))
 
     def _get_entity_audio(self, record):
-        if not isinstance(record, dict):
-            return ""
-        value = record.get("Audio") or ""
-        if isinstance(value, dict):
-            value = value.get("path") or value.get("text") or ""
-        return str(value).strip()
+        return get_entity_audio_value(record)
 
     def _play_entity_audio(self, record, name):
         audio_value = self._get_entity_audio(record)


### PR DESCRIPTION
## Summary
- add dedicated audio field definitions to creature, NPC, and PC templates and surface the picker alongside portraits in the editor
- normalize entity audio extraction in a shared helper and reuse it across map tokens, list views, and graph editors
- hook the generic detail view, list view, and map tools into the shared helper so audio cues are playable from list menus and token context menus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94fe331b8832b9b10beaf2ecaf475