### PR TITLE
Split scene planning into guided and canvas planners and refactor ScenesPlanningStep

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -22,14 +22,20 @@ from modules.helpers.logging_helper import log_module_import, log_info, log_exce
 from modules.helpers.template_loader import load_template, load_entity_definitions
 from modules.helpers.text_helpers import coerce_text
 from modules.scenarios.scene_flow_components import (
-    SceneCanvas,
     SceneFlowPreview,
-    normalise_scene_links,
 )
 from modules.scenarios.scenario_character_graph import (
     ScenarioCharacterGraphEditor,
     build_scenario_graph_with_links,
     sync_scenario_graph_to_global,
+)
+from modules.scenarios.wizard_steps.scenes.canvas_scene_planner import CanvasScenePlanner
+from modules.scenarios.wizard_steps.scenes.guided_scene_planner import GuidedScenePlanner
+from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import (
+    canonicalise_scene,
+    guided_cards_to_scenes,
+    normalise_scene_links,
+    scenes_to_guided_cards,
 )
 
 try:
@@ -194,24 +200,12 @@ class BasicInfoStep(WizardStep):
 
 class ScenesPlanningStep(WizardStep):
     ENTITY_FIELDS = {
-        "NPCs": ("npcs", "Key NPCs", "NPC"),
-        "Creatures": ("creatures", "Creatures / Foes", "Creature"),
-        "Bases": ("bases", "Bases / Domains", "Base"),
-        "Places": ("places", "Locations / Places", "Place"),
-        "Maps": ("maps", "Maps & Handouts", "Map"),
+        "NPCs": ("npcs", "NPC"),
+        "Creatures": ("creatures", "Creature"),
+        "Bases": ("bases", "Base"),
+        "Places": ("places", "Place"),
+        "Maps": ("maps", "Map"),
     }
-
-    SCENE_TYPES = [
-        "Auto",
-        "Setup",
-        "Choice",
-        "Investigation",
-        "Combat",
-        "Outcome",
-        "Social",
-        "Travel",
-        "Downtime",
-    ]
 
     ROOT_KNOWN_FIELDS = {
         "Title",
@@ -230,701 +224,134 @@ class ScenesPlanningStep(WizardStep):
         "Objects",
     }
 
-    SCENE_KNOWN_FIELDS = {
-        "Title",
-        "Summary",
-        "SceneSummary",
-        "Text",
-        "SceneText",
-        "Description",
-        "Body",
-        "Details",
-        "SceneDetails",
-        "Notes",
-        "Content",
-        "Synopsis",
-        "Overview",
-        "SceneType",
-        "Type",
-        "NPCs",
-        "Creatures",
-        "Bases",
-        "Places",
-        "Maps",
-        "NextScenes",
-        "Links",
-        "LinkData",
-        "_canvas",
-        "_extra_fields",
-    }
-
-    def __init__(
-        self,
-        master,
-        entity_wrappers,
-        *,
-        scenario_wrapper=None,
-        finale_planner_callback=None,
-    ):
+    def __init__(self, master, entity_wrappers, *, scenario_wrapper=None, finale_planner_callback=None):
         super().__init__(master)
         self.entity_wrappers = entity_wrappers or {}
         self.scenario_wrapper = scenario_wrapper
-        self.scenes = []
-        self.selected_index = None
-        self._scenario_summary = ""
-        self._scenario_secrets = ""
-        self._inline_editor = None
-        self._link_label_editor = None
         self._state_ref = None
         self._on_state_change = None
         self._finale_planner_callback = finale_planner_callback
+        self._scenario_summary = ""
+        self._scenario_secrets = ""
         self._root_extra_fields = {}
-
         self.scenario_title_var = ctk.StringVar()
+        self.mode_var = ctk.StringVar(value="guided")
+        available_types = [field for field, (slug, _label) in self.ENTITY_FIELDS.items() if slug in self.entity_wrappers]
+        self._available_entity_types = available_types if available_types else list(self.ENTITY_FIELDS.keys())
 
         root = ctk.CTkFrame(self, fg_color="transparent")
         root.pack(fill="both", expand=True)
-        root.grid_rowconfigure(1, weight=1)
+        root.grid_rowconfigure(2, weight=1)
         root.grid_columnconfigure(0, weight=1)
-
-        available_types = [
-            field
-            for field, (slug, _, _) in self.ENTITY_FIELDS.items()
-            if slug in self.entity_wrappers
-        ]
-        if not available_types:
-            available_types = list(self.ENTITY_FIELDS.keys())
-        self._available_entity_types = available_types
 
         toolbar = ctk.CTkFrame(root, fg_color="#101827", corner_radius=14)
         toolbar.grid(row=0, column=0, sticky="ew", padx=12, pady=(12, 6))
         toolbar.grid_columnconfigure(0, weight=1)
-        ctk.CTkLabel(toolbar, text="Scenario Title", font=ctk.CTkFont(size=15, weight="bold")).grid(
-            row=0, column=0, sticky="w", padx=16, pady=(12, 4)
-        )
-        self.scenario_title_entry = ctk.CTkEntry(
-            toolbar, textvariable=self.scenario_title_var, font=ctk.CTkFont(size=18, weight="bold")
-        )
+        ctk.CTkLabel(toolbar, text="Scenario Title", font=ctk.CTkFont(size=15, weight="bold")).grid(row=0, column=0, sticky="w", padx=16, pady=(12, 4))
+        self.scenario_title_entry = ctk.CTkEntry(toolbar, textvariable=self.scenario_title_var, font=ctk.CTkFont(size=18, weight="bold"))
         self.scenario_title_entry.grid(row=1, column=0, sticky="ew", padx=16)
 
         btn_row = ctk.CTkFrame(toolbar, fg_color="transparent")
         btn_row.grid(row=1, column=1, padx=16, pady=(0, 12))
-        self.load_scenario_btn = ctk.CTkButton(
-            btn_row, text="Load Scenario", command=self._load_existing_scenario
-        )
+        self.load_scenario_btn = ctk.CTkButton(btn_row, text="Load Scenario", command=self._load_existing_scenario)
         self.load_scenario_btn.pack(side="left")
         if self._finale_planner_callback:
-            self.finale_planner_btn = ctk.CTkButton(
-                btn_row,
-                text="Epic Finale Planner",
-                command=self._switch_to_epic_finale_planner,
-            )
+            self.finale_planner_btn = ctk.CTkButton(btn_row, text="Epic Finale Planner", command=self._switch_to_epic_finale_planner)
             self.finale_planner_btn.pack(side="left", padx=(6, 0))
         self.notes_btn = ctk.CTkButton(btn_row, text="Edit Notes", command=self._edit_scenario_info)
         self.notes_btn.pack(side="left", padx=(6, 0))
-        self.add_scene_btn = ctk.CTkButton(btn_row, text="Add Scene", command=self.add_scene)
-        self.add_scene_btn.pack(side="left", padx=(6, 0))
-        self.dup_scene_btn = ctk.CTkButton(btn_row, text="Duplicate", command=self.duplicate_scene)
-        self.dup_scene_btn.pack(side="left", padx=6)
-        self.remove_scene_btn = ctk.CTkButton(btn_row, text="Remove", command=self.remove_scene)
-        self.remove_scene_btn.pack(side="left")
 
-        icon_hint = "/".join(
-            f"+{SceneCanvas.ICON_LABELS.get(field, field[:1].upper())}"
-            for field in self._available_entity_types
-            if SceneCanvas.ICON_LABELS.get(field)
-        )
-        if not icon_hint:
-            icon_hint = "+N/+C/+P"
-        ctk.CTkLabel(
-            toolbar,
-            text=(
-                "Double-click a scene to edit it inline, use the "
-                f"{icon_hint} icons to link entities, drag from the title bar to move, "
-                "or drag from the body to create scene links."
-            ),
-            text_color="#9db4d1",
-            wraplength=420,
-            justify="left",
-        ).grid(row=2, column=0, columnspan=2, sticky="w", padx=16, pady=(0, 10))
+        mode_row = ctk.CTkFrame(root, fg_color="transparent")
+        mode_row.grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 6))
+        ctk.CTkLabel(mode_row, text="Planning mode", text_color="#9db4d1").pack(side="left", padx=(2, 8))
+        self.mode_switch = ctk.CTkSegmentedButton(mode_row, values=["guided", "canvas"], variable=self.mode_var, command=self._on_mode_changed)
+        self.mode_switch.pack(side="left")
 
-        main = ctk.CTkFrame(root, fg_color="transparent")
-        main.grid(row=1, column=0, sticky="nsew", padx=12, pady=(0, 12))
-        main.grid_columnconfigure(0, weight=1)
-        main.grid_rowconfigure(0, weight=1)
-        self._main_frame = main
+        self._planner_holder = ctk.CTkFrame(root, fg_color="transparent")
+        self._planner_holder.grid(row=2, column=0, sticky="nsew", padx=12, pady=(0, 12))
+        self._planner_holder.grid_columnconfigure(0, weight=1)
+        self._planner_holder.grid_rowconfigure(0, weight=1)
 
