### PR TITLE
Backfill missing EntityCreations during AI arc scenario expansion

### DIFF
--- a/modules/campaigns/services/ai/arc_scenario_entities.py
+++ b/modules/campaigns/services/ai/arc_scenario_entities.py
@@ -55,16 +55,12 @@ def build_existing_entity_lookup(foundation: dict[str, Any]) -> dict[str, set[st
         return None
 
     lookup: dict[str, set[str]] = {}
-    has_values = False
     for entity_type in ENTITY_WRAPPER_SPECS:
         raw_values = raw_catalog.get(entity_type)
         if not isinstance(raw_values, list):
             lookup[entity_type] = set()
             continue
 
-        values = {str(value).strip().casefold() for value in raw_values if str(value).strip()}
-        if values:
-            has_values = True
-        lookup[entity_type] = values
+        lookup[entity_type] = {str(value).strip().casefold() for value in raw_values if str(value).strip()}
 
-    return lookup if has_values else None
+    return lookup

--- a/modules/campaigns/services/ai/arc_scenario_expansion_service.py
+++ b/modules/campaigns/services/ai/arc_scenario_expansion_service.py
@@ -201,6 +201,19 @@ class ArcScenarioExpansionService:
         factions = ArcScenarioExpansionService._normalize_string_list(payload.get("Factions"))
         objects = ArcScenarioExpansionService._normalize_string_list(payload.get("Objects"))
 
+        ArcScenarioExpansionService._backfill_missing_entity_creations(
+            title=title,
+            summary=summary,
+            parent_arc_name=parent_arc_name,
+            places=places,
+            npcs=npcs,
+            villains=villains,
+            creatures=creatures,
+            factions=factions,
+            entity_creations=entity_creations,
+            existing_entities=existing_entities,
+        )
+
         places = ArcScenarioExpansionService._ensure_created_links_present(places, entity_creations["places"])
         villains = ArcScenarioExpansionService._ensure_created_links_present(villains, entity_creations["villains"])
         factions = ArcScenarioExpansionService._ensure_created_links_present(factions, entity_creations["factions"])
@@ -339,6 +352,136 @@ class ArcScenarioExpansionService:
                 f"Scenario '{title}' links unknown {field_name}: {', '.join(missing)}. "
                 "Add them to EntityCreations or reuse existing catalog entities."
             )
+
+    @staticmethod
+    def _backfill_missing_entity_creations(
+        *,
+        title: str,
+        summary: str,
+        parent_arc_name: str,
+        places: list[str],
+        npcs: list[str],
+        villains: list[str],
+        creatures: list[str],
+        factions: list[str],
+        entity_creations: dict[str, list[dict[str, Any]]],
+        existing_entities: dict[str, set[str]] | None,
+    ) -> None:
+        if existing_entities is None:
+            return
+
+        scenario_context = {
+            "title": title,
+            "summary": summary,
+            "parent_arc_name": parent_arc_name,
+        }
+        for entity_type, values in (
+            ("places", places),
+            ("npcs", npcs),
+            ("villains", villains),
+            ("creatures", creatures),
+            ("factions", factions),
+        ):
+            ArcScenarioExpansionService._append_missing_entity_creations(
+                entity_type=entity_type,
+                values=values,
+                entity_creations=entity_creations,
+                existing_entities=existing_entities,
+                scenario_context=scenario_context,
+            )
+
+    @staticmethod
+    def _append_missing_entity_creations(
+        *,
+        entity_type: str,
+        values: list[str],
+        entity_creations: dict[str, list[dict[str, Any]]],
+        existing_entities: dict[str, set[str]],
+        scenario_context: dict[str, str],
+    ) -> None:
+        known_existing = existing_entities.get(entity_type, set())
+        created_records = entity_creations.setdefault(entity_type, [])
+        known_created = {
+            str(item.get("Name") or "").strip().casefold()
+            for item in created_records
+            if str(item.get("Name") or "").strip()
+        }
+        for value in values:
+            key = value.casefold()
+            if key in known_existing or key in known_created:
+                continue
+            created_records.append(
+                ArcScenarioExpansionService._build_placeholder_entity_record(
+                    entity_type=entity_type,
+                    name=value,
+                    title=scenario_context["title"],
+                    summary=scenario_context["summary"],
+                    parent_arc_name=scenario_context["parent_arc_name"],
+                )
+            )
+            known_created.add(key)
+
+    @staticmethod
+    def _build_placeholder_entity_record(
+        *,
+        entity_type: str,
+        name: str,
+        title: str,
+        summary: str,
+        parent_arc_name: str,
+    ) -> dict[str, Any]:
+        summary_text = summary.strip() or f"Auto-created from generated scenario '{title}'."
+        arc_suffix = f" for arc '{parent_arc_name}'" if parent_arc_name else ""
+
+        if entity_type == "villains":
+            return {
+                "Name": name,
+                "Title": "",
+                "Archetype": "",
+                "ThreatLevel": "",
+                "Description": summary_text,
+                "Scheme": f"Auto-created from generated scenario '{title}'{arc_suffix}.",
+                "CurrentObjective": "",
+                "Secrets": "",
+                "Factions": [],
+                "Lieutenants": [],
+                "CreatureAgents": [],
+            }
+        if entity_type == "factions":
+            return {
+                "Name": name,
+                "Description": summary_text,
+                "Secrets": f"Auto-created from generated scenario '{title}'{arc_suffix}.",
+                "Villains": [],
+            }
+        if entity_type == "places":
+            return {
+                "Name": name,
+                "Description": summary_text,
+                "Secrets": f"Auto-created from generated scenario '{title}'{arc_suffix}.",
+                "NPCs": [],
+                "Villains": [],
+            }
+        if entity_type == "npcs":
+            return {
+                "Name": name,
+                "Role": "",
+                "Description": summary_text,
+                "Secret": "",
+                "Motivation": "",
+                "Background": f"Auto-created from generated scenario '{title}'{arc_suffix}.",
+                "Personality": "",
+                "Factions": [],
+            }
+        if entity_type == "creatures":
+            return {
+                "Name": name,
+                "Type": "",
+                "Description": summary_text,
+                "Weakness": "",
+                "Powers": "",
+            }
+        return {"Name": name}
 
     @staticmethod
     def _normalize_created_villains(value: Any) -> list[dict[str, Any]]:

--- a/tests/campaigns/services/test_arc_scenario_expansion_service.py
+++ b/tests/campaigns/services/test_arc_scenario_expansion_service.py
@@ -266,6 +266,79 @@ def test_arc_scenario_expansion_prompt_includes_existing_entity_catalog():
     assert "Rainmarket Compact" in prompt
 
 
+def test_arc_scenario_expansion_backfills_missing_entity_creation_records():
+    ai_client = _FakeAIClient(
+        """
+        {
+          "arcs": [
+            {
+              "arc_name": "Ghost Runners",
+              "scenarios": [
+                {
+                  "Title": "Rescue Mission in the Mutant-Rioted Zone",
+                  "Summary": "The crew pushes into a shattered district to extract a trapped asset.",
+                  "Secrets": "The rescue route is being manipulated by a hostile cell.",
+                  "Scenes": ["Enter the riot line", "Secure the asset", "Escape through the tunnels"],
+                  "Places": ["Mutant-Rioted Zone"],
+                  "NPCs": [],
+                  "Villains": ["Commandant Hex"],
+                  "Creatures": [],
+                  "Factions": ["Nazis"],
+                  "Objects": []
+                },
+                {
+                  "Title": "Ghostline Exfiltration",
+                  "Summary": "The survivors race a blockade before the trap closes for good.",
+                  "Secrets": "A second team intends to erase all witnesses.",
+                  "Scenes": ["Stage the convoy", "Break the blockade", "Choose who gets out"],
+                  "Places": ["Transit Bunker"],
+                  "NPCs": [],
+                  "Villains": ["Commandant Hex"],
+                  "Creatures": [],
+                  "Factions": ["Nazis"],
+                  "Objects": []
+                }
+              ]
+            }
+          ]
+        }
+        """
+    )
+    service = ArcScenarioExpansionService(ai_client)
+
+    result = service.generate_scenarios(
+        {
+            "name": "Stormfront",
+            "tone": "Grim",
+            "existing_entities": {
+                "villains": [],
+                "factions": [],
+                "places": [],
+                "npcs": [],
+                "creatures": [],
+            },
+        },
+        [
+            {
+                "name": "Ghost Runners",
+                "summary": "A desperate chain of extractions across occupied territory.",
+                "objective": "Keep the resistance network alive.",
+                "thread": "Occupied escape routes",
+                "scenarios": ["Signal in the Static"],
+            }
+        ],
+    )
+
+    first_scenario = result["arcs"][0]["scenarios"][0]
+    created_factions = first_scenario["EntityCreations"]["factions"]
+    created_villains = first_scenario["EntityCreations"]["villains"]
+    created_places = first_scenario["EntityCreations"]["places"]
+
+    assert any(item["Name"] == "Nazis" for item in created_factions)
+    assert any(item["Name"] == "Commandant Hex" for item in created_villains)
+    assert any(item["Name"] == "Mutant-Rioted Zone" for item in created_places)
+
+
 def test_generated_scenario_persistence_handles_duplicate_titles_before_save():
     wrapper = _FakeScenarioWrapper(items=[{"Title": "Rainmarket Ultimatum"}])
     persistence = GeneratedScenarioPersistence(


### PR DESCRIPTION
### Motivation
- AI-generated arc scenarios sometimes reference new villains, factions, or places but omit matching `EntityCreations`, causing validation failures like "links unknown Factions" during scenario generation.
- When an explicit but empty `existing_entities` catalog was present it was treated as absent, disabling validation and repair paths and letting the regression slip through.
- The change ensures generation normalizes and repairs missing entity records so the UI can save generated scenarios reliably.

### Description
- Keep an explicit `existing_entities` lookup active even when lists are empty by returning a lookup dict instead of `None` from `build_existing_entity_lookup` in `modules/campaigns/services/ai/arc_scenario_entities.py`.
- Add `_backfill_missing_entity_creations`, `_append_missing_entity_creations`, and `_build_placeholder_entity_record` helpers to `modules/campaigns/services/ai/arc_scenario_expansion_service.py` and call the backfill step during scenario normalization so missing `EntityCreations` are synthesized before validation.
- Ensure synthesized records are minimal, typed placeholders (villains, factions, places, npcs, creatures) that include a traceable summary referencing the generated scenario and parent arc.
- Add a regression test `test_arc_scenario_expansion_backfills_missing_entity_creation_records` in `tests/campaigns/services/test_arc_scenario_expansion_service.py` that verifies new faction, villain, and place names are backfilled when the AI omits `EntityCreations`.

### Testing
- Ran `pytest -q tests/campaigns/services/test_arc_scenario_expansion_service.py` and the file passed (7 passed). 
- Ran `pytest -q tests/test_campaign_builder_wizard.py -k generate_scenarios_per_arc_links_saved_titles_back_to_parent_arc` and the focused wizard test passed (1 passed, others deselected).
- The new regression test confirms generated scenarios that introduce new linked entities without `EntityCreations` now normalize successfully instead of raising validation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2e5d6cbc832ba0e360cbb89a715f)