### PR TITLE
Polish campaign arc editor UI

### DIFF
--- a/modules/campaigns/ui/arc_editor_dialog.py
+++ b/modules/campaigns/ui/arc_editor_dialog.py
@@ -4,7 +4,8 @@ import customtkinter as ctk
 from tkinter import messagebox
 
 from modules.campaigns.shared.arc_status import CANONICAL_ARC_STATUSES, canonicalize_arc_status
-from modules.campaigns.ui.widgets import ScenarioMultiSelector
+from modules.campaigns.ui.theme import ARC_EDITOR_PALETTE, ARC_EDITOR_STATUS_HINTS
+from modules.campaigns.ui.widgets import FormSection, ScenarioMultiSelector
 from modules.helpers.window_helper import position_window_at_top
 
 
@@ -14,44 +15,189 @@ class ArcEditorDialog(ctk.CTkToplevel):
     def __init__(self, master, scenarios: list[str], initial_data: dict | None = None):
         super().__init__(master)
         self.title("Campaign Arc")
-        self.geometry("700x1040")
+        self.geometry("860x940")
+        self.minsize(820, 860)
+        self.configure(fg_color=ARC_EDITOR_PALETTE.window_bg)
         self.result = None
-        self.minsize(700, 1040)
 
         initial = initial_data or {}
 
         self.name_var = ctk.StringVar(value=initial.get("name", ""))
         self.status_var = ctk.StringVar(value=canonicalize_arc_status(initial.get("status")))
         self.thread_var = ctk.StringVar(value=initial.get("thread", ""))
+        self.status_hint_var = ctk.StringVar(
+            value=ARC_EDITOR_STATUS_HINTS.get(self.status_var.get(), ARC_EDITOR_STATUS_HINTS["Planned"])
+        )
 
-        container = ctk.CTkFrame(self)
-        container.pack(fill="both", expand=True, padx=12, pady=12)
+        shell = ctk.CTkFrame(self, fg_color="transparent")
+        shell.pack(fill="both", expand=True, padx=18, pady=18)
+        shell.grid_columnconfigure(0, weight=1)
+        shell.grid_rowconfigure(1, weight=1)
 
-        ctk.CTkLabel(container, text="Arc Name").pack(anchor="w")
-        ctk.CTkEntry(container, textvariable=self.name_var).pack(fill="x", pady=(0, 8))
+        self._build_hero(shell, scenario_count=len(scenarios), initial=initial)
 
