### PR TITLE
Refactor GM Screen handouts into dedicated handouts module

### DIFF
--- a/modules/scenarios/gm_screen/handouts/__init__.py
+++ b/modules/scenarios/gm_screen/handouts/__init__.py
@@ -1,0 +1,1 @@
+"""GM Screen handouts modules."""

--- a/modules/scenarios/gm_screen/handouts/panel.py
+++ b/modules/scenarios/gm_screen/handouts/panel.py
@@ -1,0 +1,275 @@
+"""Compact handouts panel for the GM Screen."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tkinter as tk
+
+import customtkinter as ctk
+from PIL import Image
+
+from modules.scenarios.gm_screen.handouts.service import (
+    GMScreenHandoutItem,
+    collect_gm_screen_handouts,
+)
+from modules.ui.image_viewer import show_portrait
+
+_CARD_WIDTH = 156
+_CARD_HEIGHT = 166
+_CARD_GAP = 8
+_THUMBNAIL_SIZE = (128, 88)
+
+
+class GMScreenHandoutsPanel(ctk.CTkFrame):
+    """Show scenario-linked handouts in a compact clickable grid."""
+
+    def __init__(
+        self,
+        master,
+        *,
+        scenario_name: str,
+        scenario_item: dict,
+        wrappers: dict[str, object],
+        map_wrapper: object,
+        on_open=None,
+    ) -> None:
+        super().__init__(master, fg_color="transparent")
+        self.grid_rowconfigure(2, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        self._scenario_name = str(scenario_name or "").strip()
+        self._scenario_item = scenario_item if isinstance(scenario_item, dict) else {}
+        self._wrappers = wrappers
+        self._map_wrapper = map_wrapper
+        self._on_open = on_open or show_portrait
+
+        self._query_var = tk.StringVar(value="")
+        self._status_var = tk.StringVar(value="")
+        self._selected_id = ""
+        self._column_count = 1
+
+        self._handouts: list[GMScreenHandoutItem] = []
+        self._visible_cards: dict[str, ctk.CTkFrame] = {}
+        self._thumbnail_cache: dict[str, tuple[float, ctk.CTkImage]] = {}
+        self._placeholder_thumb = self._build_placeholder_thumb()
+
+        title = "Handouts"
+        if self._scenario_name:
+            title = f"Handouts · {self._scenario_name}"
+
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.grid(row=0, column=0, sticky="ew", pady=(0, 4))
+        header.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            header,
+            text=title,
+            font=ctk.CTkFont(size=16, weight="bold"),
+            anchor="w",
+        ).grid(row=0, column=0, sticky="ew")
+
+        controls = ctk.CTkFrame(header, fg_color="transparent")
+        controls.grid(row=1, column=0, sticky="ew", pady=(6, 0))
+        controls.grid_columnconfigure(0, weight=1)
+
+        search = ctk.CTkEntry(
+            controls,
+            textvariable=self._query_var,
+            placeholder_text="Filter handouts…",
+            height=30,
+        )
+        search.grid(row=0, column=0, sticky="ew", padx=(0, 6))
+        search.bind("<KeyRelease>", lambda _event: self._render_grid())
+
+        ctk.CTkButton(
+            controls,
+            text="Refresh",
+            width=88,
+            height=30,
+            command=self.refresh,
+        ).grid(row=0, column=1)
+
+        ctk.CTkLabel(
+            self,
+            textvariable=self._status_var,
+            anchor="w",
+            justify="left",
+            text_color="#F59E0B",
+            wraplength=560,
+        ).grid(row=1, column=0, sticky="ew", pady=(0, 4))
+
+        self._grid_frame = ctk.CTkScrollableFrame(self, fg_color="transparent")
+        self._grid_frame.grid(row=2, column=0, sticky="nsew")
+
+        self.bind("<Configure>", self._on_resize)
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Reload linked handouts and re-render the compact grid."""
+        self._status_var.set("")
+        self._handouts = collect_gm_screen_handouts(
+            self._scenario_item,
+            self._wrappers,
+            self._map_wrapper,
+        )
+        self._render_grid()
+
+    def _on_resize(self, _event=None) -> None:
+        width = max(self.winfo_width(), self._grid_frame.winfo_width())
+        columns = self._compute_columns(width)
+        if columns != self._column_count:
+            self._column_count = columns
+            self._render_grid()
+
+    @staticmethod
+    def _compute_columns(width: int) -> int:
+        usable = max(width - 12, _CARD_WIDTH)
+        return max(1, usable // (_CARD_WIDTH + _CARD_GAP))
+
+    def _render_grid(self) -> None:
+        for child in self._grid_frame.winfo_children():
+            child.destroy()
+        self._visible_cards.clear()
+
+        query = self._query_var.get().strip().casefold()
+        items = [
+            handout
+            for handout in self._handouts
+            if not query
+            or query in handout.title.casefold()
+            or query in (handout.subtitle or "").casefold()
+            or query in Path(handout.path).name.casefold()
+        ]
+
+        if not items:
+            ctk.CTkLabel(
+                self._grid_frame,
+                text="No scenario handouts found.",
+                anchor="w",
+            ).grid(row=0, column=0, sticky="ew", padx=4, pady=4)
+            return
+
+        for column in range(self._column_count):
+            self._grid_frame.grid_columnconfigure(column, weight=1)
+
+        for index, handout in enumerate(items):
+            row = index // self._column_count
+            column = index % self._column_count
+            card = self._build_card(self._grid_frame, handout)
+            card.grid(row=row, column=column, sticky="nsew", padx=3, pady=3)
+            self._visible_cards[handout.id] = card
+
+        self._highlight_selected()
+
+    def _build_card(self, master, handout: GMScreenHandoutItem) -> ctk.CTkFrame:
+        card = ctk.CTkFrame(master, corner_radius=10, width=_CARD_WIDTH, height=_CARD_HEIGHT)
+        card.grid_propagate(False)
+        card.grid_columnconfigure(0, weight=1)
+
+        thumb, is_broken = self._get_thumbnail(handout.path)
+        ctk.CTkLabel(card, text="", image=thumb).grid(row=0, column=0, padx=5, pady=(5, 2), sticky="n")
+
+        ctk.CTkLabel(
+            card,
+            text=handout.title,
+            anchor="w",
+            justify="left",
+            wraplength=_CARD_WIDTH - 14,
+            font=ctk.CTkFont(size=12, weight="bold"),
+        ).grid(row=1, column=0, sticky="ew", padx=7)
+
+        if handout.subtitle:
+            ctk.CTkLabel(
+                card,
+                text=handout.subtitle,
+                height=16,
+                corner_radius=8,
+                fg_color="#2F3A4E",
+                text_color="#C9D3E6",
+                font=ctk.CTkFont(size=10, weight="bold"),
+            ).grid(row=2, column=0, sticky="w", padx=7, pady=(2, 1))
+
+        ctk.CTkLabel(
+            card,
+            text="File unavailable" if is_broken else "",
+            text_color="#EF4444",
+            anchor="w",
+            font=ctk.CTkFont(size=10),
+        ).grid(row=3, column=0, sticky="ew", padx=7, pady=(0, 4))
+
+        self._bind_click_recursive(card, lambda _event, item=handout: self._open_handout(item))
+        return card
+
+    def _bind_click_recursive(self, widget, callback) -> None:
+        widget.bind("<Button-1>", callback)
+        for child in widget.winfo_children():
+            self._bind_click_recursive(child, callback)
+
+    def _get_thumbnail(self, resolved_path: str) -> tuple[ctk.CTkImage, bool]:
+        candidate = Path(resolved_path)
+        try:
+            modified_at = candidate.stat().st_mtime
+        except OSError:
+            return self._placeholder_thumb, True
+
+        cache_key = str(candidate.resolve())
+        cached = self._thumbnail_cache.get(cache_key)
+        if cached and cached[0] == modified_at:
+            return cached[1], False
+
+        try:
+            with Image.open(candidate) as img:
+                render = img.convert("RGB")
+                render.thumbnail(_THUMBNAIL_SIZE, Image.Resampling.LANCZOS)
+            ctk_image = ctk.CTkImage(light_image=render, dark_image=render, size=render.size)
+        except Exception:
+            return self._placeholder_thumb, True
+
+        self._thumbnail_cache[cache_key] = (modified_at, ctk_image)
+        return ctk_image, False
+
+    @staticmethod
+    def _build_placeholder_thumb() -> ctk.CTkImage:
+        placeholder = Image.new("RGB", _THUMBNAIL_SIZE, color="#293241")
+        return ctk.CTkImage(light_image=placeholder, dark_image=placeholder, size=_THUMBNAIL_SIZE)
+
+    def _open_handout(self, handout: GMScreenHandoutItem) -> None:
+        resolved_path = str(Path(handout.path).resolve())
+        if not Path(resolved_path).exists():
+            self._status_var.set(f"⚠ Missing file: {Path(resolved_path).name}")
+            self._render_grid()
+            return
+
+        self._selected_id = handout.id
+        self._status_var.set("")
+        self._highlight_selected()
+        self._on_open(resolved_path, handout.title)
+
+    def _highlight_selected(self) -> None:
+        for handout_id, card in self._visible_cards.items():
+            selected = handout_id == self._selected_id
+            card.configure(
+                border_width=1 if selected else 0,
+                border_color="#D9A441" if selected else "#344054",
+                fg_color="#1F2937" if selected else "#121826",
+            )
+
+
+def create_handouts_panel(
+    master,
+    *,
+    scenario_name: str,
+    scenario_item: dict,
+    wrappers: dict[str, object],
+    map_wrapper: object,
+):
+    """Factory used by GM Screen integration to mount the handouts panel."""
+
+    return GMScreenHandoutsPanel(
+        master,
+        scenario_name=scenario_name,
+        scenario_item=scenario_item,
+        wrappers=wrappers,
+        map_wrapper=map_wrapper,
+        on_open=lambda path, title: show_portrait(path, title),
+    )

--- a/modules/scenarios/gm_screen/handouts/service.py
+++ b/modules/scenarios/gm_screen/handouts/service.py
@@ -1,0 +1,38 @@
+"""Services for GM Screen handouts collection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modules.scenarios.gm_table.handouts.service import collect_scenario_handouts
+
+
+@dataclass(frozen=True)
+class GMScreenHandoutItem:
+    """Resolved handout descriptor used by the GM Screen handouts panel."""
+
+    id: str
+    title: str
+    path: str
+    kind: str
+    subtitle: str | None = None
+
+
+def collect_gm_screen_handouts(
+    scenario_item: dict,
+    wrappers: dict[str, object],
+    map_wrapper: object,
+) -> list[GMScreenHandoutItem]:
+    """Collect scenario-linked portraits and maps for the GM Screen handouts tab."""
+
+    items = collect_scenario_handouts(scenario_item, wrappers, map_wrapper)
+    return [
+        GMScreenHandoutItem(
+            id=item.id,
+            title=item.title,
+            path=item.path,
+            kind=item.kind,
+            subtitle=item.subtitle,
+        )
+        for item in items
+    ]

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -34,7 +34,7 @@ from modules.maps.controllers.display_map_controller import DisplayMapController
 from modules.scenarios.scene_flow_viewer import create_scene_flow_frame, scene_flow_content_factory
 from modules.scenarios.plot_twist_scheduler import PlotTwistScheduler
 from modules.scenarios.plot_twist_panel import PlotTwistPanel, roll_plot_twist
-from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
+from modules.scenarios.gm_screen.handouts.panel import create_handouts_panel
 from modules.scenarios.session_notes import (
     build_scene_snapshot_entry,
     build_session_debrief_entry,
@@ -2530,27 +2530,37 @@ class GMScreenView(ctk.CTkFrame):
 
     def open_handouts_tab(self, title=None):
         """Open the handouts page inside the GM screen."""
-        frame = GMTableHandoutsPage(
-            self._ensure_rich_host(),
+        container = ctk.CTkFrame(self._ensure_rich_host())
+        self._make_fullbleed(container)
+        panel = create_handouts_panel(
+            container,
             scenario_name=self.scenario_name,
             scenario_item=self.scenario,
             wrappers=self.wrappers,
             map_wrapper=self.map_wrapper,
         )
+        panel.pack(fill="both", expand=True)
+        container.handouts_panel = panel
 
         def factory(master):
             """Handle factory."""
-            return GMTableHandoutsPage(
-                master if master is not None else self._ensure_rich_host(),
+            host_parent = master if master is not None else self._ensure_rich_host()
+            frame = ctk.CTkFrame(host_parent)
+            self._make_fullbleed(frame)
+            created = create_handouts_panel(
+                frame,
                 scenario_name=self.scenario_name,
                 scenario_item=self.scenario,
                 wrappers=self.wrappers,
                 map_wrapper=self.map_wrapper,
             )
+            created.pack(fill="both", expand=True)
+            frame.handouts_panel = created
+            return frame
 
         self.add_tab(
             title or "Handouts",
-            frame,
+            container,
             content_factory=factory,
             layout_meta={"kind": "handouts", "host": "rich"},
         )


### PR DESCRIPTION
### Motivation
- Separate GM Screen handouts UI and data collection into its own subpackage to improve architecture and readability.
- Reuse existing handout-resolution logic but adapt a compact panel optimized for the GM Screen workflow and full-bleed hosting.
- Keep `gm_screen_view.py` integration thin so the GM Screen mounts the handouts panel the same way as other rich/full-bleed tabs.

### Description
- Added `modules/scenarios/gm_screen/handouts/service.py` which wraps the scenario-level handout collector and exposes `collect_gm_screen_handouts(...)` plus a simple `GMScreenHandoutItem` dataclass.
- Added `modules/scenarios/gm_screen/handouts/panel.py` which implements a compact, responsive thumbnail grid with filtering, refresh, thumbnail caching, and click-to-open behavior; the panel calls `show_portrait(path, title)` when a tile is clicked.
- Added `modules/scenarios/gm_screen/handouts/__init__.py` to expose the new subpackage.
- Updated `modules/scenarios/gm_screen_view.py` to import `create_handouts_panel` and to mount the panel inside a full-bleed rich host frame in `open_handouts_tab()` following the same factory pattern used for other rich tabs (whiteboard/map/etc.).

### Testing
- Ran a syntax/compile check with `python -m py_compile modules/scenarios/gm_screen/handouts/service.py modules/scenarios/gm_screen/handouts/panel.py modules/scenarios/gm_screen_view.py` and it succeeded.
- Executed the related unit tests with `pytest -q tests/scenarios/gm_table/handouts/test_page.py` which passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1361c3678832b99ddedd3e5152a27)