### PR TITLE
Add wait indicator for JSON import/export operations

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,4 @@
+# Release Notes
+
+## Unreleased
+- Added a brief "Please wait" indicator and wait cursor while importing or exporting JSON so that users know the app is working before the file dialog closes. The cursor and modal dismiss automatically when the operation finishes or fails.


### PR DESCRIPTION
## Summary
- add a reusable busy indicator that shows a wait cursor and modal during JSON load/save operations
- wrap JSON import/export helpers in the busy indicator so the UI returns to normal even on errors
- document the new behavior in the release notes so users understand the brief UI change

## Testing
- python -m compileall main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68db6ba996a4832ba1c189166b0124db