### PR TITLE
Fix scenario selection callback compatibility and GM Screen 2 panel rebuild crash

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -2758,7 +2758,7 @@ class MainWindow(ctk.CTk):
 
                 view.after_idle(_open_default_tabs)
 
-        def on_scenario_select(entity_type, entity_name):
+        def on_scenario_select(entity_type, entity_name, _item=None):
             """Handle scenario select."""
             selected = next(
                 (s for s in scenarios if _resolve_scenario_title(s) == entity_name),
@@ -2943,7 +2943,7 @@ class MainWindow(ctk.CTk):
 
             self.current_gm_view = root_view
 
-        def on_scenario_select(entity_type, entity_name):
+        def on_scenario_select(entity_type, entity_name, _item=None):
             """Handle scenario selection."""
             selected = next((s for s in scenarios if _resolve_scenario_title(s) == entity_name), None)
             if not selected:

--- a/modules/generic/generic_list_selection_view.py
+++ b/modules/generic/generic_list_selection_view.py
@@ -6,6 +6,7 @@ import customtkinter as ctk
 import time
 import re
 import os
+import inspect
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -266,10 +267,24 @@ class GenericListSelectionView(ctk.CTkFrame):
         if not self.on_select_callback:
             return
         entity_name = self._resolve_entity_name(item)
-        try:
-            self.on_select_callback(self.entity_type, entity_name, item)
-        except TypeError:
-            self.on_select_callback(self.entity_type, entity_name)
+        callback = self.on_select_callback
+        signature = inspect.signature(callback)
+        positional_args = [
+            parameter
+            for parameter in signature.parameters.values()
+            if parameter.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+        has_varargs = any(
+            parameter.kind == inspect.Parameter.VAR_POSITIONAL
+            for parameter in signature.parameters.values()
+        )
+        if has_varargs or len(positional_args) >= 3:
+            callback(self.entity_type, entity_name, item)
+            return
+        callback(self.entity_type, entity_name)
 
     def _resolve_entity_name(self, item):
         """Resolve entity name."""

--- a/modules/scenarios/gm_screen2/ui/workspace/compositor.py
+++ b/modules/scenarios/gm_screen2/ui/workspace/compositor.py
@@ -17,13 +17,16 @@ class WorkspaceCompositor:
         self._on_resize_split = on_resize_split
         self._on_activate_panel = on_activate_panel
         self.zone_hosts: dict[str, PanelHostFrame] = {}
+        self._layout_root: ctk.CTkFrame | None = None
 
     def rebuild(self, root_node: LayoutNode, panel_widgets: dict[str, ctk.CTkFrame], visibility: dict[str, bool]) -> None:
-        for child in self._root.winfo_children():
-            child.destroy()
+        if self._layout_root is not None and self._layout_root.winfo_exists():
+            self._layout_root.destroy()
+        self._layout_root = ctk.CTkFrame(self._root, fg_color="transparent")
         self.zone_hosts.clear()
-        built = self._build_node(self._root, root_node, panel_widgets, visibility)
+        built = self._build_node(self._layout_root, root_node, panel_widgets, visibility)
         built.pack(fill="both", expand=True)
+        self._layout_root.pack(fill="both", expand=True)
 
     def _build_node(self, parent, node: LayoutNode, panel_widgets: dict[str, ctk.CTkFrame], visibility: dict[str, bool]):
         if isinstance(node, ZoneNode):


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when selection emitters pass an optional item object to scenario selection handlers by making the handlers accept an optional third argument. 
- Avoid `TclError: bad window path name` during GM Screen 2 layout rebuilds by ensuring panel widgets are not destroyed and re-packed incorrectly.

### Description
- Updated the two `on_scenario_select` handlers in `main_window.py` to accept an optional third parameter (`_item=None`) so they remain compatible with both 2-arg and 3-arg callbacks.  
- Reworked `GenericListSelectionView._emit_selection()` to inspect the callback signature via `inspect.signature` and call the callback with either 2 or 3 positional args (or honor `*args`) instead of relying on a `TypeError` fallback, and added `import inspect`.  
- Changed `WorkspaceCompositor.rebuild()` in `modules/scenarios/gm_screen2/ui/workspace/compositor.py` to create and reuse a dedicated `_layout_root` container frame which is destroyed/recreated during rebuilds and then packed, instead of destroying all children of the workspace root, preventing invalid widget path errors.  

### Testing
- Ran `python -m py_compile main_window.py modules/generic/generic_list_selection_view.py modules/scenarios/gm_screen2/ui/workspace/compositor.py` and compilation succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77ca70068832bb8c1133be0c2fb72)