### PR TITLE
Improve scenario wizard compatibility with legacy scenes

### DIFF
--- a/tests/test_scenario_builder_wizard.py
+++ b/tests/test_scenario_builder_wizard.py
@@ -93,6 +93,77 @@ sys.modules.setdefault(
     ),
 )
 
+_fake_resampling = SimpleNamespace(LANCZOS="LANCZOS")
+class _StubImage(SimpleNamespace):
+    def __init__(self, size=(0, 0)):
+        super().__init__()
+        self._size = size
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def width(self):  # pragma: no cover - defensive
+        return self._size[0]
+
+    def height(self):  # pragma: no cover - defensive
+        return self._size[1]
+
+
+def _new_image(_mode="RGBA", size=(0, 0), _color=None):  # pragma: no cover - defensive stub
+    return _StubImage(size=size)
+
+
+class _StubImageDraw(SimpleNamespace):
+    def Draw(self, _image):  # pragma: no cover - defensive
+        return SimpleNamespace(
+            line=lambda *args, **kwargs: None,
+            ellipse=lambda *args, **kwargs: None,
+            rounded_rectangle=lambda *args, **kwargs: None,
+        )
+
+
+class _StubImageFilter(SimpleNamespace):
+    def GaussianBlur(self, radius):  # pragma: no cover - defensive
+        return ("GaussianBlur", radius)
+
+
+_fake_image_module = SimpleNamespace(
+    Resampling=_fake_resampling,
+    LANCZOS="LANCZOS",
+    new=_new_image,
+)
+_fake_imagetk_module = SimpleNamespace(PhotoImage=_StubWidget)
+_fake_image_draw = _StubImageDraw()
+_fake_image_filter = _StubImageFilter()
+_fake_pil_module = SimpleNamespace(
+    Image=_fake_image_module,
+    ImageTk=_fake_imagetk_module,
+    ImageDraw=_fake_image_draw,
+    ImageFilter=_fake_image_filter,
+    Resampling=_fake_resampling,
+    LANCZOS="LANCZOS",
+)
+sys.modules.setdefault("PIL", _fake_pil_module)
+sys.modules.setdefault("PIL.Image", _fake_image_module)
+sys.modules.setdefault("PIL.ImageTk", _fake_imagetk_module)
+sys.modules.setdefault("PIL.ImageDraw", _fake_image_draw)
+sys.modules.setdefault("PIL.ImageFilter", _fake_image_filter)
+_fake_image_grab = SimpleNamespace(grab=lambda *args, **kwargs: None)
+sys.modules.setdefault("PIL.ImageGrab", _fake_image_grab)
+setattr(_fake_pil_module, "ImageGrab", _fake_image_grab)
+
+
+class _StubRequests(SimpleNamespace):
+    def __getattr__(self, name):  # pragma: no cover - defensive stub
+        def _method(*_args, **_kwargs):
+            raise RuntimeError("Stubbed requests method accessed: {}".format(name))
+
+        return _method
+
+
+sys.modules.setdefault("requests", _StubRequests())
+sys.modules.setdefault("winsound", SimpleNamespace(PlaySound=lambda *args, **kwargs: None))
+
 from modules.scenarios import scenario_builder_wizard
 
 
@@ -171,3 +242,31 @@ def test_finish_shows_retry_dialog_on_load_failure(monkeypatch):
     assert logged_messages == [
         ("Failed to load scenarios for ScenarioBuilderWizard.", "ScenarioBuilderWizard.finish")
     ]
+
+
+def _build_scenes_step():
+    step = scenario_builder_wizard.ScenesPlanningStep.__new__(
+        scenario_builder_wizard.ScenesPlanningStep
+    )
+    return step
+
+
+def test_normalise_scene_uses_description_when_summary_missing():
+    step = _build_scenes_step()
+    entry = {"Description": "A lengthy description of the scene."}
+
+    scene = step._normalise_scene(entry, 0)
+
+    assert scene["Summary"] == "A lengthy description of the scene."
+
+
+def test_normalise_scene_collects_nested_text_fragments():
+    step = _build_scenes_step()
+    entry = {
+        "SceneText": {"text": "First part."},
+        "Notes": ["Second part.", {"extra": "Third part."}],
+    }
+
+    scene = step._normalise_scene(entry, 1)
+
+    assert scene["Summary"] == "First part.\n\nSecond part.\n\nThird part."


### PR DESCRIPTION
## Summary
- expand the scenario builder wizard to collect scene summaries from additional legacy fields and nested structures
- add unit tests that stub required GUI dependencies and verify summary extraction for legacy scene payloads

## Testing
- pytest tests/test_scenario_builder_wizard.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe599025c832b8f8571292179b63b