### PR TITLE
Fix double-click editing fallback in generic list view

### DIFF
--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -968,7 +968,13 @@ class GenericListView(ctk.CTkFrame):
 
     def on_double_click(self, event):
         # Use the row under the mouse to avoid stale focus
-        iid = self.tree.identify_row(event.y) or self.tree.focus()
+        iid = self.tree.identify_row(event.y)
+        if not iid:
+            selection = self.tree.selection()
+            if selection:
+                iid = selection[0]
+        if not iid:
+            iid = self.tree.focus()
         if not iid:
             return
         item, _ = self._find_item_by_iid(iid)


### PR DESCRIPTION
## Summary
- ensure the generic list view double-click handler falls back to the current selection when the row cannot be identified
- keep the existing focus fallback so editing still opens for valid items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4fd788df8832b8c50e5526c3c2cc3