### PR TITLE
Add theme-aware infinite desk textures to GM table

### DIFF
--- a/modules/scenarios/gm_table/desk_texture.py
+++ b/modules/scenarios/gm_table/desk_texture.py
@@ -1,0 +1,81 @@
+"""Theme-aware infinite desk texture utilities for the GM table."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from PIL import Image, ImageTk
+
+from modules.helpers import theme_manager
+
+THEME_TEXTURE_FILENAMES = {
+    theme_manager.THEME_MEDIEVAL: "medfan-desk.jpg",
+    theme_manager.THEME_DEFAULT: "modern-desk.jpg",
+    theme_manager.THEME_SF: "scifi-desk.jpg",
+}
+
+
+def resolve_theme_texture_path(theme_key: str | None) -> Path | None:
+    """Return the desk texture path for the active theme when available."""
+    key = str(theme_key or theme_manager.THEME_DEFAULT).strip().lower()
+    if key not in THEME_TEXTURE_FILENAMES:
+        key = theme_manager.THEME_DEFAULT
+    candidate = Path("assets") / THEME_TEXTURE_FILENAMES[key]
+    return candidate if candidate.exists() else None
+
+
+class InfiniteDeskTexture:
+    """Draw and update a repeating desk texture anchored in world-space."""
+
+    def __init__(self, canvas) -> None:
+        self.canvas = canvas
+        self._base_texture: Image.Image | None = None
+        self._tile_cache: dict[Tuple[int, int], ImageTk.PhotoImage] = {}
+
+    def load_theme(self, theme_key: str | None) -> bool:
+        """Load the texture for the requested theme."""
+        self._base_texture = None
+        self._tile_cache.clear()
+        texture_path = resolve_theme_texture_path(theme_key)
+        if texture_path is None:
+            return False
+        try:
+            image = Image.open(texture_path)
+            if image.mode not in {"RGB", "RGBA"}:
+                image = image.convert("RGB")
+            self._base_texture = image
+            return True
+        except Exception:
+            self._base_texture = None
+            return False
+
+    def draw(self, *, width: int, height: int, camera_x: float, camera_y: float, zoom: float) -> bool:
+        """Draw tiled texture for the provided viewport/camera."""
+        if self._base_texture is None:
+            self.canvas.delete("desk_texture")
+            return False
+        target_w = max(64, int(round(self._base_texture.width * max(0.25, float(zoom)))))
+        target_h = max(64, int(round(self._base_texture.height * max(0.25, float(zoom)))))
+        key = (target_w, target_h)
+        tile = self._tile_cache.get(key)
+        if tile is None:
+            scaled = self._base_texture.resize((target_w, target_h), Image.Resampling.LANCZOS)
+            tile = ImageTk.PhotoImage(scaled)
+            self._tile_cache = {key: tile}
+
+        offset_x = -((float(camera_x) * float(zoom)) % target_w)
+        offset_y = -((float(camera_y) * float(zoom)) % target_h)
+        cols = max(1, (int(width) // target_w) + 3)
+        rows = max(1, (int(height) // target_h) + 3)
+
+        self.canvas.delete("desk_texture")
+        start_x = int(offset_x) - target_w
+        start_y = int(offset_y) - target_h
+        for row in range(rows):
+            y = start_y + (row * target_h)
+            for col in range(cols):
+                x = start_x + (col * target_w)
+                self.canvas.create_image(x, y, anchor="nw", image=tile, tags=("desk_texture",))
+        self.canvas.lower("desk_texture")
+        return True

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from typing import Callable
 
 import customtkinter as ctk
+from modules.helpers import theme_manager
+from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
 from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
 
 
@@ -26,6 +28,8 @@ TABLE_PALETTE = {
     "accent_soft": "#453116",
     "danger": "#F87171",
 }
+
+TABLE_CANVAS_BG = "#0D111B"
 
 
 DEFAULT_PANEL_SIZES = {
@@ -1210,6 +1214,17 @@ class GMTableWorkspace(ctk.CTkFrame):
         self.surface.grid(row=0, column=0, sticky="nsew", padx=18, pady=(0, 10))
         self.surface.bind("<Configure>", self._on_surface_configure, add="+")
 
+        self._desk_texture_canvas = tk.Canvas(
+            self.surface,
+            bg=TABLE_CANVAS_BG,
+            highlightthickness=0,
+            bd=0,
+            relief="flat",
+        )
+        self._desk_texture_canvas.place(relx=0.0, rely=0.0, relwidth=1.0, relheight=1.0)
+        self._desk_texture = InfiniteDeskTexture(self._desk_texture_canvas)
+        self._desk_texture.load_theme(theme_manager.get_theme())
+
         self._snap_preview = ctk.CTkFrame(
             self.surface,
             fg_color=TABLE_PALETTE["accent_soft"],
@@ -1327,6 +1342,7 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._bind_surface_navigation()
         self.bind("<Destroy>", self._handle_workspace_destroy, add="+")
         self._refresh_navigation_hud()
+        self._refresh_desk_texture()
         self._refresh_minimap()
         self._refresh_minimized_tray()
 
@@ -1398,7 +1414,11 @@ class GMTableWorkspace(ctk.CTkFrame):
 
     def _bind_surface_navigation(self) -> None:
         """Bind camera navigation to the empty table surface."""
-        for widget in (self.surface, self._empty_state):
+        widgets = [self.surface, self._empty_state]
+        texture_canvas = getattr(self, "_desk_texture_canvas", None)
+        if texture_canvas is not None:
+            widgets.insert(1, texture_canvas)
+        for widget in widgets:
             widget.bind("<ButtonPress-1>", self._start_surface_pan, add="+")
             widget.bind("<B1-Motion>", self._pan_surface_to, add="+")
             widget.bind("<ButtonRelease-1>", self._stop_surface_pan, add="+")
@@ -1484,6 +1504,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             self._camera_zoom = _normalize_camera({"zoom": zoom})["zoom"]
         self.clear_snap_preview()
         self.clamp_panels()
+        self._refresh_desk_texture()
 
     def _camera_view_size(self) -> tuple[float, float]:
         """Return the visible world-space viewport size."""
@@ -1549,6 +1570,33 @@ class GMTableWorkspace(ctk.CTkFrame):
             if panel.layout_mode != "floating":
                 continue
             self._apply_floating_geometry(panel, self._floating_geometry_snapshot(panel))
+
+    def _refresh_desk_texture(self) -> None:
+        """Render the active theme desk texture as an infinite tiled surface."""
+        canvas = getattr(self, "_desk_texture_canvas", None)
+        texture = getattr(self, "_desk_texture", None)
+        if canvas is None or texture is None:
+            return
+        try:
+            width = int(canvas.winfo_width())
+            height = int(canvas.winfo_height())
+        except Exception:
+            width, height = self._surface_geometry()
+        if width <= 1 or height <= 1:
+            width, height = self._surface_geometry()
+        drawn = texture.draw(
+            width=width,
+            height=height,
+            camera_x=_coerce_float(getattr(self, "_camera_x", 0.0)),
+            camera_y=_coerce_float(getattr(self, "_camera_y", 0.0)),
+            zoom=max(CAMERA_MIN_ZOOM, float(getattr(self, "_camera_zoom", 1.0))),
+        )
+        if not drawn:
+            try:
+                canvas.configure(bg=TABLE_PALETTE["table_bg"])
+            except Exception:
+                pass
+        self._raise_workspace_overlays()
 
     def _refresh_navigation_hud(self) -> None:
         """Refresh camera affordances."""
@@ -1842,6 +1890,12 @@ class GMTableWorkspace(ctk.CTkFrame):
 
     def _raise_workspace_overlays(self) -> None:
         """Keep the camera HUD and minimap above every desk panel."""
+        texture_canvas = getattr(self, "_desk_texture_canvas", None)
+        if texture_canvas is not None:
+            try:
+                texture_canvas.lower()
+            except Exception:
+                pass
         for widget_name in ("_nav_hud", "_minimap_shell"):
             widget = getattr(self, widget_name, None)
             if widget is None:

--- a/tests/scenarios/gm_table/test_desk_texture.py
+++ b/tests/scenarios/gm_table/test_desk_texture.py
@@ -1,0 +1,56 @@
+"""Tests for theme-aware desk texture resolution."""
+
+from __future__ import annotations
+
+from modules.helpers import theme_manager
+from modules.scenarios.gm_table.desk_texture import (
+    InfiniteDeskTexture,
+    resolve_theme_texture_path,
+)
+
+
+class _CanvasStub:
+    def __init__(self) -> None:
+        self.deleted_tags: list[str] = []
+
+    def delete(self, tag: str) -> None:
+        self.deleted_tags.append(tag)
+
+
+def test_resolve_theme_texture_path_uses_theme_specific_file(tmp_path, monkeypatch):
+    """Medieval theme should target medfan desk asset when present."""
+    monkeypatch.chdir(tmp_path)
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    expected = assets / "medfan-desk.jpg"
+    expected.write_bytes(b"stub")
+
+    resolved = resolve_theme_texture_path(theme_manager.THEME_MEDIEVAL)
+
+    assert resolved is not None
+    assert resolved.resolve() == expected.resolve()
+
+
+def test_resolve_theme_texture_path_falls_back_to_default_theme(tmp_path, monkeypatch):
+    """Unknown themes should resolve via the modern desk texture."""
+    monkeypatch.chdir(tmp_path)
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    expected = assets / "modern-desk.jpg"
+    expected.write_bytes(b"stub")
+
+    resolved = resolve_theme_texture_path("unknown-theme")
+
+    assert resolved is not None
+    assert resolved.resolve() == expected.resolve()
+
+
+def test_infinite_desk_texture_clears_canvas_when_texture_missing():
+    """Draw should clear tagged textures when no asset is available."""
+    canvas = _CanvasStub()
+    renderer = InfiniteDeskTexture(canvas)
+
+    drawn = renderer.draw(width=800, height=600, camera_x=0.0, camera_y=0.0, zoom=1.0)
+
+    assert drawn is False
+    assert canvas.deleted_tags == ["desk_texture"]


### PR DESCRIPTION
### Motivation
- Provide a themed, infinite-tiled desk surface for the GM virtual tabletop that follows the active dynamic theme and camera (pan/zoom) so the desk feels continuous and immersive.
- Use separate asset files per theme (medfan/modern/scifi) so the medfan theme can use the user-provided `medfan-desk.jpg` while other themes use their own textures.
- Keep the workspace resilient when assets are missing by falling back to the existing solid table color.

### Description
- Added `modules/scenarios/gm_table/desk_texture.py` implementing `resolve_theme_texture_path` and `InfiniteDeskTexture` to map themes to filenames and render an infinite repeating texture anchored to world-space camera coordinates.
- Integrated the texture layer into the GM table by creating a dedicated canvas in `modules/scenarios/gm_table/workspace.py`, instantiating `InfiniteDeskTexture`, and invoking a `_refresh_desk_texture` method on camera changes and surface resize.
- Adjusted surface navigation binding to account for the new texture canvas safely when the attribute may be missing (helps lightweight tests and partial instantiation paths).
- Added focused tests in `tests/scenarios/gm_table/test_desk_texture.py` that validate theme path resolution, fallback behavior, and that the renderer clears canvas tags when no texture is loaded.
- Images are intentionally not included; the runtime expects the following filenames under `assets/`: `medfan-desk.jpg`, `modern-desk.jpg`, and `scifi-desk.jpg`.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_desk_texture.py tests/scenarios/gm_table/test_workspace.py::test_bind_surface_navigation_registers_middle_pan_on_workspace_toplevel` and the targeted tests passed (4 passed).
- An initial broader `pytest` run including other `gm_table` UI tests produced failures due to headless environment `tk.Tk()` usage and an early test path mismatch; these were addressed by normalizing path resolution in tests and making the navigation binding robust, after which the focused tests above passed.
- The new tests exercise `resolve_theme_texture_path` and `InfiniteDeskTexture.draw` fallback behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5120a9d7c832b93d57694d6bb9a4a)