### PR TITLE
Fix docked GM Table panels detaching incorrectly during middle-button desk pan

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1625,6 +1625,15 @@ class GMTableWorkspace(ctk.CTkFrame):
             zoom=target_zoom,
         )
 
+    def _pin_snapped_panels_to_world(self) -> None:
+        """Convert snapped panels into floating world-anchored panels."""
+        for panel in self._panels.values():
+            if panel.layout_mode not in SNAP_LAYOUT_MODES:
+                continue
+            world_geometry = self._screen_geometry_to_world(panel.geometry_snapshot())
+            panel.clear_layout_mode()
+            self._apply_floating_geometry(panel, world_geometry)
+
     def _start_surface_pan(self, event) -> None:
         """Start panning the infinite desk."""
         widget = getattr(event, "widget", None)
@@ -1632,6 +1641,8 @@ class GMTableWorkspace(ctk.CTkFrame):
         if widget is not self.surface and widget is not self._empty_state:
             if not is_middle_button or not self._widget_is_in_surface_subtree(widget):
                 return
+        if is_middle_button:
+            self._pin_snapped_panels_to_world()
         self.surface.focus_set()
         self._pan_origin = (
             event.x_root,

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -879,6 +879,37 @@ def test_middle_button_pan_accepts_nested_panel_content_and_ignores_unrelated_wi
     assert workspace._pan_origin is None
 
 
+def test_middle_button_pan_converts_snapped_panel_to_world_anchored_floating() -> None:
+    """Middle-drag should pin docked windows to desk coordinates before camera movement."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    panel = _FakePanel(520, 360, x=PANEL_MARGIN, y=PANEL_MARGIN)
+    panel._layout_mode = "left"
+    workspace._panels = {"notes": panel}
+    workspace.surface = _FakeWidgetNode()
+    workspace._empty_state = _FakeWidgetNode(master=workspace.surface)
+    workspace._camera_x = 400.0
+    workspace._camera_y = 240.0
+    workspace._camera_zoom = 1.0
+    workspace._pan_origin = None
+    workspace.clear_snap_preview = lambda: None
+    workspace._schedule_layout_changed = lambda: None
+    workspace.update_idletasks = lambda: None
+    workspace.surface.winfo_width = lambda: 1400
+    workspace.surface.winfo_height = lambda: 900
+
+    GMTableWorkspace._start_surface_pan(
+        workspace,
+        SimpleNamespace(widget=workspace.surface, num=2, x_root=500, y_root=320),
+    )
+    GMTableWorkspace._pan_surface_to(workspace, SimpleNamespace(x_root=560, y_root=380))
+
+    assert panel.layout_mode == "floating"
+    assert panel.world_x == 412.0
+    assert panel.world_y == 252.0
+    assert panel.x == 72
+    assert panel.y == 72
+
+
 def test_left_drag_pan_remains_limited_to_empty_surface_widgets() -> None:
     """Left-drag panning should stay scoped to the bare table surface and empty state."""
     workspace = GMTableWorkspace.__new__(GMTableWorkspace)


### PR DESCRIPTION
### Motivation

- When the user pans the table with the middle mouse button, panels that were snapped/docked incorrectly stayed viewport-anchored and followed the camera, but they should remain anchored to their desk/world coordinates instead.

### Description

- Add `_pin_snapped_panels_to_world()` in `modules/scenarios/gm_table/workspace.py` to convert panels in `SNAP_LAYOUT_MODES` into floating, world-anchored panels before a middle-button pan starts.
- Call the new helper from `_start_surface_pan(...)` when the middle button is detected so snapped windows are detached into world geometry prior to camera movement.
- Add a regression test `test_middle_button_pan_converts_snapped_panel_to_world_anchored_floating` in `tests/scenarios/gm_table/test_workspace.py` that verifies a snapped panel is converted to floating and retains correct world/viewport coordinates during a middle-button pan.

### Testing

- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py -k "middle_button_pan or snap_layouts_remain_viewport_relative_with_camera_offset or camera_pan_reprojects_floating_panel_without_changing_size"` and the selected tests passed.
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py` which shows the change is correct for logic tests but two GUI/Tk display-dependent tests fail in the headless CI environment (`no $DISPLAY`), unrelated to the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c41bf1f8832baa7c9c5bf46bed6c)