### PR TITLE
Prevent duplicate fallback Continue links in scene flow

### DIFF
--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -1443,7 +1443,13 @@ class ScenarioGraphEditor(ctk.CTkFrame):
             if not links and scene.get("index", 0) < count - 1:
                 next_scene = normalized_scenes[scene["index"] + 1]
                 if next_scene.get("tag"):
-                    links.append({"target_tag": next_scene["tag"], "text": "Continue"})
+                    links.append(
+                        {
+                            "target_tag": next_scene["tag"],
+                            "text": "Continue",
+                            "text_auto_generated": True,
+                        }
+                    )
             prepared_links = []
 
             for link in links:
@@ -1457,6 +1463,9 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                     link["text"] = ""
                 if not text:
                     text = "Continue"
+                    if not text_auto_generated:
+                        text_auto_generated = True
+                        link["text_auto_generated"] = True
 
                 target_tag = link.get("target_tag")
                 if not target_tag:


### PR DESCRIPTION
## Summary
- mark auto-generated fallback Continue links as such when building the scenario scene-flow graph
- treat empty or inferred link labels as auto-generated so they can be dropped once an explicit link resolves to the same target

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd81d14674832ba1d974a6b78f792c