### PR TITLE
Add map links to scenes and map thumbnails on GM screen

### DIFF
--- a/modules/generic/generic_editor_window.py
+++ b/modules/generic/generic_editor_window.py
@@ -392,6 +392,7 @@ class GenericEditorWindow(ctk.CTkToplevel):
             "NPCs": "npcs",
             "Creatures": "creatures",
             "Places": "places",
+            "Maps": "maps",
         }
         entity_wrappers = {}
         entity_templates = {}


### PR DESCRIPTION
## Summary
- add map support to scenario scene editor so scenes can link specific maps
- extend GM screen scene display with clickable map thumbnail gallery tied to the map tool
- load and cache map metadata and thumbnails within the GM screen view for quick access

## Testing
- python -m compileall modules/generic modules/scenarios

------
https://chatgpt.com/codex/tasks/task_e_68d96bedad0c832bbf6536a992240573