### PR TITLE
Fix scenario builder wizard state shadowing

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -966,7 +966,9 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
         self.transient(master)
         self.on_saved = on_saved
 
-        self.state = {
+        # NOTE: Avoid shadowing the inherited ``state()`` method from Tk by
+        # storing wizard data on a dedicated attribute.
+        self.wizard_state = {
             "Title": "",
             "Summary": "",
             "Secrets": "",
@@ -1053,7 +1055,7 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
         title, frame = self.steps[index]
         self.header_label.configure(text=f"Step {index + 1} of {len(self.steps)}: {title}")
         frame.tkraise()
-        frame.load_state(self.state)
+        frame.load_state(self.wizard_state)
         self._update_navigation_buttons()
 
     def _update_navigation_buttons(self):  # pragma: no cover - UI navigation
@@ -1064,14 +1066,14 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
 
     def go_next(self):  # pragma: no cover - UI navigation
         step = self.steps[self.current_step_index][1]
-        if not step.save_state(self.state):
+        if not step.save_state(self.wizard_state):
             return
         self.current_step_index += 1
         self._show_step(self.current_step_index)
 
     def go_back(self):  # pragma: no cover - UI navigation
         step = self.steps[self.current_step_index][1]
-        if not step.save_state(self.state):
+        if not step.save_state(self.wizard_state):
             return
         self.current_step_index -= 1
         self._show_step(self.current_step_index)
@@ -1081,30 +1083,30 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
 
     def finish(self):  # pragma: no cover - UI navigation
         step = self.steps[self.current_step_index][1]
-        if not step.save_state(self.state):
+        if not step.save_state(self.wizard_state):
             return
 
-        title = (self.state.get("Title") or "").strip()
+        title = (self.wizard_state.get("Title") or "").strip()
         if not title:
             messagebox.showwarning("Missing Title", "Please provide a title before saving the scenario.")
             return
 
-        secrets = self.state.get("Secrets") or ""
-        scenes = self.state.get("Scenes") or []
+        secrets = self.wizard_state.get("Secrets") or ""
+        scenes = self.wizard_state.get("Scenes") or []
         if isinstance(scenes, str):
             scenes = [scenes]
 
         payload = {
             "Title": title,
-            "Summary": self.state.get("Summary", ""),
+            "Summary": self.wizard_state.get("Summary", ""),
             "Secrets": secrets,
             "Secret": secrets,
             "Scenes": scenes,
-            "Places": list(dict.fromkeys(self.state.get("Places", []))),
-            "NPCs": list(dict.fromkeys(self.state.get("NPCs", []))),
-            "Creatures": list(dict.fromkeys(self.state.get("Creatures", []))),
-            "Factions": list(dict.fromkeys(self.state.get("Factions", []))),
-            "Objects": list(dict.fromkeys(self.state.get("Objects", []))),
+            "Places": list(dict.fromkeys(self.wizard_state.get("Places", []))),
+            "NPCs": list(dict.fromkeys(self.wizard_state.get("NPCs", []))),
+            "Creatures": list(dict.fromkeys(self.wizard_state.get("Creatures", []))),
+            "Factions": list(dict.fromkeys(self.wizard_state.get("Factions", []))),
+            "Objects": list(dict.fromkeys(self.wizard_state.get("Objects", []))),
         }
 
         buttons = {

--- a/tests/test_scenario_builder_wizard.py
+++ b/tests/test_scenario_builder_wizard.py
@@ -101,13 +101,25 @@ class _DummyStep:
         return True
 
 
+class _DummyButton:
+    def __init__(self):
+        self._state = "normal"
+
+    def cget(self, key):
+        return self._state if key == "state" else None
+
+    def configure(self, **kwargs):
+        if "state" in kwargs:
+            self._state = kwargs["state"]
+
+
 def test_finish_shows_retry_dialog_on_load_failure(monkeypatch):
     wizard = scenario_builder_wizard.ScenarioBuilderWizard.__new__(
         scenario_builder_wizard.ScenarioBuilderWizard
     )
     wizard.current_step_index = 0
     wizard.steps = [("Review", _DummyStep())]
-    wizard.state = {
+    wizard.wizard_state = {
         "Title": "Broken Scenario",
         "Summary": "",
         "Secrets": "",
@@ -120,6 +132,10 @@ def test_finish_shows_retry_dialog_on_load_failure(monkeypatch):
     }
     wizard.on_saved = None
     wizard.destroy = lambda: None
+    wizard.back_btn = _DummyButton()
+    wizard.next_btn = _DummyButton()
+    wizard.finish_btn = _DummyButton()
+    wizard.cancel_btn = _DummyButton()
 
     load_calls = []
 

--- a/tests/test_scenario_secrets.py
+++ b/tests/test_scenario_secrets.py
@@ -64,6 +64,18 @@ class _DummyStep:
         return True
 
 
+class _DummyButton:
+    def __init__(self):
+        self._state = "normal"
+
+    def cget(self, key):
+        return self._state if key == "state" else None
+
+    def configure(self, **kwargs):
+        if "state" in kwargs:
+            self._state = kwargs["state"]
+
+
 def test_finish_persists_secret_aliases(tmp_path, monkeypatch):
     db_path = tmp_path / "campaign.db"
 
@@ -80,7 +92,7 @@ def test_finish_persists_secret_aliases(tmp_path, monkeypatch):
     wizard = sbw.ScenarioBuilderWizard.__new__(sbw.ScenarioBuilderWizard)
     wizard.steps = [("dummy", _DummyStep())]
     wizard.current_step_index = 0
-    wizard.state = {
+    wizard.wizard_state = {
         "Title": "Test Scenario",
         "Summary": "Summary",
         "Secrets": "Hidden truth",
@@ -94,6 +106,10 @@ def test_finish_persists_secret_aliases(tmp_path, monkeypatch):
     wizard.scenario_wrapper = gmw.GenericModelWrapper("scenarios")
     wizard.on_saved = None
     wizard.destroy = lambda: None
+    wizard.back_btn = _DummyButton()
+    wizard.next_btn = _DummyButton()
+    wizard.finish_btn = _DummyButton()
+    wizard.cancel_btn = _DummyButton()
 
     wizard.finish()
 


### PR DESCRIPTION
## Summary
- stop assigning a dictionary to `ScenarioBuilderWizard.state` so the inherited Tk `state()` method stays callable
- update the wizard logic to use a `wizard_state` attribute throughout
- adjust related tests to use the new attribute and provide button stubs

## Testing
- pytest tests/test_scenario_builder_wizard.py tests/test_scenario_secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68db701f9870832bac540f07d485d350