### PR TITLE
Keep GM Table Home/Marks HUD and minimap always on top

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1831,6 +1831,18 @@ class GMTableWorkspace(ctk.CTkFrame):
             panel.set_focus_state(is_target)
             if is_target:
                 panel.lift()
+        self._raise_workspace_overlays()
+
+    def _raise_workspace_overlays(self) -> None:
+        """Keep the camera HUD and minimap above every desk panel."""
+        for widget_name in ("_nav_hud", "_minimap_shell"):
+            widget = getattr(self, widget_name, None)
+            if widget is None:
+                continue
+            try:
+                widget.lift()
+            except Exception:
+                continue
 
     def _visible_panel_ids(self) -> list[str]:
         """Return visible panels in z-order."""
@@ -1927,6 +1939,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             if preview is not None:
                 preview.lift()
             panel.lift()
+        self._raise_workspace_overlays()
         self._schedule_layout_changed()
 
     def remove_panel(self, panel_id: str) -> None:
@@ -2091,6 +2104,7 @@ class GMTableWorkspace(ctk.CTkFrame):
         panel = self._panels.get(panel_id)
         if panel is not None:
             panel.lift()
+        self._raise_workspace_overlays()
 
     def clear_snap_preview(self) -> None:
         """Hide the magnetic snap preview overlay."""

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -234,6 +234,14 @@ class _FakeLabel:
             self.text = kwargs["text"]
 
 
+class _FakeLiftWidget:
+    def __init__(self) -> None:
+        self.lifted = False
+
+    def lift(self) -> None:
+        self.lifted = True
+
+
 class _FakeCanvas:
     def __init__(self, *, width: int = 156, height: int = 84, measured_width: int = 1, measured_height: int = 1) -> None:
         self._width = width
@@ -687,6 +695,22 @@ def test_bring_to_front_does_not_write_z_into_definition_state() -> None:
 
     assert workspace._z_order == ["map", "notes"]
     assert workspace._definitions["notes"].state == {"text": "plan"}
+
+
+def test_bring_to_front_keeps_hud_and_minimap_above_panels() -> None:
+    """Home/Marks HUD and minimap should stay on top after focusing a panel."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace._panels = {"notes": _FakePanel(520, 360, x=84, y=56)}
+    workspace._z_order = ["notes"]
+    workspace._schedule_layout_changed = lambda: None
+    workspace._apply_focus_state = lambda _panel_id: None
+    workspace._nav_hud = _FakeLiftWidget()
+    workspace._minimap_shell = _FakeLiftWidget()
+
+    GMTableWorkspace.bring_to_front(workspace, "notes")
+
+    assert workspace._nav_hud.lifted is True
+    assert workspace._minimap_shell.lifted is True
 
 
 def test_serialize_persists_minimized_layout_metadata() -> None:


### PR DESCRIPTION
### Motivation
- Ensure the GM Table "Home/Marks" HUD and minimap remain visible above floating panel windows and during snap previews so they are always accessible to the user.

### Description
- Add `_raise_workspace_overlays()` helper on `GMTableWorkspace` which calls `lift()` on `_nav_hud` and `_minimap_shell` when present.
- Invoke the helper from `_apply_focus_state`, `bring_to_front`, and `preview_snap_target` so overlays remain above panels after focus/z-order changes and during snap preview operations.
- Add `_FakeLiftWidget` and `test_bring_to_front_keeps_hud_and_minimap_above_panels` to `tests/scenarios/gm_table/test_workspace.py` to assert overlays are lifted.
- Modified files: `modules/scenarios/gm_table/workspace.py`, `tests/scenarios/gm_table/test_workspace.py`.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py -k 'bring_to_front_keeps_hud_and_minimap_above_panels'`, which passed.
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py`; the suite ran but reported 39 passed and 2 failed because two existing tests instantiate `tk.Tk()` and fail in the headless CI environment with `TclError: no display name and no $DISPLAY`, which is unrelated to the overlay logic introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e5838b5c832bb256cb44b1067ccc)