### PR TITLE
Add structured scene section editors and one-shot legacy conversion

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -46,6 +46,11 @@ from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import (
     normalise_scene_links,
     scenes_to_guided_cards,
 )
+from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import (
+    SCENE_STRUCTURED_FIELD_LABELS,
+    convert_structured_fields_from_text,
+    parse_multiline_items,
+)
 
 try:
     _IMAGE_RESAMPLE = Image.Resampling.LANCZOS
@@ -644,7 +649,7 @@ class InlineSceneEditor(ctk.CTkFrame):
         ]
 
         self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(3, weight=1)
+        self.grid_rowconfigure(5, weight=1)
 
         ctk.CTkLabel(
             self,
@@ -674,15 +679,53 @@ class InlineSceneEditor(ctk.CTkFrame):
         self.summary_text.grid(row=3, column=0, sticky="nsew", padx=12)
         self.summary_text.insert("1.0", scene.get("Summary") or scene.get("Text") or "")
 
+        structure_section = ctk.CTkFrame(self, fg_color="#111827", corner_radius=10)
+        structure_section.grid(row=4, column=0, sticky="ew", padx=12, pady=(8, 0))
+        structure_section.grid_columnconfigure((0, 1), weight=1)
+        ctk.CTkLabel(
+            structure_section,
+            text="Scene Structure",
+            font=ctk.CTkFont(size=12, weight="bold"),
+            text_color="#b8c7e2",
+            anchor="w",
+        ).grid(row=0, column=0, sticky="w", padx=10, pady=(8, 4))
+        self._structured_prefilled = bool(scene.get("_structured_prefilled"))
+        self.convert_btn = ctk.CTkButton(
+            structure_section,
+            text="Convert from existing text",
+            width=180,
+            state="disabled" if self._structured_prefilled else "normal",
+            command=self._convert_from_summary,
+        )
+        self.convert_btn.grid(row=0, column=1, sticky="e", padx=10, pady=(8, 4))
+
+        self.structured_widgets = {}
+        for section_idx, field_name in enumerate(SCENE_STRUCTURED_FIELDS):
+            row = 1 + (section_idx // 2)
+            col = section_idx % 2
+            field_frame = ctk.CTkFrame(structure_section, fg_color="transparent")
+            field_frame.grid(row=row, column=col, sticky="nsew", padx=10, pady=(0, 8))
+            field_frame.grid_columnconfigure(0, weight=1)
+            ctk.CTkLabel(
+                field_frame,
+                text=SCENE_STRUCTURED_FIELD_LABELS.get(field_name, field_name),
+                text_color="#8fa6cc",
+                anchor="w",
+            ).grid(row=0, column=0, sticky="w", pady=(0, 4))
+            widget = ctk.CTkTextbox(field_frame, height=70, wrap="word")
+            widget.grid(row=1, column=0, sticky="ew")
+            widget.insert("1.0", "\n".join(parse_multiline_items(scene.get(field_name))))
+            self.structured_widgets[field_name] = widget
+
         ctk.CTkLabel(
             self,
             text="Ctrl+Enter to save, Esc to cancel",
             text_color="#9db4d1",
             anchor="w",
-        ).grid(row=4, column=0, sticky="ew", padx=12, pady=(6, 0))
+        ).grid(row=6, column=0, sticky="ew", padx=12, pady=(6, 0))
 
         button_row = ctk.CTkFrame(self, fg_color="transparent")
-        button_row.grid(row=5, column=0, sticky="ew", padx=12, pady=(8, 10))
+        button_row.grid(row=7, column=0, sticky="ew", padx=12, pady=(8, 10))
         button_row.grid_columnconfigure((0, 1), weight=1)
         ctk.CTkButton(button_row, text="Cancel", command=self._on_cancel).grid(
             row=0, column=0, sticky="ew", padx=(0, 6)
@@ -699,12 +742,33 @@ class InlineSceneEditor(ctk.CTkFrame):
 
         self.summary_text.focus_set()
 
+    def _convert_from_summary(self):
+        """Run legacy parser once to prefill structured fields."""
+        if self._structured_prefilled:
+            return
+        summary = self.summary_text.get("1.0", "end").strip()
+        converted = convert_structured_fields_from_text({}, summary)
+        for field_name, values in converted.items():
+            widget = self.structured_widgets.get(field_name)
+            if widget is None:
+                continue
+            widget.delete("1.0", "end")
+            widget.insert("1.0", "\n".join(values))
+        self._structured_prefilled = True
+        self.convert_btn.configure(state="disabled")
+
     def _on_save(self, _event=None):
         """Handle save."""
+        structured_data = {
+            field_name: parse_multiline_items(widget.get("1.0", "end"))
+            for field_name, widget in self.structured_widgets.items()
+        }
         data = {
             "Title": self.title_var.get().strip(),
             "SceneType": self.type_var.get().strip(),
             "Summary": self.summary_text.get("1.0", "end").strip(),
+            "_structured_prefilled": self._structured_prefilled,
+            **structured_data,
         }
         if callable(self.on_save):
             self.on_save(data)

--- a/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
@@ -10,7 +10,15 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
     SCENE_ENTITY_FIELDS,
     normalise_entity_list,
 )
-from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import normalise_scene_links
+from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import (
+    SCENE_STRUCTURED_FIELDS,
+    normalise_scene_links,
+)
+from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import (
+    SCENE_STRUCTURED_FIELD_LABELS,
+    convert_structured_fields_from_text,
+    parse_multiline_items,
+)
 
 
 class InlineSceneEditor(ctk.CTkFrame):
@@ -21,7 +29,7 @@ class InlineSceneEditor(ctk.CTkFrame):
         self.on_cancel = on_cancel
 
         self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(3, weight=1)
+        self.grid_rowconfigure(5, weight=1)
 
         ctk.CTkLabel(self, text="Scene Details", font=ctk.CTkFont(size=14, weight="bold"), anchor="w").grid(
             row=0, column=0, sticky="ew", padx=12, pady=(12, 6)
@@ -42,19 +50,77 @@ class InlineSceneEditor(ctk.CTkFrame):
         self.summary_text.grid(row=3, column=0, sticky="nsew", padx=12)
         self.summary_text.insert("1.0", scene.get("Summary") or scene.get("Text") or "")
 
+        structure_section = ctk.CTkFrame(self, fg_color="#111827", corner_radius=10)
+        structure_section.grid(row=4, column=0, sticky="ew", padx=12, pady=(8, 0))
+        structure_section.grid_columnconfigure((0, 1), weight=1)
+        ctk.CTkLabel(
+            structure_section,
+            text="Scene Structure",
+            font=ctk.CTkFont(size=12, weight="bold"),
+            text_color="#b8c7e2",
+            anchor="w",
+        ).grid(row=0, column=0, sticky="w", padx=10, pady=(8, 4))
+        self._structured_prefilled = bool(scene.get("_structured_prefilled"))
+        self.convert_btn = ctk.CTkButton(
+            structure_section,
+            text="Convert from existing text",
+            width=180,
+            state="disabled" if self._structured_prefilled else "normal",
+            command=self._convert_from_summary,
+        )
+        self.convert_btn.grid(row=0, column=1, sticky="e", padx=10, pady=(8, 4))
+        self.structured_widgets = {}
+        for section_idx, field_name in enumerate(SCENE_STRUCTURED_FIELDS):
+            row = 1 + (section_idx // 2)
+            col = section_idx % 2
+            field_frame = ctk.CTkFrame(structure_section, fg_color="transparent")
+            field_frame.grid(row=row, column=col, sticky="nsew", padx=10, pady=(0, 8))
+            field_frame.grid_columnconfigure(0, weight=1)
+            ctk.CTkLabel(
+                field_frame,
+                text=SCENE_STRUCTURED_FIELD_LABELS.get(field_name, field_name),
+                text_color="#8fa6cc",
+                anchor="w",
+            ).grid(row=0, column=0, sticky="w", pady=(0, 4))
+            widget = ctk.CTkTextbox(field_frame, height=70, wrap="word")
+            widget.grid(row=1, column=0, sticky="ew")
+            widget.insert("1.0", "\n".join(parse_multiline_items(scene.get(field_name))))
+            self.structured_widgets[field_name] = widget
+
         row = ctk.CTkFrame(self, fg_color="transparent")
-        row.grid(row=4, column=0, sticky="ew", padx=12, pady=(8, 10))
+        row.grid(row=6, column=0, sticky="ew", padx=12, pady=(8, 10))
         row.grid_columnconfigure((0, 1), weight=1)
         ctk.CTkButton(row, text="Cancel", command=self._on_cancel).grid(row=0, column=0, sticky="ew", padx=(0, 6))
         ctk.CTkButton(row, text="Save", command=self._on_save).grid(row=0, column=1, sticky="ew", padx=(6, 0))
 
+    def _convert_from_summary(self):
+        """Run legacy parser once to prefill structured fields."""
+        if self._structured_prefilled:
+            return
+        summary = self.summary_text.get("1.0", "end").strip()
+        converted = convert_structured_fields_from_text({}, summary)
+        for field_name, values in converted.items():
+            widget = self.structured_widgets.get(field_name)
+            if widget is None:
+                continue
+            widget.delete("1.0", "end")
+            widget.insert("1.0", "\n".join(values))
+        self._structured_prefilled = True
+        self.convert_btn.configure(state="disabled")
+
     def _on_save(self):
         """Handle save."""
+        structured_data = {
+            field_name: parse_multiline_items(widget.get("1.0", "end"))
+            for field_name, widget in self.structured_widgets.items()
+        }
         self.on_save(
             {
                 "Title": self.title_var.get().strip(),
                 "SceneType": self.type_var.get().strip(),
                 "Summary": self.summary_text.get("1.0", "end").strip(),
+                "_structured_prefilled": self._structured_prefilled,
+                **structured_data,
             }
         )
 
@@ -121,6 +187,8 @@ class CanvasScenePlanner(ctk.CTkFrame):
     def add_scene(self):
         """Handle add scene."""
         scene = {"Title": f"Scene {len(self.scenes) + 1}", "Summary": "", "SceneType": "", "LinkData": [], "NextScenes": [], "_canvas": {}}
+        for field_name in SCENE_STRUCTURED_FIELDS:
+            scene[field_name] = []
         self._assign_default_position(scene)
         self.scenes.append(scene)
         self.selected_index = len(self.scenes) - 1
@@ -194,6 +262,9 @@ class CanvasScenePlanner(ctk.CTkFrame):
         scene["Title"] = data.get("Title") or scene.get("Title") or f"Scene {index + 1}"
         scene["Summary"] = data.get("Summary", "")
         scene["SceneType"] = data.get("SceneType", "")
+        for field_name in SCENE_STRUCTURED_FIELDS:
+            scene[field_name] = parse_multiline_items(data.get(field_name))
+        scene["_structured_prefilled"] = bool(data.get("_structured_prefilled"))
         self._close_inline_scene_editor()
         self.canvas.set_scenes(self.scenes, self.selected_index)
 

--- a/modules/scenarios/wizard_steps/scenes/guided_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/guided_scene_planner.py
@@ -7,6 +7,12 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
     SCENE_ENTITY_FIELDS,
     normalise_entity_list,
 )
+from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import SCENE_STRUCTURED_FIELDS
+from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import (
+    SCENE_STRUCTURED_FIELD_LABELS,
+    convert_structured_fields_from_text,
+    parse_multiline_items,
+)
 
 
 class GuidedScenePlanner(ctk.CTkFrame):
@@ -31,7 +37,19 @@ class GuidedScenePlanner(ctk.CTkFrame):
         self._container.grid(row=1, column=0, sticky="nsew", padx=12, pady=(0, 12))
         self._container.grid_columnconfigure(0, weight=1)
 
-    def _new_card_data(self, *, title="", summary="", scene_type="Choice", stage="", canvas=None, extra_fields=None, entities=None):
+    def _new_card_data(
+        self,
+        *,
+        title="",
+        summary="",
+        scene_type="Choice",
+        stage="",
+        canvas=None,
+        extra_fields=None,
+        entities=None,
+        structured=None,
+        structured_prefilled=False,
+    ):
         """Internal helper for new card data."""
         card = {
             "stage": stage or "Scene",
@@ -46,6 +64,12 @@ class GuidedScenePlanner(ctk.CTkFrame):
             card[field_name] = normalise_entity_list(
                 incoming_entities.get(field_name) if isinstance(incoming_entities, dict) else None
             )
+        incoming_structured = structured or {}
+        for field_name in SCENE_STRUCTURED_FIELDS:
+            card[field_name] = parse_multiline_items(
+                incoming_structured.get(field_name) if isinstance(incoming_structured, dict) else None
+            )
+        card["_structured_prefilled"] = bool(structured_prefilled)
         return card
 
     def _card_heading(self, index):
@@ -75,6 +99,8 @@ class GuidedScenePlanner(ctk.CTkFrame):
             canvas=payload.get("_canvas"),
             extra_fields=payload.get("_extra_fields"),
             entities={field_name: payload.get(field_name) for field_name in SCENE_ENTITY_FIELDS},
+            structured={field_name: payload.get(field_name) for field_name in SCENE_STRUCTURED_FIELDS},
+            structured_prefilled=payload.get("_structured_prefilled"),
         )
 
     def _render_cards(self):
@@ -126,8 +152,45 @@ class GuidedScenePlanner(ctk.CTkFrame):
             summary.grid(row=2, column=0, sticky="ew", padx=12, pady=(8, 12))
             summary.insert("1.0", payload["Summary"])
 
+            structured_section = ctk.CTkFrame(card, fg_color="#111827", corner_radius=10)
+            structured_section.grid(row=3, column=0, sticky="ew", padx=12, pady=(0, 8))
+            structured_section.grid_columnconfigure((0, 1), weight=1)
+            ctk.CTkLabel(
+                structured_section,
+                text="Scene Structure",
+                font=ctk.CTkFont(size=12, weight="bold"),
+                text_color="#b8c7e2",
+                anchor="w",
+            ).grid(row=0, column=0, sticky="w", padx=10, pady=(8, 4))
+            convert_state = "disabled" if payload.get("_structured_prefilled") else "normal"
+            ctk.CTkButton(
+                structured_section,
+                text="Convert from existing text",
+                width=180,
+                state=convert_state,
+                command=lambda i=idx: self._prefill_structured_fields(i),
+            ).grid(row=0, column=1, sticky="e", padx=10, pady=(8, 4))
+
+            structured_widgets = {}
+            for section_idx, field_name in enumerate(SCENE_STRUCTURED_FIELDS):
+                row = 1 + (section_idx // 2)
+                col = section_idx % 2
+                field_frame = ctk.CTkFrame(structured_section, fg_color="transparent")
+                field_frame.grid(row=row, column=col, sticky="nsew", padx=10, pady=(0, 8))
+                field_frame.grid_columnconfigure(0, weight=1)
+                ctk.CTkLabel(
+                    field_frame,
+                    text=SCENE_STRUCTURED_FIELD_LABELS.get(field_name, field_name),
+                    anchor="w",
+                    text_color="#8fa6cc",
+                ).grid(row=0, column=0, sticky="w", pady=(0, 4))
+                widget = ctk.CTkTextbox(field_frame, height=74, wrap="word")
+                widget.grid(row=1, column=0, sticky="ew")
+                widget.insert("1.0", "\n".join(payload.get(field_name) or []))
+                structured_widgets[field_name] = widget
+
             entities_section = ctk.CTkFrame(card, fg_color="#111827", corner_radius=10)
-            entities_section.grid(row=3, column=0, sticky="ew", padx=12, pady=(0, 12))
+            entities_section.grid(row=4, column=0, sticky="ew", padx=12, pady=(0, 12))
             entities_section.grid_columnconfigure(0, weight=1)
             ctk.CTkLabel(
                 entities_section,
@@ -159,7 +222,27 @@ class GuidedScenePlanner(ctk.CTkFrame):
 
             payload["title_var"] = title_var
             payload["summary_widget"] = summary
+            payload["structured_widgets"] = structured_widgets
             payload["entity_vars"] = entity_vars
+
+    def _prefill_structured_fields(self, index):
+        """Run legacy parser once to prefill structured scene fields."""
+        if index < 0 or index >= len(self._cards):
+            return
+        payload = self._cards[index]
+        if payload.get("_structured_prefilled"):
+            return
+        summary_widget = payload.get("summary_widget")
+        summary = summary_widget.get("1.0", "end").strip() if summary_widget is not None else str(payload.get("Summary") or "")
+        converted = convert_structured_fields_from_text(payload, summary)
+        for field_name, values in converted.items():
+            payload[field_name] = values
+            widget = (payload.get("structured_widgets") or {}).get(field_name)
+            if widget is not None:
+                widget.delete("1.0", "end")
+                widget.insert("1.0", "\n".join(values))
+        payload["_structured_prefilled"] = True
+        self._render_cards()
 
     def _open_entity_selector(self, field_name, entity_var):
         """Open entity selector."""
@@ -185,12 +268,18 @@ class GuidedScenePlanner(ctk.CTkFrame):
             base = self._normalise_card_data(payload, idx, total)
             base["Title"] = title or base["stage"]
             base["Summary"] = summary
+            structured_widgets = payload.get("structured_widgets") or {}
+            for field_name in SCENE_STRUCTURED_FIELDS:
+                field_widget = structured_widgets.get(field_name)
+                if field_widget is not None:
+                    base[field_name] = parse_multiline_items(field_widget.get("1.0", "end"))
             entity_vars = payload.get("entity_vars") or {}
             for field_name in SCENE_ENTITY_FIELDS:
                 # Process each field_name from SCENE_ENTITY_FIELDS.
                 field_var = entity_vars.get(field_name)
                 if field_var is not None:
                     base[field_name] = normalise_entity_list(field_var.get())
+            base["_structured_prefilled"] = bool(payload.get("_structured_prefilled"))
             snapshot.append(base)
         self._cards = snapshot
 

--- a/modules/scenarios/wizard_steps/scenes/scene_structured_editor_fields.py
+++ b/modules/scenarios/wizard_steps/scenes/scene_structured_editor_fields.py
@@ -1,0 +1,44 @@
+"""Shared helpers for scene structured field editors."""
+
+from modules.scenarios.scene_structured_fields import (
+    SCENE_STRUCTURED_SECTION_FIELDS,
+    migrate_scene_to_structured_fields,
+)
+
+
+SCENE_STRUCTURED_FIELD_LABELS = {
+    section["field"]: section["title"] for section in SCENE_STRUCTURED_SECTION_FIELDS
+}
+
+
+def parse_multiline_items(raw_value):
+    """Convert multiline/bulleted text into a clean string list."""
+    if isinstance(raw_value, (list, tuple, set)):
+        values = []
+        for item in raw_value:
+            values.extend(parse_multiline_items(item))
+        return values
+    text = str(raw_value or "")
+    cleaned = []
+    seen = set()
+    for line in text.splitlines():
+        item = line.strip()
+        if not item:
+            continue
+        if item.startswith("-"):
+            item = item[1:].strip()
+        key = item.casefold()
+        if not item or key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(item)
+    return cleaned
+
+
+def convert_structured_fields_from_text(scene_payload, body_text):
+    """Run the legacy parser once and return structured scene fields."""
+    migrated = migrate_scene_to_structured_fields(scene_payload, body_text or "")
+    return {
+        section["field"]: parse_multiline_items(migrated.get(section["field"]))
+        for section in SCENE_STRUCTURED_SECTION_FIELDS
+    }


### PR DESCRIPTION
### Motivation
- Provide dedicated multiline inputs for structured scene sections (Key Beats, Conflicts/Obstacles, Clues/Hooks, Transitions, Important Locations, Involved NPCs) instead of burying them in a single `Summary` blob.
- Bind UI controls directly to structured scene keys so scene data is explicit and easier to use elsewhere in the app.
- Offer a one-shot conversion action that runs the legacy parser to prefill structured fields from existing freeform scene text to ease migration.
- Keep the implementation modular and readable by introducing a small shared helper module and separating UI changes across planners/editors.

### Description
- Added `modules/scenarios/wizard_steps/scenes/scene_structured_editor_fields.py` with `parse_multiline_items`, `convert_structured_fields_from_text`, and `SCENE_STRUCTURED_FIELD_LABELS` to centralize parsing, migration and labels.
- Extended `GuidedScenePlanner` (`modules/scenarios/wizard_steps/scenes/guided_scene_planner.py`) to render per-card multiline textboxes for each field in `SCENE_STRUCTURED_FIELDS`, include a per-card `Convert from existing text` action that runs the legacy parser once, and persist those structured keys when snapshotting/exporting cards.
- Extended the inline editor in the canvas planner (`modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py`) to show the same structured multiline inputs, provide a one-shot conversion button, initialize structured fields for new scenes, and save structured values (including `_structured_prefilled`) into the scene payload.
- Extended the inline editor used by the main scenario builder (`modules/scenarios/scenario_builder_wizard.py`) with identical structured inputs, conversion flow, and inclusion of structured values in the save payload.
- Added a `_structured_prefilled` flag to avoid overwriting manually edited structured fields after conversion and to disable the convert action once used.

### Testing
- Ran `python -m compileall modules/scenarios/wizard_steps/scenes/guided_scene_planner.py modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py modules/scenarios/scenario_builder_wizard.py modules/scenarios/wizard_steps/scenes/scene_structured_editor_fields.py` and compilation completed successfully.
- No other automated tests were run in this change; UI behavior should be verified manually in the application to confirm layout and conversion UX.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0c1755b0832bb7a7de10bf056860)