### PR TITLE
Fix GM Screen 2 scenario selection toolbar crash

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -2869,6 +2869,8 @@ class MainWindow(ctk.CTk):
         ctk.CTkOptionMenu(layout_bar, variable=selected_layout_var, values=layout_options).pack(side="left", pady=5)
         toolbar_actions = ctk.CTkFrame(layout_bar, fg_color="transparent")
         toolbar_actions.pack(side="right", padx=6, pady=5)
+        scenario_content_host = ctk.CTkFrame(parent, fg_color="transparent")
+        scenario_content_host.pack(fill="both", expand=True, padx=10, pady=(6, 10))
 
         def _resolve_scenario_title(scenario):
             """Resolve scenario title."""
@@ -2876,10 +2878,12 @@ class MainWindow(ctk.CTk):
 
         def _show_selected_scenario(selected):
             """Show selected scenario in GM Screen 2."""
-            for w in parent.winfo_children():
+            for w in scenario_content_host.winfo_children():
                 w.destroy()
-            detail_container = ctk.CTkFrame(parent)
+            detail_container = ctk.CTkFrame(scenario_content_host)
             detail_container.grid(row=0, column=0, sticky="nsew")
+            scenario_content_host.grid_rowconfigure(0, weight=1)
+            scenario_content_host.grid_columnconfigure(0, weight=1)
             resolved_layout = initial_layout
             if resolved_layout is None:
                 chosen_layout = selected_layout_var.get()


### PR DESCRIPTION
### Motivation
- Selecting a scenario destroyed the entire `parent` content, including the `toolbar_actions` frame, which caused `_tkinter.TclError: bad window path name` on subsequent toolbar access. 
- The goal is to isolate dynamic scenario content so the layout toolbar and its widgets remain intact across scenario changes.

### Description
- Added a dedicated `scenario_content_host = ctk.CTkFrame(parent, fg_color="transparent")` and packed it to host scenario detail content. 
- Updated `_show_selected_scenario` to clear only `scenario_content_host` children by using `scenario_content_host.winfo_children()` instead of `parent.winfo_children()`. 
- Create the `detail_container` inside `scenario_content_host` and configured `scenario_content_host.grid_rowconfigure(0, weight=1)` and `grid_columnconfigure(0, weight=1)` so loaded views expand correctly. 
- This preserves `toolbar_actions` (Reset/Save/Load preset) between scenario changes and avoids stale widget references.

### Testing
- Ran `python -m py_compile main_window.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77fbf90a0832bb494e0c11c102a6e)