### PR TITLE
Add plot-twist helper, expand table, and Random Tables shortcut

### DIFF
--- a/modules/helpers/random_table_loader.py
+++ b/modules/helpers/random_table_loader.py
@@ -8,6 +8,9 @@ from modules.helpers.logging_helper import log_info, log_module_import
 log_module_import(__name__)
 
 
+PLOT_TWIST_TABLE_ID = "universal_plot_twists"
+
+
 class RandomTableLoader:
     """Load and validate random tables from a JSON file or directory."""
 
@@ -189,4 +192,19 @@ class RandomTableLoader:
         return text or None
 
 
-__all__ = ["RandomTableLoader"]
+def plot_twist_data_path() -> str:
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    return os.path.join(project_root, "static", "data", "random_tables", "Plot twists.json")
+
+
+def load_plot_twist_table(table_id: str = PLOT_TWIST_TABLE_ID) -> Optional[dict]:
+    loader = RandomTableLoader(plot_twist_data_path())
+    data = loader.load()
+    table = (data.get("tables") or {}).get(table_id)
+    if table:
+        return table
+    tables = list((data.get("tables") or {}).values())
+    return tables[0] if tables else None
+
+
+__all__ = ["RandomTableLoader", "PLOT_TWIST_TABLE_ID", "plot_twist_data_path", "load_plot_twist_table"]

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -30,7 +30,7 @@ from modules.maps.world_map_view import WorldMapPanel
 from modules.maps.controllers.display_map_controller import DisplayMapController
 from modules.scenarios.scene_flow_viewer import create_scene_flow_frame, scene_flow_content_factory
 from modules.scenarios.plot_twist_scheduler import PlotTwistScheduler
