### PR TITLE
Fix missing context menu for newly added tokens

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -36,6 +36,7 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
     yw_center = (ch/2 - self.pan_y) / self.zoom
 
     token = {
+        "type":         "token",
         "entity_type":  entity_type,
         "entity_id":    entity_name,
         "image_path":   img_path,
@@ -143,6 +144,7 @@ def _paste_token(self, event=None):
 
     # Clone all relevant fields into a new token dict
     token = {
+        "type":         "token",
         "entity_type":  c["entity_type"],
         "entity_id":    c["entity_id"],
         "image_path":   c["image_path"],


### PR DESCRIPTION
## Summary
- ensure newly created tokens are tagged with the "token" type immediately
- preserve the type metadata when pasting tokens from the clipboard so UI handlers recognize them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9535ec3fc832bac2260bcdcc2fbb8