### PR TITLE
Persist structured scene fields and add legacy Text composer

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -25,6 +25,10 @@ from modules.helpers.text_helpers import coerce_text
 from modules.scenarios.scene_flow_components import (
     SceneFlowPreview,
 )
+from modules.scenarios.scene_structured_fields import (
+    compose_scene_text_from_fields,
+    normalise_structured_scene_items,
+)
 from modules.scenarios.scenario_character_graph import (
     ScenarioCharacterGraphEditor,
     build_scenario_graph_with_links,
@@ -533,7 +537,6 @@ class ScenesPlanningStep(WizardStep):
             record = {
                 "Title": scene.get("Title", "Scene"),
                 "Summary": scene.get("Summary", ""),
-                "Text": scene.get("Summary", ""),
             }
             scene_type = scene.get("SceneType", "")
             if scene_type:
@@ -546,7 +549,8 @@ class ScenesPlanningStep(WizardStep):
             for field_name in SCENE_CARD_ENTITY_FIELDS:
                 record[field_name] = normalise_entity_list(scene.get(field_name))
             for field_name in SCENE_STRUCTURED_FIELDS:
-                record[field_name] = normalise_entity_list(scene.get(field_name))
+                record[field_name] = normalise_structured_scene_items(scene.get(field_name))
+            record["Text"] = compose_scene_text_from_fields(record)
             extras = scene.get("_extra_fields")
             if isinstance(extras, dict):
                 for key, value in extras.items():

--- a/modules/scenarios/scene_structured_fields.py
+++ b/modules/scenarios/scene_structured_fields.py
@@ -57,6 +57,11 @@ def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
     return deduped
 
 
+def normalise_structured_scene_items(value: Any) -> list[str]:
+    """Normalise structured scene field values without comma splitting."""
+    return _dedupe_preserve_order(_coerce_string_list(value))
+
+
 def extract_structured_scene_sections(scene_dict: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract display sections from structured scene fields."""
     if not isinstance(scene_dict, dict):
@@ -120,3 +125,25 @@ def migrate_scene_to_structured_fields(scene_dict: dict[str, Any], body_text: st
 def get_structured_field_name_for_section_key(section_key: str) -> str | None:
     """Return canonical field name for a parser section key."""
     return _SECTION_FIELD_BY_KEY.get(str(section_key or "").strip().lower())
+
+
+def compose_scene_text_from_fields(scene_dict: dict[str, Any]) -> str:
+    """Compose a legacy text blob from summary + structured fields."""
+    if not isinstance(scene_dict, dict):
+        return str(scene_dict or "").strip()
+
+    lines: list[str] = []
+    summary = str(scene_dict.get("Summary") or "").strip()
+    if summary:
+        lines.append(summary)
+
+    for definition in SCENE_STRUCTURED_SECTION_FIELDS:
+        items = _dedupe_preserve_order(_coerce_string_list(scene_dict.get(definition["field"])))
+        if not items:
+            continue
+        if lines:
+            lines.append("")
+        lines.append(f"{definition['title']}:")
+        lines.extend(f"- {item}" for item in items)
+
+    return "\n".join(lines).strip()

--- a/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
+++ b/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
@@ -6,7 +6,12 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
     SCENE_ENTITY_FIELDS,
     normalise_entity_list,
 )
-from modules.scenarios.scene_structured_fields import SCENE_STRUCTURED_SECTION_FIELDS, migrate_scene_to_structured_fields
+from modules.scenarios.scene_structured_fields import (
+    SCENE_STRUCTURED_SECTION_FIELDS,
+    compose_scene_text_from_fields,
+    migrate_scene_to_structured_fields,
+    normalise_structured_scene_items,
+)
 
 GUIDED_BOUNDARY_FLOW = (
     ("Hook", "Setup"),
@@ -61,7 +66,7 @@ def normalise_scene_links(scene):
 def canonicalise_scene(scene, *, index=0):
     """Handle canonicalise scene."""
     if not isinstance(scene, dict):
-        return migrate_scene_to_structured_fields({
+        migrated = migrate_scene_to_structured_fields({
             "Title": f"Scene {index + 1}",
             "Summary": str(scene or ""),
             "SceneType": "",
@@ -69,6 +74,8 @@ def canonicalise_scene(scene, *, index=0):
             "NextScenes": [],
             "_canvas": {},
         }, str(scene or ""))
+        migrated["Text"] = compose_scene_text_from_fields(migrated)
+        return migrated
     data = copy.deepcopy(scene)
     summary = str(data.get("Summary") or data.get("Text") or "").strip()
     links = normalise_scene_links(data)
@@ -84,7 +91,7 @@ def canonicalise_scene(scene, *, index=0):
             for field_name in SCENE_ENTITY_FIELDS
         },
         **{
-            field_name: normalise_entity_list(data.get(field_name))
+            field_name: normalise_structured_scene_items(data.get(field_name))
             for field_name in SCENE_STRUCTURED_FIELDS
         },
         "_extra_fields": {
@@ -95,7 +102,9 @@ def canonicalise_scene(scene, *, index=0):
             }
         },
     }
-    return migrate_scene_to_structured_fields(canonical_scene, summary)
+    migrated = migrate_scene_to_structured_fields(canonical_scene, summary)
+    migrated["Text"] = compose_scene_text_from_fields(migrated)
+    return migrated
 
 
 def scenes_to_guided_cards(scenes):
@@ -143,7 +152,7 @@ def scenes_to_guided_cards(scenes):
                     for field_name in SCENE_ENTITY_FIELDS
                 },
                 **{
-                    field_name: normalise_entity_list(scene.get(field_name))
+                    field_name: normalise_structured_scene_items(scene.get(field_name))
                     for field_name in SCENE_STRUCTURED_FIELDS
                 },
                 "_extra_fields": copy.deepcopy(scene.get("_extra_fields") or {}),
@@ -190,10 +199,11 @@ def guided_cards_to_scenes(cards):
                 for field_name in SCENE_ENTITY_FIELDS
             },
             **{
-                field_name: normalise_entity_list(card.get(field_name))
+                field_name: normalise_structured_scene_items(card.get(field_name))
                 for field_name in SCENE_STRUCTURED_FIELDS
             },
         }
+        scene["Text"] = compose_scene_text_from_fields(scene)
         extras = card.get("_extra_fields")
         if isinstance(extras, dict):
             scene["_extra_fields"] = copy.deepcopy(extras)

--- a/tests/test_scenario_builder_wizard.py
+++ b/tests/test_scenario_builder_wizard.py
@@ -440,6 +440,63 @@ def test_normalise_scene_collects_nested_text_fragments():
     assert scene["Summary"] == "First part.\n\nSecond part.\n\nThird part."
 
 
+def test_save_state_persists_structured_fields_and_composed_text():
+    """Verify save_state stores structured scene fields + legacy composed text."""
+    step = _build_scenes_step()
+    step._collect_active_scenes = lambda: [
+        {
+            "Title": "Dockside Meeting",
+            "Summary": "The broker arrives late.",
+            "SceneType": "Social",
+            "SceneBeats": ["Negotiate terms, keep cover intact"],
+            "SceneClues": ["Ledger page with coded initials"],
+            "LinkData": [{"target": "Ambush", "text": "Follow the courier"}],
+            "_canvas": {"x": 120, "y": 90},
+        }
+    ]
+    step.scenario_title_var = _StubVariable("Harbor Intrigue")
+    step._scenario_summary = "Scenario summary"
+    step._scenario_secrets = "Secret note"
+    step._root_extra_fields = {}
+    step.scenes = []
+
+    state = {}
+    assert step.save_state(state) is True
+
+    persisted = state["Scenes"][0]
+    assert persisted["Summary"] == "The broker arrives late."
+    assert persisted["SceneBeats"] == ["Negotiate terms, keep cover intact"]
+    assert persisted["SceneClues"] == ["Ledger page with coded initials"]
+    assert "Key beats:" in persisted["Text"]
+    assert "- Negotiate terms, keep cover intact" in persisted["Text"]
+
+
+def test_scene_mode_adapters_round_trip_structured_fields():
+    """Verify structured fields round-trip across guided/canvas adapters."""
+    cards = [
+        {
+            "Title": "Hook",
+            "Summary": "Start at the docks.",
+            "SceneType": "Setup",
+            "SceneBeats": ["Talk to Captain Rhel, avoid suspicion"],
+        },
+        {
+            "Title": "Fallout",
+            "Summary": "Deal with consequences.",
+            "SceneType": "Outcome",
+            "SceneClues": ["Stamped crate marked OR-17"],
+        },
+    ]
+
+    scenes = scenario_builder_wizard.guided_cards_to_scenes(cards)
+    assert scenes[0]["SceneBeats"] == ["Talk to Captain Rhel, avoid suspicion"]
+    assert "Key beats:" in scenes[0]["Text"]
+
+    round_tripped = scenario_builder_wizard.scenes_to_guided_cards(scenes)
+    assert round_tripped[0]["SceneBeats"] == ["Talk to Captain Rhel, avoid suspicion"]
+    assert round_tripped[1]["SceneClues"] == ["Stamped crate marked OR-17"]
+
+
 def test_finish_embedded_can_persist_before_callback(monkeypatch):
     """Verify that finish embedded can persist before callback."""
     wizard = scenario_builder_wizard.ScenarioBuilderWizard.__new__(


### PR DESCRIPTION
### Motivation
- Make structured scene fields the canonical persisted representation while retaining a legacy `Text` blob for compatibility. 
- Ensure structured fields round-trip cleanly between guided and canvas planners so users don't lose structured data when switching modes.

### Description
- Updated `ScenesPlanningStep.save_state(...)` to persist canonical structured keys (e.g. `SceneBeats`, `SceneClues`, etc.) on each scene record and kept `Summary` as before, while composing `Text` from structured fields rather than using `Summary` as the source of truth (`modules/scenarios/scenario_builder_wizard.py`).
- Introduced `compose_scene_text_from_fields(...)` and `normalise_structured_scene_items(...)` in `modules/scenarios/scene_structured_fields.py` to generate a legacy `Text` blob from structured fields and to normalize structured values without comma-splitting.
- Updated scene canonicalization and adapters in `modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py` to normalize structured fields via `normalise_structured_scene_items(...)`, to populate the composed `Text` field from structured fields, and to preserve `_extra_fields` and `_canvas` payloads.
- Added regression tests in `tests/test_scenario_builder_wizard.py` verifying that `save_state` persists structured fields and composed `Text`, and that guided<->canvas adapters round-trip structured fields correctly.

### Testing
- Ran the focused test selection: `pytest -q tests/test_scenario_builder_wizard.py -k "save_state_persists_structured_fields_and_composed_text or scene_mode_adapters_round_trip_structured_fields"` and it passed (2 tests).
- Ran the full file: `pytest -q tests/test_scenario_builder_wizard.py` which shows existing unrelated failures in tests expecting a `_normalise_scene` method (these failures were pre-existing and not introduced by this refactor).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0d4648e4832bbbf1bfe00a809a0e)