### PR TITLE
Add world-space alignment module and workspace guide/actions integration

### DIFF
--- a/modules/scenarios/gm_table/layout/__init__.py
+++ b/modules/scenarios/gm_table/layout/__init__.py
@@ -1,5 +1,13 @@
 """Layout sizing strategies for the GM table workspace."""
 
 from .auto_size_strategy import fit_content_minimum, fit_viewport_snap
+from .world_alignment import AlignmentGuide, equal_spacing, nearest_edge_snap, pack_cluster
 
-__all__ = ["fit_content_minimum", "fit_viewport_snap"]
+__all__ = [
+    "AlignmentGuide",
+    "equal_spacing",
+    "fit_content_minimum",
+    "fit_viewport_snap",
+    "nearest_edge_snap",
+    "pack_cluster",
+]

--- a/modules/scenarios/gm_table/layout/world_alignment.py
+++ b/modules/scenarios/gm_table/layout/world_alignment.py
@@ -1,0 +1,153 @@
+"""World-space alignment helpers for GM table floating panels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+
+
+@dataclass(slots=True)
+class AlignmentGuide:
+    """Guide line descriptor in world coordinates."""
+
+    axis: str
+    world_value: float
+    span_start: float
+    span_end: float
+
+
+def _edges(geometry: dict[str, float | int]) -> dict[str, float]:
+    x = float(geometry.get("x", 0.0))
+    y = float(geometry.get("y", 0.0))
+    width = max(1.0, float(geometry.get("width", 1.0)))
+    height = max(1.0, float(geometry.get("height", 1.0)))
+    return {
+        "left": x,
+        "right": x + width,
+        "top": y,
+        "bottom": y + height,
+        "center_x": x + (width / 2.0),
+        "center_y": y + (height / 2.0),
+    }
+
+
+def nearest_edge_snap(
+    active: dict[str, float | int],
+    candidates: list[dict[str, float | int]],
+    *,
+    threshold: float = 24.0,
+) -> dict[str, object]:
+    """Return world-space edge snaps for active geometry against candidates."""
+    active_edges = _edges(active)
+    if not candidates:
+        return {"x": float(active["x"]), "y": float(active["y"]), "guides": []}
+    comparisons = (
+        ("x", "left", "left"),
+        ("x", "left", "right"),
+        ("x", "right", "left"),
+        ("x", "right", "right"),
+        ("x", "center_x", "center_x"),
+        ("y", "top", "top"),
+        ("y", "top", "bottom"),
+        ("y", "bottom", "top"),
+        ("y", "bottom", "bottom"),
+        ("y", "center_y", "center_y"),
+    )
+    best: dict[str, tuple[float, float, dict[str, float]]] = {}
+    for candidate in candidates:
+        candidate_edges = _edges(candidate)
+        for axis, active_key, candidate_key in comparisons:
+            delta = candidate_edges[candidate_key] - active_edges[active_key]
+            distance = abs(delta)
+            if distance > float(threshold):
+                continue
+            current = best.get(axis)
+            if current is None or distance < current[0]:
+                best[axis] = (distance, delta, candidate_edges)
+    snapped_x = float(active.get("x", 0.0))
+    snapped_y = float(active.get("y", 0.0))
+    guides: list[AlignmentGuide] = []
+    if "x" in best:
+        _, delta_x, candidate = best["x"]
+        snapped_x += delta_x
+        guides.append(
+            AlignmentGuide(
+                axis="x",
+                world_value=active_edges["left"] + delta_x,
+                span_start=min(active_edges["top"], candidate["top"]),
+                span_end=max(active_edges["bottom"], candidate["bottom"]),
+            )
+        )
+    if "y" in best:
+        _, delta_y, candidate = best["y"]
+        snapped_y += delta_y
+        guides.append(
+            AlignmentGuide(
+                axis="y",
+                world_value=active_edges["top"] + delta_y,
+                span_start=min(active_edges["left"], candidate["left"]),
+                span_end=max(active_edges["right"], candidate["right"]),
+            )
+        )
+    return {"x": round(snapped_x, 2), "y": round(snapped_y, 2), "guides": guides}
+
+
+def equal_spacing(rectangles: dict[str, dict[str, float | int]]) -> dict[str, float]:
+    """Return x positions for a horizontal equal-spacing distribution."""
+    if len(rectangles) < 3:
+        return {}
+    ordered = sorted(
+        rectangles.items(),
+        key=lambda item: float(item[1].get("x", 0.0)),
+    )
+    total_width = sum(max(1.0, float(geometry.get("width", 1.0))) for _, geometry in ordered)
+    left = float(ordered[0][1].get("x", 0.0))
+    last = ordered[-1][1]
+    right = float(last.get("x", 0.0)) + max(1.0, float(last.get("width", 1.0)))
+    gap = (right - left - total_width) / float(len(ordered) - 1)
+    cursor = left
+    positions: dict[str, float] = {}
+    for panel_id, geometry in ordered:
+        positions[panel_id] = round(cursor, 2)
+        cursor += max(1.0, float(geometry.get("width", 1.0))) + gap
+    return positions
+
+
+def pack_cluster(
+    rectangles: dict[str, dict[str, float | int]],
+    *,
+    gutter: float = 24.0,
+) -> dict[str, tuple[float, float]]:
+    """Pack floating windows into a compact left-to-right world cluster."""
+    if not rectangles:
+        return {}
+    ordered = sorted(
+        rectangles.items(),
+        key=lambda item: (
+            float(item[1].get("y", 0.0)),
+            float(item[1].get("x", 0.0)),
+        ),
+    )
+    min_x = min(float(geometry.get("x", 0.0)) for _, geometry in ordered)
+    min_y = min(float(geometry.get("y", 0.0)) for _, geometry in ordered)
+    total_area = sum(
+        max(1.0, float(geometry.get("width", 1.0))) * max(1.0, float(geometry.get("height", 1.0)))
+        for _, geometry in ordered
+    )
+    row_target = max(320.0, sqrt(total_area) * 1.3)
+
+    placements: dict[str, tuple[float, float]] = {}
+    cursor_x = min_x
+    cursor_y = min_y
+    row_height = 0.0
+    for panel_id, geometry in ordered:
+        width = max(1.0, float(geometry.get("width", 1.0)))
+        height = max(1.0, float(geometry.get("height", 1.0)))
+        if cursor_x > min_x and (cursor_x - min_x + width) > row_target:
+            cursor_x = min_x
+            cursor_y += row_height + gutter
+            row_height = 0.0
+        placements[panel_id] = (round(cursor_x, 2), round(cursor_y, 2))
+        row_height = max(row_height, height)
+        cursor_x += width + gutter
+    return placements

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -10,7 +10,14 @@ from typing import Callable
 import customtkinter as ctk
 from modules.helpers import theme_manager
 from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
-from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
+from modules.scenarios.gm_table.layout import (
+    AlignmentGuide,
+    equal_spacing,
+    fit_content_minimum,
+    fit_viewport_snap,
+    nearest_edge_snap,
+    pack_cluster,
+)
 
 
 TABLE_PALETTE = {
@@ -60,6 +67,7 @@ CAMERA_ZOOM_STEP = 0.15
 MINIMAP_WIDTH = 176
 MINIMAP_HEIGHT = 118
 MINIMAP_PADDING = 16
+WORLD_ALIGNMENT_THRESHOLD_PX = 18
 SNAP_LAYOUT_MODES = {
     "left",
     "right",
@@ -876,6 +884,14 @@ class GMTablePanel(ctk.CTkFrame):
             snap_menu.add_command(label=label, command=lambda value=mode: self._dispatch_window_action(f"snap:{value}"))
         menu.add_cascade(label="Snap Layout", menu=snap_menu)
         menu.add_separator()
+        menu.add_command(label="Align Left", command=lambda: self._dispatch_window_action("align_left"))
+        menu.add_command(label="Align Top", command=lambda: self._dispatch_window_action("align_top"))
+        menu.add_command(
+            label="Distribute Horizontally",
+            command=lambda: self._dispatch_window_action("distribute_horizontal"),
+        )
+        menu.add_command(label="Pack Cluster", command=lambda: self._dispatch_window_action("pack_cluster"))
+        menu.add_separator()
         menu.add_command(label="Close Others", command=lambda: self._dispatch_window_action("close_others"))
         menu.add_command(label="Cascade Windows", command=lambda: self._dispatch_window_action("cascade_all"))
         menu.add_command(label="Tile Windows", command=lambda: self._dispatch_window_action("tile_all"))
@@ -1117,6 +1133,15 @@ class GMTableWorkspace(ctk.CTkFrame):
         )
         self._snap_preview_label.place(relx=0.5, rely=0.5, anchor="center")
         self._snap_preview.place_forget()
+        self._alignment_guide_canvas = tk.Canvas(
+            self.surface,
+            highlightthickness=0,
+            bd=0,
+            relief="flat",
+            bg=TABLE_CANVAS_BG,
+        )
+        self._alignment_guide_canvas.place(relx=0.0, rely=0.0, relwidth=1.0, relheight=1.0)
+        self._alignment_guide_canvas.place_forget()
 
         self._nav_hud = ctk.CTkFrame(
             self.surface,
@@ -1208,6 +1233,9 @@ class GMTableWorkspace(ctk.CTkFrame):
 
         self.tray_buttons = ctk.CTkFrame(self.tray, fg_color="transparent")
         self.tray_buttons.grid(row=0, column=1, padx=(0, 12), pady=8, sticky="ew")
+        self.tray_actions = ctk.CTkFrame(self.tray, fg_color="transparent")
+        self.tray_actions.grid(row=0, column=2, padx=(0, 12), pady=8, sticky="e")
+        self._build_tray_actions()
 
         self._empty_state = ctk.CTkLabel(
             self.surface,
@@ -1222,6 +1250,34 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._refresh_desk_texture()
         self._refresh_minimap()
         self._refresh_minimized_tray()
+
+    def _build_tray_actions(self) -> None:
+        """Build quick world-alignment commands inside the tray."""
+        actions = (
+            ("Align Left", "align_left"),
+            ("Align Top", "align_top"),
+            ("Distribute Horizontally", "distribute_horizontal"),
+            ("Pack Cluster", "pack_cluster"),
+        )
+        frame = getattr(self, "tray_actions", None)
+        if frame is None:
+            return
+        for child in frame.winfo_children():
+            child.destroy()
+        for label, action in actions:
+            ctk.CTkButton(
+                frame,
+                text=label,
+                height=30,
+                fg_color=TABLE_PALETTE["table_chip"],
+                hover_color="#283146",
+                text_color=TABLE_PALETTE["text"],
+                corner_radius=12,
+                command=lambda value=action: self.handle_window_action(
+                    self.get_active_panel_id(include_minimized=False) or "",
+                    value,
+                ),
+            ).pack(side="left", padx=(0, 8))
 
     def _schedule_layout_changed(self) -> None:
         """Debounce layout persistence."""
@@ -1270,10 +1326,11 @@ class GMTableWorkspace(ctk.CTkFrame):
         for child in buttons_frame.winfo_children():
             child.destroy()
         minimized_ids = self._minimized_panel_ids()
-        if not minimized_ids:
-            tray.grid_remove()
-            return
         tray.grid()
+        if not minimized_ids:
+            self.tray_label.configure(text="Workspace")
+            return
+        self.tray_label.configure(text="Minimized")
         for panel_id in minimized_ids:
             definition = self._definitions.get(panel_id)
             if definition is None:
@@ -1773,6 +1830,12 @@ class GMTableWorkspace(ctk.CTkFrame):
                 texture_canvas.lower()
             except Exception:
                 pass
+        guide_canvas = getattr(self, "_alignment_guide_canvas", None)
+        if guide_canvas is not None:
+            try:
+                guide_canvas.lift()
+            except Exception:
+                pass
         for widget_name in ("_nav_hud", "_minimap_shell"):
             widget = getattr(self, widget_name, None)
             if widget is None:
@@ -2004,6 +2067,18 @@ class GMTableWorkspace(ctk.CTkFrame):
         if action == "snap_right":
             self.snap_panel(panel_id, "right")
             return
+        if action == "align_left":
+            self.align_left(panel_id)
+            return
+        if action == "align_top":
+            self.align_top(panel_id)
+            return
+        if action == "distribute_horizontal":
+            self.distribute_horizontally(panel_id)
+            return
+        if action == "pack_cluster":
+            self.pack_cluster(panel_id)
+            return
         if action == "close_others":
             self.close_other_panels(panel_id)
             return
@@ -2019,7 +2094,14 @@ class GMTableWorkspace(ctk.CTkFrame):
 
     def preview_snap_target(self, panel_id: str, mode: str | None) -> None:
         """Show or hide the live snap preview while a panel is being dragged."""
-        if mode is None or mode not in SNAP_LAYOUT_MODES:
+        self._preview_world_alignment(panel_id)
+        if mode is None:
+            preview = getattr(self, "_snap_preview", None)
+            if preview is not None:
+                preview.place_forget()
+            self._snap_preview_mode = None
+            return
+        if mode not in SNAP_LAYOUT_MODES:
             self.clear_snap_preview()
             return
         preview = getattr(self, "_snap_preview", None)
@@ -2043,6 +2125,149 @@ class GMTableWorkspace(ctk.CTkFrame):
         preview = getattr(self, "_snap_preview", None)
         if preview is not None:
             preview.place_forget()
+        self._clear_alignment_guides()
+
+    def _floating_world_geometries(self, *, include_minimized: bool = False) -> dict[str, dict[str, float | int]]:
+        """Return world-space geometry snapshots for floating panels."""
+        records: dict[str, dict[str, float | int]] = {}
+        order = list(getattr(self, "_z_order", []) or list(getattr(self, "_panels", {}).keys()))
+        for panel_id in order:
+            panel = self._panels.get(panel_id)
+            if panel is None:
+                continue
+            if panel.layout_mode != "floating":
+                if panel.layout_mode == "minimized" and include_minimized:
+                    pass
+                else:
+                    continue
+            records[panel_id] = self._floating_geometry_snapshot(panel)
+        return records
+
+    def _preview_world_alignment(self, panel_id: str) -> None:
+        """Render live world-relative alignment guides for the active drag panel."""
+        active = self._panels.get(panel_id)
+        if active is None or active.layout_mode != "floating":
+            self._clear_alignment_guides()
+            return
+        floating = self._floating_world_geometries()
+        active_geometry = floating.pop(panel_id, None)
+        if active_geometry is None:
+            self._clear_alignment_guides()
+            return
+        threshold = float(WORLD_ALIGNMENT_THRESHOLD_PX) / max(CAMERA_MIN_ZOOM, float(self._camera_zoom))
+        snap = nearest_edge_snap(active_geometry, list(floating.values()), threshold=threshold)
+        guides = list(snap.get("guides", []))
+        if not guides:
+            self._clear_alignment_guides()
+            return
+        self._render_alignment_guides(guides)
+
+    def _render_alignment_guides(self, guides: list[AlignmentGuide]) -> None:
+        """Draw world-space alignment guides in the workspace overlay layer."""
+        canvas = getattr(self, "_alignment_guide_canvas", None)
+        if canvas is None:
+            return
+        canvas.delete("all")
+        for guide in guides:
+            if guide.axis == "x":
+                x0, y0 = self._project_world_to_screen(guide.world_value, guide.span_start)
+                x1, y1 = self._project_world_to_screen(guide.world_value, guide.span_end)
+            else:
+                x0, y0 = self._project_world_to_screen(guide.span_start, guide.world_value)
+                x1, y1 = self._project_world_to_screen(guide.span_end, guide.world_value)
+            canvas.create_line(x0, y0, x1, y1, fill=TABLE_PALETTE["panel_focus"], width=2, dash=(6, 4))
+        canvas.place(relx=0.0, rely=0.0, relwidth=1.0, relheight=1.0)
+        canvas.lift()
+        self._raise_workspace_overlays()
+
+    def _clear_alignment_guides(self) -> None:
+        """Hide any live world alignment guides."""
+        canvas = getattr(self, "_alignment_guide_canvas", None)
+        if canvas is None:
+            return
+        try:
+            canvas.delete("all")
+            canvas.place_forget()
+        except Exception:
+            return
+
+    def _project_world_to_screen(self, world_x: float, world_y: float) -> tuple[int, int]:
+        """Project one world-space point into surface-local screen coordinates."""
+        zoom = max(CAMERA_MIN_ZOOM, float(getattr(self, "_camera_zoom", 1.0)))
+        x = int(round((float(world_x) - _coerce_float(getattr(self, "_camera_x", 0.0))) * zoom))
+        y = int(round((float(world_y) - _coerce_float(getattr(self, "_camera_y", 0.0))) * zoom))
+        return x, y
+
+    def align_left(self, panel_id: str | None = None) -> None:
+        """Align visible floating panels to the left edge of a reference panel."""
+        floating = self._floating_world_geometries()
+        if not floating:
+            return
+        anchor_id = panel_id if panel_id in floating else next(iter(floating.keys()))
+        target_x = float(floating[anchor_id]["x"])
+        for candidate_id, geometry in floating.items():
+            geometry["x"] = target_x
+            panel = self._panels.get(candidate_id)
+            if panel is not None:
+                panel.clear_layout_mode()
+                self._apply_floating_geometry(panel, geometry)
+        if panel_id is not None:
+            self.bring_to_front(panel_id)
+        self._schedule_layout_changed()
+
+    def align_top(self, panel_id: str | None = None) -> None:
+        """Align visible floating panels to the top edge of a reference panel."""
+        floating = self._floating_world_geometries()
+        if not floating:
+            return
+        anchor_id = panel_id if panel_id in floating else next(iter(floating.keys()))
+        target_y = float(floating[anchor_id]["y"])
+        for candidate_id, geometry in floating.items():
+            geometry["y"] = target_y
+            panel = self._panels.get(candidate_id)
+            if panel is not None:
+                panel.clear_layout_mode()
+                self._apply_floating_geometry(panel, geometry)
+        if panel_id is not None:
+            self.bring_to_front(panel_id)
+        self._schedule_layout_changed()
+
+    def distribute_horizontally(self, panel_id: str | None = None) -> None:
+        """Distribute floating panels with equal horizontal spacing."""
+        floating = self._floating_world_geometries()
+        positions = equal_spacing(floating)
+        if not positions:
+            return
+        for candidate_id, x_value in positions.items():
+            panel = self._panels.get(candidate_id)
+            geometry = floating.get(candidate_id)
+            if panel is None or geometry is None:
+                continue
+            geometry["x"] = float(x_value)
+            panel.clear_layout_mode()
+            self._apply_floating_geometry(panel, geometry)
+        if panel_id is not None:
+            self.bring_to_front(panel_id)
+        self._schedule_layout_changed()
+
+    def pack_cluster(self, panel_id: str | None = None) -> None:
+        """Pack floating panels into a compact world-space cluster."""
+        floating = self._floating_world_geometries()
+        placements = pack_cluster(floating)
+        if not placements:
+            return
+        for candidate_id, (x_value, y_value) in placements.items():
+            panel = self._panels.get(candidate_id)
+            geometry = floating.get(candidate_id)
+            if panel is None or geometry is None:
+                continue
+            geometry["x"] = float(x_value)
+            geometry["y"] = float(y_value)
+            panel.clear_layout_mode()
+            self._apply_floating_geometry(panel, geometry)
+        if panel_id is not None:
+            self.bring_to_front(panel_id)
+        self._schedule_layout_changed()
 
     def resize_panel(self, panel_id: str, width: int, height: int) -> None:
         """Resize an existing panel and keep it visible."""

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import tkinter as tk
 from types import SimpleNamespace
 
-from modules.scenarios.gm_table.layout import fit_viewport_snap
+from modules.scenarios.gm_table.layout import (
+    equal_spacing,
+    fit_viewport_snap,
+    nearest_edge_snap,
+    pack_cluster,
+)
 from modules.scenarios.gm_table.workspace import (
     PANEL_GUTTER,
     PANEL_MARGIN,
@@ -341,6 +346,32 @@ class _FakeCanvas:
         self, x0: float, y0: float, x1: float, y1: float, **_kwargs
     ) -> None:
         self.rectangles.append((x0, y0, x1, y1))
+
+
+class _FakeGuideCanvas:
+    def __init__(self) -> None:
+        self.lines: list[tuple[float, float, float, float]] = []
+        self.placed = False
+        self.lifted = False
+        self.hidden = False
+
+    def delete(self, _tag: str) -> None:
+        self.lines = []
+
+    def create_line(
+        self, x0: float, y0: float, x1: float, y1: float, **_kwargs
+    ) -> None:
+        self.lines.append((x0, y0, x1, y1))
+
+    def place(self, **_kwargs) -> None:
+        self.placed = True
+        self.hidden = False
+
+    def lift(self) -> None:
+        self.lifted = True
+
+    def place_forget(self) -> None:
+        self.hidden = True
 
 
 def test_auto_arrange_preserves_large_scenario_panel_geometry() -> None:
@@ -1158,6 +1189,101 @@ def test_screen_to_world_projects_from_camera_and_zoom() -> None:
 
     assert world_x == 300.0
     assert world_y == 160.0
+
+
+def test_nearest_edge_snap_is_world_space_only() -> None:
+    """Edge snapping should produce the same world output regardless of camera state."""
+    active = {"x": 104.0, "y": 60.0, "width": 200, "height": 120}
+    candidates = [{"x": 300.0, "y": 64.0, "width": 220, "height": 120}]
+
+    result_a = nearest_edge_snap(active, candidates, threshold=12.0)
+    result_b = nearest_edge_snap(active, candidates, threshold=12.0)
+
+    assert result_a["x"] == 100.0
+    assert result_b["x"] == 100.0
+    assert result_a["y"] == result_b["y"] == 64.0
+    assert len(result_a["guides"]) == len(result_b["guides"]) == 2
+
+
+def test_align_left_keeps_same_world_result_with_camera_offset_and_zoom() -> None:
+    """World alignment actions should not depend on viewport camera transform."""
+    def _build_workspace(camera_x: float, camera_y: float, zoom: float):
+        workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+        panel_a = _FakePanel(260, 180, x=80, y=120)
+        panel_a.world_x = 480.0
+        panel_a.world_y = 220.0
+        panel_b = _FakePanel(260, 180, x=460, y=180)
+        panel_b.world_x = 760.0
+        panel_b.world_y = 300.0
+        workspace._panels = {"a": panel_a, "b": panel_b}
+        workspace._definitions = {
+            "a": PanelDefinition(panel_id="a", kind="note", title="A", state={}),
+            "b": PanelDefinition(panel_id="b", kind="note", title="B", state={}),
+        }
+        workspace._z_order = ["a", "b"]
+        workspace._schedule_layout_changed = lambda: None
+        _prepare_workspace(workspace, camera_x=camera_x, camera_y=camera_y, zoom=zoom)
+        return workspace
+
+    workspace_a = _build_workspace(0.0, 0.0, 1.0)
+    workspace_b = _build_workspace(420.0, 260.0, 1.35)
+
+    GMTableWorkspace.align_left(workspace_a)
+    GMTableWorkspace.align_left(workspace_b)
+
+    assert workspace_a._panels["a"].world_x == workspace_b._panels["a"].world_x == 480.0
+    assert workspace_a._panels["b"].world_x == workspace_b._panels["b"].world_x == 480.0
+
+
+def test_distribute_and_pack_are_world_space_consistent() -> None:
+    """Distribution and packing should produce deterministic world coordinates."""
+    rectangles = {
+        "a": {"x": 200.0, "y": 120.0, "width": 220, "height": 140},
+        "b": {"x": 620.0, "y": 160.0, "width": 180, "height": 140},
+        "c": {"x": 980.0, "y": 180.0, "width": 200, "height": 140},
+    }
+
+    distributed = equal_spacing(rectangles)
+    packed = pack_cluster(rectangles)
+
+    assert distributed["a"] == 200.0
+    assert distributed["c"] == 980.0
+    assert distributed["a"] < distributed["b"] < distributed["c"]
+    assert packed["a"] == (200.0, 120.0)
+    assert packed["b"][1] >= packed["a"][1]
+    assert packed["c"][1] >= packed["b"][1]
+
+
+def test_preview_snap_target_renders_world_alignment_guides() -> None:
+    """Dragging in floating mode should draw world-relative alignment guide lines."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    preview = _FakePreview()
+    label = _FakeLabel()
+    guide_canvas = _FakeGuideCanvas()
+    panel_a = _FakePanel(220, 140, x=260, y=120)
+    panel_a.world_x = 500.0
+    panel_a.world_y = 200.0
+    panel_b = _FakePanel(220, 140, x=520, y=190)
+    panel_b.world_x = 740.0
+    panel_b.world_y = 205.0
+    workspace._panels = {"a": panel_a, "b": panel_b}
+    workspace._definitions = {
+        "a": PanelDefinition(panel_id="a", kind="note", title="A", state={}),
+        "b": PanelDefinition(panel_id="b", kind="note", title="B", state={}),
+    }
+    workspace._z_order = ["b", "a"]
+    workspace._snap_preview = preview
+    workspace._snap_preview_label = label
+    workspace._alignment_guide_canvas = guide_canvas
+    workspace._nav_hud = _FakeLiftWidget()
+    workspace._minimap_shell = _FakeLiftWidget()
+    _prepare_workspace(workspace, camera_x=420, camera_y=180, zoom=1.0)
+
+    GMTableWorkspace.preview_snap_target(workspace, "a", None)
+
+    assert guide_canvas.placed is True
+    assert guide_canvas.lifted is True
+    assert len(guide_canvas.lines) >= 1
 
 
 def test_middle_button_pan_accepts_nested_panel_content_and_ignores_unrelated_widgets() -> (


### PR DESCRIPTION
### Motivation
- Provide world-coordinate alignment utilities (edge snapping, equal spacing, packing) so panels can align consistently independent of camera pan/zoom.  
- Surface those behaviors as workspace actions and quick-tray buttons to let users align multiple floating panels in world space.  
- Render non-intrusive alignment guides during drag so users get visual feedback in world coordinates projected to the viewport.

### Description
- Added a new module `modules/scenarios/gm_table/layout/world_alignment.py` with `nearest_edge_snap`, `equal_spacing`, `pack_cluster`, and an `AlignmentGuide` dataclass for world-space guide descriptors.  
- Exported the new helpers from `modules/scenarios/gm_table/layout/__init__.py` so they are available from the layout package.  
- Integrated a workspace overlay canvas and guide rendering into `GMTableWorkspace` in `modules/scenarios/gm_table/workspace.py`, including `_preview_world_alignment`, `_render_alignment_guides`, `_project_world_to_screen`, and `_clear_alignment_guides`.  
- Added panel actions and workspace tray buttons: `Align Left`, `Align Top`, `Distribute Horizontally`, and `Pack Cluster`, and implemented handlers `align_left`, `align_top`, `distribute_horizontally`, and `pack_cluster` on `GMTableWorkspace`.

### Testing
- Ran a syntax check with `python -m py_compile modules/scenarios/gm_table/layout/world_alignment.py modules/scenarios/gm_table/workspace.py tests/scenarios/gm_table/test_workspace.py` which succeeded.  
- Ran unit tests with `pytest -q tests/scenarios/gm_table/test_workspace.py`; logic and world-alignment tests passed, for a final run there were 50 tests passing and 2 failures which are display-dependent `tk.Tk()` tests (`test_mount_payload_widget_grids_direct_child_widget` and `test_mount_payload_widget_preserves_existing_geometry_manager`) failing in a headless CI environment due to missing `$DISPLAY`.  
- The world-alignment specific tests (nearest-edge snapping, equal spacing, pack clustering, and guide rendering) executed and validated camera/zoom independence and guide drawing behavior (passing in CI where not display-dependent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64c5ef6cc832baed96967ac74b77a)