### PR TITLE
Improve skill_improvement guidance and projected skill preview in character creation UI

### DIFF
--- a/modules/pcs/character_creation/ui/__init__.py
+++ b/modules/pcs/character_creation/ui/__init__.py
@@ -1,6 +1,7 @@
 """UI adapters for character creation widgets."""
 
 from .advancement_binding import bind_advancement_type_and_label_vars
+from .advancement_hints import details_hint_for_advancement
 
-__all__ = ["bind_advancement_type_and_label_vars"]
+__all__ = ["bind_advancement_type_and_label_vars", "details_hint_for_advancement"]
 

--- a/modules/pcs/character_creation/ui/advancement_hints.py
+++ b/modules/pcs/character_creation/ui/advancement_hints.py
@@ -1,0 +1,14 @@
+"""Hint labels for advancement choice details in character creation UI."""
+
+from __future__ import annotations
+
+
+ADVANCEMENT_DETAILS_HINTS = {
+    "skill_improvement": "Saisir 2 compétences favorites ou 1 non-favorite, séparées par virgule.",
+}
+
+
+def details_hint_for_advancement(advancement_type: str) -> str:
+    """Return the contextual hint text shown below an advancement details field."""
+
+    return ADVANCEMENT_DETAILS_HINTS.get((advancement_type or "").strip(), "")

--- a/tests/test_advancement_effects.py
+++ b/tests/test_advancement_effects.py
@@ -1,0 +1,23 @@
+from modules.pcs.character_creation.progression.effects import _extract_matching_skills
+
+
+def test_extract_matching_skills_handles_spaces_and_case() -> None:
+    assert _extract_matching_skills("  combat ,   PERCEPTION ") == ["Combat", "Perception"]
+
+
+def test_extract_matching_skills_supports_multiple_separators() -> None:
+    assert _extract_matching_skills("Combat; Perception / Tir + Survie|Athlétisme") == [
+        "Combat",
+        "Perception",
+        "Tir",
+        "Survie",
+        "Athlétisme",
+    ]
+
+
+def test_extract_matching_skills_supports_et_separator() -> None:
+    assert _extract_matching_skills("Combat et Perception") == ["Combat", "Perception"]
+
+
+def test_extract_matching_skills_supports_missing_accents() -> None:
+    assert _extract_matching_skills("erudition, representation") == ["Érudition", "Représentation"]


### PR DESCRIPTION
### Motivation
- Clarifier l’usage du champ `details` pour l’avancement `skill_improvement` afin de réduire l’ambiguïté sur ce qui doit être saisi. 
- Donner un retour visuel immédiat des effets d’avancement sur les points de compétence (base + bonus + effets) sans écraser les valeurs saisies. 
- Rendre la détection des compétences saisies plus tolérante aux variations d’entrée (espaces, casse, différents séparateurs, `et`, accents manquants). 

### Description
- Ajout d’un petit module UI `modules/pcs/character_creation/ui/advancement_hints.py` et export via `modules/pcs/character_creation/ui/__init__.py` fournissant `details_hint_for_advancement` et un message explicite pour `skill_improvement`. 
- Dans `modules/pcs/character_creation/view.py` : affichage d’un label d’aide sous le champ `details`, liaison de la mise à jour des hints, et ajout d’une ligne `projected_points_var` qui affiche une prévisualisation « temporaire/projetée » des différences `base→après avancements` calculées avec `apply_advancement_effects` sans modifier les valeurs de base. 
- Dans `modules/pcs/character_creation/progression/effects.py` : refactor de `_extract_matching_skills` pour normaliser les tokens via `unicodedata.normalize` (suppression des diacritiques), et découpage via `re.split` pour gérer `, ; / | +` ainsi que le mot `et`, et rendre la recherche insensible à la casse et aux espaces. 
- Ajout de tests ciblés `tests/test_advancement_effects.py` couvrant espaces/casse, séparateurs multiples, `et` et accents manquants pour `_extract_matching_skills`.

### Testing
- Exécuté `pytest -q tests/test_advancement_effects.py`, qui a réussi (`4 passed`).
- Exécuté `pytest -q tests/test_character_creation_rules.py -k "skill_improvement_advancement_increases_skill_points or skill_improvement_adds_bonus_skill_point_budget"`, qui a réussi (`2 passed, 14 deselected`).
- Exécuté `pytest -q tests/test_advancement_effects.py tests/test_character_creation_rules.py` sur la suite ciblée, qui montre que 3 tests de `tests/test_character_creation_rules.py` échouent (échecs préexistants en-dehors du périmètre de ces changements) et ne sont pas liés aux modifications de parsing/UI apportées.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29f3522d8832b84e4be9a3eb4c071)