### PR TITLE
Enable single-click editing for scenario links

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -637,6 +637,18 @@ class SceneCanvas(ctk.CTkFrame):
             self._draw()
 
     def _on_click(self, event):
+        # Allow direct link label editing on single click for better accessibility
+        for x1, y1, x2, y2, source_idx, target_idx, target_value in self._link_regions:
+            if x1 <= event.x <= x2 and y1 <= event.y <= y2:
+                if callable(self.on_link_text_edit):
+                    self.on_link_text_edit(
+                        source_idx,
+                        target_idx,
+                        target_value,
+                        (x1, y1, x2, y2),
+                    )
+                return
+
         icon_idx, icon_type = self._hit_icon(event.x, event.y)
         if icon_idx is not None:
             self._select_index(icon_idx)


### PR DESCRIPTION
## Summary
- allow single-clicking a scene link label in the Scenario Builder wizard to open the in-place label editor, making link text editable again

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dc2b1a426c832b8e9d0896ba134f41