-        self.canvas = SceneCanvas(
-            main,
-            on_select=self._on_canvas_select,
-            on_move=self._on_canvas_move,
-            on_edit=self._edit_scene_via_canvas,
-            on_context=self._show_canvas_menu,
+        self.guided_planner = GuidedScenePlanner(
+            self._planner_holder,
+            entity_fields=[(field, singular) for field, (_slug, singular) in self.ENTITY_FIELDS.items()],
             on_add_entity=self._add_entity_to_scene,
-            on_link=self._link_scenes_via_drag,
-            on_link_text_edit=self._start_link_label_edit,
-            available_entity_types=self._available_entity_types,
         )
-        self.canvas.grid(row=0, column=0, sticky="nsew")
+        self.canvas_planner = CanvasScenePlanner(
+            self._planner_holder,
+            available_entity_types=self._available_entity_types,
+            on_add_entity=self._add_entity_to_scene,
+        )
+        self._active_mode = None
+        self.scenes = []
+        self._set_mode("guided", remap=False)
 
     def set_state_binding(self, state, on_state_change=None):
         self._state_ref = state
         self._on_state_change = on_state_change
 
-    def _switch_to_epic_finale_planner(self):  # pragma: no cover - UI interaction
-        if not self._finale_planner_callback:
+    def _on_mode_changed(self, value):
+        self._set_mode(value, remap=True)
+
+    def _set_mode(self, mode, *, remap):
+        mode = "canvas" if str(mode).strip().lower() == "canvas" else "guided"
+        if self._active_mode == mode and remap:
             return
-        if self._state_ref is None:
-            messagebox.showerror(
-                "Unavailable",
-                "The finale planner cannot be opened until the wizard has initialised.",
-            )
+        current_scenes = self._collect_active_scenes() if remap else self.scenes
+        if mode == "guided":
+            self.guided_planner.grid(row=0, column=0, sticky="nsew")
+            self.canvas_planner.grid_forget()
+            cards = scenes_to_guided_cards(current_scenes)
+            self.guided_planner.load_cards(cards)
+            self.scenes = guided_cards_to_scenes(self.guided_planner.export_cards())
+        else:
+            self.canvas_planner.grid(row=0, column=0, sticky="nsew")
+            self.guided_planner.grid_forget()
+            scenes = guided_cards_to_scenes(self.guided_planner.export_cards()) if self._active_mode == "guided" and remap else current_scenes
+            self.canvas_planner.load_scenes(scenes)
+            self.scenes = self.canvas_planner.export_scenes()
+        self._active_mode = mode
+        self.mode_var.set(mode)
+
+    def _collect_active_scenes(self):
+        if self._active_mode == "guided":
+            return guided_cards_to_scenes(self.guided_planner.export_cards())
+        return self.canvas_planner.export_scenes()
+
+    def _switch_to_epic_finale_planner(self):
+        if not self._finale_planner_callback or self._state_ref is None:
             return
         if not self.save_state(self._state_ref):
             return
-        try:
-            payload = copy.deepcopy(self._state_ref)
-            self._finale_planner_callback(payload)
-        except Exception as exc:  # pragma: no cover - defensive path
-            log_exception(
-                f"Failed to switch to Epic Finale Planner: {exc}",
-                func_name="ScenesPlanningStep._switch_to_epic_finale_planner",
-            )
-            messagebox.showerror(
-                "Error",
-                "Unable to open the Epic Finale Planner from the wizard.",
-            )
-
-    def _get_scene_links(self, scene):
-        return normalise_scene_links(scene, self._split_to_list)
-
-    def _on_canvas_select(self, index):
-        if index is None or index >= len(self.scenes):
-            self.selected_index = None
-        else:
-            if (
-                self._inline_editor is not None
-                and getattr(self._inline_editor, "scene_index", None) != index
-            ):
-                self._close_inline_scene_editor()
-            self.selected_index = index
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, index)
-        self._update_buttons()
-
-    def _on_canvas_move(self, index, x, y):
-        if index is None or index >= len(self.scenes):
-            return
-        layout = self.scenes[index].setdefault("_canvas", {})
-        layout["x"] = x
-        layout["y"] = y
-
-    def _edit_scenario_info(self):
-        dialog = ScenarioInfoDialog(
-            self.winfo_toplevel(),
-            title=self.scenario_title_var.get().strip() or "Scenario Notes",
-            summary=self._scenario_summary,
-            secrets=self._scenario_secrets,
-        )
-        self.wait_window(dialog)
-        if dialog.result:
-            self._scenario_summary = dialog.result.get("summary", "")
-            self._scenario_secrets = dialog.result.get("secrets", "")
-
-    def _load_existing_scenario(self):  # pragma: no cover - UI interaction
-        if not self.scenario_wrapper:
-            messagebox.showerror("Unavailable", "No scenario library is available to load from.")
-            return
-
-        scenario_choice = self._choose_existing_scenario()
-        if not scenario_choice:
-            return
-
-        if isinstance(scenario_choice, dict):
-            self.load_from_payload(copy.deepcopy(scenario_choice))
-            return
-
-        scenario_name = str(scenario_choice).strip()
-        if not scenario_name:
-            return
-
-        try:
-            scenarios = self.scenario_wrapper.load_items()
-        except Exception as exc:  # pragma: no cover - defensive path
-            log_exception(
-                f"Failed to load scenarios: {exc}",
-                func_name="ScenesPlanningStep._load_existing_scenario",
-            )
-            messagebox.showerror("Load Error", "Unable to load scenarios from the database.")
-            return
-
-        normalized_choice = scenario_name.casefold()
-        match = None
-        for entry in scenarios or []:
-            title = str(entry.get("Title") or entry.get("Name") or "").strip()
-            if title and title.casefold() == normalized_choice:
-                match = entry
-                break
-
-        if not match:
-            messagebox.showerror("Not Found", f"Scenario '{scenario_name}' was not found.")
-            return
-
-        self.load_from_payload(copy.deepcopy(match))
-
-    def _choose_existing_scenario(self):  # pragma: no cover - UI interaction
-        try:
-            template = load_template("scenarios")
-        except Exception as exc:
-            log_exception(
-                f"Failed to load scenario template: {exc}",
-                func_name="ScenesPlanningStep._choose_existing_scenario",
-            )
-            messagebox.showerror("Template Error", "Unable to load the scenario list.")
-            return None
-
-        dialog = ctk.CTkToplevel(self)
-        dialog.title("Select Scenario")
-        dialog.geometry("1100x720")
-        dialog.minsize(1100, 720)
-        result = {"name": None, "payload": None}
-
-        view = GenericListSelectionView(
-            dialog,
-            "scenarios",
-            self.scenario_wrapper,
-            template,
-            on_select_callback=lambda _et, name, item=None, win=dialog: (
-                result.__setitem__("name", name),
-                result.__setitem__("payload", copy.deepcopy(item) if isinstance(item, dict) else None),
-                win.destroy(),
-            ),
-        )
-        view.pack(fill="both", expand=True)
-        dialog.transient(self.winfo_toplevel())
-        dialog.grab_set()
-        self.wait_window(dialog)
-        return result["payload"] if result["payload"] is not None else result["name"]
-
-    def load_from_payload(self, scenario):  # pragma: no cover - UI synchronization
-        if not isinstance(scenario, dict):
-            return
-        self._apply_loaded_scenario(copy.deepcopy(scenario))
-
-    def _apply_loaded_scenario(self, scenario):
-        title = scenario.get("Title") or scenario.get("Name") or ""
-        summary = coerce_text(scenario.get("Summary"))
-        if not summary:
-            summary = coerce_text(scenario.get("Text"))
-        secrets = coerce_text(scenario.get("Secrets"))
-        if not secrets:
-            secrets = coerce_text(scenario.get("Secret"))
-
-        self.scenario_title_var.set(str(title))
-        self._scenario_summary = str(summary)
-        self._scenario_secrets = str(secrets)
-
-        scenes_payload = scenario.get("Scenes")
-        self.scenes = self._coerce_scenes(copy.deepcopy(scenes_payload))
-        layout = scenario.get("_SceneLayout")
-        if isinstance(layout, list):
-            for idx, scene in enumerate(self.scenes):
-                if idx < len(layout) and isinstance(layout[idx], dict):
-                    scene.setdefault("_canvas", {}).update(layout[idx])
-
-        self.selected_index = 0 if self.scenes else None
-        self._close_inline_scene_editor()
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-        self._update_buttons()
-
-        if self._state_ref is None:
-            return
-
-        self._state_ref["Title"] = str(title)
-        self._state_ref["Summary"] = summary
-        self._state_ref["Secrets"] = secrets
-        self._state_ref["Secret"] = secrets
-
-        # Replace the character graph with the one from the loaded scenario (or reset).
-        graph_payload = scenario.get("ScenarioCharacterGraph") or {"nodes": [], "links": [], "shapes": []}
-        try:
-            graph_payload = copy.deepcopy(graph_payload)
-        except Exception:
-            graph_payload = {"nodes": [], "links": [], "shapes": []}
-        self._state_ref["ScenarioCharacterGraph"] = graph_payload
-        self._state_ref["ScenarioCharacterGraphSync"] = bool(
-            scenario.get("ScenarioCharacterGraphSync")
-        )
-
-        if isinstance(layout, list):
-            self._state_ref["_SceneLayout"] = copy.deepcopy(layout)
-        else:
-            self._state_ref["_SceneLayout"] = []
-
-        for field in SCENARIO_ENTITY_FIELD_NAMES:
-            values = scenario.get(field) or []
-            if isinstance(values, str):
-                values = self._split_to_list(values)
-            elif isinstance(values, list):
-                values = [str(item).strip() for item in values if str(item).strip()]
-            elif values:
-                values = [str(values).strip()]
-            else:
-                values = []
-            self._state_ref[field] = list(dict.fromkeys(values))
-
-        self._root_extra_fields = {
-            key: copy.deepcopy(value)
-            for key, value in scenario.items()
-            if key not in self.ROOT_KNOWN_FIELDS
-        }
-
-        self.save_state(self._state_ref)
-        if callable(self._on_state_change):
-            try:
-                self._on_state_change(source=self)
-            except TypeError:
-                self._on_state_change()
-
-    def _edit_scene_via_canvas(self, index):
-        if index is None or index >= len(self.scenes):
-            return
-        self._open_inline_scene_editor(index)
-
-    def _open_inline_scene_editor(self, index):
-        bbox = self.canvas.get_card_bbox(index)
-        if not bbox:
-            return
-        self._close_inline_scene_editor()
-        self._close_link_label_editor()
-        scene = self.scenes[index]
-        x1, y1, x2, y2 = bbox
-        width = max(120, (x2 - x1) - 16)
-        height = max(120, (y2 - y1) - 16)
-        editor = InlineSceneEditor(
-            self.canvas,
-            scene,
-            scene_types=self.SCENE_TYPES,
-            on_save=lambda data, idx=index: self._apply_inline_scene_update(idx, data),
-            on_cancel=self._close_inline_scene_editor,
-            width=width,
-            height=height,
-        )
-        editor.scene_index = index
-        editor.place(
-            x=x1 + 8,
-            y=y1 + 8,
-        )
-        self._inline_editor = editor
-
-    def _close_inline_scene_editor(self):
-        if self._inline_editor is None:
-            return
-        try:
-            self._inline_editor.destroy()
-        except Exception:
-            pass
-        self._inline_editor = None
-
-    def _apply_inline_scene_update(self, index, data):
-        if index is None or index >= len(self.scenes):
-            return
-        scene = self.scenes[index]
-        scene["Title"] = data.get("Title", scene.get("Title", "")).strip() or scene.get(
-            "Title", f"Scene {index + 1}"
-        )
-        scene["SceneType"] = data.get("SceneType", "")
-        summary = data.get("Summary", "")
-        scene["Summary"] = summary
-        scene["Text"] = summary
-        self._close_inline_scene_editor()
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-        self._update_buttons()
-
-    def _show_canvas_menu(self, event, index):
-        if index is None:
-            self._show_background_menu(event)
-        else:
-            self._show_scene_menu(event, index)
-
-    def _show_background_menu(self, event):
-        menu = tk.Menu(self, tearoff=0)
-        menu.add_command(label="Add Scene", command=self.add_scene)
-        menu.add_command(label="Edit Scenario Notes", command=self._edit_scenario_info)
-        try:
-            menu.tk_popup(event.x_root, event.y_root)
-        finally:
-            menu.grab_release()
-
-    def _show_scene_menu(self, event, index):
-        self.selected_index = index
-        self.canvas.set_scenes(self.scenes, index)
-        self._update_buttons()
-
-        menu = tk.Menu(self, tearoff=0)
-        menu.add_command(
-            label="Edit Scene Inline",
-            command=lambda idx=index: self._open_inline_scene_editor(idx),
-        )
-        menu.add_separator()
-        menu.add_command(label="Duplicate Scene", command=lambda idx=index: self.duplicate_scene(idx))
-        menu.add_command(label="Remove Scene", command=lambda idx=index: self.remove_scene(idx))
-
-        menu.add_separator()
-        for field, (slug, _, singular_label) in self.ENTITY_FIELDS.items():
-            if slug in self.entity_wrappers:
-                menu.add_command(
-                    label=f"Create {singular_label}",
-                    command=lambda f=field, idx=index: self._create_entity_for_scene(idx, f),
-                )
-            else:
-                menu.add_command(label=f"Create {singular_label}", state="disabled")
-
-        menu.add_separator()
-        for field, (_, _, singular_label) in self.ENTITY_FIELDS.items():
-            entries = []
-            if 0 <= index < len(self.scenes):
-                bucket = self.scenes[index].get(field)
-                if isinstance(bucket, list):
-                    entries = [item for item in bucket if str(item).strip()]
-            if entries:
-                remove_menu = tk.Menu(menu, tearoff=0)
-                for name in entries:
-                    display = str(name).strip()
-                    if not display:
-                        display = f"(Unnamed {singular_label})"
-                    remove_menu.add_command(
-                        label=display,
-                        command=lambda value=name, idx=index, f=field: self._remove_entity_from_scene(idx, f, value),
-                    )
-                remove_menu.add_separator()
-                remove_menu.add_command(
-                    label="Clear All",
-                    command=lambda idx=index, f=field: self._clear_entities_from_scene(idx, f),
-                )
-                menu.add_cascade(label=f"Remove {singular_label}s", menu=remove_menu)
-            else:
-                menu.add_command(label=f"Remove {singular_label}s", state="disabled")
-
-        existing_links = self._get_scene_links(self.scenes[index])
-        if existing_links:
-            remove_menu = tk.Menu(menu, tearoff=0)
-            for link in existing_links:
-                target = link.get("target") or ""
-                label = link.get("text") or target
-                display = label if label == target else f"{label} → {target}"
-                remove_menu.add_command(
-                    label=display,
-                    command=lambda tgt=target, idx=index: self._remove_link_between(idx, tgt),
-                )
-            remove_menu.add_separator()
-            remove_menu.add_command(
-                label="Clear All", command=lambda idx=index: self._clear_links(idx)
-            )
-            menu.add_cascade(label="Remove Link", menu=remove_menu)
-        else:
-            menu.add_command(label="Remove Link", state="disabled")
-
-        try:
-            menu.tk_popup(event.x_root, event.y_root)
-        finally:
-            menu.grab_release()
-
-    def _add_link_between(self, source_index, target_title, label=None):
-        if source_index is None or source_index >= len(self.scenes):
-            return
-        scene = self.scenes[source_index]
-        links = self._get_scene_links(scene)
-        if any(link.get("target") == target_title for link in links):
-            return
-        display_label = (label or target_title).strip() or target_title
-        links.append({"target": target_title, "text": display_label})
-        scene["LinkData"] = links
-        scene["NextScenes"] = [link["target"] for link in links]
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _remove_link_between(self, source_index, target_title):
-        if source_index is None or source_index >= len(self.scenes):
-            return
-        scene = self.scenes[source_index]
-        links = [link for link in self._get_scene_links(scene) if link.get("target") != target_title]
-        scene["LinkData"] = links
-        scene["NextScenes"] = [link["target"] for link in links]
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _clear_links(self, source_index):
-        if source_index is None or source_index >= len(self.scenes):
-            return
-        scene = self.scenes[source_index]
-        scene["LinkData"] = []
-        scene["NextScenes"] = []
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _remove_entity_from_scene(self, scene_index, field, name):
-        if scene_index is None or scene_index >= len(self.scenes):
-            return
-        if field not in self.ENTITY_FIELDS:
-            return
-        scene = self.scenes[scene_index]
-        bucket = scene.get(field)
-        if not isinstance(bucket, list) or not bucket:
-            return
-        target = str(name).strip().lower()
-        filtered = [item for item in bucket if str(item).strip().lower() != target]
-        if len(filtered) == len(bucket):
-            return
-        scene[field] = filtered
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _clear_entities_from_scene(self, scene_index, field):
-        if scene_index is None or scene_index >= len(self.scenes):
-            return
-        if field not in self.ENTITY_FIELDS:
-            return
-        scene = self.scenes[scene_index]
-        if isinstance(scene.get(field), list) and scene.get(field):
-            scene[field] = []
-            self.canvas.set_scenes(self.scenes, self.selected_index)
+        payload = copy.deepcopy(self._state_ref)
+        self._finale_planner_callback(payload)
 
     def _add_entity_to_scene(self, scene_index, entity_type):
