### PR TITLE
Normalize serialized scene text payloads in Scenario Builder wizard

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -55,6 +55,7 @@ from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import
     convert_structured_fields_from_text,
     parse_multiline_items,
 )
+from modules.scenarios.wizard_steps.scenes.text_payloads import extract_plain_scene_text
 
 try:
     _IMAGE_RESAMPLE = Image.Resampling.LANCZOS
@@ -681,7 +682,7 @@ class InlineSceneEditor(ctk.CTkFrame):
 
         self.summary_text = ctk.CTkTextbox(self, wrap="word")
         self.summary_text.grid(row=3, column=0, sticky="nsew", padx=12)
-        self.summary_text.insert("1.0", scene.get("Summary") or scene.get("Text") or "")
+        self.summary_text.insert("1.0", extract_plain_scene_text(scene.get("Summary") or scene.get("Text")))
 
         structure_section = ctk.CTkFrame(self, fg_color="#111827", corner_radius=10)
         structure_section.grid(row=4, column=0, sticky="ew", padx=12, pady=(8, 0))

--- a/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
@@ -19,6 +19,7 @@ from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import
     convert_structured_fields_from_text,
     parse_multiline_items,
 )
+from modules.scenarios.wizard_steps.scenes.text_payloads import extract_plain_scene_text
 
 
 class InlineSceneEditor(ctk.CTkFrame):
@@ -48,7 +49,7 @@ class InlineSceneEditor(ctk.CTkFrame):
 
         self.summary_text = ctk.CTkTextbox(self, wrap="word")
         self.summary_text.grid(row=3, column=0, sticky="nsew", padx=12)
-        self.summary_text.insert("1.0", scene.get("Summary") or scene.get("Text") or "")
+        self.summary_text.insert("1.0", extract_plain_scene_text(scene.get("Summary") or scene.get("Text")))
 
         structure_section = ctk.CTkFrame(self, fg_color="#111827", corner_radius=10)
         structure_section.grid(row=4, column=0, sticky="ew", padx=12, pady=(8, 0))

--- a/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
+++ b/modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py
@@ -12,6 +12,7 @@ from modules.scenarios.scene_structured_fields import (
     migrate_scene_to_structured_fields,
     normalise_structured_scene_items,
 )
+from modules.scenarios.wizard_steps.scenes.text_payloads import extract_plain_scene_text
 
 GUIDED_BOUNDARY_FLOW = (
     ("Hook", "Setup"),
@@ -77,7 +78,7 @@ def canonicalise_scene(scene, *, index=0):
         migrated["Text"] = compose_scene_text_from_fields(migrated)
         return migrated
     data = copy.deepcopy(scene)
-    summary = str(data.get("Summary") or data.get("Text") or "").strip()
+    summary = extract_plain_scene_text(data.get("Summary") or data.get("Text"))
     links = normalise_scene_links(data)
     canonical_scene = {
         "Title": str(data.get("Title") or data.get("Name") or f"Scene {index + 1}").strip(),

--- a/modules/scenarios/wizard_steps/scenes/text_payloads.py
+++ b/modules/scenarios/wizard_steps/scenes/text_payloads.py
@@ -1,0 +1,31 @@
+"""Text payload normalization helpers for scenario scene editors."""
+
+from __future__ import annotations
+
+import ast
+import json
+from typing import Any
+
+from modules.helpers.text_helpers import coerce_text
+
+
+def extract_plain_scene_text(value: Any) -> str:
+    """Return user-facing plain text for scene Summary/Text payloads.
+
+    Some historical payloads stored longtext values as a serialized dictionary
+    string, e.g. ``"{'text': '...', 'formatting': {...}}"``.  This helper
+    detects those values and extracts the textual content so UI editors don't
+    display raw Python/JSON structures.
+    """
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if raw.startswith("{") or raw.startswith("["):
+            for parser in (json.loads, ast.literal_eval):
+                try:
+                    parsed = parser(raw)
+                except (ValueError, SyntaxError, TypeError):
+                    continue
+                if isinstance(parsed, (dict, list)):
+                    return coerce_text(parsed).strip()
+    return coerce_text(value).strip()

--- a/tests/scenarios/test_scene_text_payloads.py
+++ b/tests/scenarios/test_scene_text_payloads.py
@@ -1,0 +1,23 @@
+"""Tests for scene text payload normalization."""
+
+from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import canonicalise_scene
+from modules.scenarios.wizard_steps.scenes.text_payloads import extract_plain_scene_text
+
+
+def test_extract_plain_scene_text_parses_python_dict_string():
+    payload = "{'text': 'Intro line\\nSecond line', 'formatting': {'bold': []}}"
+    assert extract_plain_scene_text(payload) == "Intro line\nSecond line"
+
+
+def test_extract_plain_scene_text_parses_json_dict_string():
+    payload = '{"text":"Alpha beta","formatting":{"italic":[]}}'
+    assert extract_plain_scene_text(payload) == "Alpha beta"
+
+
+def test_canonicalise_scene_uses_plain_text_from_serialized_payload():
+    scene = {
+        "Title": "Scene 1",
+        "Text": "{'text': 'Pilot jumps from the plane.', 'formatting': {'bold': []}}",
+    }
+    canonical = canonicalise_scene(scene)
+    assert canonical["Summary"] == "Pilot jumps from the plane."


### PR DESCRIPTION
### Motivation
- Scene summaries were sometimes shown as raw serialized payloads (e.g. "{'text': ..., 'formatting': ...}") in the Scenario Builder and scene editors instead of readable plain text.
- Historic importers and tools sometimes store longtext as JSON or Python-literal strings which UI editors must render as plain text for editing and display.

### Description
- Add `extract_plain_scene_text` helper to `modules/scenarios/wizard_steps/scenes/text_payloads.py` to detect JSON/Python-literal serialized longtext and return a cleaned plain-text representation using `coerce_text`.
- Use the new normalizer in `canonicalise_scene` so canonical scene summaries use normalized text instead of raw payload strings (`modules/scenarios/wizard_steps/scenes/scene_mode_adapters.py`).
- Apply the same normalization in inline scene editors so both Guided and Canvas planners display sane text in edit forms (`modules/scenarios/scenario_builder_wizard.py` and `modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py`).
- Add regression tests `tests/scenarios/test_scene_text_payloads.py` to cover Python-literal strings, JSON strings, and canonicalization of serialized `Text` payloads.

### Testing
- Ran `pytest -q tests/scenarios/test_scene_text_payloads.py tests/test_scenario_builder_wizard.py` which produced failures unrelated to the new changes (2 tests in the pre-existing `test_scenario_builder_wizard.py` expected an internal method that is not present in the current runtime), so the combined run failed.
- Ran `pytest -q tests/scenarios/test_scene_text_payloads.py` and the new tests passed (`3 passed`).
- The changes are confined to scene text normalization and editor display logic and have targeted unit coverage via the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1989cdb0832ba95ee3145a66710a)