### PR TITLE
Fix scenario longtext formatting on secondary display

### DIFF
--- a/modules/helpers/text_helpers.py
+++ b/modules/helpers/text_helpers.py
@@ -362,7 +362,12 @@ def _coerce_text(val):
     if val is None:
         return ""
     if isinstance(val, list):
-        return " ".join(str(x) for x in val if x is not None)
+        # Recursively coerce nested longtext fragments so we never display
+        # Python reprs (e.g. dictionaries) in the UI when rich-text blocks
+        # are provided as arrays of segments.
+        return " ".join(
+            _coerce_text(x) for x in val if x is not None
+        )
     if isinstance(val, dict):
         v = val.get("text", "")
         if isinstance(v, (list, dict)):


### PR DESCRIPTION
## Summary
- recursively coerce nested longtext fragments when formatting helper text so rich scenario content renders cleanly on the secondary screen

## Testing
- pytest tests/test_scenario_builder_wizard.py -k finish -q

------
https://chatgpt.com/codex/tasks/task_e_68e35eb65f6c832ba46423edf5bf9125