### PR TITLE
Add DB-backed structured scene entity resolution and integrate into wizard save flow

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -43,6 +43,12 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
 from modules.scenarios.wizard_steps.scenes.scene_entity_aggregator import (
     collect_scene_entity_names,
 )
+from modules.scenarios.wizard_steps.scenes.entity_resolution.db_indexes import (
+    build_campaign_db_indexes,
+)
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_entity_matcher import (
+    resolve_scene_entities_from_structured,
+)
 from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import (
     SCENE_STRUCTURED_FIELDS,
     canonicalise_scene,
@@ -506,6 +512,35 @@ class ScenesPlanningStep(WizardStep):
         self._set_mode("guided", remap=False)
         self.guided_planner.load_cards(scenes_to_guided_cards(self.scenes))
 
+    def _normalise_scene(self, scene, index):
+        """Normalize a raw scene payload into canonical wizard scene data."""
+        if isinstance(scene, dict) and not scene.get("Summary"):
+            description = str(scene.get("Description") or "").strip()
+            if description:
+                scene = {**scene, "Summary": description}
+            else:
+                fragments = []
+
+                def _collect_text(value):
+                    if isinstance(value, str):
+                        text = value.strip()
+                        if text:
+                            fragments.append(text)
+                        return
+                    if isinstance(value, dict):
+                        for nested in value.values():
+                            _collect_text(nested)
+                        return
+                    if isinstance(value, (list, tuple, set)):
+                        for nested in value:
+                            _collect_text(nested)
+
+                for candidate_key in ("SceneText", "Notes"):
+                    _collect_text(scene.get(candidate_key))
+                if fragments:
+                    scene = {**scene, "Summary": "\n\n".join(fragments)}
+        return canonicalise_scene(scene, index=index)
+
     def load_state(self, state):
         """Load state."""
         self.scenario_title_var.set(state.get("Title", ""))
@@ -525,6 +560,7 @@ class ScenesPlanningStep(WizardStep):
     def save_state(self, state):
         """Save state."""
         self.scenes = self._collect_active_scenes()
+        db_indexes = build_campaign_db_indexes(getattr(self, "entity_wrappers", {}) or {})
         state["Title"] = self.scenario_title_var.get().strip()
         state["Summary"] = (self._scenario_summary or "").strip()
         secrets = (self._scenario_secrets or "").strip()
@@ -551,6 +587,11 @@ class ScenesPlanningStep(WizardStep):
                 record[field_name] = normalise_entity_list(scene.get(field_name))
             for field_name in SCENE_STRUCTURED_FIELDS:
                 record[field_name] = normalise_structured_scene_items(scene.get(field_name))
+            resolved_entities = resolve_scene_entities_from_structured(record, db_indexes)
+            for field_name in ("NPCs", "Creatures", "Places", "Clues"):
+                existing = normalise_entity_list(record.get(field_name))
+                resolved = normalise_entity_list(resolved_entities.get(field_name))
+                record[field_name] = list(dict.fromkeys(existing + resolved))
             record["Text"] = compose_scene_text_from_fields(record)
             extras = scene.get("_extra_fields")
             if isinstance(extras, dict):

--- a/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
@@ -161,7 +161,7 @@ class CanvasScenePlanner(ctk.CTkFrame):
             on_add_entity=self._on_add_entity_to_scene,
             on_link=self._link_scenes_via_drag,
             on_link_text_edit=lambda *_: None,
-            available_entity_types=["NPCs", "Creatures", "Places", "Bases", "Maps"],
+            available_entity_types=["NPCs", "Creatures", "Clues", "Places", "Bases", "Maps"],
         )
         self.canvas.grid(row=1, column=0, sticky="nsew", padx=12, pady=(0, 12))
         self._update_buttons()

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/__init__.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/__init__.py
@@ -1,0 +1,2 @@
+"""Helpers to resolve scene entities from structured fields."""
+

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/db_indexes.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/db_indexes.py
@@ -1,0 +1,57 @@
+"""Campaign DB index builders for structured scene entity resolution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+DB_ENTITY_TYPE_TO_WRAPPER_KEY = {
+    "NPCs": "npcs",
+    "Creatures": "creatures",
+    "Places": "places",
+    "Clues": "clues",
+}
+
+
+def normalise_entity_name(value: Any) -> str:
+    """Return a comparable string key for entity names."""
+    return str(value or "").strip().casefold()
+
+
+def _extract_entity_name(item: Any) -> str:
+    """Extract a display name from a wrapper record."""
+    if isinstance(item, dict):
+        raw_name = item.get("Name") or item.get("Title")
+    else:
+        raw_name = item
+    return str(raw_name or "").strip()
+
+
+def _build_single_entity_index(items: list[Any]) -> dict[str, dict[str, str]]:
+    """Build exact and normalised lookups for one entity family."""
+    exact: dict[str, str] = {}
+    normalised: dict[str, str] = {}
+    for item in items or []:
+        name = _extract_entity_name(item)
+        if not name:
+            continue
+        exact.setdefault(name, name)
+        normalised.setdefault(normalise_entity_name(name), name)
+    return {"exact": exact, "normalised": normalised}
+
+
+def build_campaign_db_indexes(entity_wrappers: dict[str, Any]) -> dict[str, dict[str, dict[str, str]]]:
+    """Build campaign indexes with exact + normalised keys for resolver matching."""
+    wrappers = entity_wrappers if isinstance(entity_wrappers, dict) else {}
+    indexes: dict[str, dict[str, dict[str, str]]] = {}
+    for entity_field, wrapper_key in DB_ENTITY_TYPE_TO_WRAPPER_KEY.items():
+        wrapper = wrappers.get(wrapper_key)
+        items: list[Any] = []
+        if wrapper is not None:
+            try:
+                items = wrapper.load_items() or []
+            except Exception:
+                items = []
+        indexes[entity_field] = _build_single_entity_index(items)
+    return indexes
+

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/structured_entity_matcher.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/structured_entity_matcher.py
@@ -1,0 +1,89 @@
+"""Resolve structured scene items to campaign entities.
+
+Business rule: only entities that already exist in the campaign DB are added.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from modules.scenarios.wizard_steps.scenes.entity_resolution.db_indexes import normalise_entity_name
+from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import parse_multiline_items
+
+
+SECTION_ENTITY_TARGETS = {
+    "SceneNPCs": ("NPCs",),
+    "SceneLocations": ("Places",),
+    "SceneClues": ("Clues",),
+    "SceneObstacles": ("Creatures", "NPCs"),
+}
+
+_TOKEN_SPLIT_RE = re.compile(r"[,\n;/(){}\[\]|:!?]+")
+_SUB_TOKEN_RE = re.compile(r"\s+(?:and|or|with|vs\.?|versus|at|in|on|near|inside|outside)\s+", flags=re.IGNORECASE)
+
+
+def _dedupe_preserve(values: Iterable[str]) -> list[str]:
+    """Deduplicate values while preserving original order."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        key = text.casefold()
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    return out
+
+
+def _tokenize_structured_item(item: Any) -> list[str]:
+    """Tokenize one structured scene item into useful match candidates."""
+    text = str(item or "").strip()
+    if not text:
+        return []
+    parts = [part.strip(" -–—•\t") for part in _TOKEN_SPLIT_RE.split(text) if part.strip()]
+    tokens: list[str] = [text]
+    for part in parts:
+        tokens.append(part)
+        tokens.extend(piece.strip() for piece in _SUB_TOKEN_RE.split(part) if piece.strip())
+    return _dedupe_preserve(tokens)
+
+
+def _match_token(token: str, entity_index: dict[str, dict[str, str]]) -> str | None:
+    """Try exact match first, then normalised match for a token."""
+    exact = (entity_index or {}).get("exact") or {}
+    normalised = (entity_index or {}).get("normalised") or {}
+    if token in exact:
+        return exact[token]
+    return normalised.get(normalise_entity_name(token))
+
+
+def resolve_scene_entities_from_structured(
+    scene_record: dict[str, Any],
+    db_indexes: dict[str, dict[str, dict[str, str]]],
+) -> dict[str, list[str]]:
+    """Resolve scene entities from structured sections against campaign DB indexes."""
+    resolved = {
+        "NPCs": [],
+        "Creatures": [],
+        "Places": [],
+        "Clues": [],
+    }
+    record = scene_record if isinstance(scene_record, dict) else {}
+    indexes = db_indexes if isinstance(db_indexes, dict) else {}
+
+    for section_name, target_fields in SECTION_ENTITY_TARGETS.items():
+        raw_items = parse_multiline_items(record.get(section_name))
+        if not raw_items:
+            continue
+        for raw_item in raw_items:
+            for token in _tokenize_structured_item(raw_item):
+                for target_field in target_fields:
+                    matched = _match_token(token, indexes.get(target_field) or {})
+                    if matched:
+                        resolved[target_field].append(matched)
+                        break
+
+    return {field: _dedupe_preserve(values) for field, values in resolved.items()}

--- a/modules/scenarios/wizard_steps/scenes/scene_entity_fields.py
+++ b/modules/scenarios/wizard_steps/scenes/scene_entity_fields.py
@@ -1,6 +1,6 @@
 """Field helpers for scenes scene entity."""
 
-SCENE_ENTITY_FIELDS = ("NPCs", "Creatures", "Bases", "Places", "Maps")
+SCENE_ENTITY_FIELDS = ("NPCs", "Creatures", "Clues", "Bases", "Places", "Maps")
 
 
 def normalise_entity_list(value):

--- a/tests/scenarios/wizard_steps/scenes/test_structured_entity_matcher.py
+++ b/tests/scenarios/wizard_steps/scenes/test_structured_entity_matcher.py
@@ -1,0 +1,63 @@
+"""Tests for structured scene entity resolution."""
+
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_entity_matcher import (
+    resolve_scene_entities_from_structured,
+)
+
+
+def _db_indexes():
+    return {
+        "NPCs": {
+            "exact": {"Captain Mira": "Captain Mira", "Wolf": "Wolf"},
+            "normalised": {"captain mira": "Captain Mira", "wolf": "Wolf"},
+        },
+        "Creatures": {
+            "exact": {"Goblin": "Goblin", "Wolf": "Wolf"},
+            "normalised": {"goblin": "Goblin", "wolf": "Wolf"},
+        },
+        "Places": {
+            "exact": {"Old Mill": "Old Mill"},
+            "normalised": {"old mill": "Old Mill"},
+        },
+        "Clues": {
+            "exact": {"Broken Seal": "Broken Seal"},
+            "normalised": {"broken seal": "Broken Seal"},
+        },
+    }
+
+
+def test_match_exact():
+    scene = {"SceneNPCs": ["Captain Mira"]}
+    resolved = resolve_scene_entities_from_structured(scene, _db_indexes())
+    assert resolved["NPCs"] == ["Captain Mira"]
+
+
+def test_match_case_insensitive():
+    scene = {"SceneLocations": ["old mill"]}
+    resolved = resolve_scene_entities_from_structured(scene, _db_indexes())
+    assert resolved["Places"] == ["Old Mill"]
+
+
+def test_non_match_adds_nothing():
+    scene = {"SceneObstacles": ["Unknown Thing"]}
+    resolved = resolve_scene_entities_from_structured(scene, _db_indexes())
+    assert resolved == {"NPCs": [], "Creatures": [], "Places": [], "Clues": []}
+
+
+def test_dedupes_across_multiple_sections():
+    scene = {
+        "SceneNPCs": ["Captain Mira"],
+        "SceneObstacles": ["Captain Mira", "Goblin"],
+    }
+    resolved = resolve_scene_entities_from_structured(scene, _db_indexes())
+    assert resolved["NPCs"] == ["Captain Mira"]
+    assert resolved["Creatures"] == ["Goblin"]
+
+
+def test_section_priority_for_ambiguous_names():
+    scene = {"SceneObstacles": ["Wolf"], "SceneClues": ["wolf"]}
+    resolved = resolve_scene_entities_from_structured(scene, _db_indexes())
+    assert resolved["Creatures"] == ["Wolf"]
+    assert resolved["NPCs"] == []
+    assert resolved["Clues"] == []
+


### PR DESCRIPTION
### Motivation
- Make structured scene sections (obstacles, clues, locations, involved NPCs) reliably map to campaign entities by only adding items that exist in the campaign DB. 
- Keep resolution logic isolated in its own submodule for readability and testability.

### Description
- Add `modules/scenarios/wizard_steps/scenes/entity_resolution` with `db_indexes.py` exposing `build_campaign_db_indexes` to build exact + normalized indexes from campaign wrappers and `structured_entity_matcher.py` exposing `resolve_scene_entities_from_structured` to tokenize structured fields and match exact then normalized names.
- Integrate resolution into the wizard finalization flow by calling `resolve_scene_entities_from_structured` from `ScenesPlanningStep.save_state` and merging resolved entities into scene `record` for fields `NPCs`, `Creatures`, `Places`, `Clues` with de-duplication while preserving order.
- Add `Clues` to `SCENE_ENTITY_FIELDS` and to `CanvasScenePlanner` `available_entity_types` so the UI/wizard treats clues as first-class entity lists.
- Add `_normalise_scene` helper inside `ScenarioBuilderWizard` to preserve existing test expectations for scene normalization (fallbacks for `Description`, `SceneText`, `Notes`) and add defensive handling when `entity_wrappers` is not present in test setups.
- Provide a short module docstring expressing the business rule: only entities present in the campaign DB are added.

### Testing
- Added `tests/scenarios/wizard_steps/scenes/test_structured_entity_matcher.py` covering exact match, case-insensitive match, non-match, dedup across sections, and ambiguous-name priority.
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_structured_entity_matcher.py tests/test_scenario_builder_wizard.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2380ed20832ba1fa2ba6488c7677)