### PR TITLE
Fix Tkinter canvas raise error in GM table alignment guides

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -2139,7 +2139,7 @@ class GMTableWorkspace(ctk.CTkFrame):
                 x1, y1 = self._project_world_to_screen(guide.span_end, guide.world_value)
             canvas.create_line(x0, y0, x1, y1, fill=TABLE_PALETTE["panel_focus"], width=2, dash=(6, 4))
         canvas.place(relx=0.0, rely=0.0, relwidth=1.0, relheight=1.0)
-        canvas.lift()
+        canvas.tkraise()
         self._raise_workspace_overlays()
 
     def _clear_alignment_guides(self) -> None:


### PR DESCRIPTION
### Motivation
- During drag preview, calling `canvas.lift()` triggered `_tkinter.TclError: wrong # args ... raise tagOrId` on Python/Tkinter because `Canvas.lift()` resolves to item-raise and expects an item/tag argument.

### Description
- Replace `canvas.lift()` with the widget-level `canvas.tkraise()` in `_render_alignment_guides` in `modules/scenarios/gm_table/workspace.py` so the overlay canvas is raised correctly without invoking `Canvas.tag_raise`.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table/workspace.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e659350a24832b93f6d94ef27458de)