### PR TITLE
Handle standalone modifiers as d20 rolls in dice markup

### DIFF
--- a/modules/helpers/dice_markup.py
+++ b/modules/helpers/dice_markup.py
@@ -199,7 +199,17 @@ def _extract_damage(right: str, span: Tuple[int, int], segment: str) -> tuple[st
             formula_part = first
             notes_part = remainder.strip()
 
-    normalized = _try_parse_formula(formula_part, force_sign=False)
+    trimmed_formula = formula_part.strip()
+    normalized: str | None = None
+
+    if trimmed_formula and trimmed_formula.startswith("+") and "d" not in trimmed_formula.lower():
+        bonus_text = _try_parse_formula(trimmed_formula, force_sign=True)
+        if bonus_text is not None:
+            normalized = _make_attack_roll_formula(bonus_text)
+
+    if normalized is None:
+        normalized = _try_parse_formula(formula_part, force_sign=False)
+
     if normalized is None:
         return None, None, ParsedError(
             message=f"Invalid damage formula '{formula_part}'.",

--- a/tests/test_dice_markup.py
+++ b/tests/test_dice_markup.py
@@ -99,6 +99,19 @@ def test_parse_inline_actions_defaults_label_when_missing():
     assert actions[0]["damage_formula"] == "1d6"
 
 
+def test_parse_inline_actions_interprets_damage_plus_modifier_as_d20():
+    text = "[Smite +8|+6 radiant]"
+    display, actions, errors = parse_inline_actions(text)
+
+    assert display == "Smite (radiant)"
+    assert errors == []
+    assert len(actions) == 1
+
+    action = actions[0]
+    assert action["damage_formula"] == "1d20+6"
+    assert action["notes"] == "radiant"
+
+
 def test_build_token_macros_uses_parsed_actions():
     actions = [
         {


### PR DESCRIPTION
## Summary
- treat damage formulas consisting of a standalone +modifier as 1d20 rolls
- add coverage ensuring inline dice markup accepts +X modifiers as d20 damage rolls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e38b51ef44832ba66d602769b5124e