### PR TITLE
Fix GM table snap docking to persist current viewport coordinates

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -817,6 +817,8 @@ class GMTablePanel(ctk.CTkFrame):
             self._minimized_restore_mode = mode
         self._layout_mode = mode
         self.apply_geometry(geometry)
+        if mode in SNAP_LAYOUT_MODES:
+            self._world_geometry = self._screen_geometry_to_world(geometry)
         self._refresh_window_controls()
 
     def restore_layout(self, *, anchor_x_root: int | None = None, anchor_y_root: int | None = None) -> bool:
@@ -920,6 +922,21 @@ class GMTablePanel(ctk.CTkFrame):
             y=int(geometry.get("y", self._current_geometry["y"])),
             width=int(geometry.get("width", self._current_geometry["width"])),
             height=int(geometry.get("height", self._current_geometry["height"])),
+        )
+
+    def _screen_geometry_to_world(self, geometry: dict[str, int]) -> dict[str, float | int]:
+        """Convert viewport-relative geometry to world-space coordinates."""
+        world_x, world_y = self._screen_to_world(
+            int(geometry.get("x", self._current_geometry["x"])),
+            int(geometry.get("y", self._current_geometry["y"])),
+        )
+        return _normalize_floating_geometry(
+            world_x,
+            world_y,
+            int(geometry.get("width", self._current_geometry["width"])),
+            int(geometry.get("height", self._current_geometry["height"])),
+            min_width=self.MIN_WIDTH,
+            min_height=self.MIN_HEIGHT,
         )
 
     def apply_floating_geometry(

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -35,6 +35,7 @@ class _FakePanel:
         self.focused = False
         self.lifted = False
         self._project_floating_geometry = None
+        self._screen_to_world = None
 
     @property
     def layout_mode(self) -> str:
@@ -103,6 +104,10 @@ class _FakePanel:
             self._restore_geometry = self.floating_geometry_snapshot()
         self._layout_mode = mode
         self.apply_geometry(geometry)
+        if mode != "floating" and callable(self._screen_to_world):
+            world_x, world_y = self._screen_to_world(geometry["x"], geometry["y"])
+            self.world_x = float(world_x)
+            self.world_y = float(world_y)
 
     def restore_layout(self, **_kwargs) -> bool:
         if self._restore_geometry is None:
@@ -159,6 +164,7 @@ def _prepare_workspace(workspace, *, width: int = 1400, height: int = 900, camer
     workspace._bookmarks = []
     for panel in getattr(workspace, "_panels", {}).values():
         panel._project_floating_geometry = workspace._project_floating_geometry
+        panel._screen_to_world = workspace._screen_to_world
 
 
 class _FakePreview:
@@ -1066,6 +1072,28 @@ def test_snap_layouts_remain_viewport_relative_with_camera_offset() -> None:
     assert notes.x == PANEL_MARGIN
     assert notes.y == PANEL_MARGIN
 
+
+
+
+def test_serialize_snapped_panel_uses_current_camera_instead_of_home() -> None:
+    """Snapping with an offset camera should persist world coordinates for the active viewport."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    panel = _FakePanel(520, 360, x=800, y=400)
+    workspace._panels = {"notes": panel}
+    workspace._definitions = {
+        "notes": PanelDefinition(panel_id="notes", kind="note", title="Notes", state={}),
+    }
+    workspace._panel_payloads = {"notes": object()}
+    workspace._z_order = ["notes"]
+    _prepare_workspace(workspace, camera_x=1200, camera_y=750)
+
+    GMTableWorkspace.snap_panel(workspace, "notes", "left")
+    serialized = GMTableWorkspace.serialize(workspace)
+    panel_state = serialized["panels"][0]["state"]
+
+    assert panel_state["layout_mode"] == "left"
+    assert panel_state["world_x"] == 1212.0
+    assert panel_state["world_y"] == 762.0
 
 def test_ensure_panel_minimum_size_keeps_snap_layout_and_only_grows_restore_geometry() -> None:
     """Readable growth on an existing snapped panel must not break its active snap layout."""


### PR DESCRIPTION
### Motivation
- Snapped/docked panels were being persisted relative to the saved home camera instead of the current viewport, causing restored/docked windows to jump when the workspace camera had been panned away from home. 
- The root cause was that entering a snap layout applied viewport geometry but did not refresh the panel's stored world coordinates from the current camera projection. 

### Description
- When a panel enters a snap/maximized mode, `GMTablePanel.enter_layout_mode` now updates the panel `_world_geometry` from viewport geometry using the current camera projection (checks `mode in SNAP_LAYOUT_MODES`).
- Added a helper `GMTablePanel._screen_geometry_to_world` to centralize viewport→world conversion and normalization and used it when transitioning into snap layouts.
- Updated the unit test scaffolding in `tests/scenarios/gm_table/test_workspace.py` so the `_FakePanel` mirrors real panel behavior during snap transitions and added `test_serialize_snapped_panel_uses_current_camera_instead_of_home` to verify serialized `world_x`/`world_y` come from the active camera.

### Testing
- Ran the focused tests with `pytest -q tests/scenarios/gm_table/test_workspace.py -k "snap_layouts_remain_viewport_relative_with_camera_offset or serialize_snapped_panel_uses_current_camera_instead_of_home or restore_after_snap_recovers_prior_world_geometry_when_camera_is_offset"` and all targeted tests passed (3 passed).
- Ran the whole file with `pytest -q tests/scenarios/gm_table/test_workspace.py` which showed 38 passed and 2 failures, where the two failing tests require a GUI display (they call `tk.Tk()`), and thus failed in this headless environment with `TclError: no display name and no $DISPLAY`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d06d9ce4832b94ef8003a9d9de1d)