### PR TITLE
Support DM syntax in dice markup parser

### DIFF
--- a/tests/test_dice_markup.py
+++ b/tests/test_dice_markup.py
@@ -112,6 +112,38 @@ def test_parse_inline_actions_interprets_damage_plus_modifier_as_d20():
     assert action["notes"] == "radiant"
 
 
+def test_parse_inline_actions_supports_dm_separator():
+    text = "[Strike +5 DM 1d8+3 slashing]"
+    display, actions, errors = parse_inline_actions(text)
+
+    assert display == "Strike (slashing)"
+    assert errors == []
+    assert len(actions) == 1
+
+    action = actions[0]
+    assert action["label"] == "Strike"
+    assert action["attack_bonus"] == "+5"
+    assert action["attack_roll_formula"] == "1d20+5"
+    assert action["damage_formula"] == "1d8+3"
+    assert action["notes"] == "slashing"
+
+
+def test_parse_inline_actions_supports_dm_with_modifier_damage():
+    text = "[Bash +4 DM +6 bludgeoning]"
+    display, actions, errors = parse_inline_actions(text)
+
+    assert display == "Bash (bludgeoning)"
+    assert errors == []
+    assert len(actions) == 1
+
+    action = actions[0]
+    assert action["label"] == "Bash"
+    assert action["attack_bonus"] == "+4"
+    assert action["attack_roll_formula"] == "1d20+4"
+    assert action["damage_formula"] == "1d20+6"
+    assert action["notes"] == "bludgeoning"
+
+
 def test_build_token_macros_uses_parsed_actions():
     actions = [
         {


### PR DESCRIPTION
## Summary
- allow the dice markup parser to treat DM sections as inline damage definitions and default attack rolls to d20 when no dice are provided
- reuse the existing damage parsing for DM segments and add coverage for damage modifiers without dice

## Testing
- pytest tests/test_dice_markup.py

------
https://chatgpt.com/codex/tasks/task_e_68e38cd36040832b928899b01e29b4eb