### PR TITLE
Add canonical structured scene section fields with migration fallback

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -1139,6 +1139,8 @@ def insert_list_longtext(
             scene_dict["Title"] = title_clean
 
         indicator_payload = build_scene_indicator_payload(scene_dict, body_text)
+        for field_name, values in (indicator_payload.get("structured_sections") or {}).items():
+            scene_dict[field_name] = list(values or [])
 
         return {
             "scene_dict": scene_dict,
@@ -1250,6 +1252,7 @@ def insert_list_longtext(
         scene_sections = build_scene_body_sections(
             body,
             body_text=body_text,
+            scene_dict=scene_dict,
             npc_names=npc_names,
             villain_names=villain_names,
             creature_names=creature_names,

--- a/modules/generic/scene_indicator_payload.py
+++ b/modules/generic/scene_indicator_payload.py
@@ -5,7 +5,11 @@ from collections.abc import Iterable
 from typing import Any
 
 from modules.helpers.text_helpers import deserialize_possible_json
-from modules.scenarios.widgets.scene_sections_parser import parse_scene_body_sections
+from modules.scenarios.scene_structured_fields import (
+    get_structured_field_name_for_section_key,
+    migrate_scene_to_structured_fields,
+    parse_scene_sections_with_structured_fallback,
+)
 
 
 _NAME_FIELD_ALIASES: dict[str, tuple[str, ...]] = {
@@ -156,7 +160,7 @@ def _merge_links(scene_dict: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _collect_names_from_sections(body_text: str, section_key: str) -> list[str]:
     """Collect names from sections."""
-    parsed = parse_scene_body_sections(body_text)
+    parsed = parse_scene_sections_with_structured_fallback({}, body_text)
     sections = parsed.get("sections") or []
     collected: list[str] = []
     for section in sections:
@@ -168,8 +172,14 @@ def _collect_names_from_sections(body_text: str, section_key: str) -> list[str]:
     return collected
 
 
+def migrate_scene_indicator_scene(scene_dict: dict[str, Any], body_text: str) -> dict[str, Any]:
+    """Populate scene payload with canonical structured section fields."""
+    return migrate_scene_to_structured_fields(scene_dict, body_text)
+
+
 def build_scene_indicator_payload(scene_dict: dict[str, Any], body_text: str) -> dict[str, Any]:
     """Build scene indicator payload."""
+    scene_dict = migrate_scene_indicator_scene(scene_dict, body_text)
     npcs = _collect_names(scene_dict, "NPCs")
     places = _collect_names(scene_dict, "Places")
     maps = _collect_names(scene_dict, "Maps")
@@ -177,9 +187,22 @@ def build_scene_indicator_payload(scene_dict: dict[str, Any], body_text: str) ->
     creatures = _collect_names(scene_dict, "Creatures")
 
     if not npcs:
+        npcs = _normalize_names(scene_dict.get("SceneNPCs") or [])
+    if not places:
+        places = _normalize_names(scene_dict.get("SceneLocations") or [])
+    if not npcs:
         npcs = _collect_names_from_sections(body_text, "involved npcs")
     if not places:
         places = _collect_names_from_sections(body_text, "important locations")
+
+    sections_payload = parse_scene_sections_with_structured_fallback(scene_dict, body_text)
+    section_field_values: dict[str, list[str]] = {}
+    for section in sections_payload.get("sections") or []:
+        section_key = str(section.get("key") or "").lower()
+        field_name = get_structured_field_name_for_section_key(section_key)
+        if not field_name:
+            continue
+        section_field_values[field_name] = _normalize_names(section.get("items") or [])
 
     links = _merge_links(scene_dict)
 
@@ -190,4 +213,15 @@ def build_scene_indicator_payload(scene_dict: dict[str, Any], body_text: str) ->
         "villain_names": villains,
         "creature_names": creatures,
         "links": links,
+        "structured_sections": {
+            field_name: section_field_values.get(field_name, _normalize_names(scene_dict.get(field_name) or []))
+            for field_name in (
+                "SceneBeats",
+                "SceneObstacles",
+                "SceneClues",
+                "SceneTransitions",
+                "SceneLocations",
+                "SceneNPCs",
+            )
+        },
     }

--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -40,6 +40,7 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_aggregator import (
     collect_scene_entity_names,
 )
 from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import (
+    SCENE_STRUCTURED_FIELDS,
     canonicalise_scene,
     guided_cards_to_scenes,
     normalise_scene_links,
@@ -538,6 +539,8 @@ class ScenesPlanningStep(WizardStep):
                 record["NextScenes"] = [link["target"] for link in links]
                 record["Links"] = [{"target": link["target"], "text": link.get("text") or link["target"]} for link in links]
             for field_name in SCENE_CARD_ENTITY_FIELDS:
+                record[field_name] = normalise_entity_list(scene.get(field_name))
+            for field_name in SCENE_STRUCTURED_FIELDS:
                 record[field_name] = normalise_entity_list(scene.get(field_name))
             extras = scene.get("_extra_fields")
             if isinstance(extras, dict):

--- a/modules/scenarios/scene_structured_fields.py
+++ b/modules/scenarios/scene_structured_fields.py
@@ -1,0 +1,122 @@
+"""Structured scene field helpers and migrations."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterable
+from typing import Any
+
+from modules.helpers.text_helpers import deserialize_possible_json
+from modules.scenarios.widgets.scene_sections_parser import parse_scene_body_sections
+
+SCENE_STRUCTURED_SECTION_FIELDS: tuple[dict[str, str], ...] = (
+    {"field": "SceneBeats", "key": "key beats", "title": "Key beats", "emoji": "🎯"},
+    {"field": "SceneObstacles", "key": "conflicts/obstacles", "title": "Conflicts/obstacles", "emoji": "⚔️"},
+    {"field": "SceneClues", "key": "clues/hooks", "title": "Clues/hooks", "emoji": "🧩"},
+    {"field": "SceneTransitions", "key": "transitions", "title": "Transitions", "emoji": "🔀"},
+    {"field": "SceneLocations", "key": "important locations", "title": "Important locations", "emoji": "📍"},
+    {"field": "SceneNPCs", "key": "involved npcs", "title": "Involved NPCs", "emoji": "🧑‍🤝‍🧑"},
+)
+
+_SECTION_FIELD_BY_KEY = {item["key"]: item["field"] for item in SCENE_STRUCTURED_SECTION_FIELDS}
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    """Internal helper for coerce string list."""
+    parsed = deserialize_possible_json(value)
+    if parsed is None:
+        return []
+    if isinstance(parsed, dict):
+        values: list[str] = []
+        for nested in parsed.values():
+            values.extend(_coerce_string_list(nested))
+        return values
+    if isinstance(parsed, (list, tuple, set)):
+        values: list[str] = []
+        for nested in parsed:
+            values.extend(_coerce_string_list(nested))
+        return values
+    if isinstance(parsed, str):
+        candidates = [part.strip() for part in parsed.splitlines() if part.strip()]
+        return candidates or ([parsed.strip()] if parsed.strip() else [])
+    text = str(parsed).strip()
+    return [text] if text else []
+
+
+def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
+    """Internal helper for dedupe preserve order."""
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for raw in values:
+        text = str(raw).strip()
+        key = text.lower()
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(text)
+    return deduped
+
+
+def extract_structured_scene_sections(scene_dict: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract display sections from structured scene fields."""
+    if not isinstance(scene_dict, dict):
+        return []
+
+    sections: list[dict[str, Any]] = []
+    for definition in SCENE_STRUCTURED_SECTION_FIELDS:
+        items = _dedupe_preserve_order(_coerce_string_list(scene_dict.get(definition["field"])))
+        if not items:
+            continue
+        sections.append(
+            {
+                "key": definition["key"],
+                "title": definition["title"],
+                "emoji": definition["emoji"],
+                "items": items,
+                "raw_text": "\n".join(f"- {item}" for item in items),
+            }
+        )
+    return sections
+
+
+def parse_scene_sections_with_structured_fallback(scene_dict: dict[str, Any], body_text: str) -> dict[str, Any]:
+    """Build parsed section payload, preferring structured scene fields."""
+    sections = extract_structured_scene_sections(scene_dict)
+    if sections:
+        return {
+            "intro_text": str(body_text or "").strip(),
+            "sections": sections,
+            "has_sections": True,
+            "source": "structured",
+        }
+    parsed = parse_scene_body_sections(body_text)
+    parsed["source"] = "parser"
+    return parsed
+
+
+def migrate_scene_to_structured_fields(scene_dict: dict[str, Any], body_text: str = "") -> dict[str, Any]:
+    """Populate canonical structured section fields from existing scene content."""
+    if not isinstance(scene_dict, dict):
+        scene_dict = {"Text": str(scene_dict or "")}
+
+    migrated = copy.deepcopy(scene_dict)
+    parser_payload = parse_scene_body_sections(body_text)
+    parsed_items_by_key = {
+        str(section.get("key") or "").lower(): _dedupe_preserve_order(section.get("items") or [])
+        for section in (parser_payload.get("sections") or [])
+    }
+
+    for definition in SCENE_STRUCTURED_SECTION_FIELDS:
+        field_name = definition["field"]
+        existing_items = _dedupe_preserve_order(_coerce_string_list(migrated.get(field_name)))
+        if existing_items:
+            migrated[field_name] = existing_items
+            continue
+        migrated[field_name] = parsed_items_by_key.get(definition["key"], [])
+
+    return migrated
+
+
+def get_structured_field_name_for_section_key(section_key: str) -> str | None:
+    """Return canonical field name for a parser section key."""
+    return _SECTION_FIELD_BY_KEY.get(str(section_key or "").strip().lower())

--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -3,9 +3,9 @@ import customtkinter as ctk
 from customtkinter import CTkLabel
 
 from modules.generic.detail_ui import get_detail_palette
+from modules.scenarios.scene_structured_fields import parse_scene_sections_with_structured_fallback
 from modules.scenarios.widgets.scene_body import create_entities_groups_grid, prepare_entities_for_group
 from modules.scenarios.widgets.scene_density import get_scene_density_style
-from modules.scenarios.widgets.scene_sections_parser import parse_scene_body_sections
 
 
 def _compute_wraplength(container_width, *, horizontal_padding, min_wrap, safety_margin=10):
@@ -154,10 +154,10 @@ def _render_card_bullets(container, items, *, expanded, font_size):
     _refresh_wrap()
 
 
-def _create_description_block(parent, body_text, *, description_font_size=13):
+def _create_description_block(parent, body_text, *, scene_dict=None, description_font_size=13):
     """Create description block."""
     palette = get_detail_palette()
-    parsed = parse_scene_body_sections(body_text)
+    parsed = parse_scene_sections_with_structured_fallback(scene_dict or {}, body_text)
     if not parsed.get("has_sections"):
         return _create_description_block_fallback(parent, body_text, description_font_size=description_font_size)
 
@@ -443,6 +443,7 @@ def _create_links_block(parent, links, open_scene_callback=None):
 def build_scene_body_sections(
     parent,
     body_text,
+    scene_dict,
     npc_names,
     villain_names,
     creature_names,
@@ -465,6 +466,7 @@ def build_scene_body_sections(
     description_block, description_label = _create_description_block(
         shell,
         body_text,
+        scene_dict=scene_dict,
         description_font_size=density_style["description_font_size"],
     )
     if has_entities or has_maps or has_links:

--- a/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
+++ b/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
@@ -6,6 +6,7 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
     SCENE_ENTITY_FIELDS,
     normalise_entity_list,
 )
+from modules.scenarios.scene_structured_fields import SCENE_STRUCTURED_SECTION_FIELDS, migrate_scene_to_structured_fields
 
 GUIDED_BOUNDARY_FLOW = (
     ("Hook", "Setup"),
@@ -18,6 +19,8 @@ LEGACY_GUIDED_FLOW = (
     ("Climax", "Combat"),
     ("Fallout", "Outcome"),
 )
+
+SCENE_STRUCTURED_FIELDS = tuple(item["field"] for item in SCENE_STRUCTURED_SECTION_FIELDS)
 
 
 def _split_to_list(value):
@@ -58,18 +61,18 @@ def normalise_scene_links(scene):
 def canonicalise_scene(scene, *, index=0):
     """Handle canonicalise scene."""
     if not isinstance(scene, dict):
-        return {
+        return migrate_scene_to_structured_fields({
             "Title": f"Scene {index + 1}",
             "Summary": str(scene or ""),
             "SceneType": "",
             "LinkData": [],
             "NextScenes": [],
             "_canvas": {},
-        }
+        }, str(scene or ""))
     data = copy.deepcopy(scene)
     summary = str(data.get("Summary") or data.get("Text") or "").strip()
     links = normalise_scene_links(data)
-    return {
+    canonical_scene = {
         "Title": str(data.get("Title") or data.get("Name") or f"Scene {index + 1}").strip(),
         "Summary": summary,
         "SceneType": str(data.get("SceneType") or data.get("Type") or "").strip(),
@@ -80,14 +83,19 @@ def canonicalise_scene(scene, *, index=0):
             field_name: normalise_entity_list(data.get(field_name))
             for field_name in SCENE_ENTITY_FIELDS
         },
+        **{
+            field_name: normalise_entity_list(data.get(field_name))
+            for field_name in SCENE_STRUCTURED_FIELDS
+        },
         "_extra_fields": {
             k: copy.deepcopy(v)
             for k, v in data.items()
             if k not in {
-                "Title", "Name", "Summary", "Text", "SceneType", "Type", "LinkData", "Links", "NextScenes", "_canvas", *SCENE_ENTITY_FIELDS
+                "Title", "Name", "Summary", "Text", "SceneType", "Type", "LinkData", "Links", "NextScenes", "_canvas", *SCENE_ENTITY_FIELDS, *SCENE_STRUCTURED_FIELDS
             }
         },
     }
+    return migrate_scene_to_structured_fields(canonical_scene, summary)
 
 
 def scenes_to_guided_cards(scenes):
@@ -134,6 +142,10 @@ def scenes_to_guided_cards(scenes):
                     field_name: normalise_entity_list(scene.get(field_name))
                     for field_name in SCENE_ENTITY_FIELDS
                 },
+                **{
+                    field_name: normalise_entity_list(scene.get(field_name))
+                    for field_name in SCENE_STRUCTURED_FIELDS
+                },
                 "_extra_fields": copy.deepcopy(scene.get("_extra_fields") or {}),
             }
         )
@@ -176,6 +188,10 @@ def guided_cards_to_scenes(cards):
             **{
                 field_name: normalise_entity_list(card.get(field_name))
                 for field_name in SCENE_ENTITY_FIELDS
+            },
+            **{
+                field_name: normalise_entity_list(card.get(field_name))
+                for field_name in SCENE_STRUCTURED_FIELDS
             },
         }
         extras = card.get("_extra_fields")


### PR DESCRIPTION
### Motivation
- Provide canonical, queryable scene section fields (beats, obstacles, clues, transitions, locations, NPCs) so UI and services can read structured data instead of parsing free text.
- Migrate existing text-only scenes into these fields where possible to improve downstream features (indicators, persistence, guided editors) while keeping backward compatibility.

### Description
- Added `modules/scenarios/scene_structured_fields.py` with canonical field definitions (`SceneBeats`, `SceneObstacles`, `SceneClues`, `SceneTransitions`, `SceneLocations`, `SceneNPCs`), extraction helpers, and a migration function `migrate_scene_to_structured_fields` that uses the existing parser to populate missing structured fields.
- Updated `modules/scenarios/widgets/scene_body_sections.py` to prefer structured fields via `parse_scene_sections_with_structured_fallback(scene_dict, body_text)` and accept a `scene_dict` parameter so rendering uses structured data first and falls back to the parser for legacy bodies.
- Added migration and structured-awareness to indicator and normalization flows: `modules/generic/scene_indicator_payload.py` now migrates scene dicts before building payloads and exposes `structured_sections` in the payload; `modules/generic/entity_detail_factory.py` attaches migrated structured fields back onto `scene_dict` before rendering.
- Ensured structured fields are carried through scene canonicalization and scenario persistence by updating `modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py` and `modules/scenarios/scenario_builder_wizard.py` so the structured fields are included when converting/canonicalizing scenes and when saving scenario payloads.

### Testing
- Ran a Python compile check: `python -m py_compile modules/scenarios/scene_structured_fields.py modules/scenarios/widgets/scene_body_sections.py modules/generic/scene_indicator_payload.py modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py modules/scenarios/scenario_builder_wizard.py modules/generic/entity_detail_factory.py`, and compilation succeeded.
- No existing unit tests were modified; runtime/behavioral tests should be performed in-app to validate UI presentation and scene persistence with mixed legacy and migrated scenes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0a4d64fc832b88b9e4b9d7f0806f)