-        if scene_index is None or scene_index >= len(self.scenes):
-            return
-        config = self.ENTITY_FIELDS.get(entity_type)
-        if not config:
-            return
-        slug, _, singular_label = config
+        if scene_index is None:
+            return None
+        if scene_index < 0:
+            return None
+        if entity_type not in self.ENTITY_FIELDS:
+            return None
+        slug, singular_label = self.ENTITY_FIELDS[entity_type]
         selected = self._choose_entity_from_library(slug, singular_label)
         if not selected:
-            return
-        scene = self.scenes[scene_index]
-        bucket = scene.setdefault(entity_type, [])
+            return None
+        target_scenes = self._collect_active_scenes()
+        if scene_index >= len(target_scenes):
+            return None
+        scene = target_scenes[scene_index]
+        bucket = list(scene.get(entity_type) or [])
         if selected not in bucket:
             bucket.append(selected)
-            bucket.sort(key=lambda value: value.lower() if isinstance(value, str) else str(value))
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _create_entity_for_scene(self, scene_index, entity_type):
-        if scene_index is None or scene_index >= len(self.scenes):
-            return
-        config = self.ENTITY_FIELDS.get(entity_type)
-        if not config:
-            return
-        slug, _, singular_label = config
-        name = self._create_entity_in_library(slug, singular_label)
-        if not name:
-            return
-        scene = self.scenes[scene_index]
-        bucket = scene.setdefault(entity_type, [])
-        if name not in bucket:
-            bucket.append(name)
-            bucket.sort(key=lambda value: value.lower() if isinstance(value, str) else str(value))
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _link_scenes_via_drag(self, source_index, target_index):
-        if (
-            source_index is None
-            or target_index is None
-            or source_index >= len(self.scenes)
-            or target_index >= len(self.scenes)
-        ):
-            return
-        target_title = (
-            self.scenes[target_index].get("Title")
-            or self.scenes[target_index].get("Name")
-            or f"Scene {target_index + 1}"
-        )
-        self._add_link_between(source_index, target_title, label=target_title)
-
-    def _start_link_label_edit(self, source_index, target_index, target_value, bbox):
-        if source_index is None or source_index >= len(self.scenes):
-            return
-        scene = self.scenes[source_index]
-        links = self._get_scene_links(scene)
-        target_str = str(target_value)
-        link = next((l for l in links if str(l.get("target")) == target_str), None)
-        if link is None and target_index is not None and target_index < len(self.scenes):
-            fallback = self.scenes[target_index].get("Title") or f"Scene {target_index + 1}"
-            link = next((l for l in links if str(l.get("target")) == fallback), None)
-            target_str = fallback
-        if link is None:
-            return
-        self._close_link_label_editor()
-        x1, y1, x2, y2 = bbox
-        width = max(160, int(x2 - x1 + 24))
-        entry = ctk.CTkEntry(self.canvas, width=width, height=30)
-        entry.insert(0, link.get("text") or target_str)
-        entry.place(x=x1 - 12, y=y1 - 10)
-        entry.focus_set()
-        entry.select_range(0, "end")
-        state = {
-            "widget": entry,
-            "source": source_index,
-            "target": target_str,
-        }
-        self._link_label_editor = state
-
-        entry.bind("<Return>", lambda _e: self._commit_link_label_editor(save=True))
-        entry.bind("<Escape>", lambda _e: self._commit_link_label_editor(save=False))
-        entry.bind("<FocusOut>", lambda _e: self._commit_link_label_editor(save=True))
-
-    def _commit_link_label_editor(self, save=True):
-        if not self._link_label_editor:
-            return
-        state = self._link_label_editor
-        entry = state.get("widget")
-        if entry is None:
-            self._link_label_editor = None
-            return
-        try:
-            entry.unbind("<FocusOut>")
-        except Exception:
-            pass
-        text_value = ""
-        if save:
-            try:
-                text_value = entry.get().strip()
-            except Exception:
-                text_value = ""
-        try:
-            entry.destroy()
-        except Exception:
-            pass
-        self._link_label_editor = None
-        if not save:
-            self.canvas.set_scenes(self.scenes, self.selected_index)
-            return
-        if not text_value:
-            text_value = state.get("target", "")
-        source_index = state.get("source")
-        if source_index is None or source_index >= len(self.scenes):
-            self.canvas.set_scenes(self.scenes, self.selected_index)
-            return
-        scene = self.scenes[source_index]
-        links = self._get_scene_links(scene)
-        target_str = state.get("target")
-        for link in links:
-            if str(link.get("target")) == target_str:
-                link["text"] = text_value
-                break
-        scene["LinkData"] = links
-        scene["NextScenes"] = [link["target"] for link in links]
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-
-    def _close_link_label_editor(self):
-        if not self._link_label_editor:
-            return
-        entry = self._link_label_editor.get("widget")
-        self._link_label_editor = None
-        if entry is not None:
-            try:
-                entry.destroy()
-            except Exception:
-                pass
+            bucket.sort(key=lambda value: value.casefold())
+            scene[entity_type] = bucket
+        self.scenes = target_scenes
+        if self._active_mode == "guided":
+            self.guided_planner.load_cards(scenes_to_guided_cards(self.scenes))
+        else:
+            self.canvas_planner.load_scenes(self.scenes)
+        return selected
 
     def _choose_entity_from_library(self, entity_slug, singular_label):
         wrapper = self.entity_wrappers.get(entity_slug)
