### PR TITLE
Stop defaulting scene links to Continue

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -719,7 +719,7 @@ def insert_list_longtext(parent, header, items, open_entity_callback=None, entit
             ctk.CTkLabel(link_section, text="Links:", font=("Arial", 13, "bold"))\
                 .pack(anchor="w")
             for link in links:
-                text_val = str(link.get("text") or "Continue").strip()
+                text_val = str(link.get("text") or "").strip()
                 target_val = link.get("target")
                 if isinstance(target_val, (int, float)):
                     target_display = f"Scene {int(target_val)}"
@@ -727,6 +727,8 @@ def insert_list_longtext(parent, header, items, open_entity_callback=None, entit
                     target_display = str(target_val)
                 else:
                     target_display = "(unspecified)"
+                if not text_val:
+                    text_val = "(no link text)"
                 CTkLabel(
                     link_section,
                     text=f"• {text_val} → {target_display}",

--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -1446,7 +1446,7 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                     links.append(
                         {
                             "target_tag": next_scene["tag"],
-                            "text": "Continue",
+                            "text": "",
                             "text_auto_generated": True,
                         }
                     )
@@ -1461,11 +1461,9 @@ class ScenarioGraphEditor(ctk.CTkFrame):
                 ):
                     text = ""
                     link["text"] = ""
-                if not text:
-                    text = "Continue"
-                    if not text_auto_generated:
-                        text_auto_generated = True
-                        link["text_auto_generated"] = True
+                if not text and not text_auto_generated:
+                    text_auto_generated = True
+                    link["text_auto_generated"] = True
 
                 target_tag = link.get("target_tag")
                 if not target_tag:


### PR DESCRIPTION
## Summary
- keep scene view link labels empty when no text is provided instead of forcing "Continue"
- prevent auto-generated scene graph links from defaulting to the label "Continue"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd84ae0108832bb30c8dcd566e3633