### PR TITLE
Fix prowess point accounting and draft normalization for prouesses

### DIFF
--- a/modules/pcs/character_creation/prowess/__init__.py
+++ b/modules/pcs/character_creation/prowess/__init__.py
@@ -1,0 +1,6 @@
+"""Prowess point helpers shared by UI, rules, and storage migration."""
+
+from .points import calculate_feat_points_from_options
+
+__all__ = ["calculate_feat_points_from_options"]
+

--- a/modules/pcs/character_creation/prowess/options.py
+++ b/modules/pcs/character_creation/prowess/options.py
@@ -1,0 +1,48 @@
+"""Prowess-option catalog and point-cost helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProwessOption:
+    name: str
+    description: str
+    variable_points: bool = False
+
+
+PROWESS_OPTIONS = [
+    ProwessOption("Bonus dommages", "+dommage (choisir 1 à 3 points).", variable_points=True),
+    ProwessOption("Armure", "+armure (choisir 1 à 3 points).", variable_points=True),
+    ProwessOption("Perce Armure", "Ignore 3 d'armure (max 2 fois, ou 4 fois pour Super Héros)."),
+    ProwessOption("Utilisation non conventionnelle", "Permet d'utiliser une compétence à la place d'une autre."),
+    ProwessOption("Effet particulier", "Effet de prouesse variable (choisir 1 à 3 points).", variable_points=True),
+    ProwessOption("Durée étendue", "Un effet qui dure une scène."),
+    ProwessOption("Portée étendue", "La prouesse fonctionne au-delà de la ligne de vue."),
+    ProwessOption("Zone d'effet", "Affecte un groupe (effet variable de 1 à 3 points).", variable_points=True),
+    ProwessOption("Bonus aux jets", "+1 sur un jet (max 2 fois)."),
+    ProwessOption("Limitation de l'effet", "Ajoute une contrainte (1/scène, atout, condition, etc.)."),
+    ProwessOption("Compétence*", "D12 en compétence ou +2 après D12 (Super Héros uniquement)."),
+    ProwessOption("Vitesse*", "Mouvement X2 puis jusqu'à des paliers extrêmes (Super Héros uniquement)."),
+]
+
+PROWESS_OPTION_LABELS = [f"{option.name} — {option.description}" for option in PROWESS_OPTIONS]
+PROWESS_OPTION_BY_LABEL = {label: option.name for label, option in zip(PROWESS_OPTION_LABELS, PROWESS_OPTIONS)}
+PROWESS_OPTION_BY_NAME = {option.name: option for option in PROWESS_OPTIONS}
+DEFAULT_OPTION_NAME = PROWESS_OPTIONS[0].name
+
+
+def option_uses_variable_points(option_name: str) -> bool:
+    return PROWESS_OPTION_BY_NAME.get(option_name, PROWESS_OPTIONS[0]).variable_points
+
+
+def parse_variable_points(option_detail: str) -> int:
+    """Extract point level from details, defaulting to 1 when absent or invalid."""
+
+    for token in (option_detail or "").replace("pt", " ").split():
+        if token.isdigit():
+            numeric = int(token)
+            if 1 <= numeric <= 3:
+                return numeric
+    return 1

--- a/modules/pcs/character_creation/prowess/points.py
+++ b/modules/pcs/character_creation/prowess/points.py
@@ -1,0 +1,43 @@
+"""Prowess point calculation helpers."""
+
+from __future__ import annotations
+
+import re
+
+from .options import DEFAULT_OPTION_NAME, PROWESS_OPTION_BY_LABEL, option_uses_variable_points, parse_variable_points
+
+
+_OPTION_COST_PATTERN = re.compile(r"^\s*(\d+)\s*pt", flags=re.IGNORECASE)
+
+
+def _split_option_value(raw_value: str) -> tuple[str, str]:
+    if ":" not in raw_value:
+        return raw_value.strip(), ""
+    option_name, option_detail = raw_value.split(":", 1)
+    return option_name.strip(), option_detail.strip()
+
+
+def _option_name_from_label_or_name(option_raw_name: str) -> str:
+    return PROWESS_OPTION_BY_LABEL.get(option_raw_name, option_raw_name or DEFAULT_OPTION_NAME)
+
+
+def _option_cost_from_string(option_value: str) -> int:
+    option_raw_name, option_detail = _split_option_value(option_value)
+    option_name = _option_name_from_label_or_name(option_raw_name)
+
+    if option_uses_variable_points(option_name):
+        return parse_variable_points(option_detail)
+
+    parsed_points_match = _OPTION_COST_PATTERN.match(option_detail)
+    if parsed_points_match:
+        parsed_points = int(parsed_points_match.group(1))
+        if 1 <= parsed_points <= 3:
+            return parsed_points
+    return 1
+
+
+def calculate_feat_points_from_options(options: list[str]) -> int:
+    """Return spent prowess points for a feat (first option is free)."""
+
+    total_option_cost = sum(_option_cost_from_string(str(option)) for option in (options or []))
+    return max(0, total_option_cost - 1)

--- a/modules/pcs/character_creation/rules_engine.py
+++ b/modules/pcs/character_creation/rules_engine.py
@@ -13,6 +13,7 @@ from .progression.rank_limits import (
     skill_cap_points_for_advancements,
 )
 from .progression import BASE_FEAT_COUNT, BASE_PROWESS_POINTS, apply_advancement_effects, prowess_points_from_advancement_choices
+from .prowess import calculate_feat_points_from_options
 
 
 class CharacterCreationError(ValueError):
@@ -150,7 +151,7 @@ def build_character(character_input: dict) -> CharacterCreationResult:
         if not limitation:
             raise CharacterCreationError("Chaque prouesse doit définir une limitation.")
 
-        expected_points = max(0, len(options) - 1)
+        expected_points = calculate_feat_points_from_options(options)
         actual_points = int(feat.get("prowess_points", expected_points) or 0)
         if actual_points != expected_points:
             raise CharacterCreationError(

--- a/modules/pcs/character_creation/storage/payload_normalizer.py
+++ b/modules/pcs/character_creation/storage/payload_normalizer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+from ..prowess import calculate_feat_points_from_options
+
 
 def _read_equipment_values(payload: dict) -> dict:
     equipment = payload.get("equipment") or {}
@@ -25,6 +27,18 @@ def _read_equipment_pe_values(payload: dict) -> dict:
     }
 
 
+def _normalize_feats(payload: dict) -> list[dict]:
+    feats = payload.get("feats") or []
+    normalized_feats: list[dict] = []
+    for feat in feats:
+        feat_data = deepcopy(feat or {})
+        options = [str(option) for option in (feat_data.get("options") or [])]
+        computed_points = calculate_feat_points_from_options(options)
+        feat_data["options"] = options
+        feat_data["prowess_points"] = computed_points
+        normalized_feats.append(feat_data)
+    return normalized_feats
+
 def normalize_draft_payload_for_form(payload: dict) -> dict:
     """Return a payload copy that always carries form-level equipment fields.
 
