### PR TITLE
fix(audio): sync audio bar track list with category and mood filters

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -366,18 +366,13 @@ class AudioBarWindow(ctk.CTkToplevel):
         if not resolved_category:
             return
 
-        mood_values = moods or ["No mood"]
+        mood_values = ["No mood", *moods] if moods else ["No mood"]
         self._syncing_filters = True
         try:
             self.mood_menu.configure(values=mood_values)
-            if moods:
-                default_mood = resolved_mood or moods[0]
-                self.mood_var.set(default_mood)
-                self.mood_menu.configure(state="normal")
-            else:
-                default_mood = None
-                self.mood_var.set("No mood")
-                self.mood_menu.configure(state="disabled")
+            default_mood = resolved_mood or "No mood"
+            self.mood_var.set(default_mood)
+            self.mood_menu.configure(state="normal")
         finally:
             self._syncing_filters = False
 
@@ -644,13 +639,13 @@ class AudioBarWindow(ctk.CTkToplevel):
         self._syncing_filters = True
         try:
             category_values = options.categories or ["No category"]
-            mood_values = options.moods or ["No mood"]
+            mood_values = ["No mood", *options.moods] if options.moods else ["No mood"]
             self.category_menu.configure(values=category_values)
             self.mood_menu.configure(values=mood_values)
             self.category_var.set(options.category or "No category")
             self.mood_var.set(options.mood or "No mood")
             self.category_menu.configure(state="normal" if options.categories else "disabled")
-            self.mood_menu.configure(state="normal" if options.moods else "disabled")
+            self.mood_menu.configure(state="normal" if options.category else "disabled")
         finally:
             self._syncing_filters = False
 

--- a/modules/audio/ui/audio_bar_filters.py
+++ b/modules/audio/ui/audio_bar_filters.py
@@ -22,7 +22,7 @@ def build_audio_bar_filter_options(
     categories = list(_safe_list_categories(library, section))
     category = _pick_value(categories, preferred_category)
     moods = list(_safe_list_moods(library, section, category)) if category else []
-    mood = _pick_value(moods, preferred_mood)
+    mood = preferred_mood if preferred_mood in moods else ""
     return AudioBarFilterOptions(
         categories=categories,
         moods=moods,


### PR DESCRIPTION
### Motivation
- The audio bar kept only the currently playing track in the dropdown after changing category or mood, preventing users from browsing the proper list for the selected filters.
- Users need an explicit “show all” mood state so changing category or mood shows the expected playlist rather than collapsing to a single track.

### Description
- Updated `build_audio_bar_filter_options` in `modules/audio/ui/audio_bar_filters.py` to keep the `preferred_mood` only when it exists in the target category instead of auto-forcing the first mood.
- Changed the category selection flow in `modules/audio/audio_bar_window.py` to always include a "No mood" option at the top of the mood dropdown and to set the default mood to `resolved_mood` or `"No mood"` when the category changes.
- Adjusted filter menu refresh logic to present moods as `['No mood', *moods]` and enable the mood dropdown whenever a category is selected to avoid disabled/stale single-item dropdowns.
- Ensured `No mood` maps to showing all tracks for the current category by translating that value to `None` when building the playlist request.

### Testing
- Ran `python -m compileall modules/audio/audio_bar_window.py modules/audio/ui/audio_bar_filters.py` and compilation succeeded without errors.
- Ran `pytest -q modules/audio` and no tests were discovered in that path (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c96d75bc832ba59f92f6251175af)