### PR TITLE
Remove duplicated section headers in GM Screen scenario view

### DIFF
--- a/modules/generic/detail_ui/theme.py
+++ b/modules/generic/detail_ui/theme.py
@@ -59,7 +59,14 @@ def get_textbox_style() -> dict:
     }
 
 
-def create_section_card(parent, title: str, subtitle: str | None = None, *, compact: bool = False):
+def create_section_card(
+    parent,
+    title: str,
+    subtitle: str | None = None,
+    *,
+    compact: bool = False,
+    show_header: bool = True,
+):
     """Create section card."""
     palette = get_detail_palette()
     outer = ctk.CTkFrame(
@@ -69,25 +76,27 @@ def create_section_card(parent, title: str, subtitle: str | None = None, *, comp
         border_color=palette["muted_border"],
         corner_radius=18,
     )
-    header = ctk.CTkFrame(outer, fg_color="transparent")
-    header.pack(fill="x", padx=16, pady=(14, 6 if compact else 8))
-    ctk.CTkLabel(
-        header,
-        text=title,
-        font=ctk.CTkFont(size=16 if compact else 17, weight="bold"),
-        text_color=palette["text"],
-    ).pack(anchor="w")
-    if subtitle:
+    if show_header:
+        header = ctk.CTkFrame(outer, fg_color="transparent")
+        header.pack(fill="x", padx=16, pady=(14, 6 if compact else 8))
         ctk.CTkLabel(
             header,
-            text=subtitle,
-            font=ctk.CTkFont(size=12),
-            text_color=palette["muted_text"],
-            wraplength=640,
-            justify="left",
-        ).pack(anchor="w", pady=(4, 0))
+            text=title,
+            font=ctk.CTkFont(size=16 if compact else 17, weight="bold"),
+            text_color=palette["text"],
+        ).pack(anchor="w")
+        if subtitle:
+            ctk.CTkLabel(
+                header,
+                text=subtitle,
+                font=ctk.CTkFont(size=12),
+                text_color=palette["muted_text"],
+                wraplength=640,
+                justify="left",
+            ).pack(anchor="w", pady=(4, 0))
     body = ctk.CTkFrame(outer, fg_color="transparent")
-    body.pack(fill="both", expand=True, padx=16, pady=(0, 16))
+    top_padding = 0 if show_header else 16
+    body.pack(fill="both", expand=True, padx=16, pady=(top_padding, 16))
     return outer, body
 
 

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -366,9 +366,9 @@ def _populate_generic_columns(columns, fields, entity, open_entity_callback):
 
 
 @log_function
-def insert_text(parent, header, content):
+def insert_text(parent, header, content, show_header=True):
     """Handle insert text."""
-    card, body = create_section_card(parent, header, compact=True)
+    card, body = create_section_card(parent, header, compact=True, show_header=show_header)
     card.pack(fill="x", padx=10, pady=(0, 12))
     box = ctk.CTkTextbox(body, wrap="word", height=58, **get_textbox_style())
     render_rtf_to_text_widget(box, content)
@@ -377,9 +377,9 @@ def insert_text(parent, header, content):
 
 
 @log_function
-def insert_longtext(parent, header, content):
+def insert_longtext(parent, header, content, show_header=True):
     """Handle insert longtext."""
-    card, body = create_section_card(parent, header)
+    card, body = create_section_card(parent, header, show_header=show_header)
     card.pack(fill="x", padx=10, pady=(0, 12))
     box = CTkTextbox(body, wrap="word", **get_textbox_style())
     render_rtf_to_text_widget(box, content)
@@ -397,9 +397,9 @@ def insert_longtext(parent, header, content):
 
 
 @log_function
-def insert_links(parent, header, items, linked_type, open_entity_callback):
+def insert_links(parent, header, items, linked_type, open_entity_callback, show_header=True):
     """Handle insert links."""
-    card, body = create_section_card(parent, header, compact=True)
+    card, body = create_section_card(parent, header, compact=True, show_header=show_header)
     card.pack(fill="x", padx=10, pady=(0, 12))
     links_row = None
     has_items = False
