### PR TITLE
Flatten GM Table Marks menu bookmark actions

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1777,15 +1777,22 @@ class GMTableWorkspace(ctk.CTkFrame):
         menu.add_command(label="Set Current View As Home", command=self.set_home_camera)
         menu.add_separator()
         menu.add_command(label="Add Or Update Bookmark...", command=self._save_bookmark_from_prompt)
-        if getattr(self, "_bookmarks", []):
-            jump_menu = tk.Menu(menu, tearoff=0)
-            delete_menu = tk.Menu(menu, tearoff=0)
-            for bookmark in getattr(self, "_bookmarks", []):
+        bookmarks = list(getattr(self, "_bookmarks", []))
+        if bookmarks:
+            menu.add_separator()
+            for bookmark in bookmarks:
                 name = str(bookmark.get("name") or "Bookmark")
-                jump_menu.add_command(label=name, command=lambda value=name: self.jump_to_bookmark(value))
-                delete_menu.add_command(label=name, command=lambda value=name: self.delete_bookmark(value))
-            menu.add_cascade(label="Jump To Bookmark", menu=jump_menu)
-            menu.add_cascade(label="Delete Bookmark", menu=delete_menu)
+                menu.add_command(
+                    label=f"Jump: {name}",
+                    command=lambda value=name: self.jump_to_bookmark(value),
+                )
+            menu.add_separator()
+            for bookmark in bookmarks:
+                name = str(bookmark.get("name") or "Bookmark")
+                menu.add_command(
+                    label=f"Delete: {name}",
+                    command=lambda value=name: self.delete_bookmark(value),
+                )
         else:
             menu.add_command(label="No Bookmarks Yet", state="disabled")
         x = button.winfo_rootx()

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -242,6 +242,46 @@ class _FakeLiftWidget:
         self.lifted = True
 
 
+class _FakeMenu:
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, object]]] = []
+        self.deleted_ranges: list[tuple[object, object]] = []
+        self.popup_at: tuple[int, int] | None = None
+        self.release_count = 0
+
+    def delete(self, start, end=None) -> None:
+        self.deleted_ranges.append((start, end))
+        self.entries.clear()
+
+    def add_command(self, **kwargs) -> None:
+        self.entries.append(("command", kwargs))
+
+    def add_separator(self) -> None:
+        self.entries.append(("separator", {}))
+
+    def tk_popup(self, x: int, y: int) -> None:
+        self.popup_at = (x, y)
+
+    def grab_release(self) -> None:
+        self.release_count += 1
+
+
+class _FakeButton:
+    def __init__(self, x: int = 12, y: int = 24, height: int = 32) -> None:
+        self._x = x
+        self._y = y
+        self._height = height
+
+    def winfo_rootx(self) -> int:
+        return self._x
+
+    def winfo_rooty(self) -> int:
+        return self._y
+
+    def winfo_height(self) -> int:
+        return self._height
+
+
 class _FakeCanvas:
     def __init__(self, *, width: int = 156, height: int = 84, measured_width: int = 1, measured_height: int = 1) -> None:
         self._width = width
@@ -1232,6 +1272,39 @@ def test_serialize_and_restore_round_trip_bookmarks_and_home_camera() -> None:
         {"name": "North Wing", "x": 320.0, "y": 180.0, "zoom": 0.9},
         {"name": "War Room", "x": 900.0, "y": 420.0, "zoom": 1.1},
     ]
+
+
+def test_show_bookmark_menu_lists_bookmarks_without_submenus() -> None:
+    """Bookmark menu should expose jump/delete actions directly in one menu."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace._bookmark_menu = _FakeMenu()
+    workspace._bookmark_button = _FakeButton()
+    workspace._bookmarks = [
+        {"name": "North Wing", "x": 320.0, "y": 180.0, "zoom": 0.9},
+        {"name": "War Room", "x": 900.0, "y": 420.0, "zoom": 1.1},
+    ]
+    workspace.jump_home = lambda: None
+    workspace.set_home_camera = lambda: None
+    workspace._save_bookmark_from_prompt = lambda: None
+    workspace.jump_to_bookmark = lambda _name: None
+    workspace.delete_bookmark = lambda _name: None
+
+    GMTableWorkspace._show_bookmark_menu(workspace)
+
+    labels = [entry[1]["label"] for entry in workspace._bookmark_menu.entries if entry[0] == "command"]
+    assert "Jump To Bookmark" not in labels
+    assert "Delete Bookmark" not in labels
+    assert labels == [
+        "Jump Home",
+        "Set Current View As Home",
+        "Add Or Update Bookmark...",
+        "Jump: North Wing",
+        "Jump: War Room",
+        "Delete: North Wing",
+        "Delete: War Room",
+    ]
+    assert workspace._bookmark_menu.popup_at == (12, 56)
+    assert workspace._bookmark_menu.release_count == 1
 
 
 def test_restore_defaults_home_camera_to_saved_camera_when_missing() -> None:


### PR DESCRIPTION
### Motivation
- Bookmarks in the GM Table were presented as nested submenus which added navigation depth and reduced discoverability.
- The intent is to expose bookmark actions directly in the Marks menu (jump/delete) with clear separators so users can operate without opening submenus.

### Description
- Replaced the nested `Jump To Bookmark` and `Delete Bookmark` submenus with inline commands labeled `Jump: <name>` and `Delete: <name>` and added separators to group sections in `modules/scenarios/gm_table/workspace.py`.
- Kept the existing top-level actions (`Jump Home`, `Set Current View As Home`, `Add Or Update Bookmark...`).
- Added lightweight test doubles `_FakeMenu` and `_FakeButton` and a new test `test_show_bookmark_menu_lists_bookmarks_without_submenus` in `tests/scenarios/gm_table/test_workspace.py` to validate the flattened menu construction without requiring a real Tk popup.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py -k bookmark_menu` which passed (`1 passed`).
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py -k bookmark` which passed (`2 passed`).
- Ran the full file `pytest -q tests/scenarios/gm_table/test_workspace.py` which showed two failures caused by Tk requiring a display (`TclError: no display name and no $DISPLAY`), these failures are unrelated to the bookmark menu changes and occur in this headless CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f5e1f46c832b9f78a6e893ce6430)