### PR TITLE
Improve scene section parsing for aliases and inline content

### DIFF
--- a/modules/scenarios/widgets/scene_section_aliases.py
+++ b/modules/scenarios/widgets/scene_section_aliases.py
@@ -1,0 +1,24 @@
+"""Alias definitions used by the scene sections parser."""
+
+SECTION_KEY_ALIASES = {
+    "key beats": "key beats",
+    "conflicts/obstacles": "conflicts/obstacles",
+    "conflicts / obstacles": "conflicts/obstacles",
+    "conflicts": "conflicts/obstacles",
+    "obstacles": "conflicts/obstacles",
+    "conflits": "conflicts/obstacles",
+    "conflits/obstacles": "conflicts/obstacles",
+    "conflits / obstacles": "conflicts/obstacles",
+    "clues/hooks": "clues/hooks",
+    "clues / hooks": "clues/hooks",
+    "clues": "clues/hooks",
+    "hooks": "clues/hooks",
+    "transitions": "transitions",
+    "important locations": "important locations",
+    "locations": "important locations",
+    "involved npcs": "involved npcs",
+    "npcs": "involved npcs",
+}
+
+CANONICAL_SECTION_KEYS = tuple(dict.fromkeys(SECTION_KEY_ALIASES.values()))
+

--- a/modules/scenarios/widgets/scene_sections_parser.py
+++ b/modules/scenarios/widgets/scene_sections_parser.py
@@ -2,6 +2,8 @@
 
 import re
 
+from modules.scenarios.widgets.scene_section_aliases import SECTION_KEY_ALIASES
+
 _SECTION_DEFINITIONS = (
     ("key beats", "Key beats", "🎯"),
     ("conflicts/obstacles", "Conflicts/obstacles", "⚔️"),
@@ -11,8 +13,9 @@ _SECTION_DEFINITIONS = (
     ("involved npcs", "Involved NPCs", "🧑‍🤝‍🧑"),
 )
 
+_ALIAS_PATTERN = "|".join(sorted((re.escape(alias) for alias in SECTION_KEY_ALIASES), key=len, reverse=True))
 _HEADER_PATTERN = re.compile(
-    r"^\s*[-*>#•·●▪]*\s*\**\s*(key beats|conflicts/obstacles|clues/hooks|transitions|important locations|involved npcs)\s*\**\s*:?\s*$",
+    rf"^\s*[-*>#•·●▪]*\s*\**\s*(?P<header>{_ALIAS_PATTERN})\s*\**\s*:?\s*(?P<inline_content>.*)$",
     re.IGNORECASE,
 )
 
@@ -51,6 +54,9 @@ def _extract_items(section_text):
     candidates = [part.strip(" -•\t") for part in re.split(r"(?:\s*;\s+|\s{2,}|\n+)", merged) if part.strip()]
     if len(candidates) == 1:
         # Handle the branch where len(candidates) == 1.
+        comma_candidates = [part.strip() for part in candidates[0].split(",") if part.strip()]
+        if len(comma_candidates) > 1:
+            candidates = comma_candidates
         sentence_candidates = [part.strip() for part in re.split(r"(?<=[.!?])\s+", candidates[0]) if part.strip()]
         if len(sentence_candidates) > 1:
             candidates = sentence_candidates
@@ -70,8 +76,17 @@ def parse_scene_body_sections(body_text):
         line_without_bullet = _HEADER_BULLET_PREFIX.sub("", line, count=1)
         header_match = _HEADER_PATTERN.match(line_without_bullet)
         if header_match:
-            current_key = header_match.group(1).strip().lower()
+            normalized_header = re.sub(r"\s+", " ", header_match.group("header").strip().lower())
+            current_key = SECTION_KEY_ALIASES.get(normalized_header)
+            if not current_key:
+                current_key = None
+                if line.strip():
+                    intro_lines.append(line)
+                continue
             sections_buffer.setdefault(current_key, [])
+            inline_content = header_match.group("inline_content").strip()
+            if inline_content:
+                sections_buffer[current_key].append(inline_content)
             continue
 
         if current_key is None:

--- a/tests/scenarios/test_scene_sections_parser.py
+++ b/tests/scenarios/test_scene_sections_parser.py
@@ -63,3 +63,57 @@ A smoky tavern hums with rumors.
         "key beats",
         "conflicts/obstacles",
     ]
+
+
+def test_parse_scene_body_sections_accepts_inline_header_content():
+    """Verify parser keeps inline content on a same-line section header."""
+    parsed = parse_scene_body_sections(
+        """
+• Key beats : Saut, infiltration du couloir principal, désactivation des caméras.
+"""
+    )
+
+    assert parsed["has_sections"] is True
+    assert parsed["sections"][0]["key"] == "key beats"
+    assert parsed["sections"][0]["items"] == [
+        "Saut",
+        "infiltration du couloir principal",
+        "désactivation des caméras.",
+    ]
+
+
+def test_parse_scene_body_sections_accepts_french_conflits_alias():
+    """Verify parser accepts `Conflits` as alias for conflicts/obstacles."""
+    parsed = parse_scene_body_sections(
+        """
+• Conflits / obstacles : Drones patrouilleurs, verrouillage biométrique.
+"""
+    )
+
+    assert parsed["has_sections"] is True
+    assert parsed["sections"][0]["key"] == "conflicts/obstacles"
+
+
+def test_parse_scene_body_sections_finds_all_inline_scene_sections():
+    """Verify parser extracts all known scene sections from inline bullet text."""
+    parsed = parse_scene_body_sections(
+        """
+Les PJ doivent pénétrer dans la structure industrielle.
+• Key beats : Saut, infiltration, désactivation des caméras.
+• Conflicts / obstacles : verrouillage biométrique, drones patrouilleurs.
+• Clues / hooks : Schéma de câblage, liste des employés.
+• Transitions : Couloir de service vers salle de contrôle.
+• Important locations : Hall d'entrée, salle de contrôle principale.
+• Involved NPCs : Dyrektorka Katarzyna Ręzycka, gardien de sécurité.
+"""
+    )
+
+    assert parsed["has_sections"] is True
+    assert [section["key"] for section in parsed["sections"]] == [
+        "key beats",
+        "conflicts/obstacles",
+        "clues/hooks",
+        "transitions",
+        "important locations",
+        "involved npcs",
+    ]


### PR DESCRIPTION
### Motivation
- Make the scene parser robust to alternate header labels and inline same-line content so the scenario builder and GM screen can extract `Key beats`, `Conflicts`, `Clues`, etc. from compact bullet payloads. 
- Support common variants and localized labels (e.g. `Conflits / obstacles`) present in user-provided scenario text.

### Description
- Added a dedicated alias registry at `modules/scenarios/widgets/scene_section_aliases.py` mapping common header variants to canonical section keys. 
- Updated `parse_scene_body_sections` in `modules/scenarios/widgets/scene_sections_parser.py` to detect header aliases via a new header regex, normalize the header, map it to the canonical key, and preserve inline content found on the same line as the header. 
- Enhanced `_extract_items` to split comma-delimited inline values into separate items so compact inline lists become discrete section items. 
- Added and extended parser tests in `tests/scenarios/test_scene_sections_parser.py` to cover inline header content, French `Conflits` alias support, and full multi-section inline payload extraction.

### Testing
- Ran targeted parser unit tests: `pytest -q tests/scenarios/test_scene_sections_parser.py tests/scenarios/test_scene_body_sections.py`. 
- Result: all targeted tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1d7ea120832bab1362798c73ef97)