### PR TITLE
Fix floating panel resize math across zoom levels

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -535,37 +535,43 @@ def _resize_floating_geometry(
     min_height: int,
 ) -> dict[str, float | int]:
     """Return resized floating geometry without constraining it to the viewport."""
-    width = int(start_geometry.get("width", min_width))
-    height = int(start_geometry.get("height", min_height))
-    x = _coerce_float(start_geometry.get("x", 0.0))
-    y = _coerce_float(start_geometry.get("y", 0.0))
+    start_width = _coerce_float(start_geometry.get("width", min_width), float(min_width))
+    start_height = _coerce_float(start_geometry.get("height", min_height), float(min_height))
+    width = start_width
+    height = start_height
+    start_x = _coerce_float(start_geometry.get("x", 0.0))
+    start_y = _coerce_float(start_geometry.get("y", 0.0))
+    x = start_x
+    y = start_y
     zoom = max(CAMERA_MIN_ZOOM, float(zoom))
+    world_delta_x = float(delta_x) / zoom
+    world_delta_y = float(delta_y) / zoom
 
     if "w" in direction:
-        x += delta_x / zoom
-        width -= int(delta_x)
+        x += world_delta_x
+        width -= world_delta_x
     if "e" in direction:
-        width += int(delta_x)
+        width += world_delta_x
     if "n" in direction:
-        y += delta_y / zoom
-        height -= int(delta_y)
+        y += world_delta_y
+        height -= world_delta_y
     if "s" in direction:
-        height += int(delta_y)
+        height += world_delta_y
 
     if width < min_width:
         if "w" in direction:
-            x = _coerce_float(start_geometry.get("x", 0.0)) + ((int(start_geometry.get("width", min_width)) - min_width) / zoom)
-        width = int(min_width)
+            x = start_x + (start_width - min_width)
+        width = float(min_width)
     if height < min_height:
         if "n" in direction:
-            y = _coerce_float(start_geometry.get("y", 0.0)) + ((int(start_geometry.get("height", min_height)) - min_height) / zoom)
-        height = int(min_height)
+            y = start_y + (start_height - min_height)
+        height = float(min_height)
 
     return _normalize_floating_geometry(
         x,
         y,
-        width,
-        height,
+        int(round(width)),
+        int(round(height)),
         min_width=min_width,
         min_height=min_height,
     )

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -13,6 +13,7 @@ from modules.scenarios.gm_table.workspace import (
     GMTableWorkspace,
     PanelDefinition,
     SNAP_MODE_LABELS,
+    _resize_floating_geometry,
     _resize_geometry,
     _resolve_snap_mode,
     _snap_geometry,
@@ -449,6 +450,66 @@ def test_resize_geometry_supports_dragging_from_top_left_corner() -> None:
     assert geometry["height"] == 400
 
 
+
+
+def test_resize_floating_geometry_keeps_zoom_1_behavior() -> None:
+    """Zoom 1.0 should keep the legacy resize deltas unchanged."""
+    geometry = _resize_floating_geometry(
+        "se",
+        start_geometry={"x": 24.0, "y": 36.0, "width": 400, "height": 300},
+        delta_x=40,
+        delta_y=20,
+        zoom=1.0,
+        min_width=GMTablePanel.MIN_WIDTH,
+        min_height=GMTablePanel.MIN_HEIGHT,
+    )
+
+    assert geometry["x"] == 24.0
+    assert geometry["y"] == 36.0
+    assert geometry["width"] == 440
+    assert geometry["height"] == 320
+
+
+def test_resize_floating_geometry_scales_resize_delta_with_zoom() -> None:
+    """Floating world geometry should resize by world delta so screen motion feels stable."""
+    start = {"x": 100.0, "y": 80.0, "width": 520, "height": 420}
+    delta_x = 60
+    delta_y = 45
+
+    half_zoom = _resize_floating_geometry(
+        "nw",
+        start_geometry=start,
+        delta_x=delta_x,
+        delta_y=delta_y,
+        zoom=0.5,
+        min_width=GMTablePanel.MIN_WIDTH,
+        min_height=GMTablePanel.MIN_HEIGHT,
+    )
+    high_zoom = _resize_floating_geometry(
+        "nw",
+        start_geometry=start,
+        delta_x=delta_x,
+        delta_y=delta_y,
+        zoom=1.5,
+        min_width=GMTablePanel.MIN_WIDTH,
+        min_height=GMTablePanel.MIN_HEIGHT,
+    )
+
+    # World deltas differ with zoom, but projected screen deltas remain stable.
+    half_zoom_width_delta_px = (start["width"] - half_zoom["width"]) * 0.5
+    high_zoom_width_delta_px = (start["width"] - high_zoom["width"]) * 1.5
+    half_zoom_height_delta_px = (start["height"] - half_zoom["height"]) * 0.5
+    high_zoom_height_delta_px = (start["height"] - high_zoom["height"]) * 1.5
+
+    assert abs(half_zoom_width_delta_px - delta_x) <= 1
+    assert abs(high_zoom_width_delta_px - delta_x) <= 1
+    assert abs(half_zoom_height_delta_px - delta_y) <= 1
+    assert abs(high_zoom_height_delta_px - delta_y) <= 1
+
+    assert half_zoom["x"] == 220.0
+    assert half_zoom["y"] == 170.0
+    assert high_zoom["x"] == 140.0
+    assert high_zoom["y"] == 110.0
 def test_resize_to_uses_drag_origin_snapshot_without_cumulative_drift() -> None:
     """Successive drag frames should stay anchored to the initial resize snapshot."""
     panel = GMTablePanel.__new__(GMTablePanel)


### PR DESCRIPTION
### Motivation

- Floating panel resize handled a mix of screen-space and world-space deltas causing perceptual jumps at non-1.0 zoom levels. 
- The goal is to make resize behavior stable across zoom by applying drag deltas consistently in world space for both position and size and keep west/north edge adjustments symmetric when clamped. 

### Description

- Harmonized `_resize_floating_geometry` to compute `world_delta_x = delta_x / zoom` and `world_delta_y = delta_y / zoom` and apply those world deltas to both `x`/`y` and `width`/`height` updates. 
- Preserve the original behavior at `zoom == 1.0` while using float math internally and returning rounded integer sizes; when clamping to minimums, west/north edges are adjusted using the original start sizes so the panel stays symmetric. 
- Added tests and a test import: `tests/scenarios/gm_table/test_workspace.py` now includes `_resize_floating_geometry` tests for zoom `1.0`, `0.5`, and `1.5`. 
- Files changed: `modules/scenarios/gm_table/workspace.py` and `tests/scenarios/gm_table/test_workspace.py`.

### Testing

- Ran the focused pytest selection `pytest -q tests/scenarios/gm_table/test_workspace.py -k "resize_floating_geometry or resize_to_uses_drag_origin_snapshot_without_cumulative_drift or resize_geometry_supports_dragging_from_top_left_corner"` and the selected tests passed (4 passed, others deselected). 
- The new tests verify: legacy behavior for `zoom=1.0`, and perceptual stability (projected screen deltas) for `zoom=0.5` and `zoom=1.5`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ab952934832b815720c492dd2974)