### PR TITLE
Exclude internal entity templates from generic management UIs and menus

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -35,6 +35,7 @@ from modules.helpers.template_loader import (
     load_template,
     load_entity_definitions,
     build_entity_wrappers,
+    NON_MANAGEABLE_ENTITY_SLUGS,
 )
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.backup_helper import (
@@ -1039,10 +1040,6 @@ class MainWindow(ctk.CTk):
             ("db_import", "Restore Campaign Backup", self.prompt_campaign_restore),
             ("asset_library", "Cross-campaign Asset Library", self.open_cross_campaign_asset_library),
         ]
-
-        # Internal entity types must not be exposed through the generic
-        # "Manage <Entity>" sidebar entries (they have dedicated flows/UI).
-        NON_MANAGEABLE_ENTITY_SLUGS = {"image_assets"}
 
         entity_buttons = []
         for slug, meta in self.entity_definitions.items():

--- a/modules/generic/custom_fields_editor.py
+++ b/modules/generic/custom_fields_editor.py
@@ -6,8 +6,8 @@ from tkinter import messagebox
 from modules.helpers.template_loader import (
     _load_base_template,
     save_custom_fields,
-    list_known_entities,
-    list_known_entity_labels,
+    list_manageable_entities,
+    list_manageable_entity_labels,
 )
 from modules.helpers.logging_helper import (
     log_function,
@@ -46,7 +46,7 @@ class CustomFieldsEditor(ctk.CTkToplevel):
         self.lift(); self.focus_force(); self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self._on_close)
 
