### PR TITLE
Add targeted scenario upsert support

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -1105,28 +1105,21 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
             "Objects": list(dict.fromkeys(self.state.get("Objects", []))),
         }
 
-        items = self.scenario_wrapper.load_items()
-        replaced = False
-        for idx, existing in enumerate(items):
-            if existing.get("Title") == title:
-                if not messagebox.askyesno(
-                    "Overwrite Scenario",
-                    f"A scenario titled '{title}' already exists. Overwrite it?",
-                ):
-                    return
-                items[idx] = payload
-                replaced = True
-                break
-
-        if not replaced:
-            items.append(payload)
+        existing = self.scenario_wrapper.get_item_by_field("Title", title)
+        replaced = existing is not None
+        if replaced:
+            if not messagebox.askyesno(
+                "Overwrite Scenario",
+                f"A scenario titled '{title}' already exists. Overwrite it?",
+            ):
+                return
 
         log_info(
             f"Saving scenario '{title}' via builder wizard (replaced={replaced})",
             func_name="ScenarioBuilderWizard.finish",
         )
 
-        self.scenario_wrapper.save_items(items)
+        self.scenario_wrapper.upsert_item(payload)
         messagebox.showinfo("Scenario Saved", f"Scenario '{title}' has been saved.")
         if callable(self.on_saved):
             try:

--- a/tests/test_generic_model_wrapper.py
+++ b/tests/test_generic_model_wrapper.py
@@ -1,0 +1,41 @@
+import pytest
+
+from db.db import ensure_entity_schema
+from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.helpers.config_helper import ConfigHelper
+
+
+@pytest.fixture()
+def temp_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "campaign.db"
+
+    def fake_get(cls, section, key, fallback=None):
+        if section == "Database" and key == "path":
+            return str(db_path)
+        return fallback
+
+    monkeypatch.setattr(ConfigHelper, "get", classmethod(fake_get))
+
+    # Ensure a fresh schema for the scenarios table inside the temporary DB.
+    ensure_entity_schema("scenarios")
+
+    return GenericModelWrapper("scenarios")
+
+
+def test_upsert_item_preserves_other_rows(temp_db):
+    wrapper = temp_db
+
+    wrapper.save_items(
+        [
+            {"Title": "Adventure 1", "Summary": "Alpha"},
+            {"Title": "Adventure 2", "Summary": "Beta"},
+        ]
+    )
+
+    wrapper.upsert_item({"Title": "Adventure 1", "Summary": "Updated"})
+
+    items = {item["Title"]: item for item in wrapper.load_items()}
+
+    assert len(items) == 2
+    assert items["Adventure 1"]["Summary"] == "Updated"
+    assert "Adventure 2" in items


### PR DESCRIPTION
## Summary
- add row decoding and lookup helpers plus a targeted `upsert_item` path to `GenericModelWrapper`
- update `ScenarioBuilderWizard.finish` to rely on the new upsert flow instead of rewriting the entire table
- add coverage ensuring the upsert path keeps other rows intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db6b722758832b870801fa182bc880