-        ctk.CTkLabel(container, text="Summary").pack(anchor="w")
-        self.summary_box = ctk.CTkTextbox(container, height=90)
-        self.summary_box.pack(fill="x", pady=(0, 8))
+        scroll = ctk.CTkScrollableFrame(shell, fg_color="transparent")
+        scroll.grid(row=1, column=0, sticky="nsew", pady=(14, 0))
+        scroll.grid_columnconfigure(0, weight=1)
+        self.content_scroll = scroll
+
+        self._build_identity_section(scroll)
+        self._build_story_section(scroll, initial)
+        self._build_scenarios_section(scroll, scenarios, initial)
+        self._build_footer(shell)
+
+        self.status_var.trace_add("write", self._update_status_hint)
+
+        self.transient(master)
+        self.grab_set()
+        self.focus_force()
+        position_window_at_top(self)
+
+    def _build_hero(self, parent: ctk.CTkFrame, *, scenario_count: int, initial: dict) -> None:
+        hero = ctk.CTkFrame(
+            parent,
+            fg_color=ARC_EDITOR_PALETTE.hero_gradient_start,
+            corner_radius=22,
+            border_width=1,
+            border_color=ARC_EDITOR_PALETTE.border,
+        )
+        hero.grid(row=0, column=0, sticky="ew")
+        hero.grid_columnconfigure(0, weight=1)
+        hero.grid_columnconfigure(1, weight=0)
+
+        title = "Refine campaign arc" if initial else "Design a new campaign arc"
+        subtitle = (
+            "Give the arc a clear promise, define the win condition, and connect the scenarios that deliver the payoff."
+        )
+
+        ctk.CTkLabel(
+            hero,
+            text=title,
+            anchor="w",
+            font=ctk.CTkFont(size=24, weight="bold"),
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+        ).grid(row=0, column=0, sticky="ew", padx=22, pady=(18, 4))
+
+        ctk.CTkLabel(
+            hero,
+            text=subtitle,
+            anchor="w",
+            justify="left",
+            wraplength=560,
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        ).grid(row=1, column=0, sticky="ew", padx=22, pady=(0, 18))
+
+        stat_card = ctk.CTkFrame(
+            hero,
+            fg_color=ARC_EDITOR_PALETTE.hero_gradient_end,
+            corner_radius=18,
+            border_width=1,
+            border_color=ARC_EDITOR_PALETTE.chip_border,
+        )
+        stat_card.grid(row=0, column=1, rowspan=2, sticky="ns", padx=18, pady=18)
+
+        ctk.CTkLabel(
+            stat_card,
+            text=str(scenario_count),
+            font=ctk.CTkFont(size=28, weight="bold"),
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+        ).pack(padx=20, pady=(14, 0))
+        ctk.CTkLabel(
+            stat_card,
+            text="scenarios ready to link",
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        ).pack(padx=20, pady=(0, 14))
+
+    def _build_identity_section(self, parent: ctk.CTkScrollableFrame) -> None:
+        section = FormSection(
+            parent,
+            title="Arc identity",
+            description="Start with a strong title and a narrative thread so the arc is easy to scan in the campaign overview.",
+        )
+        section.grid(row=0, column=0, sticky="ew", pady=(0, 14))
+        body = section.body
+        body.grid_columnconfigure((0, 1), weight=1)
+
+        self._create_field_label(body, 0, 0, "Arc name")
+        self.name_entry = ctk.CTkEntry(
+            body,
+            textvariable=self.name_var,
+            height=40,
+            corner_radius=14,
+            fg_color=ARC_EDITOR_PALETTE.surface_alt,
+            border_color=ARC_EDITOR_PALETTE.border,
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+            placeholder_text="Example: Fall of the Glass City",
+        )
+        self.name_entry.grid(row=1, column=0, sticky="ew", padx=(0, 8), pady=(0, 10))
+
+        self._create_field_label(body, 0, 1, "Narrative thread")
+        self.thread_entry = ctk.CTkEntry(
+            body,
+            textvariable=self.thread_var,
+            height=40,
+            corner_radius=14,
+            fg_color=ARC_EDITOR_PALETTE.surface_alt,
+            border_color=ARC_EDITOR_PALETTE.border,
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+            placeholder_text="Political thriller, revenge quest, corporate sabotage...",
+        )
+        self.thread_entry.grid(row=1, column=1, sticky="ew", padx=(8, 0), pady=(0, 10))
+
+        self._create_field_label(body, 2, 0, "Status")
+        self.status_menu = ctk.CTkOptionMenu(
+            body,
+            variable=self.status_var,
+            values=list(CANONICAL_ARC_STATUSES),
+            height=40,
+            corner_radius=14,
+            fg_color=ARC_EDITOR_PALETTE.success,
+            button_color=ARC_EDITOR_PALETTE.success,
+            button_hover_color=ARC_EDITOR_PALETTE.success_hover,
+            dropdown_fg_color=ARC_EDITOR_PALETTE.surface_alt,
+        )
+        self.status_menu.grid(row=3, column=0, sticky="ew", padx=(0, 8))
+
+        self.status_hint = ctk.CTkLabel(
+            body,
+            textvariable=self.status_hint_var,
+            anchor="w",
+            justify="left",
+            wraplength=300,
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        )
+        self.status_hint.grid(row=3, column=1, sticky="ew", padx=(8, 0))
+
+    def _build_story_section(self, parent: ctk.CTkScrollableFrame, initial: dict) -> None:
+        section = FormSection(
+            parent,
+            title="Story brief",
+            description="Keep these two blocks short and punchy. They should tell you what the arc is about and how you know it is resolved.",
+        )
+        section.grid(row=1, column=0, sticky="ew", pady=(0, 14))
+        body = section.body
+        body.grid_columnconfigure(0, weight=1)
+
+        self._create_field_label(body, 0, 0, "Summary")
+        self.summary_box = self._create_textbox(body, height=120)
+        self.summary_box.grid(row=1, column=0, sticky="ew", pady=(0, 12))
         self.summary_box.insert("1.0", initial.get("summary", ""))
 
