### PR TITLE
Paste map items at pointer position

### DIFF
--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -14,8 +14,8 @@ def _build_canvas(self):
     root = self.parent.winfo_toplevel()
     root.bind_all("<Control-c>", lambda event: self._copy_item()) # Use generic item copy
     root.bind_all("<Control-C>", lambda event: self._copy_item()) # Case insensitive
-    root.bind_all("<Control-v>", lambda event: self._paste_item()) # Use generic item paste
-    root.bind_all("<Control-V>", lambda event: self._paste_item()) # Case insensitive
+    root.bind_all("<Control-v>", lambda event: self._paste_item(event)) # Use generic item paste
+    root.bind_all("<Control-V>", lambda event: self._paste_item(event)) # Case insensitive
     root.bind_all("<Delete>", self._on_delete_key) # Calls updated _on_delete_key
     
     # Undo fog


### PR DESCRIPTION
## Summary
- pass the triggering key event into the global paste bindings so the paste handler can respond to keyboard shortcuts
- derive the paste target from the mouse pointer, converting screen coordinates through pan and zoom to world space
- place new items at the computed world coordinates before refreshing the canvas and saving state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95d5a1f64832ba4f1792132f6fcc4