### PR TITLE
Fix Tkinter canvas raise crash in GM table alignment preview

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -2139,7 +2139,7 @@ class GMTableWorkspace(ctk.CTkFrame):
                 x1, y1 = self._project_world_to_screen(guide.span_end, guide.world_value)
             canvas.create_line(x0, y0, x1, y1, fill=TABLE_PALETTE["panel_focus"], width=2, dash=(6, 4))
         canvas.place(relx=0.0, rely=0.0, relwidth=1.0, relheight=1.0)
-        canvas.tkraise()
+        canvas.lift()
         self._raise_workspace_overlays()
 
     def _clear_alignment_guides(self) -> None:


### PR DESCRIPTION
### Motivation
- Prevent repeated `_tkinter.TclError` crashes during panel drag/resize snap preview caused by calling the Canvas item-raising API with no arguments.

### Description
- Replaced `canvas.tkraise()` with `canvas.lift()` in `_render_alignment_guides` in `modules/scenarios/gm_table/workspace.py` to use the widget stacking API that accepts no arguments and preserves overlay behavior.

### Testing
- Compiled the module with `python -m py_compile modules/scenarios/gm_table/workspace.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65737ec78832b86cac2850c6d9919)