### PR TITLE
Handle longtext summaries in scenario wizard

### DIFF
--- a/modules/helpers/text_helpers.py
+++ b/modules/helpers/text_helpers.py
@@ -370,6 +370,18 @@ def _coerce_text(val):
         return str(v)
     return str(val)
 
+
+def coerce_text(val):
+    """Return a plain-text representation for longtext-style values.
+
+    Many parts of the UI accept data that may either be a raw string or the
+    richer ``{"text": ..., "formatting": ...}`` structure produced by
+    importers.  ``coerce_text`` normalises the value so widgets can safely
+    display it without worrying about the underlying shape.
+    """
+
+    return _coerce_text(val)
+
 def format_longtext(data, max_length=30000):
     text = _coerce_text(data)
     text = text.replace("\n", " ").strip()

--- a/modules/scenarios/scene_flow_components.py
+++ b/modules/scenarios/scene_flow_components.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Optional
 
 import customtkinter as ctk
 
+from modules.helpers.text_helpers import coerce_text
 from modules.scenarios.scene_flow_rendering import (
     SCENE_FLOW_BG,
     apply_scene_flow_canvas_styling,
@@ -184,7 +185,8 @@ class SceneFlowPreview(ctk.CTkFrame):
                 tags=(f"scene-node-{idx}", "scene-node"),
             )
             title = (scene.get("Title") or f"Scene {idx + 1}").strip() or f"Scene {idx + 1}"
-            summary = (scene.get("Summary") or scene.get("Text") or "").replace("\n", " ").strip()
+            summary_raw = scene.get("Summary") or scene.get("Text") or ""
+            summary = coerce_text(summary_raw).replace("\n", " ").strip()
             summary_display = (
                 textwrap.shorten(summary, width=120, placeholder="...")
                 if summary
@@ -466,8 +468,8 @@ class SceneCanvas(ctk.CTkFrame):
                 tags=(f"scene-node-{idx}", "scene-node"),
             )
             self._move_regions.append((x1, y1, x2, y1 + 36, idx))
-            summary = scene.get("Summary") or scene.get("Text") or ""
-            summary = " ".join(summary.split())[:160]
+            summary_raw = scene.get("Summary") or scene.get("Text") or ""
+            summary = " ".join(coerce_text(summary_raw).split())[:160]
             c.create_text(
                 x1 + 14,
                 y1 + 48,


### PR DESCRIPTION
## Summary
- expose a reusable helper to coerce longtext dictionaries into plain text
- normalise loaded scenario summaries and secrets before updating wizard state
- guard scene flow rendering against longtext values when drawing summaries

## Testing
- python -m compileall modules/helpers/text_helpers.py modules/scenarios/scenario_builder_wizard.py modules/scenarios/scene_flow_components.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe2e9e48c832b89c600719e5f3be8