### PR TITLE
Relax dice markup validation for non-combat segments

### DIFF
--- a/modules/helpers/dice_markup.py
+++ b/modules/helpers/dice_markup.py
@@ -146,11 +146,11 @@ def _parse_segment(segment: str, span: Tuple[int, int]) -> tuple[ParsedAction | 
             return None, damage_error
 
     if attack_bonus_text is None and damage_formula_text is None:
-        return None, ParsedError(
-            message="Dice markup must include an attack bonus or damage formula.",
-            span=span,
-            segment=f"[{segment}]",
-        )
+        # Treat segments that don't contain an attack bonus or damage formula as
+        # plain text. This allows large blocks of narrative text with only a
+        # handful of embedded combat actions to validate successfully – parsing
+        # should only fail when no actions are detected at all.
+        return None, None
 
     label = label_text or "Action"
     return (

--- a/tests/test_dice_markup.py
+++ b/tests/test_dice_markup.py
@@ -39,6 +39,22 @@ def test_parse_inline_actions_multiple_segments():
     assert fireball["notes"] == "fire"
 
 
+def test_parse_inline_actions_ignores_non_combat_segments():
+    text = """Lore [Some note]\n[Strike +6|1d8+3 slashing]\nFlavor [Another note]\n"""
+
+    display, actions, errors = parse_inline_actions(text)
+
+    assert "[Some note]" in display
+    assert "[Another note]" in display
+    assert errors == []
+    assert len(actions) == 1
+
+    action = actions[0]
+    assert action["label"] == "Strike"
+    assert action["attack_bonus"] == "+6"
+    assert action["damage_formula"] == "1d8+3"
+
+
 def test_parse_inline_actions_reports_errors_and_retains_markup():
     text = "Broken [Strike +7|bad] text"
     display, actions, errors = parse_inline_actions(text)


### PR DESCRIPTION
## Summary
- allow the dice markup parser to treat segments without attack or damage data as plain text so that large descriptions still validate when at least one combat action is present
- add regression coverage ensuring non-combat bracketed segments are ignored while combat entries are still parsed

## Testing
- pytest tests/test_dice_markup.py

------
https://chatgpt.com/codex/tasks/task_e_68e387743970832ba8a378c1abe0650d