### PR TITLE
Disable scenario wizard controls during persistence

### DIFF
--- a/docs/manual_qa.md
+++ b/docs/manual_qa.md
@@ -1,0 +1,6 @@
+# Manual QA Steps
+
+## Scenario Builder Wizard Save
+1. Launch the application and open the Scenario Builder wizard.
+2. Progress through each step, entering valid data until the Finish step is available.
+3. Click **Finish** and observe that the Back, Next, Finish, and Cancel buttons remain disabled until the save completes and the confirmation message appears, then return to their prior enabled states afterward.


### PR DESCRIPTION
## Summary
- disable the Scenario Builder wizard navigation buttons before running load/save operations and restore their previous states afterward
- add manual QA guidance for verifying the controls remain disabled until persistence completes

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68db6d88eae0832bb449a34d01894dc6