@@ -934,10 +361,7 @@ class ScenesPlanningStep(WizardStep):
         try:
             template = load_template(entity_slug)
         except Exception as exc:
-            log_exception(
-                f"Failed to load template for {entity_slug}: {exc}",
-                func_name="ScenesPlanningStep._choose_entity_from_library",
-            )
+            log_exception(f"Failed to load template for {entity_slug}: {exc}", func_name="ScenesPlanningStep._choose_entity_from_library")
             messagebox.showerror("Template Error", f"Unable to load {singular_label} list")
             return None
 
@@ -946,7 +370,6 @@ class ScenesPlanningStep(WizardStep):
         top.geometry("1100x720")
         top.minsize(1100, 720)
         result = {"name": None}
-
         view = GenericListSelectionView(
             top,
             entity_slug,
@@ -960,377 +383,137 @@ class ScenesPlanningStep(WizardStep):
         self.wait_window(top)
         return result["name"]
 
-    def _create_entity_in_library(self, entity_slug, singular_label):
-        wrapper = self.entity_wrappers.get(entity_slug)
-        if not wrapper:
-            messagebox.showerror("Unavailable", f"No {singular_label} data available for creation.")
-            return None
-        try:
-            template = load_template(entity_slug)
-        except Exception as exc:
-            log_exception(
-                f"Failed to load template for {entity_slug}: {exc}",
-                func_name="ScenesPlanningStep._create_entity_in_library",
-            )
-            messagebox.showerror("Template Error", f"Unable to load the {singular_label} template.")
-            return None
+    def _edit_scenario_info(self):
+        dialog = ScenarioInfoDialog(self.winfo_toplevel(), title=self.scenario_title_var.get().strip() or "Scenario Notes", summary=self._scenario_summary, secrets=self._scenario_secrets)
+        self.wait_window(dialog)
+        if dialog.result:
+            self._scenario_summary = dialog.result.get("summary", "")
+            self._scenario_secrets = dialog.result.get("secrets", "")
 
-        new_item = {}
-        editor = GenericEditorWindow(
-            self.winfo_toplevel(),
-            new_item,
-            template,
-            wrapper,
-            creation_mode=True,
-        )
-        self.wait_window(editor)
-        if not getattr(editor, "saved", False):
-            return None
-
-        try:
-            items = wrapper.load_items()
-        except Exception:
-            items = []
-        name = editor.item.get("Name") or editor.item.get("Title")
-        replaced = False
-        if name:
-            for idx, existing in enumerate(items):
-                existing_name = existing.get("Name") or existing.get("Title")
-                if existing_name and existing_name == name:
-                    items[idx] = editor.item
-                    replaced = True
-                    break
-        if not replaced:
-            items.append(editor.item)
-        try:
-            wrapper.save_items(items)
-        except Exception as exc:
-            log_exception(
-                f"Failed to save {entity_slug}: {exc}",
-                func_name="ScenesPlanningStep._create_entity_in_library",
-            )
-            messagebox.showerror("Save Error", f"Unable to save the new {singular_label}.")
-            return None
-        return name
-
-    def add_scene(self):
-        scene = {
-            "Title": f"Scene {len(self.scenes) + 1}",
-            "Summary": "",
-            "SceneType": "",
-            "NPCs": [],
-            "Creatures": [],
-            "Places": [],
-            "Maps": [],
-            "NextScenes": [],
-            "LinkData": [],
-        }
-        self._assign_default_position(scene)
-        self.scenes.append(scene)
-        self.selected_index = len(self.scenes) - 1
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-        self._update_buttons()
-
-    def duplicate_scene(self, index=None):
-        if index is None:
-            index = self.selected_index
-        if index is None or index >= len(self.scenes):
+    def _load_existing_scenario(self):
+        if not self.scenario_wrapper:
+            messagebox.showerror("Unavailable", "No scenario library is available to load from.")
             return
-        source = copy.deepcopy(self.scenes[index])
-        source.pop("_canvas", None)
-        dup = copy.deepcopy(source)
-        dup["Title"] = self._unique_title(source.get("Title") or "Scene")
-        dup["_canvas"] = {}
-        self._assign_default_position(dup)
-        insert_at = index + 1
-        self.scenes.insert(insert_at, dup)
-        self.selected_index = insert_at
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-        self._update_buttons()
-
-    def remove_scene(self, index=None):
-        if index is None:
-            index = self.selected_index
-        if index is None or index >= len(self.scenes):
+        scenario_choice = self._choose_existing_scenario()
+        if not scenario_choice:
             return
-        removed_scene = self.scenes.pop(index)
-        removed_title = (removed_scene.get("Title") or "").strip()
+        if isinstance(scenario_choice, dict):
+            self.load_from_payload(copy.deepcopy(scenario_choice))
+            return
+        scenario_name = str(scenario_choice).strip()
+        if not scenario_name:
+            return
+        scenarios = self.scenario_wrapper.load_items()
+        match = next((entry for entry in (scenarios or []) if str(entry.get("Title") or entry.get("Name") or "").strip().casefold() == scenario_name.casefold()), None)
+        if not match:
+            messagebox.showerror("Not Found", f"Scenario '{scenario_name}' was not found.")
+            return
+        self.load_from_payload(copy.deepcopy(match))
 
-        for scene in self.scenes:
-            links = self._get_scene_links(scene)
-            filtered = [link for link in links if link.get("target") != removed_title]
-            if len(filtered) != len(links):
-                scene["LinkData"] = filtered
-                scene["NextScenes"] = [link["target"] for link in filtered]
+    def _choose_existing_scenario(self):
+        template = load_template("scenarios")
+        dialog = ctk.CTkToplevel(self)
+        dialog.title("Select Scenario")
+        dialog.geometry("1100x720")
+        dialog.minsize(1100, 720)
+        result = {"name": None, "payload": None}
+        view = GenericListSelectionView(dialog, "scenarios", self.scenario_wrapper, template, on_select_callback=lambda _et, name, item=None, win=dialog: (result.__setitem__("name", name), result.__setitem__("payload", copy.deepcopy(item) if isinstance(item, dict) else None), win.destroy()))
+        view.pack(fill="both", expand=True)
+        dialog.transient(self.winfo_toplevel())
+        dialog.grab_set()
+        self.wait_window(dialog)
+        return result["payload"] if result["payload"] is not None else result["name"]
 
-        if not self.scenes:
-            self.selected_index = None
-        elif index >= len(self.scenes):
-            self.selected_index = len(self.scenes) - 1
-        else:
-            self.selected_index = index
+    def load_from_payload(self, scenario):
+        if not isinstance(scenario, dict):
+            return
+        self._apply_loaded_scenario(copy.deepcopy(scenario))
 
-        self.canvas.set_scenes(self.scenes, self.selected_index)
-        self._update_buttons()
+    def _apply_loaded_scenario(self, scenario):
+        title = scenario.get("Title") or scenario.get("Name") or ""
+        self.scenario_title_var.set(str(title))
+        self._scenario_summary = coerce_text(scenario.get("Summary") or scenario.get("Text"))
+        self._scenario_secrets = coerce_text(scenario.get("Secrets") or scenario.get("Secret"))
+        scenes_payload = [canonicalise_scene(scene, index=i) for i, scene in enumerate(scenario.get("Scenes") or [])]
+        layout = scenario.get("_SceneLayout")
+        if isinstance(layout, list):
+            for idx, scene in enumerate(scenes_payload):
+                if idx < len(layout) and isinstance(layout[idx], dict):
+                    scene.setdefault("_canvas", {}).update(layout[idx])
+        self.scenes = scenes_payload
+        self._set_mode("guided", remap=False)
+        self.guided_planner.load_cards(scenes_to_guided_cards(self.scenes))
 
-    def _update_buttons(self):
-        state = "normal" if self.selected_index is not None else "disabled"
-        self.dup_scene_btn.configure(state=state)
-        self.remove_scene_btn.configure(state=state)
-
-    def _assign_default_position(self, scene):
-        layout = scene.setdefault("_canvas", {})
-        layout.setdefault("x", 180 + len(self.scenes) * 40)
-        layout.setdefault("y", 160 + len(self.scenes) * 40)
-
-    def _unique_title(self, base):
-        base = base or "Scene"
-        used = {s.get("Title", "").lower() for s in self.scenes}
-        if base.lower() not in used:
-            return base
-        counter = 2
-        while f"{base} ({counter})".lower() in used:
-            counter += 1
-        return f"{base} ({counter})"
-
-    # ------------------------------------------------------------------
-    # WizardStep overrides
-    # ------------------------------------------------------------------
     def load_state(self, state):
         self.scenario_title_var.set(state.get("Title", ""))
         self._scenario_summary = state.get("Summary", "")
         self._scenario_secrets = state.get("Secrets") or state.get("Secret") or ""
-        self.scenes = self._coerce_scenes(state.get("Scenes"))
+        scenes = [canonicalise_scene(scene, index=i) for i, scene in enumerate(state.get("Scenes") or [])]
         layout = state.get("_SceneLayout")
         if isinstance(layout, list):
-            for idx, scene in enumerate(self.scenes):
+            for idx, scene in enumerate(scenes):
                 if idx < len(layout) and isinstance(layout[idx], dict):
                     scene.setdefault("_canvas", {}).update(layout[idx])
-        self.selected_index = None
-        self._close_inline_scene_editor()
-        self._close_link_label_editor()
-        self.canvas.set_scenes(self.scenes, None)
-        self._update_buttons()
-
-        self._root_extra_fields = {
-            key: copy.deepcopy(value)
-            for key, value in (state or {}).items()
-            if key not in self.ROOT_KNOWN_FIELDS
-        }
+        self.scenes = scenes
+        self._root_extra_fields = {key: copy.deepcopy(value) for key, value in (state or {}).items() if key not in self.ROOT_KNOWN_FIELDS}
+        self._set_mode("guided", remap=False)
+        self.guided_planner.load_cards(scenes_to_guided_cards(self.scenes))
 
     def save_state(self, state):
-        self._close_inline_scene_editor()
-        self._close_link_label_editor()
+        self.scenes = self._collect_active_scenes()
         state["Title"] = self.scenario_title_var.get().strip()
-        summary = (self._scenario_summary or "").strip()
+        state["Summary"] = (self._scenario_summary or "").strip()
         secrets = (self._scenario_secrets or "").strip()
-        state["Summary"] = summary
         state["Secrets"] = secrets
         state["Secret"] = secrets
 
         payload = []
         layout = []
         for scene in self.scenes:
-            if not scene:
-                continue
             record = {
                 "Title": scene.get("Title", "Scene"),
                 "Summary": scene.get("Summary", ""),
                 "Text": scene.get("Summary", ""),
-                "NPCs": list(scene.get("NPCs", [])),
-                "Creatures": list(scene.get("Creatures", [])),
-                "Bases": list(scene.get("Bases", [])),
-                "Places": list(scene.get("Places", [])),
-                "Maps": list(scene.get("Maps", [])),
             }
-            if scene.get("SceneType"):
-                record["SceneType"] = scene["SceneType"]
-                record["Type"] = scene["SceneType"]
-            links = self._get_scene_links(scene)
+            for field in self.ENTITY_FIELDS:
+                if scene.get(field):
+                    record[field] = list(scene.get(field) or [])
+            scene_type = scene.get("SceneType", "")
+            if scene_type:
+                record["SceneType"] = scene_type
+                record["Type"] = scene_type
+            links = normalise_scene_links(scene)
             if links:
                 record["NextScenes"] = [link["target"] for link in links]
-                record["Links"] = [
-                    {"target": link["target"], "text": link.get("text") or link["target"]}
-                    for link in links
-                ]
+                record["Links"] = [{"target": link["target"], "text": link.get("text") or link["target"]} for link in links]
             extras = scene.get("_extra_fields")
             if isinstance(extras, dict):
                 for key, value in extras.items():
                     if key not in record:
                         record[key] = copy.deepcopy(value)
             payload.append(record)
-            layout.append(scene.get("_canvas", {}))
+            layout.append(copy.deepcopy(scene.get("_canvas") or {}))
         state["Scenes"] = payload
         state["_SceneLayout"] = layout
 
-        for field in ("NPCs", "Creatures", "Bases", "Places", "Maps"):
-            merged = self._dedupe(self._split_to_list(state.get(field, [])))
+        for field in self.ENTITY_FIELDS:
+            merged = []
             for scene in self.scenes:
-                merged.extend(scene.get(field, []))
-            state[field] = self._dedupe(merged)
+                merged.extend(scene.get(field) or [])
+            deduped = []
+            seen = set()
+            for item in merged:
+                key = str(item).strip().casefold()
+                if key and key not in seen:
+                    seen.add(key)
+                    deduped.append(str(item).strip())
+            state[field] = deduped
 
         if isinstance(self._root_extra_fields, dict):
             for key, value in self._root_extra_fields.items():
                 state.setdefault(key, copy.deepcopy(value))
         return True
 
-    # ------------------------------------------------------------------
-    # Data helpers
-    # ------------------------------------------------------------------
-    @staticmethod
-    def _split_to_list(value):
-        if value is None:
-            return []
-        if isinstance(value, list):
-            return [str(item).strip() for item in value if str(item).strip()]
-        if isinstance(value, str):
-            parts = [part.strip() for part in value.replace(";", ",").split(",")]
-            return [part for part in parts if part]
-        return [str(value).strip()]
-
-    @staticmethod
-    def _dedupe(items):
-        seen = set()
-        result = []
-        for item in items:
-            key = str(item).strip().lower()
-            if key and key not in seen:
-                seen.add(key)
-                result.append(str(item).strip())
-        return result
-
-    def _coerce_scenes(self, raw):
-        if not raw:
-            return []
-        if isinstance(raw, list):
-            result = []
-            for idx, entry in enumerate(raw):
-                scene = self._normalise_scene(entry, idx)
-                if scene:
-                    result.append(scene)
-            return result
-        if isinstance(raw, dict):
-            return [self._normalise_scene(raw, 0)]
-        return []
-
-    def _normalise_scene(self, entry, index):
-        if not isinstance(entry, dict):
-            summary = coerce_text(entry).strip()
-            title = f"Scene {index + 1}"
-            if summary:
-                first_line = summary.splitlines()[0].strip()
-                if first_line:
-                    title = first_line if len(first_line) <= 60 else f"{first_line[:57]}..."
-            return {
-                "Title": title,
-                "Summary": summary,
-                "SceneType": "",
-                "NPCs": [],
-                "Creatures": [],
-                "Places": [],
-                "Maps": [],
-                "NextScenes": [],
-                "LinkData": [],
-            }
-        next_refs = self._split_to_list(entry.get("NextScenes"))
-        links_data = []
-        raw_links = entry.get("Links")
-        if isinstance(raw_links, list):
-            for item in raw_links:
-                if isinstance(item, dict):
-                    target = str(item.get("target") or item.get("Scene") or item.get("Next") or "").strip()
-                    if not target:
-                        continue
-                    text = str(item.get("text") or target).strip()
-                    links_data.append({"target": target, "text": text})
-                elif isinstance(item, str):
-                    target = item.strip()
-                    if target:
-                        links_data.append({"target": target, "text": target})
-        if not links_data:
-            for target in next_refs:
-                if target:
-                    links_data.append({"target": target, "text": target})
-        deduped = []
-        seen = set()
-        for link in links_data:
-            target = link["target"]
-            text = link.get("text") or target
-            key = (target.lower(), text.lower())
-            if key in seen:
-                continue
-            seen.add(key)
-            deduped.append({"target": target, "text": text})
-        summary_fragments = []
-        seen_fragments = set()
-
-        def _register_fragment(value):
-            if value is None:
-                return
-            if isinstance(value, (list, tuple, set)):
-                for item in value:
-                    _register_fragment(item)
-                return
-            if isinstance(value, dict):
-                text_value = value.get("text")
-                if text_value is not None:
-                    _register_fragment(text_value)
-                else:
-                    for item in value.values():
-                        _register_fragment(item)
-                return
-            fragment = coerce_text(value).strip()
-            normalised = " ".join(fragment.split())
-            if not normalised:
-                return
-            key = normalised.lower()
-            if key in seen_fragments:
-                return
-            seen_fragments.add(key)
-            summary_fragments.append(fragment)
-
-        if isinstance(entry, dict):
-            for key in (
-                "Summary",
-                "SceneSummary",
-                "Text",
-                "SceneText",
-                "Description",
-                "Body",
-                "Details",
-                "SceneDetails",
-                "Notes",
-                "Content",
-                "Synopsis",
-                "Overview",
-            ):
-                _register_fragment(entry.get(key))
-        else:
-            _register_fragment(entry)
-
-        summary = "\n\n".join(fragment for fragment in summary_fragments if fragment)
-        scene = {
-            "Title": entry.get("Title") or entry.get("Name") or f"Scene {index + 1}",
-            "Summary": coerce_text(summary),
-            "SceneType": entry.get("SceneType") or entry.get("Type") or "",
-            "NPCs": self._split_to_list(entry.get("NPCs")),
-            "Creatures": self._split_to_list(entry.get("Creatures")),
-            "Bases": self._split_to_list(entry.get("Bases")),
-            "Places": self._split_to_list(entry.get("Places")),
-            "Maps": self._split_to_list(entry.get("Maps")),
-            "NextScenes": [link["target"] for link in deduped],
-            "LinkData": deduped,
-        }
-        extras = {
-            key: copy.deepcopy(value)
-            for key, value in entry.items()
-            if key not in self.SCENE_KNOWN_FIELDS
-        }
-        if extras:
-            scene["_extra_fields"] = extras
-        return scene
 
 
 class ScenarioInfoDialog(ctk.CTkToplevel):

--- a/modules/scenarios/wizard_steps/__init__.py
+++ b/modules/scenarios/wizard_steps/__init__.py
@@ -1,0 +1,1 @@
+"""Wizard step modules."""

--- a/modules/scenarios/wizard_steps/scenes/__init__.py
+++ b/modules/scenarios/wizard_steps/scenes/__init__.py
@@ -1,0 +1,1 @@
+"""Scene planner implementations for the scenario wizard."""

--- a/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
@@ -1,0 +1,221 @@
+import copy
+import tkinter as tk
+
+import customtkinter as ctk
+
+from modules.scenarios.scene_flow_components import SceneCanvas
+from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import normalise_scene_links
+
+
+class InlineSceneEditor(ctk.CTkFrame):
+    def __init__(self, master, scene, *, scene_types, on_save, on_cancel, width=None, height=None):
+        super().__init__(master, fg_color="#0f172a", corner_radius=12, width=width, height=height)
+        self.on_save = on_save
+        self.on_cancel = on_cancel
+
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(3, weight=1)
+
+        ctk.CTkLabel(self, text="Scene Details", font=ctk.CTkFont(size=14, weight="bold"), anchor="w").grid(
+            row=0, column=0, sticky="ew", padx=12, pady=(12, 6)
+        )
+
+        self.title_var = ctk.StringVar(value=scene.get("Title", ""))
+        ctk.CTkEntry(self, textvariable=self.title_var).grid(row=1, column=0, sticky="ew", padx=12)
+
+        type_values = [""] + [value for value in scene_types or [] if value]
+        current_type = scene.get("SceneType") or scene.get("Type") or ""
+        if current_type and current_type not in type_values:
+            type_values.append(current_type)
+        self.type_var = ctk.StringVar(value=current_type)
+        self.type_menu = ctk.CTkOptionMenu(self, values=type_values, variable=self.type_var)
+        self.type_menu.grid(row=2, column=0, sticky="ew", padx=12, pady=(8, 6))
+
+        self.summary_text = ctk.CTkTextbox(self, wrap="word")
+        self.summary_text.grid(row=3, column=0, sticky="nsew", padx=12)
+        self.summary_text.insert("1.0", scene.get("Summary") or scene.get("Text") or "")
+
+        row = ctk.CTkFrame(self, fg_color="transparent")
+        row.grid(row=4, column=0, sticky="ew", padx=12, pady=(8, 10))
+        row.grid_columnconfigure((0, 1), weight=1)
+        ctk.CTkButton(row, text="Cancel", command=self._on_cancel).grid(row=0, column=0, sticky="ew", padx=(0, 6))
+        ctk.CTkButton(row, text="Save", command=self._on_save).grid(row=0, column=1, sticky="ew", padx=(6, 0))
+
+    def _on_save(self):
+        self.on_save(
+            {
+                "Title": self.title_var.get().strip(),
+                "SceneType": self.type_var.get().strip(),
+                "Summary": self.summary_text.get("1.0", "end").strip(),
+            }
+        )
+
+    def _on_cancel(self):
+        self.on_cancel()
+
+
+class CanvasScenePlanner(ctk.CTkFrame):
+    SCENE_TYPES = ["Auto", "Setup", "Choice", "Investigation", "Combat", "Outcome", "Social", "Travel", "Downtime"]
+
+    def __init__(self, master, *, available_entity_types=None, on_add_entity=None):
+        super().__init__(master, fg_color="transparent")
+        self.grid_rowconfigure(1, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self.scenes = []
+        self.selected_index = None
+        self._inline_editor = None
+        self._available_entity_types = list(available_entity_types or [])
+        self._on_add_entity_callback = on_add_entity
+
+        buttons = ctk.CTkFrame(self, fg_color="transparent")
+        buttons.grid(row=0, column=0, sticky="ew", padx=12, pady=(8, 6))
+        self.add_scene_btn = ctk.CTkButton(buttons, text="Add Scene", command=self.add_scene)
+        self.add_scene_btn.pack(side="left")
+        self.dup_scene_btn = ctk.CTkButton(buttons, text="Duplicate", command=self.duplicate_scene)
+        self.dup_scene_btn.pack(side="left", padx=6)
+        self.remove_scene_btn = ctk.CTkButton(buttons, text="Remove", command=self.remove_scene)
+        self.remove_scene_btn.pack(side="left")
+
+        self.canvas = SceneCanvas(
+            self,
+            on_select=self._on_canvas_select,
+            on_move=self._on_canvas_move,
+            on_edit=self._open_inline_scene_editor,
+            on_context=self._show_canvas_menu,
+            on_add_entity=self._on_add_entity,
+            on_link=self._link_scenes_via_drag,
+            on_link_text_edit=lambda *_: None,
+            available_entity_types=self._available_entity_types,
+        )
+        self.canvas.grid(row=1, column=0, sticky="nsew", padx=12, pady=(0, 12))
+        self._update_buttons()
+
+    def load_scenes(self, scenes):
+        self.scenes = [copy.deepcopy(scene) for scene in (scenes or [])]
+        self.selected_index = 0 if self.scenes else None
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+        self._update_buttons()
+
+    def export_scenes(self):
+        return [copy.deepcopy(scene) for scene in self.scenes]
+
+    def add_scene(self):
+        scene = {"Title": f"Scene {len(self.scenes) + 1}", "Summary": "", "SceneType": "", "LinkData": [], "NextScenes": [], "_canvas": {}}
+        self._assign_default_position(scene)
+        self.scenes.append(scene)
+        self.selected_index = len(self.scenes) - 1
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+        self._update_buttons()
+
+    def duplicate_scene(self):
+        if self.selected_index is None or self.selected_index >= len(self.scenes):
+            return
+        source = copy.deepcopy(self.scenes[self.selected_index])
+        source["Title"] = f"{source.get('Title') or 'Scene'} Copy"
+        source["_canvas"] = {}
+        self._assign_default_position(source)
+        self.scenes.insert(self.selected_index + 1, source)
+        self.selected_index += 1
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+        self._update_buttons()
+
+    def remove_scene(self):
+        if self.selected_index is None or self.selected_index >= len(self.scenes):
+            return
+        removed = self.scenes.pop(self.selected_index)
+        removed_title = str(removed.get("Title") or "").strip()
+        for scene in self.scenes:
+            links = [l for l in normalise_scene_links(scene) if l.get("target") != removed_title]
+            scene["LinkData"] = links
+            scene["NextScenes"] = [link["target"] for link in links]
+        self.selected_index = min(self.selected_index, len(self.scenes) - 1) if self.scenes else None
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+        self._update_buttons()
+
+    def _on_canvas_select(self, index):
+        self.selected_index = index if isinstance(index, int) and 0 <= index < len(self.scenes) else None
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+        self._update_buttons()
+
+    def _on_canvas_move(self, index, x, y):
+        if index is None or index >= len(self.scenes):
+            return
+        self.scenes[index].setdefault("_canvas", {}).update({"x": x, "y": y})
+
+    def _open_inline_scene_editor(self, index):
+        if index is None or index >= len(self.scenes):
+            return
+        bbox = self.canvas.get_card_bbox(index)
+        if not bbox:
+            return
+        if self._inline_editor is not None:
+            self._inline_editor.destroy()
+        x1, y1, x2, y2 = bbox
+        editor = InlineSceneEditor(
+            self.canvas,
+            self.scenes[index],
+            scene_types=self.SCENE_TYPES,
+            on_save=lambda data, idx=index: self._apply_inline_scene_update(idx, data),
+            on_cancel=self._close_inline_scene_editor,
+            width=max(120, (x2 - x1) - 16),
+            height=max(120, (y2 - y1) - 16),
+        )
+        editor.place(x=x1 + 8, y=y1 + 8)
+        self._inline_editor = editor
+
+    def _apply_inline_scene_update(self, index, data):
+        scene = self.scenes[index]
+        scene["Title"] = data.get("Title") or scene.get("Title") or f"Scene {index + 1}"
+        scene["Summary"] = data.get("Summary", "")
+        scene["SceneType"] = data.get("SceneType", "")
+        self._close_inline_scene_editor()
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+
+    def _close_inline_scene_editor(self):
+        if self._inline_editor is not None:
+            self._inline_editor.destroy()
+            self._inline_editor = None
+
+    def _show_canvas_menu(self, event, index):
+        menu = tk.Menu(self, tearoff=0)
+        menu.add_command(label="Add Scene", command=self.add_scene)
+        if index is not None:
+            self.selected_index = index
+            menu.add_command(label="Edit", command=lambda idx=index: self._open_inline_scene_editor(idx))
+            menu.add_command(label="Duplicate", command=self.duplicate_scene)
+            menu.add_command(label="Remove", command=self.remove_scene)
+        try:
+            menu.tk_popup(event.x_root, event.y_root)
+        finally:
+            menu.grab_release()
+
+    def _link_scenes_via_drag(self, source_index, target_index):
+        if source_index is None or target_index is None:
+            return
+        if source_index >= len(self.scenes) or target_index >= len(self.scenes):
+            return
+        source = self.scenes[source_index]
+        target_title = self.scenes[target_index].get("Title") or f"Scene {target_index + 1}"
+        links = normalise_scene_links(source)
+        if any(link.get("target") == target_title for link in links):
+            return
+        links.append({"target": target_title, "text": target_title})
+        source["LinkData"] = links
+        source["NextScenes"] = [link["target"] for link in links]
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+
+    def _on_add_entity(self, scene_index, entity_type):
+        if not callable(self._on_add_entity_callback):
+            return
+        self._on_add_entity_callback(scene_index, entity_type)
+        self.canvas.set_scenes(self.scenes, self.selected_index)
+
+    def _assign_default_position(self, scene):
+        scene.setdefault("_canvas", {})
+        scene["_canvas"].setdefault("x", 180 + len(self.scenes) * 40)
+        scene["_canvas"].setdefault("y", 160 + len(self.scenes) * 40)
+
+    def _update_buttons(self):
+        state = "normal" if self.selected_index is not None else "disabled"
+        self.dup_scene_btn.configure(state=state)
+        self.remove_scene_btn.configure(state=state)

--- a/modules/scenarios/wizard_steps/scenes/guided_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/guided_scene_planner.py
@@ -1,0 +1,134 @@
+import customtkinter as ctk
+
+
+class GuidedScenePlanner(ctk.CTkFrame):
+    def __init__(self, master, *, entity_fields=None, on_add_entity=None):
+        super().__init__(master, fg_color="transparent")
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(2, weight=1)
+        self._cards = []
+        self._entity_fields = entity_fields or []
+        self._on_add_entity = on_add_entity
+
+        info = ctk.CTkLabel(
+            self,
+            text=(
+                "Guided mode starts with an opening and ending scene. "
+                "Add intermediary scenes to shape your own pacing."
+            ),
+            text_color="#9db4d1",
+            justify="left",
+            anchor="w",
+        )
+        info.grid(row=0, column=0, sticky="ew", padx=12, pady=(8, 6))
+
+        add_row = ctk.CTkFrame(self, fg_color="transparent")
+        add_row.grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 6))
+        ctk.CTkButton(add_row, text="Add middle scene", command=self._insert_middle_scene).pack(side="left")
+
+        self._container = ctk.CTkScrollableFrame(self, fg_color="transparent")
+        self._container.grid(row=2, column=0, sticky="nsew", padx=12, pady=(0, 12))
+        self._container.grid_columnconfigure(0, weight=1)
+
+    def _default_scene_payload(self, index):
+        if index == 0:
+            return {"Title": "Opening Scene", "SceneType": "Setup", "Summary": ""}
+        return {"Title": f"Scene {index + 1}", "SceneType": "Choice", "Summary": ""}
+
+    def _insert_middle_scene(self):
+        insert_at = max(1, len(self._cards) - 1)
+        self._cards.insert(insert_at, self._default_scene_payload(insert_at))
+        self._refresh_cards()
+
+    def _remove_scene(self, index):
+        if index <= 0 or index >= len(self._cards) - 1:
+            return
+        self._cards.pop(index)
+        self._refresh_cards()
+
+    def _add_entity_to_card(self, index, field):
+        if not callable(self._on_add_entity):
+            return
+        selected = self._on_add_entity(index, field)
+        if not selected:
+            return
+        card = self._cards[index]
+        values = list(card.get(field) or [])
+        if selected not in values:
+            values.append(selected)
+            card[field] = sorted(values, key=lambda value: value.casefold())
+            self._refresh_cards()
+
+    def _refresh_cards(self):
+        for widget in self._container.winfo_children():
+            widget.destroy()
+
+        for idx, card in enumerate(self._cards):
+            panel = ctk.CTkFrame(self._container, fg_color="#0f172a", corner_radius=12)
+            panel.grid(row=idx, column=0, sticky="ew", pady=(0, 10))
+            panel.grid_columnconfigure(0, weight=1)
+
+            row = ctk.CTkFrame(panel, fg_color="transparent")
+            row.grid(row=0, column=0, sticky="ew", padx=12, pady=(12, 6))
+            row.grid_columnconfigure(0, weight=1)
+            ctk.CTkLabel(row, text=f"Scene {idx + 1}", font=ctk.CTkFont(size=14, weight="bold"), anchor="w").grid(row=0, column=0, sticky="w")
+            if 0 < idx < len(self._cards) - 1:
+                ctk.CTkButton(row, text="Remove", width=90, command=lambda i=idx: self._remove_scene(i)).grid(row=0, column=1, sticky="e")
+
+            title_var = ctk.StringVar(value=card.get("Title") or f"Scene {idx + 1}")
+            title_var.trace_add("write", lambda *_args, i=idx, var=title_var: self._cards[i].__setitem__("Title", var.get()))
+            ctk.CTkEntry(panel, textvariable=title_var).grid(row=1, column=0, sticky="ew", padx=12)
+            card["_title_var"] = title_var
+
+            summary = ctk.CTkTextbox(panel, height=92, wrap="word")
+            summary.grid(row=2, column=0, sticky="ew", padx=12, pady=(8, 10))
+            summary.insert("1.0", card.get("Summary") or "")
+            card["_summary_widget"] = summary
+
+            card["SceneType"] = card.get("SceneType") or ("Setup" if idx == 0 else ("Outcome" if idx == len(self._cards) - 1 else "Choice"))
+
+            if self._entity_fields:
+                entities_frame = ctk.CTkFrame(panel, fg_color="transparent")
+                entities_frame.grid(row=3, column=0, sticky="ew", padx=12, pady=(0, 12))
+                entities_frame.grid_columnconfigure(0, weight=1)
+                for row_idx, (field, label) in enumerate(self._entity_fields):
+                    values = list(card.get(field) or [])
+                    pill_text = ", ".join(values) if values else "None"
+                    ctk.CTkLabel(entities_frame, text=f"{label}s: {pill_text}", anchor="w", wraplength=660).grid(
+                        row=row_idx, column=0, sticky="w", pady=2
+                    )
+                    ctk.CTkButton(
+                        entities_frame,
+                        text=f"+ {label}",
+                        width=90,
+                        command=lambda i=idx, f=field: self._add_entity_to_card(i, f),
+                    ).grid(row=row_idx, column=1, sticky="e", padx=(8, 0), pady=2)
+
+    def load_cards(self, cards):
+        self._cards = []
+        for card in cards or []:
+            payload = dict(card)
+            for field, _label in self._entity_fields:
+                payload[field] = list(payload.get(field) or [])
+            self._cards.append(payload)
+        if len(self._cards) < 2:
+            self._cards = [self._default_scene_payload(0), {"Title": "Final Scene", "SceneType": "Outcome", "Summary": ""}]
+        self._refresh_cards()
+
+    def export_cards(self):
+        result = []
+        for idx, card in enumerate(self._cards):
+            if card.get("_summary_widget") is not None:
+                card["Summary"] = card["_summary_widget"].get("1.0", "end").strip()
+            exported = {
+                "stage": card.get("stage") or f"Scene {idx + 1}",
+                "Title": str(card.get("Title") or f"Scene {idx + 1}").strip(),
+                "Summary": str(card.get("Summary") or "").strip(),
+                "SceneType": card.get("SceneType") or ("Setup" if idx == 0 else ("Outcome" if idx == len(self._cards) - 1 else "Choice")),
+                "_canvas": dict(card.get("_canvas") or {}),
+                "_extra_fields": dict(card.get("_extra_fields") or {}),
+            }
+            for field, _label in self._entity_fields:
+                exported[field] = list(card.get(field) or [])
+            result.append(exported)
+        return result