-        ctk.CTkLabel(container, text="Objective").pack(anchor="w")
-        self.objective_box = ctk.CTkTextbox(container, height=90)
-        self.objective_box.pack(fill="x", pady=(0, 8))
+        self._create_field_label(body, 2, 0, "Objective")
+        self.objective_box = self._create_textbox(body, height=120)
+        self.objective_box.grid(row=3, column=0, sticky="ew")
         self.objective_box.insert("1.0", initial.get("objective", ""))
 
-        ctk.CTkLabel(container, text="Status").pack(anchor="w")
-        ctk.CTkOptionMenu(container, variable=self.status_var, values=list(CANONICAL_ARC_STATUSES)).pack(fill="x", pady=(0, 8))
-
-        ctk.CTkLabel(container, text="Narrative Thread").pack(anchor="w")
-        ctk.CTkEntry(container, textvariable=self.thread_var).pack(fill="x", pady=(0, 8))
-
-        self.scenario_selector = ScenarioMultiSelector(
-            container,
-            scenarios,
-            label="Linked Scenarios",
+    def _build_scenarios_section(self, parent: ctk.CTkScrollableFrame, scenarios: list[str], initial: dict) -> None:
+        section = FormSection(
+            parent,
+            title="Scenario links",
+            description="Choose the scenarios that actively advance this arc. Search and batch-select to build a tighter story path.",
         )
-        self.scenario_selector.pack(fill="x")
+        section.grid(row=2, column=0, sticky="ew", pady=(0, 14))
+
+        self.scenario_selector = ScenarioMultiSelector(section.body, scenarios, label="Linked scenarios")
+        self.scenario_selector.grid(row=0, column=0, sticky="ew")
 
         initial_scenarios = initial.get("scenarios") or []
         if not initial_scenarios and scenarios:
@@ -59,27 +205,83 @@ class ArcEditorDialog(ctk.CTkToplevel):
         self.scenario_selector.set_values(initial_scenarios)
 
         if scenarios:
-            ctk.CTkLabel(
-                container,
-                text=f"Available scenarios: {', '.join(scenarios[:12])}{'…' if len(scenarios) > 12 else ''}",
-                wraplength=660,
-                justify="left",
-            ).pack(anchor="w", pady=(8, 0))
+            helper = f"Tip: arcs usually read best when 2–5 scenarios are linked. You currently have {len(scenarios)} scenarios available."
+        else:
+            helper = "No scenarios exist yet. Save the arc now and link scenarios later from the campaign builder."
 
-        btns = ctk.CTkFrame(container, fg_color="transparent")
-        btns.pack(fill="x", pady=(10, 0))
-        ctk.CTkButton(btns, text="Cancel", command=self.destroy).pack(side="right", padx=4)
-        ctk.CTkButton(btns, text="Save Arc", command=self._save).pack(side="right", padx=4)
+        ctk.CTkLabel(
+            section.body,
+            text=helper,
+            anchor="w",
+            justify="left",
+            wraplength=620,
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        ).grid(row=1, column=0, sticky="ew", pady=(12, 0))
 
-        self.transient(master)
-        self.grab_set()
-        self.focus_force()
-        position_window_at_top(self)
+    def _build_footer(self, parent: ctk.CTkFrame) -> None:
+        footer = ctk.CTkFrame(parent, fg_color="transparent")
+        footer.grid(row=2, column=0, sticky="ew", pady=(14, 0))
+        footer.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            footer,
+            text="Aim for clarity over completeness—this editor should help you spot the arc at a glance during prep.",
+            anchor="w",
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        ).grid(row=0, column=0, sticky="w")
+
+        actions = ctk.CTkFrame(footer, fg_color="transparent")
+        actions.grid(row=0, column=1, sticky="e")
+
+        ctk.CTkButton(
+            actions,
+            text="Cancel",
+            width=120,
+            fg_color=ARC_EDITOR_PALETTE.danger,
+            hover_color=ARC_EDITOR_PALETTE.danger_hover,
+            command=self.destroy,
+        ).pack(side="right", padx=(8, 0))
+        ctk.CTkButton(
+            actions,
+            text="Save arc",
+            width=140,
+            fg_color=ARC_EDITOR_PALETTE.success,
+            hover_color=ARC_EDITOR_PALETTE.success_hover,
+            command=self._save,
+        ).pack(side="right")
+
+    def _create_field_label(self, parent: ctk.CTkFrame, row: int, column: int, text: str) -> None:
+        padx = (0, 8) if column == 0 else (8, 0)
+        ctk.CTkLabel(
+            parent,
+            text=text,
+            anchor="w",
+            font=ctk.CTkFont(size=13, weight="bold"),
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+        ).grid(row=row, column=column, sticky="w", padx=padx, pady=(0, 6))
+
+    def _create_textbox(self, parent: ctk.CTkFrame, *, height: int) -> ctk.CTkTextbox:
+        return ctk.CTkTextbox(
+            parent,
+            height=height,
+            corner_radius=16,
+            fg_color=ARC_EDITOR_PALETTE.surface_alt,
+            border_width=1,
+            border_color=ARC_EDITOR_PALETTE.border,
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+            wrap="word",
+        )
+
+    def _update_status_hint(self, *_args) -> None:
+        self.status_hint_var.set(
+            ARC_EDITOR_STATUS_HINTS.get(self.status_var.get(), ARC_EDITOR_STATUS_HINTS["Planned"])
+        )
 
     def _save(self):
         name = self.name_var.get().strip()
         if not name:
             messagebox.showwarning("Missing Name", "Arc name is required.", parent=self)
