### PR TITLE
Show full plot twist text in map toolbar

### DIFF
--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -69,11 +69,9 @@ def _build_toolbar(self):
     except Exception:
         pass
 
-    # Scrollable frame for the actual toolbar content
-    # Set a fixed height for the scrollable area, width will be determined by content
-    # The scrollbar will appear automatically if content width exceeds available width.
-    toolbar_height = 65 # Adjust as needed for your icon/widget sizes
-    toolbar = ctk.CTkScrollableFrame(toolbar_container, orientation="horizontal", height=toolbar_height)
+    # Scrollable frame for the actual toolbar content.
+    # Let the height expand to fit content so longer plot twists can show fully.
+    toolbar = ctk.CTkScrollableFrame(toolbar_container, orientation="horizontal")
     toolbar.pack(fill="x", expand=True) # Make the scrollable area fill the container
 
     # Load icons

--- a/modules/scenarios/plot_twist_panel.py
+++ b/modules/scenarios/plot_twist_panel.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-import textwrap
 from typing import Callable, Optional
 
 import customtkinter as ctk
@@ -184,7 +183,4 @@ class PlotTwistPanel(ctk.CTkFrame):
         self._apply_result(result)
 
     def _format_result(self, result: PlotTwistResult) -> str:
-        if self._layout != "toolbar":
-            return result.result
-        single_line = " ".join(result.result.split())
-        return textwrap.shorten(single_line, width=80, placeholder="…")
+        return result.result


### PR DESCRIPTION
### Motivation
- The plot twist text shown in the map toolbar was being truncated to a single shortened line, which hides long entries.
- The toolbar area had a fixed height which prevented longer plot twists from being visible in the UI.

### Description
- Stop truncating the plot twist by changing `PlotTwistPanel._format_result` to return the full `result.result` string.
- Remove the now-unused `textwrap` import from `modules/scenarios/plot_twist_panel.py`.
- Allow the toolbar content area to grow vertically by removing the fixed `height=65` from the `CTkScrollableFrame` in `modules/maps/views/toolbar_view.py` so long plot twists can display fully.

### Testing
- No automated tests were executed for this change.
- Manual UI verification is recommended to confirm long plot twist text now wraps/expands as expected within the toolbar.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694baf6f202c832b94bc8e8a4e36bf61)