### PR TITLE
Add image-library ZIP import support for GitHub bundles

### DIFF
--- a/modules/image_assets/service.py
+++ b/modules/image_assets/service.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from typing import Any, Iterable
 
 from modules.image_assets.repository import ImageAssetsRepository
+from modules.image_assets.services.github_bundle_import_service import (
+    ImageLibraryBundleAnalysis,
+    ImageLibraryBundleImportService,
+    ImageLibraryBundleImportSummary,
+)
 from modules.image_assets.services.import_service import ImageAssetImportService, ImageAssetsImportSummary
 from modules.image_assets.services.search_service import (
     ImageAssetSearchResultDTO,
@@ -22,6 +27,7 @@ class ImageAssetsService:
         self.repository = repository or ImageAssetsRepository()
         self.import_service = ImageAssetImportService(self.repository)
         self.search_service = ImageAssetSearchService(self.repository)
+        self.bundle_import_service = ImageLibraryBundleImportService()
 
     def upsert_asset(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Upsert one image asset by hash/path."""
@@ -70,3 +76,11 @@ class ImageAssetsService:
             recursive=recursive,
             reindex_changed_only=reindex_changed_only,
         )
+
+    def analyze_image_library_bundle(self, zip_path: str) -> ImageLibraryBundleAnalysis:
+        """Analyze a GitHub-style image library bundle zip before import."""
+        return self.bundle_import_service.analyze_bundle(zip_path)
+
+    def import_image_library_bundle(self, zip_path: str, *, overwrite: bool) -> ImageLibraryBundleImportSummary:
+        """Import a GitHub-style image library bundle zip into image assets."""
+        return self.bundle_import_service.import_bundle(zip_path, overwrite=overwrite)

--- a/modules/image_assets/services/__init__.py
+++ b/modules/image_assets/services/__init__.py
@@ -1,6 +1,11 @@
 """Image-asset services package."""
 
 from modules.image_assets.services.import_service import ImageAssetImportService, ImageAssetsImportSummary
+from modules.image_assets.services.github_bundle_import_service import (
+    ImageLibraryBundleAnalysis,
+    ImageLibraryBundleImportService,
+    ImageLibraryBundleImportSummary,
+)
 from modules.image_assets.services.search_service import (
     ImageAssetSearchService,
     ImageSearchFilters,
@@ -10,6 +15,9 @@ from modules.image_assets.services.search_service import (
 __all__ = [
     "ImageAssetImportService",
     "ImageAssetsImportSummary",
+    "ImageLibraryBundleAnalysis",
+    "ImageLibraryBundleImportService",
+    "ImageLibraryBundleImportSummary",
     "ImageAssetSearchService",
     "ImageSearchFilters",
     "SortOption",

--- a/modules/image_assets/services/github_bundle_import_service.py
+++ b/modules/image_assets/services/github_bundle_import_service.py
@@ -1,0 +1,72 @@
+"""Import GitHub image-library bundle zips into the active campaign image library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from modules.generic.cross_campaign_asset_service import (
+    analyze_bundle,
+    apply_import_for_entity_types,
+    cleanup_analysis,
+    get_active_campaign,
+)
+
+
+@dataclass(slots=True)
+class ImageLibraryBundleAnalysis:
+    """Metadata extracted from a bundle before import."""
+
+    duplicate_names: list[str]
+    has_image_assets: bool
+
+
+@dataclass(slots=True)
+class ImageLibraryBundleImportSummary:
+    """Outcome of an image-library-only bundle import."""
+
+    imported: int
+    updated: int
+    skipped: int
+
+
+class ImageLibraryBundleImportService:
+    """Service dedicated to importing image-library GitHub bundle archives."""
+
+    _ALLOWED_ENTITY_TYPES = {"image_assets"}
+
+    def analyze_bundle(self, zip_path: str | Path) -> ImageLibraryBundleAnalysis:
+        """Inspect bundle and return duplicate information for image assets."""
+        archive_path = Path(zip_path)
+        campaign = get_active_campaign()
+        analysis = analyze_bundle(archive_path, campaign.db_path)
+        try:
+            image_records = analysis.data_by_type.get("image_assets", [])
+            duplicates = analysis.duplicates.get("image_assets", [])
+            return ImageLibraryBundleAnalysis(
+                duplicate_names=list(duplicates),
+                has_image_assets=bool(image_records),
+            )
+        finally:
+            cleanup_analysis(analysis)
+
+    def import_bundle(self, zip_path: str | Path, *, overwrite: bool) -> ImageLibraryBundleImportSummary:
+        """Import image assets from bundle into active campaign."""
+        archive_path = Path(zip_path)
+        campaign = get_active_campaign()
+        analysis = analyze_bundle(archive_path, campaign.db_path)
+        try:
+            result = apply_import_for_entity_types(
+                analysis,
+                campaign,
+                entity_types=self._ALLOWED_ENTITY_TYPES,
+                overwrite=overwrite,
+                progress_callback=None,
+            )
+            return ImageLibraryBundleImportSummary(
+                imported=int(result.get("imported", 0) or 0),
+                updated=int(result.get("updated", 0) or 0),
+                skipped=int(result.get("skipped", 0) or 0),
+            )
+        finally:
+            cleanup_analysis(analysis)

--- a/modules/ui/image_library/dialogs/import_directories_dialog.py
+++ b/modules/ui/image_library/dialogs/import_directories_dialog.py
@@ -78,6 +78,7 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
 
         ctk.CTkButton(side, text="Add directory...", command=self._add_directory).pack(fill="x", pady=(0, 6))
         ctk.CTkButton(side, text="Bulk add...", command=self._bulk_add_directories).pack(fill="x", pady=6)
+        ctk.CTkButton(side, text="Import ZIP...", command=self._import_bundle_zip).pack(fill="x", pady=6)
         ctk.CTkButton(side, text="Remove selected", command=self._remove_selected).pack(fill="x", pady=6)
         ctk.CTkButton(side, text="Clear", command=self._clear).pack(fill="x", pady=6)
 
@@ -121,6 +122,52 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
                 break
 
         self._append_roots(selected_roots)
+
+    def _import_bundle_zip(self) -> None:
+        """Import a GitHub-style image-library bundle zip into the shared library."""
+        zip_path = filedialog.askopenfilename(
+            parent=self,
+            title="Import GitHub Image Library ZIP",
+            filetypes=[("Zip Files", "*.zip"), ("All Files", "*.*")],
+        )
+        if not zip_path:
+            return
+
+        analysis = self._service.analyze_image_library_bundle(zip_path)
+        if not analysis.has_image_assets:
+            messagebox.showinfo(
+                "No Image Library Assets",
+                "This archive does not contain any image library assets.",
+                parent=self,
+            )
+            return
+
+        overwrite = True
+        if analysis.duplicate_names:
+            response = messagebox.askyesnocancel(
+                "Overwrite Existing Image Library Entries?",
+                "Some image assets already exist in the active campaign.\n\n"
+                f"Image assets: {len(analysis.duplicate_names)}\n\n"
+                "Yes = overwrite duplicates\n"
+                "No = keep existing and skip duplicates\n"
+                "Cancel = abort import",
+                parent=self,
+            )
+            if response is None:
+                return
+            overwrite = bool(response)
+
+        summary = self._service.import_image_library_bundle(zip_path, overwrite=overwrite)
+        messagebox.showinfo(
+            "ZIP Import Complete",
+            (
+                "Image library ZIP import completed.\n\n"
+                f"Imported: {summary.imported}\n"
+                f"Updated: {summary.updated}\n"
+                f"Skipped: {summary.skipped}"
+            ),
+            parent=self,
+        )
 
     def _append_roots(self, candidates: list[str]) -> None:
         """Append incoming root candidates after normalization and dedupe."""


### PR DESCRIPTION
### Motivation
- Provide a way to import image-library ZIP bundles exported from the GitHub gallery format directly into the app's image library so users can add images from GitHub bundles without manual extraction.

### Description
- Add a new service `modules/image_assets/services/github_bundle_import_service.py` with `ImageLibraryBundleImportService`, `ImageLibraryBundleAnalysis`, and `ImageLibraryBundleImportSummary` to analyze and import `image_assets` from a bundle using existing bundle parsing logic (`analyze_bundle`, `apply_import_for_entity_types`).
- Wire the new service into the image assets facade by adding `bundle_import_service` and two new methods `analyze_image_library_bundle(...)` and `import_image_library_bundle(...)` on `ImageAssetsService` (`modules/image_assets/service.py`).
- Add an `Import ZIP...` button and the `_import_bundle_zip` handler to the image library import dialog (`modules/ui/image_library/dialogs/import_directories_dialog.py`) which performs file selection, pre-import analysis, duplicate overwrite confirmation via `messagebox`, and a completion summary.
- Export the new service types in `modules/image_assets/services/__init__.py` so they are available to callers.

### Testing
- Compiled modified modules with `python -m compileall modules/image_assets/service.py modules/image_assets/services/github_bundle_import_service.py modules/ui/image_library/dialogs/import_directories_dialog.py modules/image_assets/services/__init__.py` and the compilation succeeded.
- Confirmed the new modules are syntactically valid by running the Python compilation step across the changed files and observing no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb70e485c832bb204c6db7128e2f1)