### PR TITLE
Add selection mode and multi-selection operations to map tool

### DIFF
--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -76,12 +76,15 @@ def _on_delete_key(self, event=None):
                 self._hovered_marker = None
             return "break"
 
-    if not self.selected_token: # selected_token now refers to the selected item
+    targets = []
+    resolver = getattr(self, "_resolve_operation_targets", None)
+    if callable(resolver):
+        targets = resolver(self.selected_token, item_types=None)
+    elif self.selected_token:
+        targets = [self.selected_token]
+    if not targets:
         return
-
-    item_to_delete = self.selected_token
-    self.selected_token = None # Clear selection before deleting
-    self._delete_item(item_to_delete) # Use the generic delete method
+    self._delete_item(targets) # Use the generic delete method
 
 def on_paint2(self, event):
     """Paint or erase fog using a square brush of size self.brush_size,

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -171,7 +171,7 @@ def _build_toolbar(self):
     tool_label.pack(side="left", padx=(20,2), pady=8)
     self.drawing_tool_menu = ctk.CTkOptionMenu(
         toolbar,
-        values=["Token", "Rectangle", "Oval"],
+        values=["Selection", "Token", "Rectangle", "Oval"],
         command=self._on_drawing_tool_change, # To be created in DisplayMapController
         width=dropdown_width,
     )


### PR DESCRIPTION
## Summary
- introduce selection state tracking with highlight overlays and a drag-to-select marquee
- add a toolbar selection mode and modifier-aware multi-selection handling on the map canvas
- apply context menu and delete operations to every selected item while keeping audio playback token-specific

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95f61b5ac832b8a2643c0fb837ee8