### PR TITLE
Remove GM table tray quick-arrange controls and include snapped panels in alignment actions

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1233,9 +1233,6 @@ class GMTableWorkspace(ctk.CTkFrame):
 
         self.tray_buttons = ctk.CTkFrame(self.tray, fg_color="transparent")
         self.tray_buttons.grid(row=0, column=1, padx=(0, 12), pady=8, sticky="ew")
-        self.tray_actions = ctk.CTkFrame(self.tray, fg_color="transparent")
-        self.tray_actions.grid(row=0, column=2, padx=(0, 12), pady=8, sticky="e")
-        self._build_tray_actions()
 
         self._empty_state = ctk.CTkLabel(
             self.surface,
@@ -1250,34 +1247,6 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._refresh_desk_texture()
         self._refresh_minimap()
         self._refresh_minimized_tray()
-
-    def _build_tray_actions(self) -> None:
-        """Build quick world-alignment commands inside the tray."""
-        actions = (
-            ("Align Left", "align_left"),
-            ("Align Top", "align_top"),
-            ("Distribute Horizontally", "distribute_horizontal"),
-            ("Pack Cluster", "pack_cluster"),
-        )
-        frame = getattr(self, "tray_actions", None)
-        if frame is None:
-            return
-        for child in frame.winfo_children():
-            child.destroy()
-        for label, action in actions:
-            ctk.CTkButton(
-                frame,
-                text=label,
-                height=30,
-                fg_color=TABLE_PALETTE["table_chip"],
-                hover_color="#283146",
-                text_color=TABLE_PALETTE["text"],
-                corner_radius=12,
-                command=lambda value=action: self.handle_window_action(
-                    self.get_active_panel_id(include_minimized=False) or "",
-                    value,
-                ),
-            ).pack(side="left", padx=(0, 8))
 
     def _schedule_layout_changed(self) -> None:
         """Debounce layout persistence."""
@@ -2143,13 +2112,24 @@ class GMTableWorkspace(ctk.CTkFrame):
             records[panel_id] = self._floating_geometry_snapshot(panel)
         return records
 
+    def _arrangeable_world_geometries(self) -> dict[str, dict[str, float | int]]:
+        """Return world geometries for every visible panel that can be arranged."""
+        records: dict[str, dict[str, float | int]] = {}
+        order = list(getattr(self, "_z_order", []) or list(getattr(self, "_panels", {}).keys()))
+        for panel_id in order:
+            panel = self._panels.get(panel_id)
+            if panel is None or panel.layout_mode == "minimized":
+                continue
+            records[panel_id] = self._floating_geometry_snapshot(panel)
+        return records
+
     def _preview_world_alignment(self, panel_id: str) -> None:
         """Render live world-relative alignment guides for the active drag panel."""
         active = self._panels.get(panel_id)
         if active is None or active.layout_mode != "floating":
             self._clear_alignment_guides()
             return
-        floating = self._floating_world_geometries()
+        floating = self._arrangeable_world_geometries()
         active_geometry = floating.pop(panel_id, None)
         if active_geometry is None:
             self._clear_alignment_guides()
@@ -2199,8 +2179,8 @@ class GMTableWorkspace(ctk.CTkFrame):
         return x, y
 
     def align_left(self, panel_id: str | None = None) -> None:
-        """Align visible floating panels to the left edge of a reference panel."""
-        floating = self._floating_world_geometries()
+        """Align visible panels to the left edge of a reference panel."""
+        floating = self._arrangeable_world_geometries()
         if not floating:
             return
         anchor_id = panel_id if panel_id in floating else next(iter(floating.keys()))
@@ -2216,8 +2196,8 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._schedule_layout_changed()
 
     def align_top(self, panel_id: str | None = None) -> None:
-        """Align visible floating panels to the top edge of a reference panel."""
-        floating = self._floating_world_geometries()
+        """Align visible panels to the top edge of a reference panel."""
+        floating = self._arrangeable_world_geometries()
         if not floating:
             return
         anchor_id = panel_id if panel_id in floating else next(iter(floating.keys()))
@@ -2233,8 +2213,8 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._schedule_layout_changed()
 
     def distribute_horizontally(self, panel_id: str | None = None) -> None:
-        """Distribute floating panels with equal horizontal spacing."""
-        floating = self._floating_world_geometries()
+        """Distribute visible panels with equal horizontal spacing."""
+        floating = self._arrangeable_world_geometries()
         positions = equal_spacing(floating)
         if not positions:
             return
@@ -2251,8 +2231,8 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._schedule_layout_changed()
 
     def pack_cluster(self, panel_id: str | None = None) -> None:
-        """Pack floating panels into a compact world-space cluster."""
-        floating = self._floating_world_geometries()
+        """Pack visible panels into a compact world-space cluster."""
+        floating = self._arrangeable_world_geometries()
         placements = pack_cluster(floating)
         if not placements:
             return

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -370,6 +370,9 @@ class _FakeGuideCanvas:
     def lift(self) -> None:
         self.lifted = True
 
+    def tkraise(self) -> None:
+        self.lift()
+
     def place_forget(self) -> None:
         self.hidden = True
 
@@ -1233,6 +1236,48 @@ def test_align_left_keeps_same_world_result_with_camera_offset_and_zoom() -> Non
 
     assert workspace_a._panels["a"].world_x == workspace_b._panels["a"].world_x == 480.0
     assert workspace_a._panels["b"].world_x == workspace_b._panels["b"].world_x == 480.0
+
+
+def test_world_arrangement_actions_include_snapped_panels() -> None:
+    """Alignment and distribution actions should include snapped (non-minimized) panels."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    panel_a = _FakePanel(260, 180, x=120, y=140)
+    panel_a.world_x = 420.0
+    panel_a.world_y = 260.0
+    panel_b = _FakePanel(260, 180, x=740, y=360)
+    panel_b.world_x = 860.0
+    panel_b.world_y = 520.0
+    panel_c = _FakePanel(260, 180, x=980, y=420)
+    panel_c.world_x = 1100.0
+    panel_c.world_y = 560.0
+    panel_b.enter_layout_mode("right", {"x": 980, "y": 0, "width": 420, "height": 900})
+    workspace._panels = {"a": panel_a, "b": panel_b, "c": panel_c}
+    workspace._definitions = {
+        "a": PanelDefinition(panel_id="a", kind="note", title="A", state={}),
+        "b": PanelDefinition(panel_id="b", kind="note", title="B", state={}),
+        "c": PanelDefinition(panel_id="c", kind="note", title="C", state={}),
+    }
+    workspace._z_order = ["a", "b", "c"]
+    workspace._schedule_layout_changed = lambda: None
+    workspace.bring_to_front = lambda *_args, **_kwargs: None
+    _prepare_workspace(workspace, camera_x=120.0, camera_y=80.0, zoom=1.2)
+
+    GMTableWorkspace.align_left(workspace, "a")
+
+    assert workspace._panels["a"].world_x == 420.0
+    assert workspace._panels["b"].world_x == 420.0
+    assert workspace._panels["b"].layout_mode == "floating"
+
+    workspace._panels["b"].enter_layout_mode("left", {"x": 0, "y": 120, "width": 420, "height": 780})
+    GMTableWorkspace.align_top(workspace, "a")
+
+    assert workspace._panels["a"].world_y == 260.0
+    assert workspace._panels["b"].world_y == 260.0
+
+    workspace._panels["b"].enter_layout_mode("left", {"x": 0, "y": 120, "width": 420, "height": 780})
+    GMTableWorkspace.distribute_horizontally(workspace, "a")
+
+    assert workspace._panels["b"].layout_mode == "floating"
 
 
 def test_distribute_and_pack_are_world_space_consistent() -> None:


### PR DESCRIPTION
### Motivation
- Remove the small quick-arrange button strip in the GM virtual table tray (the Align/Distribute/Pack row shown in the screenshot) to declutter the UI.
- Fix alignment/distribution actions (`Align Left`, `Align Top`, `Distribute Horizontally`, `Pack Cluster`) so they actually operate on all visible panels (including snapped/non-floating panels) rather than only on already-floating panels.

### Description
- Removed the tray quick-action frame and its `_build_tray_actions` usage so the button strip is no longer rendered in the tray (`modules/scenarios/gm_table/workspace.py`).
- Added `_arrangeable_world_geometries()` which returns world geometries for every visible, non-minimized panel, and used it from `align_left`, `align_top`, `distribute_horizontally`, and `pack_cluster` so snapped panels are included in arrangements (`modules/scenarios/gm_table/workspace.py`).
- Small docstring clarifications for the affected arrange functions to reflect they act on visible panels.
- Test updates: added `test_world_arrangement_actions_include_snapped_panels` to cover the regression and updated the `_FakeGuideCanvas` test double to support `tkraise()` so guide rendering tests don't error (`tests/scenarios/gm_table/test_workspace.py`).

### Testing
- Ran targeted tests with `pytest -q tests/scenarios/gm_table/test_workspace.py -k "world_arrangement_actions_include_snapped_panels or align_left_keeps_same_world_result_with_camera_offset_and_zoom or preview_snap_target_renders_world_alignment_guides or distribute_and_pack_are_world_space_consistent"` and after addressing test failures the focused run completed successfully (`4 passed`).
- Note: running the full GUI test file in a headless CI environment will raise Tk/Tcl display errors (`no $DISPLAY`); the changes themselves were validated via the focused test runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e651dfe0b0832b97e0111795fbc6c5)