@@ -45,4 +59,5 @@ def normalize_draft_payload_for_form(payload: dict) -> dict:
     normalized["weapon_pe"] = equipment_pe["weapon"]
     normalized["armor_pe"] = equipment_pe["armor"]
     normalized["utility_pe"] = equipment_pe["utility"]
+    normalized["feats"] = _normalize_feats(payload)
     return normalized

--- a/modules/pcs/character_creation/ui/prowess/options.py
+++ b/modules/pcs/character_creation/ui/prowess/options.py
@@ -1,49 +1,23 @@
-"""Prowess-option catalog and point-cost helpers."""
+"""Backward-compatible re-export for prowess option catalog."""
 
-from __future__ import annotations
+from ...prowess.options import (
+    DEFAULT_OPTION_NAME,
+    PROWESS_OPTION_BY_LABEL,
+    PROWESS_OPTION_BY_NAME,
+    PROWESS_OPTION_LABELS,
+    PROWESS_OPTIONS,
+    ProwessOption,
+    option_uses_variable_points,
+    parse_variable_points,
+)
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class ProwessOption:
-    name: str
-    description: str
-    variable_points: bool = False
-
-
-PROWESS_OPTIONS = [
-    ProwessOption("Bonus dommages", "+dommage (choisir 1 à 3 points).", variable_points=True),
-    ProwessOption("Armure", "+armure (choisir 1 à 3 points).", variable_points=True),
-    ProwessOption("Perce Armure", "Ignore 3 d'armure (max 2 fois, ou 4 fois pour Super Héros)."),
-    ProwessOption("Utilisation non conventionnelle", "Permet d'utiliser une compétence à la place d'une autre."),
-    ProwessOption("Effet particulier", "Effet de prouesse variable (choisir 1 à 3 points).", variable_points=True),
-    ProwessOption("Durée étendue", "Un effet qui dure une scène."),
-    ProwessOption("Portée étendue", "La prouesse fonctionne au-delà de la ligne de vue."),
-    ProwessOption("Zone d'effet", "Affecte un groupe (effet variable de 1 à 3 points).", variable_points=True),
-    ProwessOption("Bonus aux jets", "+1 sur un jet (max 2 fois)."),
-    ProwessOption("Limitation de l'effet", "Ajoute une contrainte (1/scène, atout, condition, etc.)."),
-    ProwessOption("Compétence*", "D12 en compétence ou +2 après D12 (Super Héros uniquement)."),
-    ProwessOption("Vitesse*", "Mouvement X2 puis jusqu'à des paliers extrêmes (Super Héros uniquement)."),
+__all__ = [
+    "ProwessOption",
+    "PROWESS_OPTIONS",
+    "PROWESS_OPTION_LABELS",
+    "PROWESS_OPTION_BY_LABEL",
+    "PROWESS_OPTION_BY_NAME",
+    "DEFAULT_OPTION_NAME",
+    "option_uses_variable_points",
+    "parse_variable_points",
 ]
-
-PROWESS_OPTION_LABELS = [f"{option.name} — {option.description}" for option in PROWESS_OPTIONS]
-PROWESS_OPTION_BY_LABEL = {label: option.name for label, option in zip(PROWESS_OPTION_LABELS, PROWESS_OPTIONS)}
-PROWESS_OPTION_BY_NAME = {option.name: option for option in PROWESS_OPTIONS}
-DEFAULT_OPTION_NAME = PROWESS_OPTIONS[0].name
-
-
-def option_uses_variable_points(option_name: str) -> bool:
-    return PROWESS_OPTION_BY_NAME.get(option_name, PROWESS_OPTIONS[0]).variable_points
-
-
-def parse_variable_points(option_detail: str) -> int:
-    """Extract point level from details, defaulting to 1 when absent or invalid."""
-
-    for token in (option_detail or "").replace("pt", " ").split():
-        if token.isdigit():
-            numeric = int(token)
-            if 1 <= numeric <= 3:
-                return numeric
-    return 1
-

--- a/modules/pcs/character_creation/ui/prowess_editor.py
+++ b/modules/pcs/character_creation/ui/prowess_editor.py
@@ -6,6 +6,7 @@ import tkinter as tk
 
 import customtkinter as ctk
 
+from ..prowess import calculate_feat_points_from_options
 from .prowess.options import (
     DEFAULT_OPTION_NAME,
     PROWESS_OPTION_BY_LABEL,
@@ -199,8 +200,23 @@ class ProwessEditor:
         return sum(self._prowess_points_for_card(card) for card in self._cards)
 
     def _prowess_points_for_card(self, card: dict) -> int:
-        total_option_cost = sum(self._prowess_cost_for_option_row(option_row) for option_row in card["options"])
-        return max(0, total_option_cost - 1)
+        serialized_options = []
+        for option_row in card["options"]:
+            option_label = option_row["label_var"].get()
+            option_name = PROWESS_OPTION_BY_LABEL.get(option_label, DEFAULT_OPTION_NAME)
+            detail = option_row["detail_var"].get().strip()
+
+            if option_uses_variable_points(option_name):
+                points = parse_variable_points(option_row["points_var"].get())
+                effect = POINT_EFFECT_BY_LEVEL[points]
+                composed_detail = f"{points} pt ({effect})"
+                if detail:
+                    composed_detail = f"{composed_detail} - {detail}"
+                serialized_options.append(f"{option_name} : {composed_detail}")
+            else:
+                serialized_options.append(f"{option_name} : {detail}" if detail else option_name)
+
+        return calculate_feat_points_from_options(serialized_options)
 
     def _prowess_cost_for_option_row(self, option_row: dict) -> int:
         option_label = option_row["label_var"].get()

--- a/tests/test_character_creation_prowess_points.py
+++ b/tests/test_character_creation_prowess_points.py
@@ -1,0 +1,15 @@
+from modules.pcs.character_creation.prowess import calculate_feat_points_from_options
+
+
+def test_calculate_feat_points_first_option_is_free_for_flat_options():
+    options = ["Perce Armure", "Durée étendue"]
+    assert calculate_feat_points_from_options(options) == 1
+
+
+def test_calculate_feat_points_parses_variable_and_fixed_costs_from_options():
+    options = [
+        "Bonus dommages : 3 pt (+7)",
+        "Perce Armure",
+        "Durée étendue : 2 pt",
+    ]
+    assert calculate_feat_points_from_options(options) == 5

--- a/tests/test_character_creation_rules.py
+++ b/tests/test_character_creation_rules.py
@@ -232,3 +232,27 @@ def test_skill_cap_increases_with_advancement_thresholds():
 
     result = build_character(payload)
     assert result.skill_dice["Combat"] == "d12+2"
+
+
+def test_build_character_validates_prowess_points_using_option_costs():
+    payload = _payload()
+    payload["feats"] = [
+        {
+            "name": "Maîtrise",
+            "options": ["Bonus dommages : 3 pt (+7)", "Durée étendue"],
+            "limitation": "Canalisation",
+            "prowess_points": 1,
+        },
+        {
+            "name": "Feu",
+            "options": ["Dommages", "Zone", "Portée"],
+            "limitation": "Flamme requise",
+            "prowess_points": 2,
+        },
+    ]
+
+    try:
+        build_character(payload)
+        assert False, "Expected CharacterCreationError"
+    except CharacterCreationError as exc:
+        assert "total de points incohérent" in str(exc)

--- a/tests/test_character_draft_payload_normalizer.py
+++ b/tests/test_character_draft_payload_normalizer.py
@@ -32,3 +32,20 @@ def test_normalizer_reads_legacy_equipement_keys():
     assert normalized["weapon_pe"] == 1
     assert normalized["armor_pe"] == 2
     assert normalized["utility_pe"] == 1
+
+
+def test_normalizer_recomputes_prowess_points_from_options():
+    payload = {
+        "feats": [
+            {
+                "name": "Attaque mystique",
+                "options": ["Bonus dommages : 3 pt (+7)", "Durée étendue"],
+                "limitation": "Concentration",
+                "prowess_points": 1,
+            }
+        ]
+    }
+
+    normalized = normalize_draft_payload_for_form(payload)
+
+    assert normalized["feats"][0]["prowess_points"] == 3

--- a/tests/test_prowess_editor_points.py
+++ b/tests/test_prowess_editor_points.py
@@ -39,10 +39,11 @@ sys.modules.setdefault(
 from modules.pcs.character_creation.ui.prowess_editor import ProwessEditor
 
 
-def _row(root, label: str, points: str = "1") -> dict:
+def _row(root, label: str, points: str = "1", detail: str = "") -> dict:
     return {
         "label_var": tk.StringVar(master=root, value=label),
         "points_var": tk.StringVar(master=root, value=points),
+        "detail_var": tk.StringVar(master=root, value=detail),
         "row_box": _StubWidget(),
         "remove_button": _StubWidget(),
     }


### PR DESCRIPTION
### Motivation
- Correct a bug where the first displayed prouesse option (cost 1) was not deducted from the available prowess points and ensure saved drafts/load path use the new cost model. 
- Centralize prowess option cost logic so UI, rules validation and draft normalization remain consistent across save/load and validation flows.

### Description
- Add a shared prowess domain: `modules/pcs/character_creation/prowess` with `points.py` implementing `calculate_feat_points_from_options` and `options.py` hosting the option catalog. 
- Update the UI `ProwessEditor` to compute per-feat cost from serialized option strings using `calculate_feat_points_from_options`. 
- Use the same calculator in the rules engine (`build_character`) to validate `prowess_points` consistency instead of `len(options) - 1`. 
- Normalize loaded drafts in `storage/payload_normalizer.py` by recomputing `prowess_points` from saved `options`, and keep a backward-compatible re-export under `ui/prowess/options.py`. 
- Add/adjust tests covering the new calculation, editor stubs, rules validation and draft normalization (`tests/test_character_creation_prowess_points.py`, updates to `tests/test_prowess_editor_points.py`, `tests/test_character_draft_payload_normalizer.py`, and an added focused assertion in `tests/test_character_creation_rules.py`).

### Testing
- Ran `pytest -q tests/test_character_creation_prowess_points.py tests/test_prowess_editor_points.py tests/test_character_draft_payload_normalizer.py` and all targeted tests passed (`7 passed`).
- Ran `pytest -q tests/test_character_creation_prowess_points.py tests/test_prowess_editor_points.py tests/test_character_draft_payload_normalizer.py tests/test_character_creation_rules.py -k "validates_prowess_points_using_option_costs"` and the focused validation test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a55f809810832ba1d32c043b92ebc8)