-from modules.scenarios.plot_twist_panel import PlotTwistPanel
+from modules.scenarios.plot_twist_panel import PlotTwistPanel, roll_plot_twist
 from modules.ui.chatbot_dialog import (
     open_chatbot_dialog,
     _DEFAULT_NAME_FIELD_OVERRIDES as CHATBOT_NAME_OVERRIDES,
@@ -569,10 +569,18 @@ class GMScreenView(ctk.CTkFrame):
             pass
 
     def _handle_mid_plot_twist(self):
-        messagebox.showinfo("Plot Twist", "Mid-session plot twist time!")
+        result = roll_plot_twist()
+        messagebox.showinfo(
+            "Plot Twist",
+            f"Mid-session plot twist:\n{result.result}\n\n{result.table} · Roll {result.roll}",
+        )
 
     def _handle_end_plot_twist(self):
-        messagebox.showinfo("Plot Twist", "End-of-session plot twist time!")
+        result = roll_plot_twist()
+        messagebox.showinfo(
+            "Plot Twist",
+            f"End-of-session plot twist:\n{result.result}\n\n{result.table} · Roll {result.roll}",
+        )
 
     def _persist_scene_state(self):
         if not self._state_loaded:

--- a/modules/scenarios/plot_twist_panel.py
+++ b/modules/scenarios/plot_twist_panel.py
@@ -2,19 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-import os
 from typing import Callable, Optional
 
 import customtkinter as ctk
 
 from modules.dice import dice_engine
 from modules.helpers.logging_helper import log_exception, log_info, log_methods, log_module_import
-from modules.helpers.random_table_loader import RandomTableLoader
+from modules.helpers.random_table_loader import PLOT_TWIST_TABLE_ID, load_plot_twist_table
 
 log_module_import(__name__)
-
-
-PLOT_TWIST_TABLE_ID = "universal_plot_twists"
 
 
 @dataclass(frozen=True)
@@ -42,21 +38,11 @@ _listeners: list[Callable[[PlotTwistResult], None]] = []
 _table_cache: Optional[dict] = None
 
 
-def _plot_twist_data_path() -> str:
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    return os.path.join(project_root, "static", "data", "random_tables", "Plot twists.json")
-
-
 def _load_plot_twist_table() -> Optional[dict]:
     global _table_cache
     if _table_cache:
         return _table_cache
-    loader = RandomTableLoader(_plot_twist_data_path())
-    data = loader.load()
-    table = (data.get("tables") or {}).get(PLOT_TWIST_TABLE_ID)
-    if not table:
-        tables = list((data.get("tables") or {}).values())
-        table = tables[0] if tables else None
+    table = load_plot_twist_table(PLOT_TWIST_TABLE_ID)
     _table_cache = table
     return table
 

--- a/modules/scenarios/random_tables_panel.py
+++ b/modules/scenarios/random_tables_panel.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox
 
 from modules.dice import dice_engine
-from modules.helpers.random_table_loader import RandomTableLoader
+from modules.helpers.random_table_loader import PLOT_TWIST_TABLE_ID, RandomTableLoader
 from modules.helpers.logging_helper import (
     log_exception,
     log_info,
@@ -133,6 +133,7 @@ class RandomTablesPanel(ctk.CTkFrame):
         ctk.CTkEntry(actions, textvariable=self.count_var, width=60).grid(row=0, column=2, padx=(4, 8))
         ctk.CTkButton(actions, text="Roll Multiple", command=self.roll_multiple).grid(row=0, column=3, sticky="w")
         ctk.CTkButton(actions, text="Edit Table", command=self._edit_selected_table).grid(row=0, column=4, padx=(8, 0))
+        ctk.CTkButton(actions, text="Plot Twists", command=self._jump_to_plot_twists).grid(row=0, column=5, padx=(8, 0))
 
         history_frame = ctk.CTkFrame(self)
         history_frame.grid(row=3, column=0, sticky="nsew", padx=8, pady=(0, 8))
@@ -327,6 +328,20 @@ class RandomTablesPanel(ctk.CTkFrame):
         except Exception as exc:
             log_exception(exc, func_name="RandomTablesPanel._edit_selected_table")
             messagebox.showerror("Random Tables", f"Unable to open editor:\n{exc}")
+
+    # ------------------------------------------------------------------
+    def _jump_to_plot_twists(self) -> None:
+        if PLOT_TWIST_TABLE_ID not in self.tables:
+            messagebox.showinfo("Random Tables", "The Plot Twists table is not available.")
+            return
+        if hasattr(self, "category_var"):
+            self.category_var.set("All")
+        if hasattr(self, "style_var"):
+            self.style_var.set("All")
+        if hasattr(self, "tag_var"):
+            self.tag_var.set("")
+        self.selected_table_id = PLOT_TWIST_TABLE_ID
+        self._refresh_table_list()
 
     # ------------------------------------------------------------------
     def get_state(self) -> Dict:

--- a/static/data/random_tables/Plot twists.json
+++ b/static/data/random_tables/Plot twists.json
@@ -10,7 +10,7 @@
         {
           "id": "universal_plot_twists",
           "title": "Nearly-Universal Plot Twists",
-          "dice": "1d16",
+          "dice": "1d40",
           "description": "Generic plot twists you can layer onto almost any adventure framework.",
           "tags": ["twist", "generic", "meta"],
           "entries": [
@@ -77,6 +77,102 @@
             {
               "range": "16",
               "result": "Rival party: another competent adventuring group is on the same job with different goals; sometimes they’re allies, sometimes competition, sometimes future enemies."
+            },
+            {
+              "range": "17",
+              "result": "Double agent: a trusted ally or contact is secretly reporting to the opposition and steering the PCs into traps."
+            },
+            {
+              "range": "18",
+              "result": "Timeline slip: the disaster already started (or hasn’t yet); the PCs must adjust to a shifted timetable and lost time."
+            },
+            {
+              "range": "19",
+              "result": "Decoy objective: the artifact, map, or target is a fake; the real prize is elsewhere or already moved."
+            },
+            {
+              "range": "20",
+              "result": "Shared fate: the antagonist and PCs are mystically linked; harming one harms the other, forcing a non-lethal solution."
+            },
+            {
+              "range": "21",
+              "result": "Half-truth clue: the key information is technically true but dangerously misleading without hidden context."
+            },
+            {
+              "range": "22",
+              "result": "Sponsor flips: the group’s patron changes priorities or sides, demanding the PCs sabotage their own mission."
+            },
+            {
+              "range": "23",
+              "result": "Third faction revealed: an unseen power has been manipulating both sides for its own agenda."
+            },
+            {
+              "range": "24",
+              "result": "Guardian, not monster: the apparent threat is actually holding something worse at bay or protecting innocents."
+            },
+            {
+              "range": "25",
+              "result": "Disaster interrupts: a storm, quake, or magical surge reshapes the map and raises the stakes mid-mission."
+            },
+            {
+              "range": "26",
+              "result": "Law on the hunt: authorities label the PCs criminals, forcing them to clear their names while solving the main problem."
+            },
+            {
+              "range": "27",
+              "result": "Resource collapse: time, air, or supplies run out faster than expected; rationing becomes critical."
+            },
+            {
+              "range": "28",
+              "result": "Impostor in the room: a key NPC is a shapeshifter, illusion, or disguised enemy operative."
+            },
+            {
+              "range": "29",
+              "result": "Conflicting contracts: the same reward has already been promised to a rival group or faction."
+            },
+            {
+              "range": "30",
+              "result": "Living location: the dungeon, city, or ship is sentient and reacts to the PCs’ choices."
+            },
+            {
+              "range": "31",
+              "result": "Victory condition flips: success now requires preserving or restoring the objective, not destroying it."
+            },
+            {
+              "range": "32",
+              "result": "Benevolent villain: the antagonist is trying to prevent a greater catastrophe; the PCs must reassess their goals."
+            },
+            {
+              "range": "33",
+              "result": "Hidden countdown: a ritual or detonation will complete at a precise hour, forcing a race against the clock."
+            },
+            {
+              "range": "34",
+              "result": "Rumor war: misinformation spreads, turning allies and the public against the PCs."
+            },
+            {
+              "range": "35",
+              "result": "Escape blocked: the obvious exit or transport is destroyed, forcing a desperate alternate route."
+            },
+            {
+              "range": "36",
+              "result": "Scale shock: the threat is far larger (or smaller) than expected, changing tactics dramatically."
+            },
+            {
+              "range": "37",
+              "result": "Mirror mission: the opposing side believes the PCs are the villains; both groups think they’re the heroes."
+            },
+            {
+              "range": "38",
+              "result": "Unstable power source: the magic, tech, or relic needed to win might destroy everything if pushed too far."
+            },
+            {
+              "range": "39",
+              "result": "Unexpected heir: a new claimant insists the objective belongs to them by right or lineage."
+            },
+            {
+              "range": "40",
+              "result": "It was a test: the entire mission was staged to evaluate the PCs, and failure has real consequences."
             }
           ]
         }


### PR DESCRIPTION
### Motivation
- Centralize loading of the Plot Twists table so plot-twist rolls and scheduler callbacks always use the correct source instead of requiring manual filtering. 
- Provide a larger, richer Plot Twists dataset for more varied results. 
- Make the Random Tables UI more convenient by adding a one-click shortcut to jump to the Plot Twists table. 

### Description
- Added `PLOT_TWIST_TABLE_ID`, `plot_twist_data_path`, and `load_plot_twist_table` to `modules/helpers/random_table_loader.py` and exported them via `__all__` to provide a dedicated helper for the Plot Twists table. 
- Rewired `modules/scenarios/plot_twist_panel.py` to use `load_plot_twist_table` (cached) for fetching the `universal_plot_twists` table. 
- Updated `modules/scenarios/gm_screen_view.py` scheduler callbacks to call `roll_plot_twist()` and display the rolled result and metadata in the message box. 
- Added a `Plot Twists` button and `_jump_to_plot_twists` helper in `modules/scenarios/random_tables_panel.py` that clears filters and selects the `universal_plot_twists` table. 
- Replaced `static/data/random_tables/Plot twists.json` with an expanded table (40 entries) and increased the dice range to `1d40` for broader results.

### Testing
- No automated tests were executed for these changes.
- Basic local file reads and grep/inspection were used during development to verify connections between modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad7496638832bb5035924680e5ba2)