### PR TITLE
Add GM Screen 2 desktop panel workflow

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -221,6 +221,7 @@ class MainWindow(ctk.CTk):
         root.bind_all("<F7>", lambda _event: self.open_sound_manager())
         root.bind_all("<F8>", lambda _event: self.open_dice_roller())
         root.bind_all("<F9>", lambda _event: self.open_campaign_builder())
+        root.bind_all("<F10>", lambda _event: self.open_gm_screen2())
         root.bind_all("<F12>", lambda _event: self.destroy())
 
     def open_ai_settings(self):
@@ -997,6 +998,7 @@ class MainWindow(ctk.CTk):
             SidebarItemSpec("import_creatures_pdf", "Import NPCs/Creatures from PDF", self.open_creature_importer),
             SidebarItemSpec("import_objects_pdf", "Import Equipment from PDF", self.open_object_importer),
             SidebarItemSpec("gm_screen", "Open GM Screen", self.open_gm_screen),
+            SidebarItemSpec("gm_screen2", "Open GM Screen 2 (Desktop Panels)", self.open_gm_screen2),
             SidebarItemSpec("export_scenarios", "Export Scenarios", self.preview_and_export_scenarios),
             SidebarItemSpec("export_campaign_dossier", "Export Entire Campaign (Dossier Binder)", self.open_campaign_dossier_exporter),
             SidebarItemSpec("generate_portraits", "Generate Portraits", self.generate_missing_portraits),
@@ -2816,6 +2818,150 @@ class MainWindow(ctk.CTk):
             scenario_wrapper,
             load_template("scenarios"),
             on_select_callback=on_scenario_select