+            self.name_entry.focus_set()
             return
 
         scenarios = self.scenario_selector.get_values()

--- a/modules/campaigns/ui/theme/__init__.py
+++ b/modules/campaigns/ui/theme/__init__.py
@@ -1,0 +1,3 @@
+from .arc_editor_tokens import ARC_EDITOR_PALETTE, ARC_EDITOR_STATUS_HINTS, ArcEditorPalette
+
+__all__ = ["ARC_EDITOR_PALETTE", "ARC_EDITOR_STATUS_HINTS", "ArcEditorPalette"]

--- a/modules/campaigns/ui/theme/arc_editor_tokens.py
+++ b/modules/campaigns/ui/theme/arc_editor_tokens.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ArcEditorPalette:
+    """Centralized colors and copy tokens for the campaign arc editor."""
+
+    window_bg: str = "#10151d"
+    surface: str = "#161d27"
+    surface_alt: str = "#1c2633"
+    border: str = "#2c3a4c"
+    text_primary: str = "#f3f7ff"
+    text_secondary: str = "#9eacc0"
+    accent: str = "#38bdf8"
+    accent_soft: str = "#15384a"
+    success: str = "#22c55e"
+    success_hover: str = "#16a34a"
+    danger: str = "#334155"
+    danger_hover: str = "#475569"
+    chip_bg: str = "#0f2533"
+    chip_border: str = "#21465f"
+    hero_gradient_start: str = "#102033"
+    hero_gradient_end: str = "#143a2b"
+
+
+ARC_EDITOR_PALETTE = ArcEditorPalette()
+
+ARC_EDITOR_STATUS_HINTS = {
+    "Planned": "Outline the core conflict and pin the first missions players should hear about.",
+    "In Progress": "Keep objectives concrete so you can track progress between linked scenarios.",
+    "Paused": "Capture why the arc cooled off and what would reignite it later in the campaign.",
+    "Completed": "Record the payoff and legacy so future arcs can build on the fallout.",
+}

--- a/modules/campaigns/ui/widgets/__init__.py
+++ b/modules/campaigns/ui/widgets/__init__.py
@@ -1,4 +1,5 @@
 from .date_field import CampaignDateField
+from .form_section import FormSection
 from .scenario_multi_selector import ScenarioMultiSelector
 
-__all__ = ["CampaignDateField", "ScenarioMultiSelector"]
+__all__ = ["CampaignDateField", "FormSection", "ScenarioMultiSelector"]