@@ -667,9 +667,9 @@ def _create_entity_dashboard_card(list_wrap, *, title, portrait_builder=None, po
     return row_card
 
 @log_function
-def insert_npc_table(parent, header, npc_names, open_entity_callback):
+def insert_npc_table(parent, header, npc_names, open_entity_callback, show_header=True):
     """Handle insert NPC table."""
-    card, body = create_section_card(parent, header, compact=True)
+    card, body = create_section_card(parent, header, compact=True, show_header=show_header)
     card.pack(fill="both", expand=True, padx=10, pady=(0, 12))
 
     palette = get_detail_palette()
@@ -718,9 +718,9 @@ def insert_npc_table(parent, header, npc_names, open_entity_callback):
         row_card.grid(row=r, column=0, sticky="ew", pady=(0, 10))
 
 @log_function
-def insert_creature_table(parent, header, creature_names, open_entity_callback):
+def insert_creature_table(parent, header, creature_names, open_entity_callback, show_header=True):
     """Handle insert creature table."""
-    card, body = create_section_card(parent, header, compact=True)
+    card, body = create_section_card(parent, header, compact=True, show_header=show_header)
     card.pack(fill="both", expand=True, padx=10, pady=(0, 12))
 
     palette = get_detail_palette()
@@ -770,9 +770,9 @@ def insert_creature_table(parent, header, creature_names, open_entity_callback):
         row_card.grid(row=r, column=0, sticky="ew", pady=(0, 10))
 
 @log_function
-def insert_villain_table(parent, header, villain_names, open_entity_callback):
+def insert_villain_table(parent, header, villain_names, open_entity_callback, show_header=True):
     """Handle insert villain table."""
-    card, body = create_section_card(parent, header, compact=True)
+    card, body = create_section_card(parent, header, compact=True, show_header=show_header)
     card.pack(fill="both", expand=True, padx=10, pady=(0, 12))
 
     palette = get_detail_palette()
@@ -829,11 +829,11 @@ def insert_villain_table(parent, header, villain_names, open_entity_callback):
         row_card.grid(row=r, column=0, sticky="ew", pady=(0, 10))
 
 @log_function
-def insert_places_table(parent, header, place_names, open_entity_callback):
+def insert_places_table(parent, header, place_names, open_entity_callback, show_header=True):
     """
     Render places as dashboard cards instead of a raw grid.
     """
-    card, body = create_section_card(parent, header, compact=True)
+    card, body = create_section_card(parent, header, compact=True, show_header=show_header)
     card.pack(fill="both", expand=True, padx=10, pady=(0, 12))
 
     palette = get_detail_palette()
@@ -1768,7 +1768,7 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
         section_frame = _get_section_frame(section_name)
 
         if ftype == "text":
-            insert_text(section_frame, name, value)
+            insert_text(section_frame, name, value, show_header=name != section_name)
         elif ftype == "list_longtext":
             if name == "Scenes" and gm_view_instance is not None:
                 # Handle the branch where name == 'Scenes' and GM view instance is available.
@@ -1778,6 +1778,7 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
                     section_frame,
                     "Scenes",
                     "Run the scenario as a scene list or switch to scene flow.",
+                    show_header=False,
                 )
                 scenes_card.pack(fill="both", expand=True, padx=10, pady=(0, 12))
 
@@ -2018,17 +2019,18 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
                     open_entity_callback,
                     entity_collector=scene_entity_tracker,
                     gm_view=gm_view_instance,
+                    show_header=name != section_name,
                 )
         elif ftype == "longtext":
-            insert_longtext(section_frame, name, value)
+            insert_longtext(section_frame, name, value, show_header=name != section_name)
         elif ftype == "list":
             # Handle the branch where ftype == 'list'.
             linked = field.get("linked_type")
             items  = value if isinstance(value, list) else []
             if linked == "NPCs":
-                insert_npc_table(section_frame, "NPCs", items, open_entity_callback)
+                insert_npc_table(section_frame, "NPCs", items, open_entity_callback, show_header=False)
             elif linked == "Villains":
-                insert_villain_table(section_frame, "Villains", items, open_entity_callback)
+                insert_villain_table(section_frame, "Villains", items, open_entity_callback, show_header=False)
             elif linked == "Creatures":
                 # Handle the branch where linked == 'Creatures'.
                 filtered_creatures = [
@@ -2037,11 +2039,11 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
                 ]
                 if not filtered_creatures:
                     continue
-                insert_creature_table(section_frame, "Creatures", filtered_creatures, open_entity_callback)
+                insert_creature_table(section_frame, "Creatures", filtered_creatures, open_entity_callback, show_header=False)
             elif linked == "Places":
-                insert_places_table(section_frame, "Places", items, open_entity_callback)
+                insert_places_table(section_frame, "Places", items, open_entity_callback, show_header=False)
             else:
-                insert_links(section_frame, name, items, linked, open_entity_callback)
+                insert_links(section_frame, name, items, linked, open_entity_callback, show_header=name != section_name)
 
     insert_relationship_table(
         _get_section_frame("NPCs"),
@@ -2055,6 +2057,7 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
         secrets_section,
         "Secrets",
         "Hidden truths, leverage, and reveals to hold in reserve.",
+        show_header=False,
     )
     secrets_card.pack(fill="x", padx=10, pady=(0, 12))
     secrets_text_label = CTkLabel(


### PR DESCRIPTION
### Motivation
- Scenario detail cards inside the GM Screen showed the same section title twice (left navigation + card header), wasting vertical space. 
- Provide a way for section cards to render without repeating the title while keeping existing callers working.

### Description
- Added a `show_header: bool` option to `create_section_card` in `modules/generic/detail_ui/theme.py` to allow rendering the card body without the card header. 
- Propagated `show_header` through entity detail helpers in `modules/generic/entity_detail_factory.py` by extending `insert_text`, `insert_longtext`, `insert_links`, `insert_npc_table`, `insert_creature_table`, `insert_villain_table`, and `insert_places_table` with a `show_header` parameter. 
- Updated the scenario-detail rendering logic to pass `show_header=False` for sections that duplicate the left-side navigation (Scenes, NPCs, Villains, Creatures, Places, Secrets) and to suppress redundant field headers inside those sections. 
- Kept default behavior unchanged for callers that do not opt into `show_header`, preserving backward compatibility.

### Testing
- Compiled the modified modules with `python -m py_compile modules/generic/entity_detail_factory.py modules/generic/detail_ui/theme.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88832cc70832ba714ec5bc51c7899)