### PR TITLE
Add debug output for inline action parsing

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -1251,6 +1251,11 @@ class DisplayMapController:
 
         plain_text = self._extract_longtext_text(raw_stats_value)
         cleaned_text, actions, errors = parse_inline_actions(plain_text)
+        print(
+            "[DEBUG] _get_token_hover_text: parse_inline_actions returned"
+            f" {len(actions)} actions and {len(errors)} errors for token"
+            f" '{token.get('entity_id', 'Unknown')}'"
+        )
 
         token["_inline_markup_source"] = plain_text
         token["_inline_markup_display"] = cleaned_text or plain_text


### PR DESCRIPTION
## Summary
- add console debug output in the token hover text builder so inline action parsing activity is visible during interaction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cce94f94832baa55a97e88b0f4d4