### PR TITLE
Keep AI Run window frontmost without stealing focus

### DIFF
--- a/modules/ui/windows/ai_run_window/ai_run_window.py
+++ b/modules/ui/windows/ai_run_window/ai_run_window.py
@@ -32,6 +32,7 @@ class AIRunWindow(ctk.CTkToplevel):
 
         ctk.CTkButton(self, text="Close", command=self._on_close).pack(anchor="e", padx=16, pady=(0, 12))
         self.protocol("WM_DELETE_WINDOW", self._on_close)
+        self.transient(master)
         position_window_at_top(self)
 
     def _on_close(self):
@@ -42,7 +43,8 @@ class AIRunWindow(ctk.CTkToplevel):
     def show(self) -> None:
         self.deiconify()
         self.lift()
-        self.focus_force()
+        self.attributes("-topmost", True)
+        self.after_idle(lambda: self.attributes("-topmost", False))
 
     def render(self, state: AIRequestState) -> None:
         self.title(AIRunWindowViewModel.title(state))


### PR DESCRIPTION
### Motivation
- Ensure the AI Run panel appears in front of the current window when opened while remaining non-modal and not stealing the user's input focus.

### Description
- Register the `AIRunWindow` as `transient(master)` and change `show()` to pulse `-topmost` (`self.attributes("-topmost", True)` then `after_idle` to clear it) instead of calling `focus_force()`, so the window is brought to front without permanently staying on top or stealing focus.

### Testing
- `python -m py_compile modules/ui/windows/ai_run_window/ai_run_window.py` ran successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8f2579284832b851e19d2e1674882)