+        )
+        list_selection.pack(fill="both", expand=True)
+        self.current_gm_view = None
+        _finalize_gm_shell()
+
+    def open_gm_screen2(self, *, show_empty_message=True, scenario_name=None, initial_layout=None):
+        """Open desktop-panel variant of the GM screen (GM Screen 2)."""
+        self.clear_current_content()
+        self._gm_mode = True
+
+        scenario_wrapper = self.entity_wrappers.get("scenarios") or GenericModelWrapper("scenarios")
+        self.entity_wrappers.setdefault("scenarios", scenario_wrapper)
+        scenarios = scenario_wrapper.load_items()
+        if not scenarios:
+            if show_empty_message:
+                messagebox.showwarning("No Scenarios", "No scenarios available.")
+            else:
+                log_info(
+                    "Skipped opening GM Screen 2 because no scenarios are available",
+                    func_name="main_window.MainWindow.open_gm_screen2",
+                )
+            return
+
+        layout_manager = GMScreenLayoutManager()
+        layout_map = layout_manager.list_layouts()
+        default_label = "Use Scenario Default"
+        layout_options = [default_label]
+        layout_options.extend(sorted(layout_map.keys()))
+        selected_layout_var = tk.StringVar(value=default_label)
+
+        if getattr(self, "banner_frame", None) and self.banner_frame.winfo_exists():
+            if not self.banner_frame.winfo_ismapped():
+                self.banner_frame.pack(fill="x")
+        else:
+            self.banner_frame = self._create_banner_frame()
+            self.banner_frame.pack(fill="x")
+        pcs_items = {pc["Name"]: pc for pc in self.pc_wrapper.load_items()}
+        if pcs_items:
+            display_pcs_in_banner(self.banner_frame, pcs_items)
+
+        self.inner_content_frame.grid(row=1, column=0, sticky="nsew")
+        for w in self.inner_content_frame.winfo_children():
+            w.destroy()
+        parent = self.inner_content_frame
+
+        layout_bar = ctk.CTkFrame(parent)
+        layout_bar.pack(fill="x", padx=10, pady=(5, 0))
+        ctk.CTkLabel(layout_bar, text="GM Screen 2 layout:").pack(side="left", padx=(0, 10), pady=5)
+        ctk.CTkOptionMenu(layout_bar, variable=selected_layout_var, values=layout_options).pack(side="left", pady=5)
+        ctk.CTkLabel(
+            layout_bar,
+            text="Ctrl+1..9: afficher/masquer panneau • Ctrl+0: restaurer tous",
+        ).pack(side="right", padx=6, pady=5)
+
+        def _resolve_scenario_title(scenario):
+            """Resolve scenario title."""
+            return str((scenario or {}).get("Title") or (scenario or {}).get("Name") or "").strip()
+
+        def _show_selected_scenario(selected):
+            """Show selected scenario in GM Screen 2."""
+            for w in parent.winfo_children():
+                w.destroy()
+            detail_container = ctk.CTkFrame(parent)
+            detail_container.grid(row=0, column=0, sticky="nsew")
+            resolved_layout = initial_layout
+            if resolved_layout is None:
+                chosen_layout = selected_layout_var.get()
+                resolved_layout = None if chosen_layout == default_label else chosen_layout
+
+            from modules.scenarios.gm_screen2 import GMScreen2View
+
+            view = GMScreen2View(
+                detail_container,
+                scenario_item=selected,
+                initial_layout=resolved_layout,
+                layout_manager=layout_manager,
+            )
+            view.pack(fill="both", expand=True)
+            self.current_gm_view = view
+
+            default_layout = layout_manager.get_scenario_default(view.scenario_name)
+            has_saved_layout = bool(resolved_layout or default_layout)
+            if not has_saved_layout:
+                def _open_default_tabs():
+                    """Open default desktop tabs."""
+                    scenario_tab = view.tabs.get(view.scenario_name)
+                    if not scenario_tab:
+                        view.after(50, _open_default_tabs)
+                        return
+                    view.open_whiteboard_tab(activate=False)
+
+                view.after_idle(_open_default_tabs)
+
+        def on_scenario_select(entity_type, entity_name):
+            """Handle scenario selection."""
+            selected = next((s for s in scenarios if _resolve_scenario_title(s) == entity_name), None)
+            if not selected:
+                messagebox.showwarning("Not Found", f"Scenario '{entity_name}' not found.")
+                return
+            _show_selected_scenario(selected)
+
+        def _finalize_gm_shell():
+            """Finalize shell layout and banner controls."""
+            def _safe_update_banner_toggle(**kwargs):
+                """Safely update banner toggle button."""
+                button = getattr(self, "banner_toggle_btn", None)
+                if button is None:
+                    return
+                if not getattr(button, "winfo_exists", lambda: 0)():
+                    return
+                try:
+                    button.configure(**kwargs)
+                except Exception:
+                    return
+                if "state" in kwargs:
+                    try:
+                        button._state = kwargs["state"]
+                    except Exception:
+                        pass
+
+            self.banner_visible = True
+            _safe_update_banner_toggle(text="▲", state="disabled")
+            self.content_frame.grid_rowconfigure(0, weight=0)
+            self.content_frame.grid_rowconfigure(1, weight=1)
+            self.content_frame.grid_columnconfigure(0, weight=1)
+            self.inner_content_frame.grid_rowconfigure(0, weight=1)
+            self.inner_content_frame.grid_columnconfigure(0, weight=1)
+            _safe_update_banner_toggle(text="▲", state="normal")
+
+        if scenario_name:
+            selected = next((s for s in scenarios if _resolve_scenario_title(s) == str(scenario_name).strip()), None)
+            if not selected:
+                messagebox.showwarning("Not Found", f"Scenario '{scenario_name}' not found.")
+                return
+            _show_selected_scenario(selected)
+            _finalize_gm_shell()
+            return
+
+        list_selection = GenericListSelectionView(
+            parent,
+            "scenarios",
+            scenario_wrapper,
+            load_template("scenarios"),
+            on_select_callback=on_scenario_select,
         )
         list_selection.pack(fill="both", expand=True)
         self.current_gm_view = None

--- a/modules/scenarios/gm_screen2/__init__.py
+++ b/modules/scenarios/gm_screen2/__init__.py
@@ -1,0 +1,5 @@
+"""GM Screen 2 public exports."""
+
+from .desktop_view import GMScreen2View
+
+__all__ = ["GMScreen2View"]

