### PR TITLE
Prevent token info window from closing when rolling inline dice

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -782,6 +782,20 @@ class DisplayMapController:
                 if pointer_widget is not None:
                     candidates.append(pointer_widget)
 
+            # Ensure widgets that currently have focus within any active hover
+            # popup windows are considered.  Some CustomTkinter widgets don't
+            # consistently show up via ``focus_get`` on the canvas or via
+            # ``winfo_containing`` queries, which previously caused the token
+            # info window to be dismissed when clicking inline dice buttons.
+            popups = getattr(self, "_active_hover_popups", set())
+            for popup in list(popups):
+                try:
+                    focus_widget = popup.focus_get()
+                except Exception:
+                    focus_widget = None
+                if focus_widget is not None:
+                    candidates.append(focus_widget)
+
             return candidates
 
         candidates = _collect_focus_candidates()


### PR DESCRIPTION
## Summary
- keep focused widgets from inline token info popups in the focus-out checks so they aren't dismissed when dice buttons are used

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e0095228832baba22886ef3841f6