### PR TITLE
Fix scenario detail scroll host layout in GM tabs

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -1277,7 +1277,8 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
     content_frame.grid_rowconfigure(0, weight=1)
     content_frame.grid_columnconfigure(0, weight=1)
 
-    scrollable_frame = build_scroll_host(content_frame)
+    scrollable_frame = ctk.CTkScrollableFrame(content_frame, fg_color="transparent")
+    scrollable_frame.grid(row=0, column=0, sticky="nsew")
     frame._scrollable_frame = scrollable_frame
     for attr in ("_parent_canvas", "_scroll_canvas", "_scrollbar"):
         try:


### PR DESCRIPTION
### Motivation
- Restore correct vertical layout for scenario detail tabs in the GM screen after a previous change to a shared scroll host produced a large empty space at the top.

### Description
- Replace `build_scroll_host(content_frame)` with a `CTkScrollableFrame` placed via `grid` inside `create_scenario_detail_frame`, and preserve the `_scrollable_frame`, `_parent_canvas`, `_scroll_canvas`, and `_scrollbar` wiring so tab-level scroll/reset logic remains functional (changed file: `modules/generic/entity_detail_factory.py`).

### Testing
- Ran `python -m py_compile modules/generic/entity_detail_factory.py modules/scenarios/gm_screen_view.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54bd138b0832bb1b62efe127821b9)