### PR TITLE
Add rectangular multi-selection and bulk actions to map tool

### DIFF
--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -76,12 +76,16 @@ def _on_delete_key(self, event=None):
                 self._hovered_marker = None
             return "break"
 
-    if not self.selected_token: # selected_token now refers to the selected item
+    selected_items = list(getattr(self, "selected_items", []) or [])
+    if not selected_items and getattr(self, "selected_token", None):
+        selected_items = [self.selected_token]
+    if not selected_items:
         return
 
-    item_to_delete = self.selected_token
-    self.selected_token = None # Clear selection before deleting
-    self._delete_item(item_to_delete) # Use the generic delete method
+    for item in list(selected_items):
+        self._delete_item(item)
+
+    return "break"
 
 def on_paint2(self, event):
     """Paint or erase fog using a square brush of size self.brush_size,


### PR DESCRIPTION
## Summary
- add drag-selection rectangle with modifier-aware selection logic and visual feedback on the map canvas
- update context menu, copy/paste, and delete handlers to operate on homogeneous multi-selections of tokens, shapes, or markers
- ensure keyboard shortcuts apply only to the current selection and expand token/shape/marker helpers for bulk operations

## Testing
- python -m compileall modules/maps/controllers/display_map_controller.py modules/maps/views/canvas_view.py

------
https://chatgpt.com/codex/tasks/task_e_68d98a810494832b908aa51265a73d43