### PR TITLE
Refactor GM table snap/minimum sizing into dedicated strategies

### DIFF
--- a/modules/scenarios/gm_table/layout/__init__.py
+++ b/modules/scenarios/gm_table/layout/__init__.py
@@ -1,0 +1,5 @@
+"""Layout sizing strategies for the GM table workspace."""
+
+from .auto_size_strategy import fit_content_minimum, fit_viewport_snap
+
+__all__ = ["fit_content_minimum", "fit_viewport_snap"]

--- a/modules/scenarios/gm_table/layout/auto_size_strategy.py
+++ b/modules/scenarios/gm_table/layout/auto_size_strategy.py
@@ -1,0 +1,140 @@
+"""Explicit sizing strategies for GM table panel layouts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+PANEL_MARGIN = 12
+PANEL_GUTTER = 12
+
+
+DEFAULT_CONTENT_MINIMUMS: dict[str, tuple[int, int]] = {
+    "campaign_dashboard": (780, 560),
+    "world_map": (860, 620),
+    "map_tool": (900, 640),
+    "scene_flow": (860, 600),
+    "image_library": (860, 580),
+    "handouts": (760, 560),
+    "loot_generator": (620, 520),
+    "whiteboard": (900, 640),
+    "random_tables": (680, 560),
+    "plot_twists": (460, 320),
+    "entity": (580, 520),
+    "puzzle_display": (700, 540),
+    "character_graph": (860, 620),
+    "scenario_graph": (860, 620),
+    "note": (520, 360),
+}
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(maximum, value))
+
+
+def _surface_dimensions(surface: Any, *, minimum_width: int = 640, minimum_height: int = 420) -> tuple[int, int]:
+    try:
+        width = int(surface.winfo_width())
+    except Exception:
+        width = minimum_width
+    try:
+        height = int(surface.winfo_height())
+    except Exception:
+        height = minimum_height
+    return max(minimum_width, width), max(minimum_height, height)
+
+
+def _constrain_panel_geometry(
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    *,
+    surface_w: int,
+    surface_h: int,
+    min_width: int,
+    min_height: int,
+    margin: int = PANEL_MARGIN,
+) -> dict[str, int]:
+    max_width = max(min_width, int(surface_w) - (margin * 2))
+    max_height = max(min_height, int(surface_h) - (margin * 2))
+    width = _clamp(int(width), int(min_width), max_width)
+    height = _clamp(int(height), int(min_height), max_height)
+    x = _clamp(int(x), margin, max(margin, int(surface_w) - width - margin))
+    y = _clamp(int(y), margin, max(margin, int(surface_h) - height - margin))
+    return {"x": x, "y": y, "width": width, "height": height}
+
+
+def fit_viewport_snap(panel, surface, mode: str) -> dict[str, int]:
+    """Return viewport-relative geometry for snap/magnets regardless of world camera."""
+    min_width = max(1, int(getattr(panel, "MIN_WIDTH", 300)))
+    min_height = max(1, int(getattr(panel, "MIN_HEIGHT", 220)))
+    surface_w, surface_h = _surface_dimensions(surface)
+
+    full_width = max(min_width, int(surface_w) - (PANEL_MARGIN * 2))
+    full_height = max(min_height, int(surface_h) - (PANEL_MARGIN * 2))
+    split_width = max(min_width * 2, full_width - PANEL_GUTTER)
+    split_height = max(min_height * 2, full_height - PANEL_GUTTER)
+    half_width = max(min_width, split_width // 2)
+    half_height = max(min_height, split_height // 2)
+    strip_height = _clamp(
+        int(round(full_height * 0.28)),
+        min_height,
+        max(min_height, full_height - min_height - PANEL_GUTTER),
+    )
+
+    if mode == "maximize":
+        return _constrain_panel_geometry(
+            PANEL_MARGIN,
+            PANEL_MARGIN,
+            full_width,
+            full_height,
+            surface_w=surface_w,
+            surface_h=surface_h,
+            min_width=min_width,
+            min_height=min_height,
+        )
+
+    mode_map: dict[str, tuple[int, int, int, int]] = {
+        "left": (PANEL_MARGIN, PANEL_MARGIN, half_width, full_height),
+        "right": (surface_w - PANEL_MARGIN - half_width, PANEL_MARGIN, half_width, full_height),
+        "top": (PANEL_MARGIN, PANEL_MARGIN, full_width, half_height),
+        "bottom": (PANEL_MARGIN, surface_h - PANEL_MARGIN - half_height, full_width, half_height),
+        "top_left": (PANEL_MARGIN, PANEL_MARGIN, half_width, half_height),
+        "top_right": (surface_w - PANEL_MARGIN - half_width, PANEL_MARGIN, half_width, half_height),
+        "bottom_left": (PANEL_MARGIN, surface_h - PANEL_MARGIN - half_height, half_width, half_height),
+        "bottom_right": (surface_w - PANEL_MARGIN - half_width, surface_h - PANEL_MARGIN - half_height, half_width, half_height),
+        "top_strip": (PANEL_MARGIN, PANEL_MARGIN, full_width, strip_height),
+        "bottom_strip": (PANEL_MARGIN, surface_h - PANEL_MARGIN - strip_height, full_width, strip_height),
+    }
+
+    if mode not in mode_map:
+        raise ValueError(f"Unsupported snap mode: {mode}")
+
+    x, y, width, height = mode_map[mode]
+    return _constrain_panel_geometry(
+        x,
+        y,
+        width,
+        height,
+        surface_w=surface_w,
+        surface_h=surface_h,
+        min_width=min_width,
+        min_height=min_height,
+    )
+
+
+def fit_content_minimum(panel_kind: str, state: dict | None) -> dict[str, int]:
+    """Return readable minimum content dimensions for a panel kind and payload."""
+    kind = str(panel_kind or "entity")
+    width, height = DEFAULT_CONTENT_MINIMUMS.get(kind, DEFAULT_CONTENT_MINIMUMS["entity"])
+
+    if kind == "entity":
+        entity_type = str((state or {}).get("entity_type") or "").strip()
+        if entity_type == "Scenarios":
+            width, height = 920, 680
+        elif entity_type in {"Informations", "Places", "Bases"}:
+            width, height = 760, 580
+        else:
+            width, height = 680, 560
+
+    return {"width": int(width), "height": int(height)}

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 import customtkinter as ctk
+from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
 
 
 TABLE_PALETTE = {
@@ -2091,12 +2092,23 @@ class GMTableWorkspace(ctk.CTkFrame):
         panel = self._panels.get(panel_id)
         if panel is None:
             return
+        definition = self._definitions.get(panel_id)
+        minimum = fit_content_minimum(
+            definition.kind if definition is not None else "entity",
+            definition.state if definition is not None else {},
+        )
         current_geometry = panel.geometry_snapshot()
         current_width = max(GMTablePanel.MIN_WIDTH, int(current_geometry["width"]))
         current_height = max(GMTablePanel.MIN_HEIGHT, int(current_geometry["height"]))
-        target_width = max(current_width, int(width))
-        target_height = max(current_height, int(height))
+        target_width = max(current_width, int(width), int(minimum["width"]))
+        target_height = max(current_height, int(height), int(minimum["height"]))
         if target_width == current_width and target_height == current_height:
+            return
+        if panel.layout_mode in SNAP_LAYOUT_MODES:
+            restore = getattr(panel, "_restore_geometry", None)
+            if isinstance(restore, dict):
+                restore["width"] = max(int(restore.get("width", target_width)), target_width)
+                restore["height"] = max(int(restore.get("height", target_height)), target_height)
             return
         self.resize_panel(panel_id, target_width, target_height)
 
@@ -2198,14 +2210,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             panel = self._panels.get(panel_id)
             if panel is None:
                 return
-        surface_w, surface_h = self._surface_geometry()
-        geometry = _snap_geometry(
-            mode,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=GMTablePanel.MIN_WIDTH,
-            min_height=GMTablePanel.MIN_HEIGHT,
-        )
+        geometry = fit_viewport_snap(panel, self.surface, mode)
         panel.enter_layout_mode(mode, geometry)
         companion_mode = SNAP_COMPLEMENT_MODES.get(mode)
         if companion_mode is not None:
@@ -2215,13 +2220,7 @@ class GMTableWorkspace(ctk.CTkFrame):
                 if companion is not None:
                     companion.enter_layout_mode(
                         companion_mode,
-                        _snap_geometry(
-                            companion_mode,
-                            surface_w=surface_w,
-                            surface_h=surface_h,
-                            min_width=GMTablePanel.MIN_WIDTH,
-                            min_height=GMTablePanel.MIN_HEIGHT,
-                        ),
+                        fit_viewport_snap(companion, self.surface, companion_mode),
                     )
         self.bring_to_front(panel_id)
 
@@ -2275,18 +2274,18 @@ class GMTableWorkspace(ctk.CTkFrame):
             definition = self._definitions.get(panel_id)
             if panel is None:
                 continue
-            preferred_width, preferred_height = resolve_default_panel_size(
+            preferred = fit_content_minimum(
                 definition.kind if definition is not None else "entity",
-                definition.state if definition is not None else None,
+                definition.state if definition is not None else {},
             )
             geometry = panel.geometry_snapshot()
             width = _clamp(
-                max(int(geometry["width"]), int(preferred_width)),
+                max(int(geometry["width"]), int(preferred["width"])),
                 GMTablePanel.MIN_WIDTH,
                 max_width,
             )
             height = _clamp(
-                max(int(geometry["height"]), int(preferred_height)),
+                max(int(geometry["height"]), int(preferred["height"])),
                 GMTablePanel.MIN_HEIGHT,
                 max_height,
             )

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -988,6 +988,41 @@ def test_snap_layouts_remain_viewport_relative_with_camera_offset() -> None:
     assert world_map.layout_mode == "right"
     assert notes.x == PANEL_MARGIN
     assert world_map.x == 1400 - PANEL_MARGIN - world_map.winfo_width()
+    GMTableWorkspace.snap_panel(workspace, "notes", "maximize")
+    assert notes.layout_mode == "maximize"
+    assert notes.x == PANEL_MARGIN
+    assert notes.y == PANEL_MARGIN
+
+
+def test_ensure_panel_minimum_size_keeps_snap_layout_and_only_grows_restore_geometry() -> None:
+    """Readable growth on an existing snapped panel must not break its active snap layout."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    panel = _FakePanel(520, 360, x=12, y=12)
+    panel._layout_mode = "left"
+    panel._restore_geometry = {
+        "x": 40.0,
+        "y": 30.0,
+        "width": 480,
+        "height": 320,
+    }
+    workspace._panels = {"notes": panel}
+    workspace._definitions = {
+        "notes": PanelDefinition(panel_id="notes", kind="entity", title="Scenario", state={"entity_type": "Scenarios"}),
+    }
+    workspace._z_order = ["notes"]
+    _prepare_workspace(workspace, camera_x=260, camera_y=120)
+
+    GMTableWorkspace.ensure_panel_minimum_size(workspace, "notes", 920, 680)
+
+    assert panel.layout_mode == "left"
+    assert panel.winfo_width() == 520
+    assert panel.winfo_height() == 360
+    assert panel._restore_geometry == {
+        "x": 40.0,
+        "y": 30.0,
+        "width": 920,
+        "height": 680,
+    }
 
 
 def test_restore_after_snap_recovers_prior_world_geometry_when_camera_is_offset() -> None:


### PR DESCRIPTION
### Motivation
- Centralize sizing logic to make snap (viewport-relative) and content-minimum (readable sizes) behaviour explicit and reusable.
- Ensure reopening or growing panels respects current snap/maximized layout instead of forcing layout resets.

### Description
- Added a new layout strategy module `modules/scenarios/gm_table/layout/auto_size_strategy.py` exposing `fit_viewport_snap(panel, surface, mode)` and `fit_content_minimum(panel_kind, state)` and a small `layout/__init__.py` to export them.
- Wired `fit_viewport_snap` into `GMTableWorkspace.snap_panel` for both the primary panel and its snap companion so snap/maximize geometry is computed strictly relative to the viewport.
- Replaced per-panel preferred-size resolution inside `GMTableWorkspace.auto_arrange` with `fit_content_minimum` to determine readable minimums per kind (including entity-type special cases).
- Updated `GMTableWorkspace.ensure_panel_minimum_size` to consult `fit_content_minimum` and to, when the panel is currently snapped/maximized, grow only the stored `_restore_geometry` (so the active snap layout is preserved) instead of forcing an immediate resize/layout change.
- Added targeted tests in `tests/scenarios/gm_table/test_workspace.py` that verify viewport-relative snap/maximize with camera offsets and that ensuring minimum size on an already-snapped panel only grows the restore geometry and does not break the active snap layout.

### Testing
- Ran a focused test set against workspace layout behaviors: `pytest -q tests/scenarios/gm_table/test_workspace.py -k 'snap_layouts_remain_viewport_relative_with_camera_offset or ensure_panel_minimum_size_keeps_snap_layout_and_only_grows_restore_geometry or auto_arrange_preserves_large_scenario_panel_geometry or snap_panel_tiles_two_panels_side_by_side or snap_panel_stacks_two_panels_top_and_bottom or restore_after_snap_recovers_prior_world_geometry_when_camera_is_offset'` — all targeted tests passed (6 passed, 30 deselected).
- Ran the full `tests/scenarios/gm_table/test_workspace.py` suite which shows two failures in this headless CI environment because some tests instantiate `tk.Tk()` and fail with `no $DISPLAY` (environment limitation, not regressions in the new sizing logic); the remainder passed (34 passed, 2 failed).
- Attempting to run both `test_workspace.py` and `test_gm_table_view.py` together hit collection failure in this environment due to a missing Pillow `ImageFont` import required by unrelated map tests (import-time dependency), so full combined test collection could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ad455bf8832b99ea2b7c5ba63347)