### PR TITLE
Add GM Table handouts tests and view routing coverage

### DIFF
--- a/tests/scenarios/gm_table/test_gm_table_handouts_page.py
+++ b/tests/scenarios/gm_table/test_gm_table_handouts_page.py
@@ -1,0 +1,159 @@
+"""Tests for GM Table handouts page rendering and interactions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import modules.scenarios.gm_table.handouts.page as page_module
+from modules.scenarios.gm_table.handouts.service import HandoutItem
+
+
+class _Var:
+    def __init__(self, value: str = "") -> None:
+        self._value = value
+
+    def get(self) -> str:
+        return self._value
+
+    def set(self, value: str) -> None:
+        self._value = value
+
+
+class _Widget:
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.children = []
+        self.bindings = {}
+        if args and hasattr(args[0], "children"):
+            args[0].children.append(self)
+
+    def grid(self, **kwargs) -> None:
+        self.grid_kwargs = kwargs
+
+    def grid_propagate(self, _flag: bool) -> None:
+        return None
+
+    def bind(self, event, callback) -> None:
+        self.bindings[event] = callback
+
+    def winfo_children(self):
+        return list(self.children)
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+    def configure(self, **kwargs) -> None:
+        self.kwargs.update(kwargs)
+
+    def grid_columnconfigure(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class _GridFrame:
+    def __init__(self) -> None:
+        self.children = []
+
+    def winfo_children(self):
+        return list(self.children)
+
+    def grid_columnconfigure(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _item(path: str, *, handout_id: str = "NPCs:Kara:kara.png", title: str = "Kara") -> HandoutItem:
+    return HandoutItem(
+        id=handout_id,
+        title=title,
+        entity_type="NPCs",
+        source_name=title,
+        path=path,
+        kind="portrait",
+        subtitle="NPC",
+    )
+
+
+def test_render_grid_shows_empty_state_when_no_handouts(monkeypatch) -> None:
+    labels = []
+
+    class _Label(_Widget):
+        def __init__(self, *args, **kwargs) -> None:
+            labels.append(kwargs.get("text"))
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(page_module.ctk, "CTkLabel", _Label)
+
+    view = page_module.GMTableHandoutsPage.__new__(page_module.GMTableHandoutsPage)
+    view._grid_frame = _GridFrame()
+    view._visible_cards = {}
+    view._query_var = _Var("")
+    view._handouts = []
+    view._column_count = 2
+
+    page_module.GMTableHandoutsPage._render_grid(view)
+
+    assert labels[-1] == "No scenario handouts found."
+
+
+def test_render_grid_builds_compact_cards_for_collected_handouts() -> None:
+    created = []
+
+    class _Card:
+        def __init__(self, handout_id: str) -> None:
+            self.handout_id = handout_id
+            self.grid_calls = []
+
+        def grid(self, **kwargs) -> None:
+            self.grid_calls.append(kwargs)
+
+    def _build(master, handout):
+        card = _Card(handout.id)
+        created.append(card)
+        return card
+
+    view = page_module.GMTableHandoutsPage.__new__(page_module.GMTableHandoutsPage)
+    view._grid_frame = _GridFrame()
+    view._visible_cards = {}
+    view._query_var = _Var("")
+    view._column_count = 2
+    view._highlight_selected = lambda: created.append("highlight")
+    view._build_card = _build
+    view._handouts = [
+        _item("/tmp/a.png", handout_id="one"),
+        _item("/tmp/b.png", handout_id="two"),
+        _item("/tmp/c.png", handout_id="three"),
+    ]
+
+    page_module.GMTableHandoutsPage._render_grid(view)
+
+    assert [card.handout_id for card in created if hasattr(card, "handout_id")] == ["one", "two", "three"]
+    assert created[0].grid_calls[0]["row"] == 0
+    assert created[1].grid_calls[0]["column"] == 1
+    assert created[2].grid_calls[0]["row"] == 1
+    assert set(view._visible_cards.keys()) == {"one", "two", "three"}
+
+
+def test_clicking_card_opens_portrait_with_expected_path_and_title(monkeypatch, tmp_path) -> None:
+    image_path = tmp_path / "kara.png"
+    image_path.write_bytes(b"png")
+    handout = _item(str(image_path), title="Kara Voss")
+
+    monkeypatch.setattr(page_module.ctk, "CTkFrame", _Widget)
+    monkeypatch.setattr(page_module.ctk, "CTkLabel", _Widget)
+    monkeypatch.setattr(page_module.ctk, "CTkFont", lambda **_kwargs: object())
+
+    shown = []
+    monkeypatch.setattr(page_module, "show_portrait", lambda path, title=None: shown.append((path, title)))
+
+    view = page_module.GMTableHandoutsPage.__new__(page_module.GMTableHandoutsPage)
+    view._status_var = _Var("")
+    view._selected_id = ""
+    view._highlight_selected = lambda: None
+    view._get_thumbnail = lambda _path: (object(), False)
+
+    card = page_module.GMTableHandoutsPage._build_card(view, _GridFrame(), replace(handout))
+    card.bindings["<Button-1>"](None)
+
+    assert shown == [(str(Path(image_path).resolve()), "Kara Voss")]
+    assert view._selected_id == handout.id

--- a/tests/scenarios/gm_table/test_gm_table_handouts_service.py
+++ b/tests/scenarios/gm_table/test_gm_table_handouts_service.py
@@ -1,0 +1,55 @@
+"""Tests for GM Table handout collection service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import modules.scenarios.gm_table.handouts.service as service_module
+
+
+def _wrapper(items):
+    return SimpleNamespace(load_items=lambda: items)
+
+
+def test_collect_scenario_handouts_collects_maps_and_portraits_with_dedupe_and_order(monkeypatch, tmp_path) -> None:
+    """Service should gather linked portraits/maps, skip missing, dedupe, and keep deterministic order."""
+    aria = tmp_path / "aria.png"
+    zara = tmp_path / "zara.png"
+    map_img = tmp_path / "city-map.png"
+    aria.write_bytes(b"png")
+    zara.write_bytes(b"png")
+    map_img.write_bytes(b"png")
+
+    monkeypatch.setattr(service_module, "parse_portrait_value", lambda value: [str(value)] if value else [])
+    monkeypatch.setattr(service_module, "resolve_portrait_candidate", lambda value, _campaign_dir: value)
+
+    wrappers = {
+        "NPCs": _wrapper(
+            [
+                {"Name": "Zara", "Portrait": str(zara)},
+                {"Name": "Aria", "Portrait": str(aria)},
+                {"Name": "Ghost", "Portrait": str(tmp_path / "missing.png")},
+                {"Name": "Echo", "Portrait": str(zara)},
+            ]
+        ),
+        "Creatures": _wrapper([]),
+        "Villains": _wrapper([]),
+        "Places": _wrapper([]),
+        "Bases": _wrapper([]),
+        "PCs": _wrapper([]),
+        "Factions": _wrapper([]),
+    }
+    map_wrapper = _wrapper([{"Name": "City", "Image": str(map_img)}])
+
+    scenario = {
+        "NPCs": ["Zara", "Aria", "Ghost", "Echo"],
+        "Maps": ["City"],
+    }
+
+    handouts = service_module.collect_scenario_handouts(scenario, wrappers, map_wrapper)
+
+    assert [item.path for item in handouts] == [str(map_img.resolve()), str(zara.resolve()), str(aria.resolve())]
+    assert [item.kind for item in handouts] == ["map", "portrait", "portrait"]
+    assert all(Path(item.path).exists() for item in handouts)
+    assert len({item.path for item in handouts}) == len(handouts)

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -232,3 +232,62 @@ def test_context_menu_binding_helpers_skip_hosts_without_menu_api(monkeypatch) -
     )
     assert callable(recursive_handler)
     assert recursive_calls[-1][0] is widget