--- a/modules/campaigns/ui/widgets/form_section.py
+++ b/modules/campaigns/ui/widgets/form_section.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.campaigns.ui.theme import ARC_EDITOR_PALETTE
+
+
+class FormSection(ctk.CTkFrame):
+    """Reusable card section with title and optional helper copy."""
+
+    def __init__(self, master, *, title: str, description: str | None = None):
+        super().__init__(
+            master,
+            fg_color=ARC_EDITOR_PALETTE.surface,
+            corner_radius=18,
+            border_width=1,
+            border_color=ARC_EDITOR_PALETTE.border,
+        )
+        self.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            self,
+            text=title,
+            anchor="w",
+            font=ctk.CTkFont(size=16, weight="bold"),
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+        ).grid(row=0, column=0, sticky="ew", padx=18, pady=(16, 2))
+
+        if description:
+            ctk.CTkLabel(
+                self,
+                text=description,
+                anchor="w",
+                justify="left",
+                wraplength=620,
+                text_color=ARC_EDITOR_PALETTE.text_secondary,
+            ).grid(row=1, column=0, sticky="ew", padx=18, pady=(0, 12))
+            self.content_row = 2
+        else:
+            self.content_row = 1
+
+        self.body = ctk.CTkFrame(self, fg_color="transparent")
+        self.body.grid(row=self.content_row, column=0, sticky="nsew", padx=18, pady=(0, 18))
+        self.body.grid_columnconfigure(0, weight=1)

--- a/modules/campaigns/ui/widgets/scenario_multi_selector.py
+++ b/modules/campaigns/ui/widgets/scenario_multi_selector.py
@@ -1,69 +1,205 @@
 from __future__ import annotations
 
-import tkinter as tk
-
 import customtkinter as ctk
+
+from modules.campaigns.ui.theme import ARC_EDITOR_PALETTE
 
 
 class ScenarioMultiSelector(ctk.CTkFrame):
-    """Searchable multi-select list used to link scenarios to a campaign arc."""
+    """Searchable multi-select control with quick actions and visible selected chips."""
 
     def __init__(self, master, scenarios: list[str], *, label: str = "Scenarios"):
-        super().__init__(master)
+        super().__init__(master, fg_color="transparent")
         self.grid_columnconfigure(0, weight=1)
 
-        ctk.CTkLabel(self, text=label).grid(row=0, column=0, sticky="w", pady=(0, 4))
+        self._all_scenarios = list(scenarios or [])
+        self._selected_scenarios: set[str] = set()
+        self._scenario_vars: dict[str, ctk.StringVar] = {}
+        self._scenario_checks: list[tuple[str, ctk.CTkCheckBox]] = []
+
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.grid(row=0, column=0, sticky="ew", pady=(0, 8))
+        header.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            header,
+            text=label,
+            anchor="w",
+            font=ctk.CTkFont(size=15, weight="bold"),
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+        ).grid(row=0, column=0, sticky="w")
+
+        self.selection_count_label = ctk.CTkLabel(
+            header,
+            text="0 selected",
+            anchor="e",
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        )
+        self.selection_count_label.grid(row=0, column=1, sticky="e")
 
         self.search_var = ctk.StringVar(value="")
-        self.search_entry = ctk.CTkEntry(self, textvariable=self.search_var, placeholder_text="Search scenarios...")
-        self.search_entry.grid(row=1, column=0, sticky="ew", pady=(0, 4))
+        search_row = ctk.CTkFrame(self, fg_color="transparent")
+        search_row.grid(row=1, column=0, sticky="ew", pady=(0, 10))
+        search_row.grid_columnconfigure(0, weight=1)
+
+        self.search_entry = ctk.CTkEntry(
+            search_row,
+            textvariable=self.search_var,
+            placeholder_text="Search by scenario title, location, or hook...",
+            height=38,
+            corner_radius=14,
+            fg_color=ARC_EDITOR_PALETTE.surface_alt,
+            border_color=ARC_EDITOR_PALETTE.border,
+            text_color=ARC_EDITOR_PALETTE.text_primary,
+        )
+        self.search_entry.grid(row=0, column=0, sticky="ew", padx=(0, 8))
         self.search_entry.bind("<KeyRelease>", self._on_search)
 
-        self.listbox = tk.Listbox(self, selectmode=tk.MULTIPLE, exportselection=False, height=8)
-        self.listbox.grid(row=2, column=0, sticky="ew")
+        ctk.CTkButton(
+            search_row,
+            text="Select visible",
+            width=118,
+            fg_color=ARC_EDITOR_PALETTE.accent_soft,
+            hover_color=ARC_EDITOR_PALETTE.chip_border,
+            command=self._select_visible,
+        ).grid(row=0, column=1, padx=(0, 6))
 
