### PR TITLE
Fix AI scenario expansion prompt to include existing entity catalog

### DIFF
--- a/modules/campaigns/services/ai/prompt_builders.py
+++ b/modules/campaigns/services/ai/prompt_builders.py
@@ -206,6 +206,14 @@ def build_arc_scenario_expansion_prompt(foundation: dict[str, Any], arcs: list[d
         "stakes": _clean(foundation.get("stakes")),
         "themes": [_clean(theme) for theme in (foundation.get("themes") or []) if _clean(theme)],
         "notes": _clean(foundation.get("notes")),
+        "existing_entities": {
+            entity_type: [
+                _clean(name)
+                for name in (foundation.get("existing_entities", {}).get(entity_type) or [])
+                if _clean(name)
+            ]
+            for entity_type in ("villains", "factions", "places", "npcs", "creatures")
+        },
     }
     arc_payload = [
         {
@@ -227,7 +235,7 @@ def build_arc_scenario_expansion_prompt(foundation: dict[str, Any], arcs: list[d
         "Use the parent arc's name, summary, objective, thread, and linked scenario titles as the narrative seed.\n"
         "Preserve traceability inside the scenario text itself by explicitly mentioning the parent arc name, inherited thread, and the already-linked source scenario titles.\n"
         "Prefer reusing existing entities from the campaign catalog in about 90% of links. Only invent a new villain, faction, place, NPC, or creature when the arc genuinely needs one.\n"
-        "If you invent a new linked entity, add its full record under EntityCreations in the same scenario payload.\n"
+        "If you invent a new linked entity that is not listed in campaign foundation.existing_entities, add its full record under EntityCreations in the same scenario payload.\n"
         "Do not omit any arc. Do not generate more than 2 scenarios for any arc. Do not generate fewer than 2 scenarios for any arc.\n\n"
         "Campaign foundation:\n"
         f"{json.dumps(foundation_payload, ensure_ascii=False, indent=2)}\n\n"
@@ -243,7 +251,8 @@ def build_arc_scenario_expansion_prompt(foundation: dict[str, Any], arcs: list[d
         "- Each scenario must include at least 1 villain, at least 1 faction, and at least 1 place.\n"
         "- NPCs and Creatures are optional, but include them whenever the premise naturally needs them.\n"
         "- Places, NPCs, Villains, Creatures, Factions, and Objects must always be JSON arrays, even when empty.\n"
-        "- Reuse existing entities whenever they fit; create new entities only for genuine gaps in the current catalog.\n"
+        "- Reuse names from campaign foundation.existing_entities whenever they fit.\n"
+        "- If you use any villain, faction, place, NPC, or creature name that is not in campaign foundation.existing_entities, include it in EntityCreations with a matching Name.\n"
         "- Keep each scenario self-contained enough to save directly as a scenario record.\n"
     )
 

--- a/tests/campaigns/services/test_arc_scenario_expansion_service.py
+++ b/tests/campaigns/services/test_arc_scenario_expansion_service.py
@@ -125,6 +125,76 @@ def test_arc_scenario_expansion_generates_exactly_two_scenarios_per_arc():
     assert "Hidden conspiracy" in ai_client.messages[1]["content"]
 
 
+def test_arc_scenario_expansion_prompt_includes_existing_entity_catalog():
+    ai_client = _FakeAIClient(
+        """
+        {
+          "arcs": [
+            {
+              "arc_name": "Guild War",
+              "scenarios": [
+                {
+                  "Title": "Rainmarket Ultimatum",
+                  "Summary": "The crew traces the conspiracy into Rainmarket.",
+                  "Secrets": "A broker carries the ledger fragment.",
+                  "Scenes": ["Stake out the market", "Interrogate the broker", "Escape the crackdown"],
+                  "Places": ["Rainmarket"],
+                  "NPCs": ["Rika Vale"],
+                  "Villains": ["Marshal Vey"],
+                  "Creatures": [],
+                  "Factions": ["Rainmarket Compact"],
+                  "Objects": ["Ledger Fragment"]
+                },
+                {
+                  "Title": "Ash Dock Reckoning",
+                  "Summary": "A trap at Ash Dock forces the crew to expose the mole.",
+                  "Secrets": "The dockmaster answers to the same patron.",
+                  "Scenes": ["Follow the dock rumor", "Survive the ambush", "Corner the mole"],
+                  "Places": ["Ash Dock"],
+                  "NPCs": ["Dockmaster Neral"],
+                  "Villains": ["Marshal Vey"],
+                  "Creatures": [],
+                  "Factions": ["Rainmarket Compact"],
+                  "Objects": []
+                }
+              ]
+            }
+          ]
+        }
+        """
+    )
+    service = ArcScenarioExpansionService(ai_client)
+
+    service.generate_scenarios(
+        {
+            "name": "Stormfront",
+            "tone": "Noir",
+            "existing_entities": {
+                "villains": ["Marshal Vey"],
+                "factions": ["Rainmarket Compact"],
+                "places": ["Rainmarket", "Ash Dock"],
+                "npcs": ["Rika Vale", "Dockmaster Neral"],
+                "creatures": ["Clockwork Hound"],
+            },
+        },
+        [
+            {
+                "name": "Guild War",
+                "summary": "Street-level pressure escalates.",
+                "objective": "Identify the patron behind the gang war.",
+                "thread": "Hidden conspiracy",
+                "scenarios": ["Cold Open"],
+            }
+        ],
+    )
+
+    prompt = ai_client.messages[1]["content"]
+    assert '"existing_entities"' in prompt
+    assert "Marshal Vey" in prompt
+    assert "Rika Vale" in prompt
+    assert "Rainmarket Compact" in prompt
+
+
 def test_generated_scenario_persistence_handles_duplicate_titles_before_save():
     wrapper = _FakeScenarioWrapper(items=[{"Title": "Rainmarket Ultimatum"}])
     persistence = GeneratedScenarioPersistence(


### PR DESCRIPTION
### Motivation
- The AI-generated scenarios could reference invented entity names that the validator later rejected because the model was not provided the campaign's existing entity catalog.
- The prompt needed to explicitly include the campaign `existing_entities` so the model can reuse known names and only invent new entities when appropriate.

### Description
- Updated `build_arc_scenario_expansion_prompt` to include an `existing_entities` block in the prompt foundation containing `villains`, `factions`, `places`, `npcs`, and `creatures`.
- Tightened the prompt rules to require that any newly invented linked `villain`, `faction`, `place`, `NPC`, or `creature` not present in `campaign foundation.existing_entities` must also be defined in `EntityCreations`.
- Clarified reuse guidance to prefer names from `campaign foundation.existing_entities` and to require matching `Name` entries in `EntityCreations` when inventing new links.
- Added a regression test `test_arc_scenario_expansion_prompt_includes_existing_entity_catalog` to verify the generated prompt contains the provided existing-entity catalog.

### Testing
- Ran `pytest -q tests/campaigns/services/test_arc_scenario_expansion_service.py tests/test_campaign_builder_wizard.py` and observed all tests pass (`15 passed`).
- The new regression test verifies the prompt includes `existing_entities` and concrete names like `Marshal Vey`, `Rika Vale`, and `Rainmarket Compact`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc29ab2d7c832bb0003726827bb3bf)