### PR TITLE
Add structured scene entity resolution from planner sections

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -43,11 +43,9 @@ from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
 from modules.scenarios.wizard_steps.scenes.scene_entity_aggregator import (
     collect_scene_entity_names,
 )
-from modules.scenarios.wizard_steps.scenes.entity_resolution.db_indexes import (
-    build_campaign_db_indexes,
-)
-from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_entity_matcher import (
-    resolve_scene_entities_from_structured,
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_to_entities import (
+    build_campaign_entity_indexes,
+    resolve_entities_from_structured,
 )
 from modules.scenarios.wizard_steps.scenes.scene_mode_adapters import (
     SCENE_STRUCTURED_FIELDS,
@@ -241,6 +239,7 @@ class ScenesPlanningStep(WizardStep):
         "_SceneLayout",
         "NPCs",
         "Creatures",
+        "Clues",
         "Bases",
         "Places",
         "Maps",
@@ -560,7 +559,7 @@ class ScenesPlanningStep(WizardStep):
     def save_state(self, state):
         """Save state."""
         self.scenes = self._collect_active_scenes()
-        db_indexes = build_campaign_db_indexes(getattr(self, "entity_wrappers", {}) or {})
+        db_indexes = build_campaign_entity_indexes(getattr(self, "entity_wrappers", {}) or {})
         state["Title"] = self.scenario_title_var.get().strip()
         state["Summary"] = (self._scenario_summary or "").strip()
         secrets = (self._scenario_secrets or "").strip()
@@ -587,7 +586,7 @@ class ScenesPlanningStep(WizardStep):
                 record[field_name] = normalise_entity_list(scene.get(field_name))
             for field_name in SCENE_STRUCTURED_FIELDS:
                 record[field_name] = normalise_structured_scene_items(scene.get(field_name))
-            resolved_entities = resolve_scene_entities_from_structured(record, db_indexes)
+            resolved_entities = resolve_entities_from_structured(record, db_indexes)
             for field_name in ("NPCs", "Creatures", "Places", "Clues"):
                 existing = normalise_entity_list(record.get(field_name))
                 resolved = normalise_entity_list(resolved_entities.get(field_name))

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/__init__.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/__init__.py
@@ -1,2 +1,13 @@
-"""Helpers to resolve scene entities from structured fields."""
+"""Helpers for structured scene entity resolution."""
 
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_to_entities import (
+    build_campaign_entity_indexes,
+    normalize_name,
+    resolve_entities_from_structured,
+)
+
+__all__ = [
+    "build_campaign_entity_indexes",
+    "normalize_name",
+    "resolve_entities_from_structured",
+]

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/db_indexes.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/db_indexes.py
@@ -1,57 +1,20 @@
-"""Campaign DB index builders for structured scene entity resolution."""
+"""Backward compatible campaign DB index helpers."""
 
 from __future__ import annotations
 
 from typing import Any
 
-
-DB_ENTITY_TYPE_TO_WRAPPER_KEY = {
-    "NPCs": "npcs",
-    "Creatures": "creatures",
-    "Places": "places",
-    "Clues": "clues",
-}
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_to_entities import (
+    build_campaign_entity_indexes,
+    normalize_name,
+)
 
 
 def normalise_entity_name(value: Any) -> str:
-    """Return a comparable string key for entity names."""
-    return str(value or "").strip().casefold()
+    """Legacy alias for name normalization."""
+    return normalize_name(value)
 
 
-def _extract_entity_name(item: Any) -> str:
-    """Extract a display name from a wrapper record."""
-    if isinstance(item, dict):
-        raw_name = item.get("Name") or item.get("Title")
-    else:
-        raw_name = item
-    return str(raw_name or "").strip()
-
-
-def _build_single_entity_index(items: list[Any]) -> dict[str, dict[str, str]]:
-    """Build exact and normalised lookups for one entity family."""
-    exact: dict[str, str] = {}
-    normalised: dict[str, str] = {}
-    for item in items or []:
-        name = _extract_entity_name(item)
-        if not name:
-            continue
-        exact.setdefault(name, name)
-        normalised.setdefault(normalise_entity_name(name), name)
-    return {"exact": exact, "normalised": normalised}
-
-
-def build_campaign_db_indexes(entity_wrappers: dict[str, Any]) -> dict[str, dict[str, dict[str, str]]]:
-    """Build campaign indexes with exact + normalised keys for resolver matching."""
-    wrappers = entity_wrappers if isinstance(entity_wrappers, dict) else {}
-    indexes: dict[str, dict[str, dict[str, str]]] = {}
-    for entity_field, wrapper_key in DB_ENTITY_TYPE_TO_WRAPPER_KEY.items():
-        wrapper = wrappers.get(wrapper_key)
-        items: list[Any] = []
-        if wrapper is not None:
-            try:
-                items = wrapper.load_items() or []
-            except Exception:
-                items = []
-        indexes[entity_field] = _build_single_entity_index(items)
-    return indexes
-
+def build_campaign_db_indexes(entity_wrappers: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Legacy alias for campaign entity indexes."""
+    return build_campaign_entity_indexes(entity_wrappers)

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/structured_entity_matcher.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/structured_entity_matcher.py
@@ -1,89 +1,17 @@
-"""Resolve structured scene items to campaign entities.
-
-Business rule: only entities that already exist in the campaign DB are added.
-"""
+"""Backward compatible structured scene entity matching helpers."""
 
 from __future__ import annotations
 
-import re
-from collections.abc import Iterable
 from typing import Any
 
-from modules.scenarios.wizard_steps.scenes.entity_resolution.db_indexes import normalise_entity_name
-from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import parse_multiline_items
-
-
-SECTION_ENTITY_TARGETS = {
-    "SceneNPCs": ("NPCs",),
-    "SceneLocations": ("Places",),
-    "SceneClues": ("Clues",),
-    "SceneObstacles": ("Creatures", "NPCs"),
-}
-
-_TOKEN_SPLIT_RE = re.compile(r"[,\n;/(){}\[\]|:!?]+")
-_SUB_TOKEN_RE = re.compile(r"\s+(?:and|or|with|vs\.?|versus|at|in|on|near|inside|outside)\s+", flags=re.IGNORECASE)
-
-
-def _dedupe_preserve(values: Iterable[str]) -> list[str]:
-    """Deduplicate values while preserving original order."""
-    out: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        text = str(value or "").strip()
-        key = text.casefold()
-        if not text or key in seen:
-            continue
-        seen.add(key)
-        out.append(text)
-    return out
-
-
-def _tokenize_structured_item(item: Any) -> list[str]:
-    """Tokenize one structured scene item into useful match candidates."""
-    text = str(item or "").strip()
-    if not text:
-        return []
-    parts = [part.strip(" -–—•\t") for part in _TOKEN_SPLIT_RE.split(text) if part.strip()]
-    tokens: list[str] = [text]
-    for part in parts:
-        tokens.append(part)
-        tokens.extend(piece.strip() for piece in _SUB_TOKEN_RE.split(part) if piece.strip())
-    return _dedupe_preserve(tokens)
-
-
-def _match_token(token: str, entity_index: dict[str, dict[str, str]]) -> str | None:
-    """Try exact match first, then normalised match for a token."""
-    exact = (entity_index or {}).get("exact") or {}
-    normalised = (entity_index or {}).get("normalised") or {}
-    if token in exact:
-        return exact[token]
-    return normalised.get(normalise_entity_name(token))
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_to_entities import (
+    resolve_entities_from_structured,
+)
 
 
 def resolve_scene_entities_from_structured(
     scene_record: dict[str, Any],
-    db_indexes: dict[str, dict[str, dict[str, str]]],
+    db_indexes: dict[str, dict[str, Any]],
 ) -> dict[str, list[str]]:
-    """Resolve scene entities from structured sections against campaign DB indexes."""
-    resolved = {
-        "NPCs": [],
-        "Creatures": [],
-        "Places": [],
-        "Clues": [],
-    }
-    record = scene_record if isinstance(scene_record, dict) else {}
-    indexes = db_indexes if isinstance(db_indexes, dict) else {}
-
-    for section_name, target_fields in SECTION_ENTITY_TARGETS.items():
-        raw_items = parse_multiline_items(record.get(section_name))
-        if not raw_items:
-            continue
-        for raw_item in raw_items:
-            for token in _tokenize_structured_item(raw_item):
-                for target_field in target_fields:
-                    matched = _match_token(token, indexes.get(target_field) or {})
-                    if matched:
-                        resolved[target_field].append(matched)
-                        break
-
-    return {field: _dedupe_preserve(values) for field, values in resolved.items()}
+    """Legacy alias for structured scene resolver."""
+    return resolve_entities_from_structured(scene_record, db_indexes)

--- a/modules/scenarios/wizard_steps/scenes/entity_resolution/structured_to_entities.py
+++ b/modules/scenarios/wizard_steps/scenes/entity_resolution/structured_to_entities.py
@@ -1,0 +1,211 @@
+"""Structured scene -> campaign entity resolution helpers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable
+from typing import Any
+
+from modules.scenarios.wizard_steps.scenes.scene_structured_editor_fields import parse_multiline_items
+
+SECTION_ENTITY_TARGETS = {
+    "SceneNPCs": ("NPCs",),
+    "SceneLocations": ("Places",),
+    "SceneObstacles": ("Creatures", "NPCs"),
+    "SceneClues": ("Clues",),
+}
+
+DB_ENTITY_TYPE_TO_WRAPPER_KEY = {
+    "NPCs": "npcs",
+    "Creatures": "creatures",
+    "Places": "places",
+    "Clues": "clues",
+}
+
+_LIGHT_PUNCTUATION_RE = re.compile(r"[\.,;:!?\"'`´’“”()\[\]{}_/\\|-]+")
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def normalize_name(text: Any) -> str:
+    """Normalize entity names for resilient matching."""
+    raw = str(text or "").strip().lower()
+    if not raw:
+        return ""
+    no_marks = "".join(
+        char
+        for char in unicodedata.normalize("NFKD", raw)
+        if not unicodedata.combining(char)
+    )
+    simplified = _LIGHT_PUNCTUATION_RE.sub(" ", no_marks)
+    return " ".join(simplified.split())
+
+
+def _name_tokens(value: Any) -> tuple[str, ...]:
+    return tuple(_WORD_RE.findall(normalize_name(value)))
+
+
+def _dedupe_preserve(values: Iterable[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    return out
+
+
+def _extract_entity_name(item: Any) -> str:
+    if isinstance(item, dict):
+        raw_name = item.get("Name") or item.get("Title")
+    else:
+        raw_name = item
+    return str(raw_name or "").strip()
+
+
+def build_campaign_entity_indexes(entity_wrappers: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Build exact and normalized indexes for campaign entities."""
+    wrappers = entity_wrappers if isinstance(entity_wrappers, dict) else {}
+    indexes: dict[str, dict[str, Any]] = {}
+
+    for entity_field, wrapper_key in DB_ENTITY_TYPE_TO_WRAPPER_KEY.items():
+        exact: dict[str, str] = {}
+        normalized: dict[str, str] = {}
+        tokenized: list[dict[str, Any]] = []
+        wrapper = wrappers.get(wrapper_key)
+        items: list[Any] = []
+        if wrapper is not None:
+            try:
+                items = wrapper.load_items() or []
+            except Exception:
+                items = []
+
+        for item in items:
+            name = _extract_entity_name(item)
+            if not name:
+                continue
+            exact.setdefault(name, name)
+            normalized_name = normalize_name(name)
+            normalized.setdefault(normalized_name, name)
+            tokenized.append({
+                "name": name,
+                "tokens": frozenset(_name_tokens(name)),
+            })
+
+        indexes[entity_field] = {
+            "exact": exact,
+            "normalized": normalized,
+            "tokenized": tokenized,
+        }
+
+    return indexes
+
+
+def _edit_distance_leq_one(a: str, b: str) -> bool:
+    if a == b:
+        return True
+    if abs(len(a) - len(b)) > 1:
+        return False
+    if len(a) > len(b):
+        a, b = b, a
+
+    i = j = edits = 0
+    while i < len(a) and j < len(b):
+        if a[i] == b[j]:
+            i += 1
+            j += 1
+            continue
+        edits += 1
+        if edits > 1:
+            return False
+        if len(a) == len(b):
+            i += 1
+            j += 1
+        else:
+            j += 1
+
+    if j < len(b) or i < len(a):
+        edits += 1
+    return edits <= 1
+
+
+def _match_partial(candidate_tokens: frozenset[str], entity_index: dict[str, Any]) -> str | None:
+    if not candidate_tokens:
+        return None
+
+    subset_candidates: list[tuple[str, int]] = []
+    fuzzy_match: str | None = None
+
+    tokenized_entries = list(entity_index.get("tokenized") or [])
+    if not tokenized_entries:
+        for name in (entity_index.get("exact") or {}).values():
+            tokenized_entries.append({"name": name, "tokens": frozenset(_name_tokens(name))})
+
+    for entry in tokenized_entries:
+        entity_name = entry.get("name")
+        entity_tokens = entry.get("tokens") or frozenset()
+        if not entity_name or not entity_tokens:
+            continue
+        if entity_tokens.issubset(candidate_tokens):
+            subset_candidates.append((entity_name, len(entity_tokens)))
+            continue
+
+        if len(entity_tokens) == 1:
+            entity_token = next(iter(entity_tokens))
+            if len(entity_token) < 6:
+                continue
+            for token in candidate_tokens:
+                if len(token) < 6:
+                    continue
+                if _edit_distance_leq_one(token, entity_token):
+                    if fuzzy_match and fuzzy_match != entity_name:
+                        return None
+                    fuzzy_match = entity_name
+                    break
+
+    if subset_candidates:
+        subset_candidates.sort(key=lambda item: item[1], reverse=True)
+        top_name, top_size = subset_candidates[0]
+        competing = [name for name, size in subset_candidates if size == top_size and name != top_name]
+        if not competing:
+            return top_name
+    return fuzzy_match
+
+
+def _match_candidate(candidate: str, entity_index: dict[str, Any]) -> str | None:
+    exact = entity_index.get("exact") or {}
+    normalized = entity_index.get("normalized") or entity_index.get("normalised") or {}
+
+    if candidate in exact:
+        return exact[candidate]
+
+    normalized_candidate = normalize_name(candidate)
+    if normalized_candidate in normalized:
+        return normalized[normalized_candidate]
+
+    return _match_partial(frozenset(_name_tokens(candidate)), entity_index)
+
+
+def resolve_entities_from_structured(scene: dict[str, Any], indexes: dict[str, dict[str, Any]]) -> dict[str, list[str]]:
+    """Resolve scene entities from structured fields using campaign indexes."""
+    resolved = {"NPCs": [], "Creatures": [], "Places": [], "Clues": []}
+    record = scene if isinstance(scene, dict) else {}
+    campaign_indexes = indexes if isinstance(indexes, dict) else {}
+
+    for section, target_fields in SECTION_ENTITY_TARGETS.items():
+        candidates = parse_multiline_items(record.get(section))
+        if not candidates:
+            continue
+        for candidate in candidates:
+            for target_field in target_fields:
+                match = _match_candidate(str(candidate or "").strip(), campaign_indexes.get(target_field) or {})
+                if match:
+                    resolved[target_field].append(match)
+                    break
+
+    return {field: _dedupe_preserve(values) for field, values in resolved.items()}

--- a/tests/scenarios/wizard_steps/scenes/entity_resolution/test_structured_to_entities.py
+++ b/tests/scenarios/wizard_steps/scenes/entity_resolution/test_structured_to_entities.py
@@ -1,0 +1,73 @@
+"""Tests for structured -> entities resolver."""
+
+from modules.scenarios.wizard_steps.scenes.entity_resolution.structured_to_entities import (
+    build_campaign_entity_indexes,
+    normalize_name,
+    resolve_entities_from_structured,
+)
+
+
+class _Wrapper:
+    def __init__(self, items):
+        self._items = items
+
+    def load_items(self):
+        return list(self._items)
+
+
+def _entity_wrappers():
+    return {
+        "npcs": _Wrapper([{"Name": "Katarzyna Ręzycka"}, {"Name": "Captain Mira"}, {"Name": "Katarzyna"}]),
+        "creatures": _Wrapper([{"Name": "Ghoul"}, {"Name": "Stone Golem"}]),
+        "places": _Wrapper([{"Name": "Królewska Wieża"}]),
+        "clues": _Wrapper([{"Name": "Journal de Ręka"}]),
+    }
+
+
+def test_normalize_name_removes_diacritics_and_light_punctuation():
+    assert normalize_name("  Ręzycka, Katarzyna!  ") == "rezycka katarzyna"
+
+
+def test_partial_subset_match_from_structured_npc_line():
+    indexes = build_campaign_entity_indexes(_entity_wrappers())
+    scene = {"SceneNPCs": ["Dyrektorka Katarzyna Ręzycka"]}
+
+    resolved = resolve_entities_from_structured(scene, indexes)
+
+    assert resolved["NPCs"] == ["Katarzyna Ręzycka"]
+
+
+def test_fuzzy_single_token_typo_distance_one_matches_when_unique():
+    indexes = build_campaign_entity_indexes(_entity_wrappers())
+    scene = {"SceneNPCs": ["Katazyna"]}
+
+    resolved = resolve_entities_from_structured(scene, indexes)
+
+    assert resolved["NPCs"] == ["Katarzyna"]
+
+
+def test_diacritics_match_across_places_and_clues():
+    indexes = build_campaign_entity_indexes(_entity_wrappers())
+    scene = {
+        "SceneLocations": ["Krolewska Wieza"],
+        "SceneClues": ["Journal de Reka"],
+    }
+
+    resolved = resolve_entities_from_structured(scene, indexes)
+
+    assert resolved["Places"] == ["Królewska Wieża"]
+    assert resolved["Clues"] == ["Journal de Ręka"]
+
+
+def test_generic_obstacle_lines_do_not_create_false_positives():
+    indexes = build_campaign_entity_indexes(_entity_wrappers())
+    scene = {
+        "SceneObstacles": [
+            "gardien de sécurité",
+            "drones autonomes",
+        ]
+    }
+
+    resolved = resolve_entities_from_structured(scene, indexes)
+
+    assert resolved == {"NPCs": [], "Creatures": [], "Places": [], "Clues": []}


### PR DESCRIPTION
### Motivation
- Automatically map structured planner lines (SceneNPCs/SceneLocations/SceneObstacles/SceneClues) to existing campaign entities to reduce manual work when saving scenes.
- Provide robust name matching that tolerates case, diacritics, light punctuation, multi-word titles and small typos while avoiding false positives.

### Description
- Add `modules/scenarios/wizard_steps/scenes/entity_resolution/structured_to_entities.py` implementing `normalize_name(text)`, `build_campaign_entity_indexes(entity_wrappers)`, and `resolve_entities_from_structured(scene, indexes)` with exact, normalized, cautious token-subset partial and single-token fuzzy (edit distance <= 1) matching and order-preserving dedupe.
- Integrate resolver into `ScenesPlanningStep.save_state` in `modules/scenarios/scenario_builder_wizard.py` to build indexes once, resolve structured sections after record assembly, and merge results into `NPCs`, `Creatures`, `Places`, and `Clues` while preserving manual entries (`existing + resolved`) and de-duplicating.
- Ensure `Clues` is included in scene entity field constants (`SCENE_ENTITY_FIELDS`) and in `ROOT_KNOWN_FIELDS` for consistent persistence and state handling.
- Keep backward compatibility by making `db_indexes.py`, `structured_entity_matcher.py` delegate to the new module and expose a small `__init__` API surface.
- Add targeted unit tests at `tests/scenarios/wizard_steps/scenes/entity_resolution/test_structured_to_entities.py` covering diacritics/punctuation normalization, partial token subset matching for titles, single-token typo handling, and avoiding false positives on generic obstacle lines.

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/entity_resolution/test_structured_to_entities.py tests/scenarios/wizard_steps/scenes/test_structured_entity_matcher.py tests/test_scenario_builder_wizard.py` and all tests passed.
- Existing structured matcher tests and the scenario builder wizard tests were exercised and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd28eacb00832bb8acc25acc528cc6)