### PR TITLE
Fix NameError when detaching GM screen tabs

### DIFF
--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -2394,7 +2394,10 @@ class GMScreenView(ctk.CTkFrame):
 
         detached_window.deiconify()
         self._motion.fade_in_window(detached_window, duration_ms=180)
-        print(f"[DETACH] Detached window shown at {GRAPH_W}×{GRAPH_H}")
+        detached_window.update_idletasks()
+        shown_w = detached_window.winfo_width()
+        shown_h = detached_window.winfo_height()
+        print(f"[DETACH] Detached window shown at {shown_w}×{shown_h}")
 
         # Portrait & scenario-graph restoration (unchanged)…
         if hasattr(old_frame, "scenario_graph_editor") and hasattr(old_frame.scenario_graph_editor, "get_state"):


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` crash in the tab detach flow caused by undefined debug variables `GRAPH_W`/`GRAPH_H` when showing a detached window.

### Description
- Replace the broken debug print with a runtime-safe retrieval of the detached window size using `detached_window.update_idletasks()` and `detached_window.winfo_width()/winfo_height()` and log those values instead.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_screen_view.py` which succeeded. 
- Searched the file for `GRAPH_W|GRAPH_H` to confirm the undefined debug variables were removed, which found no occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75e8ce718832bbdc11185f238f27e)