### PR TITLE
Add Handouts panel support to GM Table workspace

### DIFF
--- a/modules/scenarios/gm_table/handouts_page.py
+++ b/modules/scenarios/gm_table/handouts_page.py
@@ -1,0 +1,158 @@
+"""Handouts page for the GM Table workspace."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+import tkinter as tk
+from tkinter import messagebox
+
+import customtkinter as ctk
+
+from modules.helpers.config_helper import ConfigHelper
+
+
+class GMTableHandoutsPage(ctk.CTkFrame):
+    """Browse and open campaign handout files."""
+
+    def __init__(
+        self,
+        master,
+        *,
+        scenario_name: str = "",
+        initial_state: dict | None = None,
+    ) -> None:
+        super().__init__(master, fg_color="transparent")
+        self.grid_rowconfigure(2, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        state = dict(initial_state or {})
+        self._scenario_name = str(scenario_name or state.get("scenario_name") or "").strip()
+        self._query_var = tk.StringVar(value=str(state.get("query") or ""))
+        self._selected_path = str(state.get("selected_path") or "")
+        self._handout_paths: list[str] = []
+        self._row_buttons: dict[str, ctk.CTkButton] = {}
+
+        title_text = "Handouts"
+        if self._scenario_name:
+            title_text = f"Handouts · {self._scenario_name}"
+        ctk.CTkLabel(
+            self,
+            text=title_text,
+            font=ctk.CTkFont(size=16, weight="bold"),
+            anchor="w",
+        ).grid(row=0, column=0, sticky="ew", pady=(0, 8))
+
+        controls = ctk.CTkFrame(self, fg_color="transparent")
+        controls.grid(row=1, column=0, sticky="ew", pady=(0, 8))
+        controls.grid_columnconfigure(0, weight=1)
+
+        search = ctk.CTkEntry(controls, textvariable=self._query_var, placeholder_text="Filter handouts…")
+        search.grid(row=0, column=0, sticky="ew", padx=(0, 8))
+        search.bind("<KeyRelease>", lambda _event: self._render_rows())
+
+        ctk.CTkButton(
+            controls,
+            text="Refresh",
+            width=96,
+            command=self._refresh_handouts,
+        ).grid(row=0, column=1)
+
+        self._list_frame = ctk.CTkScrollableFrame(self, fg_color="transparent")
+        self._list_frame.grid(row=2, column=0, sticky="nsew")
+        self._list_frame.grid_columnconfigure(0, weight=1)
+
+        self._refresh_handouts()
+
+    def _refresh_handouts(self) -> None:
+        """Reload files from campaign handout directories."""
+        self._handout_paths = self._collect_handout_files()
+        self._render_rows()
+
+    def _collect_handout_files(self) -> list[str]:
+        """Return available handout files relative to the campaign directory."""
+        campaign_dir = Path(ConfigHelper.get_campaign_dir())
+        candidate_dirs = (
+            campaign_dir / "Handouts",
+            campaign_dir / "handouts",
+            campaign_dir / "assets" / "handouts",
+        )
+        discovered: set[str] = set()
+        for folder in candidate_dirs:
+            if not folder.exists() or not folder.is_dir():
+                continue
+            for file_path in folder.rglob("*"):
+                if file_path.is_file():
+                    discovered.add(str(file_path.relative_to(campaign_dir)))
+        return sorted(discovered, key=str.lower)
+
+    def _render_rows(self) -> None:
+        """Render row buttons based on the active query filter."""
+        for child in self._list_frame.winfo_children():
+            child.destroy()
+        self._row_buttons.clear()
+
+        query = self._query_var.get().strip().lower()
+        visible_paths = [
+            relative_path
+            for relative_path in self._handout_paths
+            if not query or query in relative_path.lower()
+        ]
+        if not visible_paths:
+            ctk.CTkLabel(
+                self._list_frame,
+                text="No handout files found. Add files to Handouts/ or assets/handouts.",
+                anchor="w",
+                justify="left",
+            ).grid(row=0, column=0, sticky="ew", padx=4, pady=4)
+            return
+
+        for row_index, relative_path in enumerate(visible_paths):
+            button = ctk.CTkButton(
+                self._list_frame,
+                text=relative_path,
+                anchor="w",
+                fg_color="transparent",
+                hover_color="#283146",
+                command=lambda path=relative_path: self._open_handout(path),
+            )
+            button.grid(row=row_index, column=0, sticky="ew", padx=2, pady=2)
+            self._row_buttons[relative_path] = button
+        self._highlight_selection()
+
+    def _highlight_selection(self) -> None:
+        """Apply a distinct color to the selected row."""
+        for relative_path, button in self._row_buttons.items():
+            is_selected = relative_path == self._selected_path
+            button.configure(
+                fg_color="#374151" if is_selected else "transparent",
+                text_color="#F4F7FB",
+            )
+
+    def _open_handout(self, relative_path: str) -> None:
+        """Open a handout in the system default app."""
+        resolved = Path(ConfigHelper.get_campaign_dir()) / relative_path
+        if not resolved.exists():
+            messagebox.showerror("Handouts", f"File not found:\n{relative_path}")
+            return
+        self._selected_path = relative_path
+        self._highlight_selection()
+        try:
+            if sys.platform.startswith("win"):
+                os.startfile(str(resolved))  # type: ignore[attr-defined]
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", str(resolved)])
+            else:
+                subprocess.Popen(["xdg-open", str(resolved)])
+        except Exception as exc:
+            messagebox.showerror("Handouts", f"Unable to open file:\n{exc}")
+
+    def get_state(self) -> dict:
+        """Return serializable page state for workspace persistence."""
+        return {
+            "query": self._query_var.get().strip(),
+            "selected_path": self._selected_path,
+            "scenario_name": self._scenario_name,
+        }

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -32,6 +32,7 @@ DEFAULT_PANEL_SIZES = {
     "map_tool": (900, 640),
     "scene_flow": (860, 600),
     "image_library": (860, 580),
+    "handouts": (760, 560),
     "loot_generator": (620, 520),
     "whiteboard": (900, 640),
     "random_tables": (680, 560),

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -21,6 +21,7 @@ from modules.objects.loot_generator_panel import LootGeneratorPanel
 from modules.puzzles.puzzle_display_window import create_puzzle_display_frame
 from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
+from modules.scenarios.gm_table.handouts_page import GMTableHandoutsPage
 from modules.scenarios.gm_table.pages import (
     GMTableHostedPage,
     GMTableImageLibraryPage,
@@ -123,6 +124,7 @@ class GMTableView(ctk.CTkFrame):
             "Map Tool",
             "Scene Flow",
             "Image Library",
+            "Handouts",
             "Loot Generator",
             "Whiteboard",
             "Random Tables",
@@ -260,6 +262,7 @@ class GMTableView(ctk.CTkFrame):
         self._create_panel("campaign_dashboard", "Campaign Dashboard", {})
         self._create_panel("random_tables", "Random Tables", {})
         self._create_panel("plot_twists", "Plot Twists", {})
+        self._create_panel("handouts", "Handouts", {"scenario_name": self.scenario_name})
         self._create_panel("note", "Session Notes", {"text": ""})
         self.workspace.auto_arrange()
 
@@ -376,6 +379,9 @@ class GMTableView(ctk.CTkFrame):
         if option == "Image Library":
             self._create_panel("image_library", "Image Library", {})
             return
+        if option == "Handouts":
+            self._create_panel("handouts", "Handouts", {"scenario_name": self.scenario_name})
+            return
         if option == "Loot Generator":
             self._create_panel("loot_generator", "Loot Generator", {})
             return
@@ -444,6 +450,12 @@ class GMTableView(ctk.CTkFrame):
                 )
             if kind == "image_library":
                 return GMTableImageLibraryPage(parent, initial_state=definition.state)
+            if kind == "handouts":
+                return GMTableHandoutsPage(
+                    parent,
+                    scenario_name=self.scenario_name,
+                    initial_state=definition.state,
+                )
             if kind == "loot_generator":
                 return GMTableHostedPage(
                     parent,


### PR DESCRIPTION
### Motivation
- Provide a dedicated Handouts panel in the GM Table so GMs can browse and open campaign handout files directly from the workspace.
- Ensure the new panel integrates with the existing panel lifecycle and workspace layout persistence.

### Description
- Add a new `Handouts` add-menu option and route it in `_handle_add_option` to call `self._create_panel("handouts", "Handouts", {"scenario_name": self.scenario_name})` in `modules/scenarios/gm_table_view.py`.
- Seed the handouts panel in the default workspace via `_seed_default_panels` so it opens automatically for a scenario in `modules/scenarios/gm_table_view.py`.
- Create a new `GMTableHandoutsPage` class in `modules/scenarios/gm_table/handouts_page.py` that discovers handout files under campaign paths (`Handouts/`, `handouts/`, `assets/handouts/`), provides filtering, opens files with the system default app, and exposes `get_state()`.
- Mount the `handouts` kind in `_mount_panel_content` to return `GMTableHandoutsPage`, and register a default panel size for `handouts` in `modules/scenarios/gm_table/workspace.py` so layout geometry behaves consistently.
- Keep persistence compatible by returning only plain serializable fields (`query`, `selected_path`, `scenario_name`) from `GMTableHandoutsPage.get_state()` so the existing `GMTableWorkspace.serialize()`/`restore()` flow can handle it.

### Testing
- Ran byte-compile on the affected modules with `python -m compileall modules/scenarios/gm_table_view.py modules/scenarios/gm_table/handouts_page.py modules/scenarios/gm_table/workspace.py` and it completed successfully.
- Verified the workspace files were updated and the new module compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12f2620e4832b911f4c4697c6aa91)