### PR TITLE
Add marker-linked map navigation

### DIFF
--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -444,6 +444,7 @@ def _persist_tokens(self):
                     "entry_width": t.get("entry_width", 180),
                     "border_color": t.get("border_color", "#00ff00"),
                     "video_path": storage_video,
+                    "linked_map": t.get("linked_map", ""),
                 })
             else:
                 # Silently skip unknown types for now

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -370,6 +370,7 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "entry_width": rec.get("entry_width", 180),
                 "border_color": rec.get("border_color", "#00ff00"),
                 "video_path": rec.get("video_path", ""),
+                "linked_map": rec.get("linked_map", ""),
                 "border_canvas_id": None,
                 "entry_widget": None,
                 "description_popup": None,


### PR DESCRIPTION
## Summary
- allow map markers to link to other maps and open them via double-click or a context-menu command
- provide a dialog to set or clear the linked map for a marker
- persist the linked-map metadata when saving or loading map data

## Testing
- python -m compileall modules/maps

------
https://chatgpt.com/codex/tasks/task_e_68e2c28df6b8832b95fde18782629c7a