### PR TITLE
Fix GM Table resize drift by anchoring to drag-origin snapshot

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1061,10 +1061,9 @@ class GMTablePanel(ctk.CTkFrame):
         if self._resize_origin is None:
             return
         root_x, root_y, start_geometry, direction = self._resize_origin
-        start_world = self.floating_geometry_snapshot()
         geometry = _resize_floating_geometry(
             direction,
-            start_geometry=start_world,
+            start_geometry=start_geometry,
             delta_x=event.x_root - root_x,
             delta_y=event.y_root - root_y,
             zoom=max(CAMERA_MIN_ZOOM, float(self._get_camera_zoom())),

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -449,6 +449,41 @@ def test_resize_geometry_supports_dragging_from_top_left_corner() -> None:
     assert geometry["height"] == 400
 
 
+def test_resize_to_uses_drag_origin_snapshot_without_cumulative_drift() -> None:
+    """Successive drag frames should stay anchored to the initial resize snapshot."""
+    panel = GMTablePanel.__new__(GMTablePanel)
+    panel._resize_origin = (
+        100,
+        200,
+        {"x": 24.0, "y": 36.0, "width": 400, "height": 300},
+        "se",
+    )
+    panel._get_camera_zoom = lambda: 1.0
+
+    current_geometry = {"x": 24.0, "y": 36.0, "width": 400, "height": 300}
+    applied_geometries: list[dict[str, float | int]] = []
+
+    def _floating_geometry_snapshot():
+        return dict(current_geometry)
+
+    def _apply_floating_geometry(geometry):
+        current_geometry.update(geometry)
+        applied_geometries.append(dict(geometry))
+
+    panel.floating_geometry_snapshot = _floating_geometry_snapshot
+    panel.apply_floating_geometry = _apply_floating_geometry
+
+    panel._resize_to(SimpleNamespace(x_root=130, y_root=240))
+    panel._resize_to(SimpleNamespace(x_root=140, y_root=260))
+
+    assert applied_geometries[0]["width"] == 430
+    assert applied_geometries[0]["height"] == 340
+    assert applied_geometries[1]["width"] == 440
+    assert applied_geometries[1]["height"] == 360
+    assert applied_geometries[1]["x"] == 24.0
+    assert applied_geometries[1]["y"] == 36.0
+
+
 def test_clamp_panels_reflows_maximized_panel_when_surface_changes() -> None:
     """Docked panels should stay docked when the GM Table itself is resized."""
     workspace = GMTableWorkspace.__new__(GMTableWorkspace)


### PR DESCRIPTION
### Motivation
- Prevent cumulative size/position drift when resizing a floating panel by anchoring each frame to the initial drag-start geometry instead of using a fresh snapshot every frame.
- Preserve the existing pointer-delta calculation (`event.x_root - root_x`, `event.y_root - root_y`) and zoom adjustments while making the base geometry fixed for the drag session.
- Add a unit test to assert successive frames follow the absolute cursor displacement from the original drag origin.

### Description
- Changed `GMTablePanel._resize_to` to use the `start_geometry` stored in `self._resize_origin` as the fixed base for resize calculations instead of calling `self.floating_geometry_snapshot()` each frame.
- Kept delta, zoom, and min-dimension handling and forwarded those values into `_resize_floating_geometry` unchanged.
- Added `test_resize_to_uses_drag_origin_snapshot_without_cumulative_drift` to `tests/scenarios/gm_table/test_workspace.py` which simulates two successive resize events during a single drag and asserts dimensions/position are anchored to the original snapshot.

### Testing
- Ran the focused tests with `pytest -q tests/scenarios/gm_table/test_workspace.py -k "resize_to_uses_drag_origin_snapshot_without_cumulative_drift or resize_geometry_supports_dragging_from_top_left_corner"` and both targeted cases passed (`2 passed`).
- Ran the entire file with `pytest -q tests/scenarios/gm_table/test_workspace.py` and observed environment-specific failures: `test_mount_payload_widget_grids_direct_child_widget` and `test_mount_payload_widget_preserves_existing_geometry_manager` failed with `tkinter.TclError: no display name and no $DISPLAY environment variable`, indicating headless-display limitations rather than regressions in the resize change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a9bd3f8c832bafd4b9fd4482a1d4)