-        self._all_scenarios = list(scenarios or [])
-        self._visible_scenarios: list[str] = []
-        self._selected_scenarios: set[str] = set()
-        self._refresh_list()
+        ctk.CTkButton(
+            search_row,
+            text="Clear",
+            width=86,
+            fg_color=ARC_EDITOR_PALETTE.danger,
+            hover_color=ARC_EDITOR_PALETTE.danger_hover,
+            command=self._clear_selection,
+        ).grid(row=0, column=2)
+
+        self.selected_chips = ctk.CTkFrame(
+            self,
+            fg_color=ARC_EDITOR_PALETTE.surface_alt,
+            corner_radius=16,
+            border_width=1,
+            border_color=ARC_EDITOR_PALETTE.border,
+        )
+        self.selected_chips.grid(row=2, column=0, sticky="ew", pady=(0, 10))
+        self.selected_chips.grid_columnconfigure(0, weight=1)
+
+        self.selected_summary_label = ctk.CTkLabel(
+            self.selected_chips,
+            text="No scenarios linked yet. Pick the chapters that move this arc forward.",
+            anchor="w",
+            justify="left",
+            wraplength=620,
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+        )
+        self.selected_summary_label.grid(row=0, column=0, sticky="ew", padx=14, pady=12)
+
+        self.results_scroll = ctk.CTkScrollableFrame(
+            self,
+            height=280,
+            fg_color=ARC_EDITOR_PALETTE.surface_alt,
+            corner_radius=16,
+            border_width=1,
+            border_color=ARC_EDITOR_PALETTE.border,
+        )
+        self.results_scroll.grid(row=3, column=0, sticky="ew")
+        self.results_scroll.grid_columnconfigure(0, weight=1)
+
+        self.empty_results_label = ctk.CTkLabel(
+            self,
+            text="No scenarios match this filter.",
+            text_color=ARC_EDITOR_PALETTE.text_secondary,
+            anchor="w",
+        )
+
+        self._build_scenario_list()
+        self._filter_visible_scenarios()
+        self._refresh_selected_summary()
 
     def set_values(self, values: list[str]):
-        self._selected_scenarios = {
-            str(value).strip() for value in (values or []) if str(value).strip()
-        }
-        self._apply_selection()
+        self._selected_scenarios = {str(value).strip() for value in (values or []) if str(value).strip()}
+        self._sync_checkboxes()
+        self._refresh_selected_summary()
 
     def get_values(self) -> list[str]:
-        self._capture_current_selection()
         return [name for name in self._all_scenarios if name in self._selected_scenarios]
 
-    def _on_search(self, _event=None):
-        self._capture_current_selection()
-        self._refresh_list(query=self.search_var.get().strip())
+    def _build_scenario_list(self) -> None:
+        for widget in self.results_scroll.winfo_children():
+            widget.destroy()
+        self._scenario_checks.clear()
 
-    def _capture_current_selection(self):
-        visible_set = set(self._visible_scenarios)
-        self._selected_scenarios.difference_update(visible_set)
-        for index in self.listbox.curselection():
-            if 0 <= index < len(self._visible_scenarios):
-                self._selected_scenarios.add(self._visible_scenarios[index])
+        for row, scenario in enumerate(self._all_scenarios):
+            var = ctk.StringVar(value="on" if scenario in self._selected_scenarios else "off")
+            check = ctk.CTkCheckBox(
+                self.results_scroll,
+                text=scenario,
+                variable=var,
+                onvalue="on",
+                offvalue="off",
+                corner_radius=8,
+                fg_color=ARC_EDITOR_PALETTE.accent,
+                hover_color=ARC_EDITOR_PALETTE.accent,
+                border_color=ARC_EDITOR_PALETTE.border,
+                text_color=ARC_EDITOR_PALETTE.text_primary,
+                command=lambda name=scenario: self._toggle_scenario(name),
+            )
+            check.grid(row=row, column=0, sticky="ew", padx=10, pady=6)
+            self._scenario_vars[scenario] = var
+            self._scenario_checks.append((scenario, check))
 
-    def _refresh_list(self, query: str = ""):
-        lowered = query.lower()
-        if lowered:
-            self._visible_scenarios = [
-                scenario for scenario in self._all_scenarios if lowered in scenario.lower()
-            ]
+    def _on_search(self, _event=None) -> None:
+        self._filter_visible_scenarios()
+
+    def _filter_visible_scenarios(self) -> None:
+        query = self.search_var.get().strip().lower()
+        any_visible = False
+        for row, (scenario, check) in enumerate(self._scenario_checks):
+            visible = not query or query in scenario.lower()
+            if visible:
+                check.grid(row=row, column=0, sticky="ew", padx=10, pady=6)
+                any_visible = True
+            else:
+                check.grid_remove()
+
+        if any_visible:
+            self.empty_results_label.grid_remove()
         else:
-            self._visible_scenarios = list(self._all_scenarios)
+            self.empty_results_label.grid(row=4, column=0, sticky="ew", pady=(8, 0))
 
-        self.listbox.delete(0, tk.END)
-        for scenario in self._visible_scenarios:
-            self.listbox.insert(tk.END, scenario)
-        self._apply_selection()
+    def _toggle_scenario(self, scenario: str) -> None:
+        if self._scenario_vars[scenario].get() == "on":
+            self._selected_scenarios.add(scenario)
+        else:
+            self._selected_scenarios.discard(scenario)
+        self._refresh_selected_summary()
 
-    def _apply_selection(self):
-        self.listbox.selection_clear(0, tk.END)
-        for index, scenario in enumerate(self._visible_scenarios):
-            if scenario in self._selected_scenarios:
-                self.listbox.selection_set(index)
+    def _select_visible(self) -> None:
+        query = self.search_var.get().strip().lower()
+        for scenario, _check in self._scenario_checks:
+            if not query or query in scenario.lower():
+                self._selected_scenarios.add(scenario)
+        self._sync_checkboxes()
+        self._refresh_selected_summary()
+
+    def _clear_selection(self) -> None:
+        self._selected_scenarios.clear()
+        self._sync_checkboxes()
+        self._refresh_selected_summary()
+
+    def _sync_checkboxes(self) -> None:
+        for scenario, var in self._scenario_vars.items():
+            var.set("on" if scenario in self._selected_scenarios else "off")
+
+    def _refresh_selected_summary(self) -> None:
+        selected = [name for name in self._all_scenarios if name in self._selected_scenarios]
+        self.selection_count_label.configure(text=f"{len(selected)} selected")
+        if not selected:
+            self.selected_summary_label.configure(
+                text="No scenarios linked yet. Pick the chapters that move this arc forward."
+            )
+            return
+
+        preview = "  •  ".join(selected[:4])
+        if len(selected) > 4:
+            preview += f"  •  +{len(selected) - 4} more"
+        self.selected_summary_label.configure(text=preview)


### PR DESCRIPTION
### Motivation
- Improve the campaign arc editor to feel more modern, readable, and helpful for story-first workflows. 
- Introduce a clearer visual hierarchy, contextual guidance, and richer selection controls so building an arc is faster and less error-prone. 
- Split the UI into smaller files and a theme token module to make the code architecture easier to maintain and extend.

### Description
- Replace the old dialog with a redesigned `ArcEditorDialog` that adds a hero header, card-style `FormSection`s, improved spacing/typography, status hinting, and a clearer footer with action buttons. 
- Replace the simple listbox with a new `ScenarioMultiSelector` that supports search, `Select visible`, `Clear`, checkbox-based batch selection, and a live selection summary. 
- Centralize colors and copy into `modules/campaigns/ui/theme/arc_editor_tokens.py` and expose them via `modules/campaigns/ui/theme/__init__.py`. 
- Add a reusable `FormSection` widget at `modules/campaigns/ui/widgets/form_section.py` and export it from the widgets package, and update `modules/campaigns/ui/widgets/scenario_multi_selector.py` and `modules/campaigns/ui/arc_editor_dialog.py` to use the new components.

### Testing
- Ran Python byte-compile on the modified modules with `python -m py_compile modules/campaigns/ui/arc_editor_dialog.py modules/campaigns/ui/widgets/scenario_multi_selector.py modules/campaigns/ui/widgets/form_section.py modules/campaigns/ui/theme/arc_editor_tokens.py modules/campaigns/ui/theme/__init__.py modules/campaigns/ui/widgets/__init__.py`, which succeeded. 
- Attempted a lightweight runtime smoke test that would import `ArcEditorDialog` and instantiate the dialog, but it could not run because `customtkinter` is not installed in the environment. 
- No automated visual screenshot test was run due to the environment limitations for UI rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda4c320a4832b842f4032a14554d6)