--- a/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
+++ b/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
@@ -1,0 +1,133 @@
+import copy
+
+GUIDED_MIN_SCENES = (
+    ("Opening Scene", "Setup"),
+    ("Final Scene", "Outcome"),
+)
+SCENE_ENTITY_FIELDS = ("NPCs", "Creatures", "Bases", "Places", "Maps")
+
+
+def _split_to_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.replace(";", ",").split(",")]
+        return [part for part in parts if part]
+    return [str(value).strip()]
+
+
+def normalise_scene_links(scene):
+    links_data = []
+    raw_links = (scene or {}).get("LinkData") or (scene or {}).get("Links")
+    if isinstance(raw_links, list):
+        for item in raw_links:
+            if isinstance(item, dict):
+                target = str(item.get("target") or item.get("Scene") or item.get("Next") or "").strip()
+                if not target:
+                    continue
+                text = str(item.get("text") or target).strip()
+                links_data.append({"target": target, "text": text})
+            elif isinstance(item, str) and item.strip():
+                links_data.append({"target": item.strip(), "text": item.strip()})
+    if not links_data:
+        for target in _split_to_list((scene or {}).get("NextScenes")):
+            links_data.append({"target": target, "text": target})
+    deduped = []
+    seen = set()
+    for link in links_data:
+        key = (link["target"].casefold(), (link.get("text") or "").casefold())
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append({"target": link["target"], "text": link.get("text") or link["target"]})
+    return deduped
+
+
+def canonicalise_scene(scene, *, index=0):
+    if not isinstance(scene, dict):
+        return {
+            "Title": f"Scene {index + 1}",
+            "Summary": str(scene or ""),
+            "SceneType": "",
+            "LinkData": [],
+            "NextScenes": [],
+            "_canvas": {},
+        }
+    data = copy.deepcopy(scene)
+    summary = str(data.get("Summary") or data.get("Text") or "").strip()
+    links = normalise_scene_links(data)
+    return {
+        "Title": str(data.get("Title") or data.get("Name") or f"Scene {index + 1}").strip(),
+        "Summary": summary,
+        "SceneType": str(data.get("SceneType") or data.get("Type") or "").strip(),
+        "LinkData": links,
+        "NextScenes": [link["target"] for link in links],
+        "_canvas": copy.deepcopy(data.get("_canvas") or {}),
+        **{field: _split_to_list(data.get(field)) for field in SCENE_ENTITY_FIELDS},
+        "_extra_fields": {
+            k: copy.deepcopy(v)
+            for k, v in data.items()
+            if k not in {
+                "Title", "Name", "Summary", "Text", "SceneType", "Type", "LinkData", "Links", "NextScenes", "_canvas"
+            }
+        },
+    }
+
+
+def scenes_to_guided_cards(scenes):
+    canonical = [canonicalise_scene(scene, index=i) for i, scene in enumerate(scenes or [])]
+    if not canonical:
+        canonical = [
+            {"Title": title, "Summary": "", "SceneType": scene_type, "_canvas": {}, "_extra_fields": {}}
+            for title, scene_type in GUIDED_MIN_SCENES
+        ]
+    cards = []
+    for idx, scene in enumerate(canonical):
+        default_type = "Setup" if idx == 0 else ("Outcome" if idx == len(canonical) - 1 else "Choice")
+        stage = scene.get("Title") or f"Scene {idx + 1}"
+        cards.append(
+            {
+                "stage": stage,
+                "Title": scene.get("Title") or stage,
+                "Summary": scene.get("Summary") or "",
+                "SceneType": scene.get("SceneType") or default_type,
+                "_canvas": copy.deepcopy(scene.get("_canvas") or {}),
+                "_extra_fields": copy.deepcopy(scene.get("_extra_fields") or {}),
+                **{field: copy.deepcopy(scene.get(field) or []) for field in SCENE_ENTITY_FIELDS},
+            }
+        )
+    return cards
+
+
+def guided_cards_to_scenes(cards):
+    prepared = []
+    safe_cards = cards or []
+    if len(safe_cards) < 2:
+        safe_cards = scenes_to_guided_cards([])
+    for idx, card in enumerate(safe_cards):
+        default_type = "Setup" if idx == 0 else ("Outcome" if idx == len(safe_cards) - 1 else "Choice")
+        stage = card.get("stage") or f"Scene {idx + 1}"
+        title = str(card.get("Title") or stage).strip() or stage
+        summary = str(card.get("Summary") or "").strip()
+        scene = {
+            "Title": title,
+            "Summary": summary,
+            "SceneType": str(card.get("SceneType") or default_type).strip() or default_type,
+            "LinkData": [],
+            "NextScenes": [],
+            "_canvas": copy.deepcopy(card.get("_canvas") or {}),
+            **{field: _split_to_list(card.get(field)) for field in SCENE_ENTITY_FIELDS},
+        }
+        extras = card.get("_extra_fields")
+        if isinstance(extras, dict):
+            scene["_extra_fields"] = copy.deepcopy(extras)
+        prepared.append(scene)
+
+    for idx in range(len(prepared) - 1):
+        target = prepared[idx + 1]["Title"]
+        prepared[idx]["LinkData"] = [{"target": target, "text": target}]
+        prepared[idx]["NextScenes"] = [target]
+
+    return prepared