+
+
+def test_handle_add_option_routes_handouts_panel_creation() -> None:
+    """Add menu handouts option should spawn a handouts panel."""
+    captured = []
+    view = GMTableView.__new__(GMTableView)
+    view.scenario_name = "Night Run"
+    view._create_panel = lambda kind, title, state: captured.append((kind, title, state))
+
+    GMTableView._handle_add_option(view, "Handouts")
+
+    assert captured == [("handouts", "Handouts", {"scenario_name": "Night Run"})]
+
+
+def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
+    """Handouts panel should mount the dedicated handouts page."""
+    captured = {}
+
+    class _DummyHandoutsPage:
+        def __init__(self, parent, **kwargs) -> None:
+            captured["parent"] = parent
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(gm_table_view_module, "GMTableHandoutsPage", _DummyHandoutsPage)
+
+    view = GMTableView.__new__(GMTableView)
+    view.scenario_name = "Night Run"
+    view.scenario = {"Title": "Night Run"}
+    view.wrappers = {"NPCs": object()}
+    view.map_wrapper = object()
+    definition = gm_table_view_module.PanelDefinition(
+        panel_id="panel-handouts",
+        kind="handouts",
+        title="Handouts",
+        state={"query": "map"},
+    )
+
+    mounted = GMTableView._mount_panel_content(view, object(), definition)
+
+    assert isinstance(mounted, _DummyHandoutsPage)
+    assert captured["kwargs"]["scenario_name"] == "Night Run"
+    assert captured["kwargs"]["scenario_item"] == {"Title": "Night Run"}
+    assert captured["kwargs"]["initial_state"] == {"query": "map"}
+
+
+def test_seed_default_panels_includes_handouts_opened_for_scenario() -> None:
+    """Starter tabletop should include the handouts panel bound to the current scenario."""
+    captured = []
+    view = GMTableView.__new__(GMTableView)
+    view.scenario_name = "Night Run"
+    view.open_entity_panel = lambda entity_type, name: captured.append(("open", entity_type, name))
+    view._create_panel = lambda kind, title, state: captured.append(("panel", kind, title, state))
+    view.workspace = SimpleNamespace(auto_arrange=lambda: captured.append(("arrange",)))
+
+    GMTableView._seed_default_panels(view)
+
+    assert ("panel", "handouts", "Handouts", {"scenario_name": "Night Run"}) in captured
+    assert captured[0] == ("open", "Scenarios", "Night Run")
+    assert captured[-1] == ("arrange",)


