### PR TITLE
Guard GM table zoom while panning

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1655,8 +1655,10 @@ class GMTableWorkspace(ctk.CTkFrame):
         """Finish a camera pan gesture."""
         self._pan_origin = None
 
-    def _zoom_surface(self, event) -> None:
+    def _zoom_surface(self, event):
         """Zoom the desk around the cursor position."""
+        if self._pan_origin is not None:
+            return "break"
         try:
             screen_x = int(event.x)
             screen_y = int(event.y)

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -906,6 +906,48 @@ def test_left_drag_pan_remains_limited_to_empty_surface_widgets() -> None:
     assert workspace._pan_origin == (120, 160, 40.0, 24.0)
 
 
+def test_zoom_surface_ignored_while_pan_is_active() -> None:
+    """Zoom events should be ignored when a pan gesture is active."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace._camera_x = 40.0
+    workspace._camera_y = 24.0
+    workspace._camera_zoom = 1.0
+    workspace._pan_origin = (120, 160, 40.0, 24.0)
+    workspace._set_camera = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("_set_camera should not be called during active pan")
+    )
+
+    result = GMTableWorkspace._zoom_surface(
+        workspace,
+        SimpleNamespace(x=200, y=140, delta=120),
+    )
+
+    assert result == "break"
+    assert workspace._camera_zoom == 1.0
+
+
+def test_zoom_surface_updates_camera_when_pan_is_inactive() -> None:
+    """Zoom should keep working normally when no pan gesture is active."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace._camera_x = 40.0
+    workspace._camera_y = 24.0
+    workspace._camera_zoom = 1.0
+    workspace._pan_origin = None
+    workspace._panels = {}
+    workspace._camera_status_label = None
+    workspace._minimap_canvas = None
+    workspace._schedule_layout_changed = lambda: None
+    workspace.clear_snap_preview = lambda: None
+    workspace.clamp_panels = lambda: None
+
+    GMTableWorkspace._zoom_surface(
+        workspace,
+        SimpleNamespace(x=200, y=140, delta=120),
+    )
+
+    assert workspace._camera_zoom > 1.0
+
+
 def test_bind_surface_navigation_registers_middle_pan_on_workspace_toplevel() -> None:
     """Middle-button pan should be scoped to this workspace via the containing toplevel."""
     workspace = GMTableWorkspace.__new__(GMTableWorkspace)


### PR DESCRIPTION
### Motivation
- Empêcher la manipulation du zoom pendant qu’un panoramique (pan) est actif pour éviter des interactions conflictuelles et des déplacements de caméra inattendus.
- Bloquer la propagation de l’événement Tk pendant un pan pour éviter que d’autres handlers reçoivent un zoom accidentel.

### Description
- Ajout d’une garde au début de `GMTableWorkspace._zoom_surface` qui retourne immédiatement `"break"` si `self._pan_origin` est défini afin d’ignorer l’événement de zoom pendant un pan (fichier `modules/scenarios/gm_table/workspace.py`).
- Ajout de deux tests dans `tests/scenarios/gm_table/test_workspace.py` : un test vérifiant qu’en pan actif `_zoom_surface` ne modifie pas `self._camera_zoom` et n’appelle pas `_set_camera`, et un test vérifiant que `_zoom_surface` fonctionne normalement quand `_pan_origin` est `None`.
- Organisation des modifications en sous-répertoires et fichiers existants pour préserver l’architecture lisible du projet.

### Testing
- Exécuté `pytest -q tests/scenarios/gm_table/test_workspace.py -k "zoom_surface or pan"` et les tests ciblés ont réussi (`17 passed, 21 deselected`).
- Exécuté `pytest -q tests/scenarios/gm_table/test_workspace.py` et la suite complète a réussi pour la plupart mais a produit 2 échecs liés à l’absence de `$DISPLAY` (environnement headless) dans des tests de montage de widgets Tkinter qui sont indépendants du changement apporté; le reste de la suite a passé (`36 passed, 2 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c2182ea8832b800197b554a232a9)