### PR TITLE
Fix Tkinter raise error when rendering alignment guides

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -2177,7 +2177,7 @@ class GMTableWorkspace(ctk.CTkFrame):
                 x1, y1 = self._project_world_to_screen(guide.span_end, guide.world_value)
             canvas.create_line(x0, y0, x1, y1, fill=TABLE_PALETTE["panel_focus"], width=2, dash=(6, 4))
         canvas.place(relx=0.0, rely=0.0, relwidth=1.0, relheight=1.0)
-        canvas.lift()
+        canvas.tkraise()
         self._raise_workspace_overlays()
 
     def _clear_alignment_guides(self) -> None:


### PR DESCRIPTION
### Motivation
- Prevent a Tkinter crash when drawing world-space alignment guides by avoiding a call that invokes the canvas item/tag raise API without required arguments, which caused a `_tkinter.TclError`.

### Description
- Replace `canvas.lift()` with `canvas.tkraise()` in `modules/scenarios/gm_table/workspace.py` inside `_render_alignment_guides` so the guide Canvas widget is raised in the widget stacking order.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table/workspace.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65055e564832b9ce23fb57c1910a9)