### PR TITLE
Wrap scene entity chips into responsive multi-row grid

### DIFF
--- a/modules/scenarios/widgets/scene_body/entities_group_card.py
+++ b/modules/scenarios/widgets/scene_body/entities_group_card.py
@@ -7,6 +7,9 @@ import customtkinter as ctk
 from modules.scenarios.widgets.entity_chips import create_entity_chip
 from .constants import DEFAULT_VISIBLE_CHIPS
 
+CHIP_HORIZONTAL_GAP = 6
+CHIP_VERTICAL_GAP = 6
+
 
 def create_entities_group_card(
     parent,
@@ -52,16 +55,21 @@ def create_entities_group_card(
     initial_entities = entities[:max_visible]
     hidden_entities = entities[max_visible:]
 
+    initial_chips = []
     for entity_payload in initial_entities:
-        create_entity_chip(
-            chips_container,
-            group_label=group_label,
-            entity_payload=entity_payload,
-            palette=palette,
-            open_entity_callback=open_entity_callback,
-        ).pack(side="left", padx=(0, 6), pady=(0, 6))
+        initial_chips.append(
+            create_entity_chip(
+                chips_container,
+                group_label=group_label,
+                entity_payload=entity_payload,
+                palette=palette,
+                open_entity_callback=open_entity_callback,
+            )
+        )
 
     if not hidden_entities:
+        _reflow_chips(chips_container, initial_chips)
+        chips_container.bind("<Configure>", lambda _event: _reflow_chips(chips_container, initial_chips), add="+")
         return card
 
     hidden_chips = []
@@ -89,25 +97,62 @@ def create_entities_group_card(
         font=ctk.CTkFont(size=12, weight="bold"),
     )
 
-    def _pack_toggle_button():
-        """Pack toggle button."""
-        toggle_button.pack_forget()
-        toggle_button.pack(side="left", padx=(0, 6), pady=(0, 6))
+    show_all = False
+
+    def _visible_widgets():
+        """Return visible widgets in display order."""
+        if show_all:
+            return [*initial_chips, *hidden_chips, toggle_button]
+        return [*initial_chips, toggle_button]
 
     def _show_less():
         """Show less."""
-        for hidden_chip in hidden_chips:
-            hidden_chip.pack_forget()
+        nonlocal show_all
+        show_all = False
         toggle_button.configure(text=f"+{len(hidden_chips)} more", command=_show_more)
-        _pack_toggle_button()
+        _reflow_chips(chips_container, _visible_widgets())
 
     def _show_more():
         """Show more."""
-        toggle_button.pack_forget()
-        for hidden_chip in hidden_chips:
-            hidden_chip.pack(side="left", padx=(0, 6), pady=(0, 6))
+        nonlocal show_all
+        show_all = True
         toggle_button.configure(text="Show less", command=_show_less)
-        toggle_button.pack(side="left", padx=(0, 6), pady=(0, 6))
+        _reflow_chips(chips_container, _visible_widgets())
 
+    chips_container.bind("<Configure>", lambda _event: _reflow_chips(chips_container, _visible_widgets()), add="+")
     _show_less()
     return card
+
+
+def _reflow_chips(chips_container, widgets):
+    """Reflow chips into a wrapping grid according to container width."""
+    if not widgets:
+        return
+
+    chips_container.update_idletasks()
+    container_width = max(chips_container.winfo_width(), chips_container.winfo_reqwidth(), 1)
+    columns = _estimate_columns(container_width, widgets)
+
+    for widget in chips_container.winfo_children():
+        try:
+            widget.grid_forget()
+        except Exception:
+            continue
+
+    for index, widget in enumerate(widgets):
+        widget.grid(
+            row=index // columns,
+            column=index % columns,
+            padx=(0, CHIP_HORIZONTAL_GAP),
+            pady=(0, CHIP_VERTICAL_GAP),
+            sticky="w",
+        )
+
+
+def _estimate_columns(container_width, widgets):
+    """Estimate how many chips can fit in one row."""
+    width_hints = [max(widget.winfo_reqwidth(), 1) for widget in widgets]
+    if not width_hints:
+        return 1
+    average_chip_width = max(80, sum(width_hints) // len(width_hints))
+    return max(1, container_width // (average_chip_width + CHIP_HORIZONTAL_GAP))

--- a/tests/scenarios/test_entities_group_card.py
+++ b/tests/scenarios/test_entities_group_card.py
@@ -1,0 +1,68 @@
+"""Tests for entities group card layout helpers."""
+
+from modules.scenarios.widgets.scene_body.entities_group_card import _estimate_columns, _reflow_chips
+
+
+class _FakeWidget:
+    def __init__(self, reqwidth: int) -> None:
+        self._reqwidth = reqwidth
+        self.grid_calls = []
+        self.grid_forget_calls = 0
+
+    def winfo_reqwidth(self) -> int:
+        return self._reqwidth
+
+    def grid_forget(self) -> None:
+        self.grid_forget_calls += 1
+
+    def grid(self, **kwargs) -> None:
+        self.grid_calls.append(kwargs)
+
+
+class _FakeContainer:
+    def __init__(self, width: int, children: list[_FakeWidget]) -> None:
+        self._width = width
+        self._children = children
+
+    def update_idletasks(self) -> None:
+        return None
+
+    def winfo_width(self) -> int:
+        return self._width
+
+    def winfo_reqwidth(self) -> int:
+        return self._width
+
+    def winfo_children(self) -> list[_FakeWidget]:
+        return self._children
+
+
+def test_estimate_columns_respects_narrow_viewport() -> None:
+    """Narrow containers should reduce chip columns."""
+    widgets = [_FakeWidget(120), _FakeWidget(130), _FakeWidget(125)]
+
+    columns = _estimate_columns(220, widgets)
+
+    assert columns == 1
+
+
+def test_reflow_chips_places_all_entities_and_toggle_in_order() -> None:
+    """The final "+N more" control should be the last visible grid element."""
+    visible_widgets = [
+        _FakeWidget(110),
+        _FakeWidget(115),
+        _FakeWidget(120),
+        _FakeWidget(118),
+    ]
+    toggle_widget = _FakeWidget(90)
+    ordered_widgets = [*visible_widgets, toggle_widget]
+    container = _FakeContainer(width=250, children=ordered_widgets)
+
+    _reflow_chips(container, ordered_widgets)
+
+    for widget in ordered_widgets:
+        assert widget.grid_calls, "Every visible item should be placed in the grid"
+
+    last_call = toggle_widget.grid_calls[-1]
+    assert last_call["row"] >= 1, "Narrow viewport should wrap to multiple rows"
+    assert last_call["column"] == 0, "Toggle button should remain the last grid item"


### PR DESCRIPTION
### Motivation
- Les chips d'entités utilisaient `pack(side="left")` et ne se wrappaient pas automatiquement en viewport étroit, rendant des entités inaccessibles; l'objectif est d'ajouter un comportement de wrapping réactif.

### Description
- Remplacement du positionnement horizontal par défaut dans `create_entities_group_card` par un reflow en grille via la nouvelle fonction `_reflow_chips` qui calcule les colonnes selon `chips_container.winfo_width()` et place les widgets avec `grid(row, column)`.
- Ajout de l'aide `_estimate_columns` et des constantes `CHIP_HORIZONTAL_GAP`/`CHIP_VERTICAL_GAP` pour estimer la largeur et espacer les chips.
- Le reflow est déclenché au rendu initial et sur resize via `chips_container.bind("<Configure>", ...)`, et la logique `visible_limit` / `hidden_entities` est conservée avec un `_visible_widgets()` qui garantit que le bouton `+N more`/`Show less` reste le dernier élément rendu.
- Aucun changement dans la chaîne d'appel existante (`build_scene_body_sections` → `create_entities_groups_grid` → `create_entities_group_card`), donc GM Screen et GM Table héritent du nouveau comportement automatiquement.

### Testing
- Ajout d'un test ciblé `tests/scenarios/test_entities_group_card.py` qui vérifie `_estimate_columns` et que `_reflow_chips` positionne tous les widgets et maintient le toggle en fin d'ordre.
- Lancement des tests automatisés ciblés avec `pytest -q tests/scenarios/test_entities_group_card.py tests/scenarios/test_scene_body_sections.py` a retourné `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65333e40c832b9f3a24de4e3122e1)