### PR TITLE
Ensure portrait and token assets use relative paths

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1892,7 +1892,13 @@ class MainWindow(ctk.CTk):
             img = img.convert("RGB")
             img.thumbnail(MAX_PORTRAIT_SIZE)
             img.save(dest_path)
-        return dest_path
+        try:
+            relative_path = os.path.relpath(dest_path, campaign_dir)
+        except ValueError:
+            return dest_path
+        if relative_path.startswith(".."):
+            return dest_path
+        return relative_path.replace(os.sep, "/")
 
     def import_portraits_from_directory(self):
         """Match and import portraits from a directory for all portrait-capable entities."""

--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -672,8 +672,9 @@ class GenericListView(ctk.CTkFrame):
         campaign_dir = ConfigHelper.get_campaign_dir()
         portrait_path = item.get("Portrait", "") if item else ""
         if portrait_path:
-            portrait_path = os.path.join(campaign_dir, portrait_path)
-            has_portrait = bool(portrait_path and os.path.isabs(portrait_path))
+            if not os.path.isabs(portrait_path):
+                portrait_path = os.path.join(campaign_dir, portrait_path)
+            has_portrait = os.path.exists(portrait_path)
         else:
             has_portrait = False
 


### PR DESCRIPTION
## Summary
- save generated portraits using campaign-relative paths instead of absolute ones
- normalize relative portrait checks in list views and map selector token loading
- ensure token persistence stores relative image paths and resolves them when loading or copying

## Testing
- python -m compileall main_window.py modules/generic/generic_list_view.py modules/maps/views/map_selector.py modules/maps/services/token_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68de128d431c832b88ecaec42660dd35