### PR TITLE
Unify snap geometry path and add preview-vs-final regression coverage

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -337,154 +337,23 @@ def _snap_geometry(
     margin: int = PANEL_MARGIN,
     gutter: int = PANEL_GUTTER,
 ) -> dict[str, int]:
-    """Return the target geometry for a snapped or maximized panel."""
-    full_width = max(min_width, int(surface_w) - (margin * 2))
-    full_height = max(min_height, int(surface_h) - (margin * 2))
-    split_width = max(min_width * 2, full_width - gutter)
-    split_height = max(min_height * 2, full_height - gutter)
-    half_width = max(min_width, split_width // 2)
-    half_height = max(min_height, split_height // 2)
-    strip_height = _clamp(
-        int(round(full_height * 0.28)),
-        min_height,
-        max(min_height, full_height - min_height - gutter),
-    )
+    """Backward-compatible wrapper around :func:`fit_viewport_snap`."""
 
-    if mode == "maximize":
-        return _constrain_panel_geometry(
-            margin,
-            margin,
-            full_width,
-            full_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
+    class _SnapPanelProxy:
+        MIN_WIDTH = 1
+        MIN_HEIGHT = 1
 
-    if mode == "left":
-        return _constrain_panel_geometry(
-            margin,
-            margin,
-            half_width,
-            full_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "right":
-        return _constrain_panel_geometry(
-            int(surface_w) - margin - half_width,
-            margin,
-            half_width,
-            full_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "top":
-        return _constrain_panel_geometry(
-            margin,
-            margin,
-            full_width,
-            half_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "bottom":
-        return _constrain_panel_geometry(
-            margin,
-            int(surface_h) - margin - half_height,
-            full_width,
-            half_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "top_left":
-        return _constrain_panel_geometry(
-            margin,
-            margin,
-            half_width,
-            half_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "top_right":
-        return _constrain_panel_geometry(
-            int(surface_w) - margin - half_width,
-            margin,
-            half_width,
-            half_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "bottom_left":
-        return _constrain_panel_geometry(
-            margin,
-            int(surface_h) - margin - half_height,
-            half_width,
-            half_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "bottom_right":
-        return _constrain_panel_geometry(
-            int(surface_w) - margin - half_width,
-            int(surface_h) - margin - half_height,
-            half_width,
-            half_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "top_strip":
-        return _constrain_panel_geometry(
-            margin,
-            margin,
-            full_width,
-            strip_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
-    if mode == "bottom_strip":
-        return _constrain_panel_geometry(
-            margin,
-            int(surface_h) - margin - strip_height,
-            full_width,
-            strip_height,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=min_width,
-            min_height=min_height,
-            margin=margin,
-        )
+    class _SnapSurfaceProxy:
+        def winfo_width(self) -> int:
+            return int(surface_w)
 
-    raise ValueError(f"Unsupported snap mode: {mode}")
+        def winfo_height(self) -> int:
+            return int(surface_h)
+
+    panel_proxy = _SnapPanelProxy()
+    panel_proxy.MIN_WIDTH = max(1, int(min_width))
+    panel_proxy.MIN_HEIGHT = max(1, int(min_height))
+    return fit_viewport_snap(panel_proxy, _SnapSurfaceProxy(), mode)
 
 
 def _resize_geometry(
@@ -2157,20 +2026,13 @@ class GMTableWorkspace(ctk.CTkFrame):
         label = getattr(self, "_snap_preview_label", None)
         if preview is None or label is None:
             return
-        surface_w, surface_h = _surface_dimensions(self.surface)
-        geometry = _snap_geometry(
-            mode,
-            surface_w=surface_w,
-            surface_h=surface_h,
-            min_width=GMTablePanel.MIN_WIDTH,
-            min_height=GMTablePanel.MIN_HEIGHT,
-        )
+        panel = self._panels.get(panel_id)
+        geometry = fit_viewport_snap(panel or GMTablePanel, self.surface, mode)
         self._snap_preview_mode = mode
         label.configure(text=SNAP_MODE_LABELS.get(mode, "Snap"))
         preview.configure(width=geometry["width"], height=geometry["height"])
         preview.place(x=geometry["x"], y=geometry["y"])
         preview.lift()
-        panel = self._panels.get(panel_id)
         if panel is not None:
             panel.lift()
         self._raise_workspace_overlays()
@@ -2354,16 +2216,9 @@ class GMTableWorkspace(ctk.CTkFrame):
         if panel.layout_mode in (SNAP_LAYOUT_MODES - {"maximize"}) and panel.restore_layout():
             self.bring_to_front(panel_id)
             return
-        surface_w, surface_h = self._surface_geometry()
         panel.enter_layout_mode(
             "maximize",
-            _snap_geometry(
-                "maximize",
-                surface_w=surface_w,
-                surface_h=surface_h,
-                min_width=GMTablePanel.MIN_WIDTH,
-                min_height=GMTablePanel.MIN_HEIGHT,
-            ),
+            fit_viewport_snap(panel, self.surface, "maximize"),
         )
         self.bring_to_front(panel_id)
 
@@ -2444,20 +2299,11 @@ class GMTableWorkspace(ctk.CTkFrame):
     def clamp_panels(self) -> None:
         """Reproject floating panels and keep snapped panels viewport-relative."""
         self.update_idletasks()
-        surface_w, surface_h = _surface_dimensions(self.surface)
         for panel in self._panels.values():
             if panel.layout_mode == "minimized":
                 continue
             if panel.layout_mode in SNAP_LAYOUT_MODES:
-                panel.apply_geometry(
-                    _snap_geometry(
-                        panel.layout_mode,
-                        surface_w=surface_w,
-                        surface_h=surface_h,
-                        min_width=GMTablePanel.MIN_WIDTH,
-                        min_height=GMTablePanel.MIN_HEIGHT,
-                    )
-                )
+                panel.apply_geometry(fit_viewport_snap(panel, self.surface, panel.layout_mode))
                 continue
             self._apply_floating_geometry(panel, self._floating_geometry_snapshot(panel))
         self._schedule_layout_changed()
@@ -2567,8 +2413,8 @@ class GMTableWorkspace(ctk.CTkFrame):
                         layout_mode,
                         surface_w=surface_w,
                         surface_h=surface_h,
-                        min_width=GMTablePanel.MIN_WIDTH,
-                        min_height=GMTablePanel.MIN_HEIGHT,
+                        min_width=panel.MIN_WIDTH,
+                        min_height=panel.MIN_HEIGHT,
                     )
                 )
                 panel._refresh_window_controls()

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tkinter as tk
 from types import SimpleNamespace
 
+from modules.scenarios.gm_table.layout import fit_viewport_snap
 from modules.scenarios.gm_table.workspace import (
     PANEL_GUTTER,
     PANEL_MARGIN,
@@ -21,6 +22,9 @@ from modules.scenarios.gm_table.workspace import (
 
 
 class _FakePanel:
+    MIN_WIDTH = GMTablePanel.MIN_WIDTH
+    MIN_HEIGHT = GMTablePanel.MIN_HEIGHT
+
     def __init__(self, width: int, height: int, *, x: int = 0, y: int = 0) -> None:
         self._width = width
         self._height = height
@@ -809,13 +813,7 @@ def test_preview_snap_target_resizes_preview_without_passing_size_to_place() -> 
 
     GMTableWorkspace.preview_snap_target(workspace, "notes", "left")
 
-    expected_left = _snap_geometry(
-        "left",
-        surface_w=1400,
-        surface_h=900,
-        min_width=GMTablePanel.MIN_WIDTH,
-        min_height=GMTablePanel.MIN_HEIGHT,
-    )
+    expected_left = fit_viewport_snap(panel, workspace.surface, "left")
     assert preview.width == expected_left["width"]
     assert preview.height == expected_left["height"]
     assert preview.place_calls[-1] == {"x": expected_left["x"], "y": expected_left["y"]}
@@ -826,13 +824,7 @@ def test_preview_snap_target_resizes_preview_without_passing_size_to_place() -> 
 
     GMTableWorkspace.preview_snap_target(workspace, "notes", "bottom_right")
 
-    expected_quadrant = _snap_geometry(
-        "bottom_right",
-        surface_w=1400,
-        surface_h=900,
-        min_width=GMTablePanel.MIN_WIDTH,
-        min_height=GMTablePanel.MIN_HEIGHT,
-    )
+    expected_quadrant = fit_viewport_snap(panel, workspace.surface, "bottom_right")
     assert preview.width == expected_quadrant["width"]
     assert preview.height == expected_quadrant["height"]
     assert preview.place_calls[-1] == {
@@ -841,6 +833,53 @@ def test_preview_snap_target_resizes_preview_without_passing_size_to_place() -> 
     }
     assert label.text == SNAP_MODE_LABELS["bottom_right"]
     assert workspace._snap_preview_mode == "bottom_right"
+
+
+def test_preview_snap_target_matches_snap_panel_geometry_for_all_modes() -> None:
+    """Preview rectangle and final snapped geometry should always match."""
+    snap_modes = (
+        "left",
+        "right",
+        "top",
+        "bottom",
+        "top_left",
+        "top_right",
+        "bottom_left",
+        "bottom_right",
+        "top_strip",
+        "bottom_strip",
+        "maximize",
+    )
+    for mode in snap_modes:
+        workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+        preview = _FakePreview()
+        label = _FakeLabel()
+        panel = _FakePanel(520, 360, x=84, y=56)
+        workspace._panels = {"notes": panel}
+        workspace._definitions = {
+            "notes": PanelDefinition(
+                panel_id="notes", kind="note", title="Notes", state={}
+            ),
+        }
+        workspace._z_order = ["notes"]
+        _prepare_workspace(workspace, camera_x=320, camera_y=180)
+        workspace._snap_preview = preview
+        workspace._snap_preview_label = label
+        workspace._snap_preview_mode = None
+
+        GMTableWorkspace.preview_snap_target(workspace, "notes", mode)
+
+        preview_geometry = {
+            "x": preview.place_calls[-1]["x"],
+            "y": preview.place_calls[-1]["y"],
+            "width": preview.width,
+            "height": preview.height,
+        }
+
+        GMTableWorkspace.snap_panel(workspace, "notes", mode)
+        final_geometry = panel.geometry_snapshot()
+
+        assert preview_geometry == final_geometry
 
 
 def test_preview_snap_target_clears_overlay_for_invalid_mode() -> None:


### PR DESCRIPTION
### Motivation
- Eliminate duplicated snap-layout math and ensure preview overlay uses the exact same sizing logic as final snapping to avoid drift between preview and applied panel geometry.
- Provide regression coverage asserting preview rectangle equals final snapped geometry across all snap modes to prevent future divergence.

### Description
- Replaced preview geometry computation in `GMTableWorkspace.preview_snap_target` to call `fit_viewport_snap` (the same strategy used by `snap_panel`).
- Replaced the large `_snap_geometry` implementation with a small backward-compatible wrapper that delegates to `fit_viewport_snap` so there is a single source of truth for snap math.
- Updated snap-related flows to use `fit_viewport_snap` directly where a panel and surface exist (`toggle_panel_maximize`, `clamp_panels`, and companion snapping), and used the wrapper during layout restore to remain compatible with existing call sites.
- Added a regression test `test_preview_snap_target_matches_snap_panel_geometry_for_all_modes` that asserts the preview rectangle and final panel geometry are identical for all modes (`left/right/top/bottom/top_left/top_right/bottom_left/bottom_right/top_strip/bottom_strip/maximize`).

### Testing
- Ran the focused snap-related test subset including the new regression: `pytest -q tests/scenarios/gm_table/test_workspace.py -k "...restore_rehydrates_quadrant_layout_mode or preview_snap_target_matches_snap_panel_geometry_for_all_modes or preview_snap_target_resizes_preview_without_passing_size_to_place or snap_geometry_supports_quadrants_and_strips"` and observed the snap/preview/restore tests pass (8 passed, 40 deselected).
- A full run of the workspace test file in this headless/container environment initially exposed unrelated Tk display failures (`no $DISPLAY`) for UI mounting tests; these are environmental and not caused by the snap changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53610ce44832b8960f15872d7e32d)