-        self.entities = list_known_entities() or [
+        self.entities = list_manageable_entities() or [
             # Fallback ordering if discovery fails
             "scenarios", "pcs", "npcs", "creatures", "factions", "places", "objects", "informations", "clues", "maps"
         ]
@@ -92,7 +92,7 @@ class CustomFieldsEditor(ctk.CTkToplevel):
         ctk.CTkLabel(form, text="Linked Type (for list)").grid(row=2, column=0, padx=4, pady=4, sticky="w")
         self.linked_var = tk.StringVar(value="")
         # linked types are discovered dynamically from all known entity templates
-        self.known_linked = [""] + list_known_entity_labels()
+        self.known_linked = [""] + list_manageable_entity_labels()
         self.linked_menu = ctk.CTkOptionMenu(form, values=self.known_linked, variable=self.linked_var)
         self.linked_menu.grid(row=2, column=1, padx=4, pady=4, sticky="ew")
 
@@ -144,7 +144,7 @@ class CustomFieldsEditor(ctk.CTkToplevel):
 
     def _refresh_linked_options(self):
         """Refresh linked options."""
-        dynamic_labels = list_known_entity_labels()
+        dynamic_labels = list_manageable_entity_labels()
         values = [""] + dynamic_labels
         existing_linked = {
             str(f.get("linked_type", "")).strip()

--- a/modules/helpers/template_loader.py
+++ b/modules/helpers/template_loader.py
@@ -39,6 +39,10 @@ _BUILTIN_ENTITY_METADATA = {
     "image_assets": {"label": "Image Assets", "icon": "assets/import_icon.png"},
 }
 
+# Entity templates that should remain internal and must not appear in
+# generic "Manage <Entity>" or field-customization selectors.
+NON_MANAGEABLE_ENTITY_SLUGS = {"image_assets", "events"}
+
 @log_function
 def _default_template_path(entity_name: str) -> str:
     """Internal helper for default template path."""
@@ -555,6 +559,22 @@ def list_known_entities() -> list:
 
 
 @log_function
+def list_manageable_entities() -> list:
+    """Return known entity slugs that should be user-manageable in generic UIs."""
+
+    entities = [
+        slug
+        for slug in list_known_entities()
+        if slug not in NON_MANAGEABLE_ENTITY_SLUGS
+    ]
+    log_debug(
+        f"Discovered {len(entities)} manageable entity templates",
+        func_name="modules.helpers.template_loader.list_manageable_entities",
+    )
+    return entities
+
+
+@log_function
 def list_known_entity_labels() -> list:
     """Return display labels for every discovered entity template."""
 
@@ -562,6 +582,19 @@ def list_known_entity_labels() -> list:
     labels = []
     for slug in sorted(definitions.keys()):
         # Process each slug from sorted(definitions.keys()).
+        label = str(definitions.get(slug, {}).get("label") or "").strip()
+        if label:
+            labels.append(label)
+    return labels
+
+
+@log_function
+def list_manageable_entity_labels() -> list:
+    """Return display labels for user-manageable entity templates."""
+
+    definitions = load_entity_definitions()
+    labels = []
+    for slug in list_manageable_entities():
         label = str(definitions.get(slug, {}).get("label") or "").strip()
         if label:
             labels.append(label)

--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from tkinter import messagebox
 from typing import Callable
 
+from modules.helpers.template_loader import NON_MANAGEABLE_ENTITY_SLUGS
+
 
 @dataclass(slots=True)
 class MenuCommandSpec:
@@ -47,6 +49,8 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
     """Build menu specs."""
     entity_items: list[MenuCommandSpec] = []
     for slug, meta in getattr(app, "entity_definitions", {}).items():
+        if slug in NON_MANAGEABLE_ENTITY_SLUGS:
+            continue
         label = meta.get("label") or slug.replace("_", " ").title()
         entity_items.append(
             _command(

--- a/tests/test_template_loader_entities.py
+++ b/tests/test_template_loader_entities.py
@@ -13,3 +13,35 @@ def test_list_known_entity_labels_returns_sorted_display_labels(monkeypatch):
     monkeypatch.setattr(template_loader, "load_entity_definitions", lambda: defs)
 
     assert template_loader.list_known_entity_labels() == ["Alpha", "Beta", "Zeta"]
+
+
+def test_list_manageable_entities_excludes_internal_slugs(monkeypatch):
+    """Internal entities should not surface in generic management lists."""
+    monkeypatch.setattr(
+        template_loader,
+        "list_known_entities",
+        lambda: ["events", "image_assets", "maps", "npcs"],
+    )
+
+    assert template_loader.list_manageable_entities() == ["maps", "npcs"]
+
+
+def test_list_manageable_entity_labels_excludes_internal_slugs(monkeypatch):
+    """Manageable labels should omit internal entities."""
+    monkeypatch.setattr(
+        template_loader,
+        "list_manageable_entities",
+        lambda: ["maps", "npcs"],
+    )
+    monkeypatch.setattr(
+        template_loader,
+        "load_entity_definitions",
+        lambda: {
+            "events": {"label": "Events"},
+            "image_assets": {"label": "Image Assets"},
+            "maps": {"label": "Maps"},
+            "npcs": {"label": "NPCs"},
+        },
+    )
+
+    assert template_loader.list_manageable_entity_labels() == ["Maps", "NPCs"]

--- a/tests/ui/test_menu_sections_image_commands.py
+++ b/tests/ui/test_menu_sections_image_commands.py
@@ -61,3 +61,65 @@ def test_menu_sections_expose_image_library_commands() -> None:
 
     assert "Import Image Directories…" in labels
     assert "Open Image Library" in labels
+
+
+def test_campaign_menu_hides_internal_manage_entity_entries() -> None:
+    """Campaign overview should not expose internal entity management commands."""
+    app = SimpleNamespace(
+        entity_definitions={
+            "events": {"label": "Events"},
+            "image_assets": {"label": "Image Assets"},
+            "npcs": {"label": "NPCs"},
+        },
+        open_entity=lambda _slug: None,
+        change_database_storage=lambda: None,
+        prompt_campaign_backup=lambda: None,
+        prompt_campaign_restore=lambda: None,
+        open_system_selector=lambda: None,
+        select_swarmui_path=lambda: None,
+        open_custom_fields_editor=lambda: None,
+        open_new_entity_type_dialog=lambda: None,
+        open_system_manager_dialog=lambda: None,
+        open_cross_campaign_asset_library=lambda: None,
+        open_auto_improve_panel=lambda: None,
+        destroy=lambda: None,
+        refresh_entities=lambda: None,
+        open_gm_screen=lambda: None,
+        open_campaign_graph_view=lambda: None,
+        open_world_map=lambda: None,
+        open_character_graph_editor=lambda: None,
+        open_villain_graph_editor=lambda: None,
+        open_faction_graph_editor=lambda: None,
+        open_scenario_graph_editor=lambda: None,
+        open_scene_flow_viewer=lambda: None,
+        open_random_table_editor=lambda: None,
+        open_scenario_generator=lambda: None,
+        open_scenario_builder=lambda: None,
+        open_campaign_builder=lambda: None,
+        preview_and_export_scenarios=lambda: None,
+        open_campaign_dossier_exporter=lambda: None,
+        open_scenario_importer=lambda: None,
+        open_creature_importer=lambda: None,
+        open_object_importer=lambda: None,
+        generate_missing_portraits=lambda: None,
+        import_portraits_from_directory=lambda: None,
+        open_image_directory_importer=lambda: None,
+        open_image_library_browser=lambda: None,
+        map_tool=lambda: None,
+        open_whiteboard=lambda: None,
+        open_dice_roller=lambda: None,
+        open_sound_manager=lambda: None,
+        open_timer_window=lambda: None,
+        open_character_creation=lambda: None,
+        open_audio_bar=lambda: None,
+        open_dice_bar=lambda: None,
+    )
+
+    specs = build_menu_specs(app)
+    campaign_menu = next(menu for menu in specs if menu.label == "Campaign")
+    overview_group = next(group for group in campaign_menu.groups if group.title == "Overview")
+    labels = [item.label for item in overview_group.items]
+
+    assert "Manage NPCs" in labels
+    assert "Manage Events" not in labels
+    assert "Manage Image Assets" not in labels


### PR DESCRIPTION
### Motivation

- Prevent internal-only entity templates (such as image/library backends and events) from being exposed in generic "Manage <Entity>" flows and field-customization selectors.

### Description

- Introduce `NON_MANAGEABLE_ENTITY_SLUGS` in `modules.helpers.template_loader` to centralize slugs that should remain internal and not be shown in generic UIs. 
- Add `list_manageable_entities` and `list_manageable_entity_labels` helpers in `modules.helpers.template_loader` that filter out internal slugs and return only user-manageable entities or labels. 
- Update `modules/generic/custom_fields_editor.py` to use `list_manageable_entities` and `list_manageable_entity_labels` so the custom fields editor only lists manageable entities as options. 
- Update `main_window.py` and `modules/ui/menu/menu_sections.py` to respect `NON_MANAGEABLE_ENTITY_SLUGS` and skip building generic "Manage <Entity>" entries for internal slugs. 
- Add/adjust tests in `tests/test_template_loader_entities.py` and `tests/ui/test_menu_sections_image_commands.py` to assert internal slugs are excluded from the manageable/entity label lists and campaign menu entries.

### Testing

- Ran the entity template tests with `pytest -q tests/test_template_loader_entities.py` and confirmed the new tests for `list_manageable_entities` and `list_manageable_entity_labels` passed. 
- Ran the affected UI menu tests with `pytest -q tests/ui/test_menu_sections_image_commands.py` and confirmed the new assertions about hidden internal "Manage" entries passed. 
- Ran the targeted test files together with `pytest -q` for a quick verification of impacted areas and saw the tests run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3df5b1bac832b87b54408efbd9852)