### PR TITLE
Enhance world map inspector with entity listing and notes persistence

### DIFF
--- a/Campaigns/DresdenFiles/templates/creatures_template.json
+++ b/Campaigns/DresdenFiles/templates/creatures_template.json
@@ -33,6 +33,10 @@
       "type": "text"
     },
     {
+      "name": "Notes",
+      "type": "longtext"
+    },
+    {
       "name": "Portrait",
       "type": "text"
     },

--- a/Campaigns/DresdenFiles/templates/npcs_template.json
+++ b/Campaigns/DresdenFiles/templates/npcs_template.json
@@ -41,6 +41,10 @@
       "type": "longtext"
     },
     {
+      "name": "Notes",
+      "type": "longtext"
+    },
+    {
       "name": "Genre",
       "type": "text"
     },

--- a/Campaigns/DresdenFiles/templates/pcs_template.json
+++ b/Campaigns/DresdenFiles/templates/pcs_template.json
@@ -21,6 +21,10 @@
       "type": "longtext"
     },
     {
+      "name": "Notes",
+      "type": "longtext"
+    },
+    {
       "name": "Factions",
       "type": "list",
       "linked_type": "Factions"

--- a/Campaigns/DresdenFiles/templates/places_template.json
+++ b/Campaigns/DresdenFiles/templates/places_template.json
@@ -22,6 +22,10 @@
       "type": "longtext"
     },
     {
+      "name": "Notes",
+      "type": "longtext"
+    },
+    {
       "name": "Portrait",
       "type": "text"
     },

--- a/json/npcs_template.json
+++ b/json/npcs_template.json
@@ -4,6 +4,7 @@
       {"name": "Role", "type": "text"},
       {"name": "Description", "type": "longtext"},
       {"name": "Factions", "type": "list", "linked_type": "Factions"},
+      {"name": "Notes", "type": "longtext"},
       {"name": "Portrait", "type": "text"}
   ]
 }

--- a/modules/creatures/creatures_template.json
+++ b/modules/creatures/creatures_template.json
@@ -8,6 +8,7 @@
       {"name": "Stats", "type": "longtext"},
       {"name": "Background", "type": "longtext"},
       {"name": "Genre", "type": "text"},
+      {"name": "Notes", "type": "longtext"},
       {"name": "Portrait", "type": "text"},
       {"name": "Audio", "type": "audio"}
   ]

--- a/modules/npcs/npcs_template.json
+++ b/modules/npcs/npcs_template.json
@@ -41,6 +41,10 @@
       "type": "longtext"
     },
     {
+      "name": "Notes",
+      "type": "longtext"
+    },
+    {
       "name": "Genre",
       "type": "text"
     },

--- a/modules/pcs/pcs_template.json
+++ b/modules/pcs/pcs_template.json
@@ -5,6 +5,7 @@
       {"name": "Background", "type": "longtext"},
       {"name": "Secret", "type": "longtext"},
       {"name": "Traits", "type": "longtext"},
+      {"name": "Notes", "type": "longtext"},
       {"name": "Factions", "type": "list", "linked_type": "Factions"},
       {"name": "Objects", "type": "list", "linked_type": "Objects"},
       {"name": "Portrait", "type": "text"},

--- a/modules/places/places_template.json
+++ b/modules/places/places_template.json
@@ -5,6 +5,7 @@
       {"name": "NPCs", "type": "list", "linked_type": "NPCs"},
       {"name": "PlayerDisplay", "type": "boolean"},
       {"name": "Secrets", "type": "longtext"},
+      {"name": "Notes", "type": "longtext"},
       {"name": "Portrait", "type": "text"},
       {"name": "Audio", "type": "text"}
   ]


### PR DESCRIPTION
## Summary
- rename the inspector's "Relationships" tab to "Entities" and populate it with NPC and creature entries including portraits, summaries, and quick inspect actions
- allow campaign notes to be edited and saved for the selected entity directly from the inspector, persisting the text to the database
- add a longtext Notes field to the NPC, PC, creature, and place templates (including the Dresden sample templates) to support the new editor

## Testing
- python -m compileall modules/maps/world_map_view.py

------
https://chatgpt.com/codex/tasks/task_e_68dad32dffc4832b9ffc907cfcea227b