### PR TITLE
Fix scenario tab border colors

### DIFF
--- a/modules/ui/vertical_section_tabs.py
+++ b/modules/ui/vertical_section_tabs.py
@@ -40,6 +40,8 @@ class VerticalSectionTabs(ctk.CTkFrame):
         self._button_container = ctk.CTkFrame(self, fg_color="transparent")
         self._button_container.pack(fill="both", expand=True, padx=8, pady=(0, 8))
 
+        self._inactive_border_color = palette["surface_card"]
+
         for section in sections:
             button = ctk.CTkButton(
                 self._button_container,
@@ -52,7 +54,7 @@ class VerticalSectionTabs(ctk.CTkFrame):
                 corner_radius=14,
                 height=38,
                 border_width=1,
-                border_color="transparent",
+                border_color=self._inactive_border_color,
                 command=lambda name=section: self._on_select(name),
             )
             button.bind("<Button-3>", lambda event, name=section: self._on_pin_toggle(name))
@@ -89,7 +91,7 @@ class VerticalSectionTabs(ctk.CTkFrame):
             button.configure(
                 font=self._font_bold if is_active else self._font_normal,
                 fg_color=self._palette["surface_overlay"] if is_active else "transparent",
-                border_color=self._palette["pill_border"] if is_active else "transparent",
+                border_color=self._palette["pill_border"] if is_active else self._inactive_border_color,
                 text_color=self._palette["text"] if is_active else self._palette["muted_text"],
             )
             self._resize_button(name)


### PR DESCRIPTION
### Motivation
- Prevent a CustomTkinter `ValueError: transparency is not allowed for this attribute` raised when creating `CTkButton` with a `border_color` set to `"transparent"`.

### Description
- Introduce `self._inactive_border_color = palette["surface_card"]` in `VerticalSectionTabs` and use it for inactive button borders instead of the literal `"transparent"` value.
- Use the palette `pill_border` for active tabs while reusing the new inactive color for non-active tabs to preserve visual behavior.
- Keep existing layout, fonts, sizing logic, and pin/selection behavior unchanged.

### Testing
- Ran `python -m py_compile modules/ui/vertical_section_tabs.py` and it succeeded.
- Ran `pytest -q`; test collection failed with unrelated pre-existing repository issues (missing `requests`, PIL import problems, and multiple import/circular-import errors), so full test-suite verification is blocked but the patched file compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17f3731fc832bada1a5b62569f209)