### PR TITLE
Fix AI categorize error handling

### DIFF
--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -1517,7 +1517,13 @@ class GenericListView(ctk.CTkFrame):
                     f"AI categorization failed: {exc}",
                     func_name="GenericListView.ai_categorize_objects",
                 )
-                self.after(0, lambda: messagebox.showerror("AI Categorize", f"Failed to categorize objects: {exc}"))
+                error_message = str(exc)
+                self.after(
+                    0,
+                    lambda msg=error_message: messagebox.showerror(
+                        "AI Categorize", f"Failed to categorize objects: {msg}"
+                    ),
+                )
                 return
 
             def apply_results():


### PR DESCRIPTION
## Summary
- prevent AI categorize error dialog from referencing an out-of-scope exception variable
- capture the exception message in the background worker before scheduling the UI callback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4bdd63538832bb2fad970e0b033d9