### PR TITLE
Fix grouped list value formatting

### DIFF
--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -628,7 +628,9 @@ class GenericListView(ctk.CTkFrame):
                 base_iid = sanitize_id(raw or f"item_{int(time.time()*1000)}").lower()
                 iid = unique_iid(self.tree, base_iid)
                 name_text = self._format_cell("#0", item.get(self.unique_field, ""), iid)
-                vals = tuple(self._format_cell(col, item.get(c, ""), iid) for c in self.columns)
+                vals = tuple(
+                    self._format_cell(c, item.get(c, ""), iid) for c in self.columns
+                )
                 try:
                     self.tree.insert(group_id, "end", iid=iid, text=name_text, values=vals)
                     color = self.row_colors.get(base_iid)


### PR DESCRIPTION
## Summary
- ensure grouped list insertion formats values using the proper column key
- align grouped tree population with ungrouped batches to avoid runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e096befdd0832ba538a2036d620653