### PR DESCRIPTION
### Motivation
- Provide unit coverage for the handouts feature to ensure portraits/maps are collected and rendered correctly and that the GM Table add-menu routes and panel mounting support handouts.
- Protect against regressions in collection (missing files, dedupe, order) and in the UI page behavior (empty state, card layout, click-to-open).

### Description
- Added `tests/scenarios/gm_table/test_gm_table_handouts_service.py` to validate `collect_scenario_handouts` collects map and portrait images, ignores missing files, deduplicates by path, and preserves deterministic ordering.
- Added `tests/scenarios/gm_table/test_gm_table_handouts_page.py` to assert empty-state rendering, compact card-grid building, and that clicking a card calls `show_portrait` with the expected resolved path and title (UI interactions are monkeypatched/stubbed for isolation).
- Extended `tests/scenarios/gm_table/test_gm_table_view.py` with tests verifying the add-menu `Handouts` option creates a `kind="handouts"` panel, that `_mount_panel_content` returns the handouts page for that kind, and that the default seed includes opening a handouts panel for the current scenario.
- Minor test shim added in the handouts page tests to stub `grid_propagate` on the fake widget used for CTk widgets so the page's card-building code can exercise click behavior without real GUI widgets.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_gm_table_handouts_service.py tests/scenarios/gm_table/test_gm_table_handouts_page.py` which completed successfully (`4 passed`).
- Ran `python -m py_compile tests/scenarios/gm_table/test_gm_table_view.py` which passed static compilation checks.
- Attempting to run the full `pytest` including `test_gm_table_view.py` failed during collection due to an import-time `PIL.ImageFont` error originating from the environment (unrelated to these test additions), so the view-level pytest run was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1325bd004832ba7cf18ff90528935)