### PR TITLE
Set GM Table starter layout to open Scenario detail + Handouts

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -363,37 +363,21 @@ class GMTableView(ctk.CTkFrame):
         self._workspace_loaded = True
 
     def _seed_default_panels(self) -> None:
-        """Build a map-centric default workspace."""
-        starter_map_name = self._infer_starting_map_name()
+        """Build the default workspace focused on scenario and handouts."""
         self._create_panel(
-            "world_map",
-            "Scene Map",
-            self._panel_state(map_name=starter_map_name),
-            geometry={"x": 24, "y": 24, "width": 980, "height": 640},
-        )
-        self._create_panel(
-            "map_tool",
-            "Map Tool",
-            self._panel_state(map_name=starter_map_name),
-            geometry={"x": 1020, "y": 24, "width": 620, "height": 640},
+            "entity",
+            f"Scenario: {self.scenario_name}",
+            {
+                "entity_type": "Scenarios",
+                "entity_name": self.scenario_name,
+            },
+            geometry={"x": 24, "y": 24, "width": 1040, "height": 760},
         )
         self._create_panel(
             "handouts",
             "Handouts",
             {"scenario_name": self.scenario_name},
-            geometry={"x": 24, "y": 680, "width": 440, "height": 300},
-        )
-        self._create_panel(
-            "note",
-            "Session Notes",
-            {"text": ""},
-            geometry={"x": 476, "y": 680, "width": 520, "height": 300},
-        )
-        self._create_panel(
-            "scene_flow",
-            f"Scene Flow: {self.scenario_name}",
-            {"scenario_title": self.scenario_name},
-            geometry={"x": 1012, "y": 680, "width": 628, "height": 300},
+            geometry={"x": 1080, "y": 24, "width": 560, "height": 760},
         )
 
     def _persist_layout(self) -> None:

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -294,8 +294,8 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
     assert captured["kwargs"]["initial_state"] == {"query": "map"}
 
 
-def test_seed_default_panels_builds_map_first_vtt_layout() -> None:
-    """Starter tabletop should default to a map-centric VTT workspace."""
+def test_seed_default_panels_opens_scenario_and_handouts_panels() -> None:
+    """Starter tabletop should open scenario details alongside handouts."""
     captured = []
     view = GMTableView.__new__(GMTableView)
     view.scenario_name = "Night Run"
@@ -308,34 +308,16 @@ def test_seed_default_panels_builds_map_first_vtt_layout() -> None:
 
     assert captured == [
         (
-            "world_map",
-            "Scene Map",
-            {"map_name": "Docks"},
-            {"x": 24, "y": 24, "width": 980, "height": 640},
-        ),
-        (
-            "map_tool",
-            "Map Tool",
-            {"map_name": "Docks"},
-            {"x": 1020, "y": 24, "width": 620, "height": 640},
+            "entity",
+            "Scenario: Night Run",
+            {"entity_type": "Scenarios", "entity_name": "Night Run"},
+            {"x": 24, "y": 24, "width": 1040, "height": 760},
         ),
         (
             "handouts",
             "Handouts",
             {"scenario_name": "Night Run"},
-            {"x": 24, "y": 680, "width": 440, "height": 300},
-        ),
-        (
-            "note",
-            "Session Notes",
-            {"text": ""},
-            {"x": 476, "y": 680, "width": 520, "height": 300},
-        ),
-        (
-            "scene_flow",
-            "Scene Flow: Night Run",
-            {"scenario_title": "Night Run"},
-            {"x": 1012, "y": 680, "width": 628, "height": 300},
+            {"x": 1080, "y": 24, "width": 560, "height": 760},
         ),
     ]
 


### PR DESCRIPTION
### Motivation
- The GM virtual tabletop should open the scenario detail window and the handouts window when a scenario is chosen, instead of the previous map-first starter layout.
- This change makes the initial GM focus match the expected workflow: inspect the selected scenario and quickly access its handouts.

### Description
- Replaced the map-centric starter layout in `GMTableView._seed_default_panels` with two primary panels: an `entity` panel for the selected `Scenarios` item and a `handouts` panel for the scenario, with updated geometry sizing.
- The new entity panel is opened as `"Scenario: {self.scenario_name}"` with state `{ "entity_type": "Scenarios", "entity_name": self.scenario_name }` and the handouts panel state remains `{ "scenario_name": self.scenario_name }`.
- Updated the GM Table unit test in `tests/scenarios/gm_table/test_gm_table_view.py` to assert the new default panels and renamed the test to `test_seed_default_panels_opens_scenario_and_handouts_panels`.

### Testing
- Ran `python -m compileall modules/scenarios/gm_table_view.py tests/scenarios/gm_table/test_gm_table_view.py`, which completed successfully.
- Ran `pytest -q tests/scenarios/gm_table/test_gm_table_view.py`, which failed during test collection in this environment due to an unrelated `PIL.ImageFont` import error (missing Pillow font support), not related to the layout changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64a0c9824832ba0625e92e0e9b572)