### PR TITLE
Harden portrait monitor detection and single-screen overlay behavior

### DIFF
--- a/modules/ui/image_viewer.py
+++ b/modules/ui/image_viewer.py
@@ -1,11 +1,12 @@
 """Viewer for image."""
 # modules/ui/image_viewer.py
-import os, ctypes
-from modules.helpers.config_helper import ConfigHelper
+import os
+import ctypes
 from ctypes import wintypes
 import tkinter as tk
 import customtkinter as ctk
 from PIL import Image, ImageTk
+from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.portrait_helper import resolve_portrait_path
 from modules.helpers.logging_helper import (
     log_function,
@@ -22,19 +23,40 @@ MAX_PORTRAIT_SIZE = (1024, 1024)
 
 @log_function
 def _configure_single_monitor_overlay(win, monitors):
-    """Keep portrait window visible on single-screen setups without blocking interaction."""
+    """Keep portrait window visible on single-screen setups."""
     if len(monitors) != 1:
         return
     try:
+        win.lift()
+        win.focus_force()
         win.attributes("-topmost", True)
     except Exception:
         # Ignore unsupported/failed topmost attribute on some environments.
         return
 
+
+@log_function
+def _fallback_primary_monitor():
+    """Build a safe single-monitor fallback from Tk screen metrics."""
+    probe = tk.Tk()
+    probe.withdraw()
+    try:
+        width = int(probe.winfo_screenwidth())
+        height = int(probe.winfo_screenheight())
+    finally:
+        probe.destroy()
+    if width <= 0 or height <= 0:
+        return []
+    return [(0, 0, width, height)]
+
+
 @log_function
 def _get_monitors():
     """Return list of (x, y, width, height)."""
     monitors = []
+    if os.name != "nt":
+        return _fallback_primary_monitor()
+
     def _enum(hMonitor, hdcMonitor, lprcMonitor, dwData):
         """Internal helper for enum."""
         rect = lprcMonitor.contents
@@ -42,12 +64,16 @@ def _get_monitors():
                         rect.right - rect.left,
                         rect.bottom - rect.top))
         return True
-    MonitorEnumProc = ctypes.WINFUNCTYPE(
-        wintypes.BOOL, wintypes.HMONITOR, wintypes.HDC,
-        ctypes.POINTER(wintypes.RECT), wintypes.LPARAM)
-    ctypes.windll.user32.EnumDisplayMonitors(
-        0, 0, MonitorEnumProc(_enum), 0)
-    return monitors
+    try:
+        monitor_enum_proc = ctypes.WINFUNCTYPE(
+            wintypes.BOOL, wintypes.HMONITOR, wintypes.HDC,
+            ctypes.POINTER(wintypes.RECT), wintypes.LPARAM)
+        ctypes.windll.user32.EnumDisplayMonitors(
+            0, 0, monitor_enum_proc(_enum), 0)
+    except Exception:
+        return _fallback_primary_monitor()
+
+    return monitors or _fallback_primary_monitor()
 
 @log_function
 def show_portrait(path, title=None):
@@ -73,6 +99,11 @@ def show_portrait(path, title=None):
 
     # pick a monitor (second if available)
     monitors = _get_monitors()
+    if not monitors:
+        log_warning("No monitors detected for portrait viewer", func_name="show_portrait")
+        tk.messagebox.showerror("Error", "Unable to detect any display.")
+        return
+
     target = monitors[1] if len(monitors) > 1 else monitors[0]
     sx, sy, sw, sh = target
 

--- a/tests/ui/image_viewer/test_image_viewer_monitors.py
+++ b/tests/ui/image_viewer/test_image_viewer_monitors.py
@@ -1,0 +1,54 @@
+"""Tests for monitor detection and single-monitor overlay behavior."""
+
+from modules.ui import image_viewer
+
+
+class _FakeWindow:
+    def __init__(self):
+        self.calls = []
+
+    def lift(self):
+        self.calls.append(("lift",))
+
+    def focus_force(self):
+        self.calls.append(("focus_force",))
+
+    def attributes(self, *args):
+        self.calls.append(("attributes",) + args)
+
+
+def test_configure_single_monitor_overlay_brings_window_to_front():
+    win = _FakeWindow()
+
+    image_viewer._configure_single_monitor_overlay(win, [(0, 0, 1920, 1080)])
+
+    assert ("lift",) in win.calls
+    assert ("focus_force",) in win.calls
+    assert ("attributes", "-topmost", True) in win.calls
+
+
+def test_get_monitors_uses_fallback_when_not_windows(monkeypatch):
+    expected = [(0, 0, 1280, 720)]
+    monkeypatch.setattr(image_viewer.os, "name", "posix")
+    monkeypatch.setattr(image_viewer, "_fallback_primary_monitor", lambda: expected)
+
+    monitors = image_viewer._get_monitors()
+
+    assert monitors == expected
+
+
+def test_get_monitors_uses_fallback_when_windows_enum_fails(monkeypatch):
+    expected = [(0, 0, 1366, 768)]
+
+    monkeypatch.setattr(image_viewer.os, "name", "nt")
+    monkeypatch.setattr(image_viewer, "_fallback_primary_monitor", lambda: expected)
+    monkeypatch.setattr(
+        image_viewer.ctypes,
+        "WINFUNCTYPE",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        raising=False,
+    )
+
+    monitors = image_viewer._get_monitors()
+
+    assert monitors == expected


### PR DESCRIPTION
### Motivation

- Avoid crashes and attribute errors when monitor enumeration is unavailable or when running on non-Windows platforms by making the portrait viewer resilient to missing monitor data.
- Make single-monitor portrait overlays more reliable by ensuring the window is raised and focused before toggling `-topmost` so the window appears on top consistently.

### Description

- Updated `modules/ui/image_viewer.py` to add a Tk-based fallback `_fallback_primary_monitor()` that derives a safe primary display rectangle from `Tk` screen metrics and returns `[(0,0,width,height)]` when enumeration is unavailable.
- Modified `_get_monitors()` to use the fallback on non-Windows platforms and to catch failures from Windows monitor enumeration, returning the fallback when enumeration fails or yields no monitors.
- Improved `_configure_single_monitor_overlay()` to call `win.lift()` and `win.focus_force()` before setting the `-topmost` attribute so single-monitor overlays are brought to the front reliably.
- Added a defensive check in `show_portrait()` to display a clear error and return early when no displays can be detected.
- Added targeted unit tests in `tests/ui/image_viewer/test_image_viewer_monitors.py` to validate single-monitor overlay behavior and both fallback branches for `_get_monitors()`.

### Testing

- Ran `pytest -q tests/ui/image_viewer/test_image_viewer_monitors.py` and all tests passed (`3 passed`).
- The added tests cover `
`- `_configure_single_monitor_overlay` brings the window to front on single monitor behavior,
`- `_get_monitors` fallback when not Windows, and
`- `_get_monitors` fallback when Windows enumeration fails.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3fe7992c832ba03ff7748402e3c1)