### PR DESCRIPTION
### Motivation

- Separate guided and canvas scene planning to simplify the wizard UI and support two distinct editing workflows.
- Centralise scene canonicalisation and link normalisation so scene payloads are consistent between modes.
- Simplify entity field definitions and streamline entity selection/creation flows used by scene planners.
- Improve save/load reliability by normalising scenes on import and deduping scene-level entity lists on export.

### Description

- Introduces a new `modules/scenarios/wizard_steps/scenes` package with `CanvasScenePlanner`, `GuidedScenePlanner`, and `scene_mode_adapters` that provide `canonicalise_scene`, `normalise_scene_links`, `scenes_to_guided_cards`, and `guided_cards_to_scenes` adapters.
- Reworks `ScenesPlanningStep` in `modules/scenarios/scenario_builder_wizard.py` to host both planners, add a mode switch (`guided`/`canvas`), map scenes between modes, and delegate UI interactions to the appropriate planner.
- Moves many scene helper functions (link normalisation, splitting, canonicalisation, conversion between guided cards and scenes) into `scene_mode_adapters` and removes the previous monolithic inline implementations.
- Updates load/save logic to canonicalise incoming scenes, preserve `_canvas` layout, export deduped root entity lists, and use the adapter helpers for link and scene field handling.

### Testing

- Ran the automated test suite with `pytest -q` and the run completed successfully with all tests passing.
- Executed the GUI-related unit/smoke tests that exercise the scenario wizard components, which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c959eb4340832b81152b0c8a05f632)