### PR TITLE
Add GM Screen 2 action to Campaign menu

### DIFF
--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -118,6 +118,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                     helper="live reference views during play",
                     items=[
                         _command("GM Screen", app.open_gm_screen, shortcut="F1", icon_key="gm_screen"),
+                        _command("GM Screen 2", app.open_gm_screen2, shortcut="F10", icon_key="gm_screen"),
                         _command("Campaign Overview", app.open_campaign_graph_view, icon_key="campaign_graph"),
                         _command("World Map", app.open_world_map, shortcut="F5", icon_key="world_map"),
                     ],
@@ -202,6 +203,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                             lambda: messagebox.showinfo(
                                 "Keyboard Shortcuts",
                                 "F1: GM Screen\n"
+                                "F10: GM Screen 2\n"
                                 "F2: Map Tool\n"
                                 "F3: Whiteboard\n"
                                 "F4: Scenario Builder\n"

--- a/tests/ui/test_menu_sections_image_commands.py
+++ b/tests/ui/test_menu_sections_image_commands.py
@@ -24,6 +24,7 @@ def test_menu_sections_expose_image_library_commands() -> None:
         destroy=lambda: None,
         refresh_entities=lambda: None,
         open_gm_screen=lambda: None,
+        open_gm_screen2=lambda: None,
         open_campaign_graph_view=lambda: None,
         open_world_map=lambda: None,
         open_character_graph_editor=lambda: None,


### PR DESCRIPTION
### Motivation
- Expose the desktop-panel variant of the GM screen in the app menu so users can open the alternate GM screen layout from the menu bar.
- Keep keyboard shortcut guidance in sync by listing the new action in the shortcuts help dialog.

### Description
- Added a `GM Screen 2` menu entry under `Campaign -> Table Surfaces` wired to `app.open_gm_screen2` with shortcut label `F10` in `modules/ui/menu/menu_sections.py`.
- Updated the `Help -> Shortcuts` help text to include `F10: GM Screen 2` in `modules/ui/menu/menu_sections.py`.
- Adjusted the menu-spec test fixture to provide `open_gm_screen2` on the fake app in `tests/ui/test_menu_sections_image_commands.py`.

### Testing
- Ran `pytest -q tests/ui/test_menu_sections_image_commands.py` and it passed (`1 passed`).
- Attempted `pytest -q tests/test_main_window_shortcuts.py` (and combined runs), which failed during collection due to an external environment dependency: `ImportError` for `PIL.ImageEnhance`, unrelated to the menu change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75baaf62c832bb47283b43be5ef22)