--- a/modules/scenarios/gm_screen2/desktop_view.py
+++ b/modules/scenarios/gm_screen2/desktop_view.py
@@ -1,0 +1,11 @@
+"""Desktop-focused variant of the GM screen."""
+
+from modules.scenarios.gm_screen_view import GMScreenView
+
+
+class GMScreen2View(GMScreenView):
+    """GM Screen variant that opens panels in desktop mode by default."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("desktop_mode", True)
+        super().__init__(*args, **kwargs)

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -65,7 +65,7 @@ DEFAULT_MAP_THUMBNAIL_SIZE = (200, 140)
 
 @log_methods
 class GMScreenView(ctk.CTkFrame):
-    def __init__(self, master, scenario_item, *args, initial_layout=None, layout_manager=None, **kwargs):
+    def __init__(self, master, scenario_item, *args, initial_layout=None, layout_manager=None, desktop_mode=False, **kwargs):
         """Initialize the GMScreenView instance."""
         super().__init__(master, *args, **kwargs)
         # Persistent cache for portrait images
@@ -93,6 +93,7 @@ class GMScreenView(ctk.CTkFrame):
         self._session_mid_var = tk.StringVar()
         self._session_end_var = tk.StringVar()
         self._reduced_motion_var = tk.BooleanVar(value=False)
+        self.desktop_mode = bool(desktop_mode)
 
         self._load_persisted_state()
         self._load_motion_settings()
@@ -106,6 +107,7 @@ class GMScreenView(ctk.CTkFrame):
         self._ctrl_shift_C_binding = None
         self._ctrl_shift_c_release_binding = None
         self._ctrl_shift_C_release_binding = None
+        self._panel_shortcut_bindings = []
         self._layout_settle_scheduler = LayoutSettleScheduler(self)
         self._layout_probe_signature = None
         self._bound_layout_hosts = set()
@@ -685,6 +687,13 @@ class GMScreenView(ctk.CTkFrame):
             self._ctrl_shift_C_release_binding = top.bind(
                 "<Control-Shift-KeyRelease-C>", self.open_chatbot, add="+"
             )
+            if self.desktop_mode:
+                for idx in range(1, 10):
+                    sequence = f"<Control-Key-{idx}>"
+                    binding = top.bind(sequence, lambda _event=None, panel_index=idx - 1: self._toggle_panel_shortcut(panel_index), add="+")
+                    self._panel_shortcut_bindings.append((sequence, binding))
+                zero_binding = top.bind("<Control-Key-0>", lambda _event=None: self.restore_all_panels(), add="+")
+                self._panel_shortcut_bindings.append(("<Control-Key-0>", zero_binding))
         except Exception:
             self._bound_shortcut_owner = None
             self._ctrl_f_binding = None
@@ -693,6 +702,7 @@ class GMScreenView(ctk.CTkFrame):
             self._ctrl_shift_C_binding = None
             self._ctrl_shift_c_release_binding = None
             self._ctrl_shift_C_release_binding = None
+            self._panel_shortcut_bindings = []
 
     def _teardown_toplevel_shortcuts(self):
         """Tear down toplevel shortcuts."""
@@ -713,6 +723,9 @@ class GMScreenView(ctk.CTkFrame):
                 top.unbind("<Control-Shift-KeyRelease-c>", self._ctrl_shift_c_release_binding)
             if self._ctrl_shift_C_release_binding:
                 top.unbind("<Control-Shift-KeyRelease-C>", self._ctrl_shift_C_release_binding)
+            for sequence, binding in list(self._panel_shortcut_bindings):
+                if binding:
+                    top.unbind(sequence, binding)
         except Exception:
             pass
         finally:
@@ -723,6 +736,50 @@ class GMScreenView(ctk.CTkFrame):
             self._ctrl_F_binding = None
             self._ctrl_shift_c_release_binding = None
             self._ctrl_shift_C_release_binding = None
+
+    def _toggle_panel_shortcut(self, panel_index: int):
+        """Toggle a detached panel visibility from keyboard shortcuts."""
+        if panel_index < 0 or panel_index >= len(self.tab_order):
+            return
+        tab_name = self.tab_order[panel_index]
+        self.toggle_panel_visibility(tab_name)
+
+    def toggle_panel_visibility(self, tab_name: str):
+        """Minimize/restore a detached panel, or detach an attached one."""
+        tab = self.tabs.get(tab_name)
+        if not tab:
+            return
+        if not tab.get("detached"):
+            self.detach_tab(tab_name)
+            return
+        window = tab.get("window")
+        if window is None or not window.winfo_exists():
+            tab["detached"] = False
+            tab["window"] = None
+            return
+        try:
+            if window.state() == "withdrawn":
+                window.deiconify()
+                window.lift()
+            else:
+                window.withdraw()
+        except Exception:
+            pass
+
+    def restore_all_panels(self):
+        """Restore all detached panels in desktop mode."""
+        for tab_name in self.tab_order:
+            tab = self.tabs.get(tab_name)
+            if not tab or not tab.get("detached"):
+                continue
+            window = tab.get("window")
+            if window is None or not window.winfo_exists():
+                continue
+            try:
+                window.deiconify()
+                window.lift()
+            except Exception:
+                continue
 
     def _on_destroy(self, event=None):
         """Handle destroy."""
@@ -1227,6 +1284,9 @@ class GMScreenView(ctk.CTkFrame):
 
         self.reposition_add_button()
         self._refresh_command_deck()
+
+        if self.desktop_mode:
+            self.after_idle(lambda n=name: self.toggle_panel_visibility(n) if n in self.tabs and not self.tabs[n].get("detached") else None)
 
     def _teardown_tab_content(self, frame):
         """Tear down tab content."""
@@ -1770,6 +1830,15 @@ class GMScreenView(ctk.CTkFrame):
                 meta.pop("controller", None)
             elif meta.get("kind") == "campaign_dashboard":
                 meta.pop("cache", None)
+            tab_state = {"detached": bool(tab_info.get("detached"))}
+            window = tab_info.get("window")
+            if window is not None and getattr(window, "winfo_exists", lambda: False)():
+                try:
+                    tab_state["geometry"] = window.geometry()
+                    tab_state["minimized"] = (window.state() == "withdrawn")
+                except Exception:
+                    pass
+            meta["desktop"] = tab_state
             layout_tabs.append(meta)
         return {
             "scenario": self.scenario_name,
@@ -2069,6 +2138,18 @@ class GMScreenView(ctk.CTkFrame):
             for tab_name in list(self.tabs.keys()):
                 self._reset_tab_scroll_state(tab_name)
 
+            desktop_states = {}
+            for tab_def in tabs:
+                tab_title = str(tab_def.get("title") or "").strip()
+                if not tab_title:
+                    continue
+                desktop_state = tab_def.get("desktop")
+                if isinstance(desktop_state, dict):
+                    desktop_states[tab_title] = desktop_state
+
+            if self.desktop_mode and desktop_states:
+                self.after_idle(lambda states=desktop_states: self._apply_desktop_layout_states(states))
+
             if set_default:
                 self.layout_manager.set_scenario_default(self.scenario_name, layout_name)
             elif layout.get("scenario") == self.scenario_name and layout_name == self.layout_manager.get_scenario_default(self.scenario_name):
@@ -2098,6 +2179,36 @@ class GMScreenView(ctk.CTkFrame):
             self.after_idle(_restore_next)
 
         self.after_idle(_restore_next)
+
+    def _apply_desktop_layout_states(self, states):
+        """Apply detached/minimized/geometry state from a saved layout."""
+        for tab_name, desktop_state in (states or {}).items():
+            tab = self.tabs.get(tab_name)
+            if not tab:
+                continue
+            should_detach = bool(desktop_state.get("detached"))
+            if should_detach and not tab.get("detached"):
+                self.detach_tab(tab_name)
+            elif not should_detach and tab.get("detached"):
+                self.reattach_tab(tab_name)
+
+            tab = self.tabs.get(tab_name)
+            window = tab.get("window") if tab else None
+            if window is None or not getattr(window, "winfo_exists", lambda: False)():
+                continue
+            geometry = desktop_state.get("geometry")
+            if geometry:
+                try:
+                    window.geometry(str(geometry))
+                except Exception:
+                    pass
+            try:
+                if desktop_state.get("minimized"):
+                    window.withdraw()
+                else:
+                    window.deiconify()
+            except Exception:
+                pass
 
     def _open_entity_from_layout(self, entity_type, entity_name):
         """Open entity from layout."""
@@ -2276,12 +2387,10 @@ class GMScreenView(ctk.CTkFrame):
                 ge._on_canvas_configure(cfg)
                 ge.set_state(state)
 
-        # Hard-code size for all graph windows
-        GRAPH_W, GRAPH_H = 1600, 800
-        x_off = getattr(GMScreenView, "detached_count", 0) * (GRAPH_W + 10)
-        y_off = 0
-        detached_window.geometry(f"{GRAPH_W}x{GRAPH_H}")
-        GMScreenView.detached_count = getattr(GMScreenView, "detached_count", 0) + 1
+        # Default geometry for detached panels (can be overridden by saved layouts).
+        default_geometry = "1600x800"
+        saved_geometry = ((self.tabs.get(name, {}).get("meta") or {}).get("desktop") or {}).get("geometry")
+        detached_window.geometry(str(saved_geometry or default_geometry))
 
         detached_window.deiconify()
         self._motion.fade_in_window(detached_window, duration_ms=180)


### PR DESCRIPTION
## Summary
- Added a new `GMScreen2View` in `modules/scenarios/gm_screen2/` as a desktop-focused variant of the existing GM screen.
- Kept the existing `open_gm_screen` behavior intact and added `open_gm_screen2` in `main_window.py`.
- Added a new sidebar entry and `F10` shortcut to launch GM Screen 2.
- Extended `GMScreenView` with an optional `desktop_mode` flag to support desktop panel workflows without changing panel internals.
- Implemented panel-level shortcut controls in desktop mode:
  - `Ctrl+1..9` toggle individual panels
  - `Ctrl+0` restore all detached panels
- Extended layout serialization/restoration to persist detached panel state (`detached`, `geometry`, `minimized`) for existing panels.

## Notes
- This implementation reuses existing panel content and logic, and only changes panel behavior via placement/state controls in desktop mode.
- Existing GM Screen remains available and unchanged for current users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7596d0d04832b8227aa9dbb5aff64)