### PR TITLE
Scale snap thresholds, add edge hysteresis, relax corner/strip gates, and add focused tests

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -279,42 +279,50 @@ def _resolve_snap_mode(
     height = max(1, int(surface_h))
     x = int(pointer_x)
     y = int(pointer_y)
-    if x < 0 or y < 0 or x > width or y > height:
+    min_threshold = max(16, int(threshold))
+    x_threshold = max(min_threshold, int(round(width * 0.06)))
+    y_threshold = max(min_threshold, int(round(height * 0.06)))
+    hysteresis = max(8, int(round(min(x_threshold, y_threshold) * 0.35)))
+
+    if x < -hysteresis or y < -hysteresis or x > width + hysteresis or y > height + hysteresis:
         return None
 
-    x_ratio = x / width
-    y_ratio = y / height
-    threshold = max(16, int(threshold))
+    clamped_x = _clamp(x, 0, width)
+    clamped_y = _clamp(y, 0, height)
+    x_ratio = clamped_x / width
+    y_ratio = clamped_y / height
+    corner_x_limit = min(int(round(width * 0.30)), int(round((x_threshold + hysteresis) * 2.2)))
+    corner_y_limit = min(int(round(height * 0.30)), int(round((y_threshold + hysteresis) * 2.2)))
 
-    if y <= threshold:
-        if x_ratio <= 0.24:
+    if clamped_y <= y_threshold + hysteresis:
+        if clamped_x <= corner_x_limit:
             return "top_left"
-        if x_ratio >= 0.76:
+        if clamped_x >= width - corner_x_limit:
             return "top_right"
-        if 0.40 <= x_ratio <= 0.60:
+        if 0.38 <= x_ratio <= 0.62:
             return "maximize"
         return "top"
-    if y >= height - threshold:
-        if x_ratio <= 0.24:
+    if clamped_y >= height - (y_threshold + hysteresis):
+        if clamped_x <= corner_x_limit:
             return "bottom_left"
-        if x_ratio >= 0.76:
+        if clamped_x >= width - corner_x_limit:
             return "bottom_right"
         return "bottom"
-    if x <= threshold:
-        if y_ratio <= 0.24:
+    if clamped_x <= x_threshold + hysteresis:
+        if clamped_y <= corner_y_limit:
             return "top_left"
-        if y_ratio >= 0.76:
+        if clamped_y >= height - corner_y_limit:
             return "bottom_left"
         return "left"
-    if x >= width - threshold:
-        if y_ratio <= 0.24:
+    if clamped_x >= width - (x_threshold + hysteresis):
+        if clamped_y <= corner_y_limit:
             return "top_right"
-        if y_ratio >= 0.76:
+        if clamped_y >= height - corner_y_limit:
             return "bottom_right"
         return "right"
-    if 0.18 <= x_ratio <= 0.82 and 0.14 <= y_ratio <= 0.28:
+    if 0.14 <= x_ratio <= 0.86 and 0.12 <= y_ratio <= 0.34:
         return "top_strip"
-    if 0.18 <= x_ratio <= 0.82 and 0.72 <= y_ratio <= 0.86:
+    if 0.14 <= x_ratio <= 0.86 and 0.66 <= y_ratio <= 0.88:
         return "bottom_strip"
     return None
 

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -475,6 +475,49 @@ def test_resolve_snap_mode_supports_stacks_quadrants_and_strips() -> None:
     )
 
 
+def test_resolve_snap_mode_scales_threshold_for_large_surface() -> None:
+    """Large workspaces should still snap when the pointer is near an edge."""
+    surface_w = 3840
+    surface_h = 2160
+
+    assert (
+        _resolve_snap_mode(700, 20, surface_w=surface_w, surface_h=surface_h) == "top"
+    )
+    assert (
+        _resolve_snap_mode(20, 900, surface_w=surface_w, surface_h=surface_h) == "left"
+    )
+
+
+def test_resolve_snap_mode_handles_high_dpi_like_dimensions() -> None:
+    """Scaled dimensions should keep strip and maximize hotspots reachable."""
+    surface_w = 3000
+    surface_h = 2000
+
+    assert (
+        _resolve_snap_mode(surface_w // 2, 70, surface_w=surface_w, surface_h=surface_h)
+        == "maximize"
+    )
+    assert (
+        _resolve_snap_mode(
+            surface_w // 2,
+            int(surface_h * 0.31),
+            surface_w=surface_w,
+            surface_h=surface_h,
+        )
+        == "top_strip"
+    )
+
+
+def test_resolve_snap_mode_uses_hysteresis_tolerance_near_edges() -> None:
+    """Small out-of-bounds drifts should keep the expected edge snap target."""
+    surface_w = 1400
+    surface_h = 900
+
+    assert _resolve_snap_mode(-8, 24, surface_w=surface_w, surface_h=surface_h) == "top_left"
+    assert _resolve_snap_mode(surface_w + 8, 24, surface_w=surface_w, surface_h=surface_h) == "top_right"
+    assert _resolve_snap_mode(surface_w + 8, surface_h - 24, surface_w=surface_w, surface_h=surface_h) == "bottom_right"
+
+
 def test_snap_geometry_supports_quadrants_and_strips() -> None:
     """The richer snap layouts should resolve to stable workspace geometry."""
     surface_w = 1400


### PR DESCRIPTION
### Motivation
- Improve snap behavior so snap thresholds remain usable on very large or high-DPI viewports by scaling with viewport size while keeping a sane minimum.  
- Reduce accidental snap dropouts caused by tiny out-of-bounds pointer jitter by introducing a small hysteresis tolerance around edges.  
- Make corner and strip hotspot gates less brittle so common near-edge drags resolve to the intended snap target.  

### Description
- Refactored `_resolve_snap_mode` in `modules/scenarios/gm_table/workspace.py` to compute `x_threshold`/`y_threshold` as the max of a fixed minimum and a percentage of viewport width/height, and to derive a `hysteresis` tolerance for slight out-of-bounds pointer positions.  
- Added clamping and relaxed corner/strip ratio tests (with capped corner expansion) so corner / strip hotspots are broader but bounded on very large surfaces.  
- Preserved maximize/strip ratio checks but widened their ranges to be reachable under scaled dimensions.  
- Added focused unit tests in `tests/scenarios/gm_table/test_workspace.py` that verify large-surface threshold scaling, high-DPI-like dimensions, and small out-of-bounds pointer hysteresis behavior.  

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py -k resolve_snap_mode` and the new and related `resolve_snap_mode` tests passed (4 passed).  
- Ran the entire `tests/scenarios/gm_table/test_workspace.py` file which revealed two unrelated GUI tests failing in this headless CI environment due to Tkinter requiring a display (`_tkinter.TclError: no display name and no $DISPLAY environment variable`), while the rest passed (45 passed, 2 failed).  
- The change set is limited to `modules/scenarios/gm_table/workspace.py` and `tests/scenarios/gm_table/test_workspace.py` and automated assertions for the snap behavior are green in a non-GUI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5354238a8832b8908db143bf26cc6)