### PR TITLE
Seed default handouts tab when no scenario layout is set

### DIFF
--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -1247,8 +1247,15 @@ class GMScreenView(ctk.CTkFrame):
         if not layout_name:
             layout_name = self.layout_manager.get_scenario_default(self.scenario_name)
         if not layout_name:
+            self._seed_default_startup_tabs()
             return
         self.load_layout(layout_name, silent=True)
+
+    def _seed_default_startup_tabs(self):
+        """Seed default startup tabs when no explicit layout is available."""
+        if "Handouts" in self.tabs:
+            return
+        self.open_handouts_tab("Handouts")
 
     def _initialize_context_menu(self):
         """Internal helper for initialize context menu."""


### PR DESCRIPTION
### Motivation
- Ensure the GM screen opens a default Handouts tab at startup when there is no pending or scenario-default layout, while preserving existing layout-driven behavior.

### Description
- Add helper `def _seed_default_startup_tabs()` and call it from `_apply_initial_layout()` when `layout_name` is empty; the helper idempotently opens the `Handouts` tab if not already present.

### Testing
- Ran `python -m compileall modules/scenarios/gm_screen_view.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e135754954832b9c098ed869fb727e)