### PR TITLE
Restrict inline scene editor save to Ctrl+Enter

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -1583,7 +1583,8 @@ class InlineSceneEditor(ctk.CTkFrame):
             row=0, column=1, sticky="ew", padx=(6, 0)
         )
 
-        self.title_entry.bind("<Return>", self._on_save)
+        self.title_entry.bind("<Control-Return>", self._on_save)
+        self.title_entry.bind("<Command-Return>", self._on_save)
         self.title_entry.bind("<Escape>", self._on_cancel)
         self.summary_text.bind("<Control-Return>", self._on_save)
         self.summary_text.bind("<Command-Return>", self._on_save)


### PR DESCRIPTION
## Summary
- prevent the inline scene editor from saving when Enter is pressed in the title field
- keep saving accessible with Ctrl+Enter and Command+Enter shortcuts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc264f9c9c832bb42835b95fa4fe01