### PR TITLE
Prevent token hover popups from closing during inline dice rolls

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -776,9 +776,10 @@ class DisplayMapController:
                 if focus_widget is not None:
                     candidates.append(focus_widget)
 
+            pointer_coords = None
             try:
-                pointer_x, pointer_y = canvas.winfo_pointerxy()
-                pointer_widget = canvas.winfo_containing(pointer_x, pointer_y)
+                pointer_coords = canvas.winfo_pointerxy()
+                pointer_widget = canvas.winfo_containing(*pointer_coords)
             except tk.TclError:
                 pointer_widget = None
             if pointer_widget is not None:
@@ -797,6 +798,15 @@ class DisplayMapController:
                     focus_widget = None
                 if focus_widget is not None:
                     candidates.append(focus_widget)
+
+                if pointer_coords is not None:
+                    try:
+                        popup_pointer_widget = popup.winfo_containing(*pointer_coords)
+                    except tk.TclError:
+                        popup_pointer_widget = None
+                    else:
+                        if popup_pointer_widget is not None:
+                            candidates.append(popup_pointer_widget)
 
             return candidates
 


### PR DESCRIPTION
## Summary
- include hover popup widgets detected under the pointer when evaluating focus changes
- ensure inline dice buttons inside token info popups are treated as part of the popup so the hover stays open

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e560e160832b86e3d1e7961b58e1