### PR TITLE
Wrap entity chips in responsive grid with reflow and toggle

### DIFF
--- a/modules/scenarios/widgets/scene_body/entities_group_card.py
+++ b/modules/scenarios/widgets/scene_body/entities_group_card.py
@@ -8,6 +8,30 @@ from modules.scenarios.widgets.entity_chips import create_entity_chip
 from .constants import DEFAULT_VISIBLE_CHIPS
 
 
+CHIP_GAP_X = 6
+CHIP_GAP_Y = 6
+FALLBACK_CHIP_WIDTH = 120
+
+
+def _estimate_columns(container_width: int, widgets) -> int:
+    """Estimate how many chips can fit in a single row."""
+    if container_width <= 0:
+        return 1
+    sample_widths = []
+    for widget in widgets:
+        try:
+            width = int(widget.winfo_reqwidth())
+        except Exception:
+            width = 0
+        if width > 0:
+            sample_widths.append(width)
+    if not sample_widths:
+        return 1
+    average_width = max(FALLBACK_CHIP_WIDTH, int(sum(sample_widths) / len(sample_widths)))
+    per_chip = max(1, average_width + CHIP_GAP_X)
+    return max(1, container_width // per_chip)
+
+
 def create_entities_group_card(
     parent,
     *,
@@ -52,62 +76,99 @@ def create_entities_group_card(
     initial_entities = entities[:max_visible]
     hidden_entities = entities[max_visible:]
 
+    initial_chips = []
     for entity_payload in initial_entities:
-        create_entity_chip(
+        initial_chip = create_entity_chip(
             chips_container,
             group_label=group_label,
             entity_payload=entity_payload,
             palette=palette,
             open_entity_callback=open_entity_callback,
-        ).pack(side="left", padx=(0, 6), pady=(0, 6))
-
-    if not hidden_entities:
-        return card
+        )
+        initial_chips.append(initial_chip)
 
     hidden_chips = []
     for hidden_payload in hidden_entities:
-        hidden_chip = create_entity_chip(
-            chips_container,
-            group_label=group_label,
-            entity_payload=hidden_payload,
-            palette=palette,
-            open_entity_callback=open_entity_callback,
+        hidden_chips.append(
+            create_entity_chip(
+                chips_container,
+                group_label=group_label,
+                entity_payload=hidden_payload,
+                palette=palette,
+                open_entity_callback=open_entity_callback,
+            )
         )
-        hidden_chips.append(hidden_chip)
 
-    toggle_button = ctk.CTkButton(
-        chips_container,
-        text="",
-        width=0,
-        height=28,
-        corner_radius=999,
-        fg_color=palette["pill_bg"],
-        hover_color=palette["surface_card"],
-        text_color=palette["muted_text"],
-        border_width=1,
-        border_color=palette["pill_border"],
-        font=ctk.CTkFont(size=12, weight="bold"),
-    )
+    toggle_button = None
+    is_expanded = False
+    if hidden_chips:
+        toggle_button = ctk.CTkButton(
+            chips_container,
+            text="",
+            width=0,
+            height=28,
+            corner_radius=999,
+            fg_color=palette["pill_bg"],
+            hover_color=palette["surface_card"],
+            text_color=palette["muted_text"],
+            border_width=1,
+            border_color=palette["pill_border"],
+            font=ctk.CTkFont(size=12, weight="bold"),
+        )
 
-    def _pack_toggle_button():
-        """Pack toggle button."""
-        toggle_button.pack_forget()
-        toggle_button.pack(side="left", padx=(0, 6), pady=(0, 6))
+    all_widgets = [*initial_chips, *hidden_chips]
+    if toggle_button is not None:
+        all_widgets.append(toggle_button)
+
+    def _visible_widgets():
+        """Return widgets visible in current state."""
+        if is_expanded:
+            visible = [*initial_chips, *hidden_chips]
+        else:
+            visible = [*initial_chips]
+        if toggle_button is not None:
+            visible.append(toggle_button)
+        return visible
+
+    def _reflow_chips(_event=None):
+        """Place chips in a wrapping grid based on container width."""
+        if not chips_container.winfo_exists():
+            return
+        width = int(chips_container.winfo_width() or 0)
+        visible_widgets = _visible_widgets()
+        for widget in all_widgets:
+            widget.grid_forget()
+        if not visible_widgets:
+            return
+
+        columns = _estimate_columns(width, visible_widgets)
+        for col in range(columns):
+            chips_container.grid_columnconfigure(col, weight=0)
+
+        for index, widget in enumerate(visible_widgets):
+            row = index // columns
+            col = index % columns
+            widget.grid(row=row, column=col, sticky="w", padx=(0, CHIP_GAP_X), pady=(0, CHIP_GAP_Y))
 
     def _show_less():
         """Show less."""
-        for hidden_chip in hidden_chips:
-            hidden_chip.pack_forget()
-        toggle_button.configure(text=f"+{len(hidden_chips)} more", command=_show_more)
-        _pack_toggle_button()
+        nonlocal is_expanded
+        is_expanded = False
+        if toggle_button is not None:
+            toggle_button.configure(text=f"+{len(hidden_chips)} more", command=_show_more)
+        _reflow_chips()
 
     def _show_more():
         """Show more."""
-        toggle_button.pack_forget()
-        for hidden_chip in hidden_chips:
-            hidden_chip.pack(side="left", padx=(0, 6), pady=(0, 6))
-        toggle_button.configure(text="Show less", command=_show_less)
-        toggle_button.pack(side="left", padx=(0, 6), pady=(0, 6))
+        nonlocal is_expanded
+        is_expanded = True
+        if toggle_button is not None:
+            toggle_button.configure(text="Show less", command=_show_less)
+        _reflow_chips()
 
-    _show_less()
+    chips_container.bind("<Configure>", _reflow_chips, add="+")
+    chips_container.after_idle(_reflow_chips)
+
+    if hidden_chips:
+        _show_less()
     return card

--- a/tests/scenarios/test_entities_group_card.py
+++ b/tests/scenarios/test_entities_group_card.py
@@ -1,0 +1,127 @@
+"""Tests for entities group card chip reflow behavior."""
+
+from modules.scenarios.widgets.scene_body import entities_group_card as subject
+
+
+class _FakeWidget:
+    def __init__(self, parent=None, width=80, **_kwargs):
+        self.parent = parent
+        self.width = width
+        self.exists = True
+        self.children = []
+        self.bound = {}
+        self.grid_info = None
+        self.config = {}
+        if parent is not None and hasattr(parent, "children"):
+            parent.children.append(self)
+
+    def pack(self, *args, **kwargs):
+        return None
+
+    def pack_forget(self, *args, **kwargs):
+        return None
+
+    def grid(self, *args, **kwargs):
+        self.grid_info = kwargs
+
+    def grid_forget(self, *args, **kwargs):
+        self.grid_info = None
+
+    def bind(self, sequence, callback, add=None):
+        self.bound[sequence] = callback
+
+    def after_idle(self, callback):
+        callback()
+
+    def winfo_width(self):
+        return self.width
+
+    def winfo_reqwidth(self):
+        return self.width
+
+    def winfo_exists(self):
+        return self.exists
+
+    def grid_columnconfigure(self, *args, **kwargs):
+        return None
+
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+
+class _FakeFrame(_FakeWidget):
+    pass
+
+
+class _FakeLabel(_FakeWidget):
+    pass
+
+
+class _FakeButton(_FakeWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.config.update(kwargs)
+
+
+class _FakeFont:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _install_fake_ctk(monkeypatch):
+    fake_ctk = type(
+        "_FakeCTk",
+        (),
+        {
+            "CTkFrame": _FakeFrame,
+            "CTkLabel": _FakeLabel,
+            "CTkButton": _FakeButton,
+            "CTkFont": _FakeFont,
+        },
+    )
+    monkeypatch.setattr(subject, "ctk", fake_ctk)
+
+
+def test_estimate_columns_uses_container_width():
+    chips = [_FakeWidget(width=90), _FakeWidget(width=100), _FakeWidget(width=110)]
+
+    assert subject._estimate_columns(280, chips) == 2
+
+
+def test_group_card_reflow_keeps_hidden_entities_accessible_in_narrow_viewport(monkeypatch):
+    _install_fake_ctk(monkeypatch)
+
+    def _fake_create_entity_chip(parent, **_kwargs):
+        return _FakeWidget(parent=parent, width=90)
+
+    monkeypatch.setattr(subject, "create_entity_chip", _fake_create_entity_chip)
+
+    palette = {
+        "surface_overlay": "#111",
+        "pill_border": "#222",
+        "text": "#fff",
+        "muted_text": "#888",
+        "pill_bg": "#333",
+        "surface_card": "#444",
+    }
+
+    root = _FakeFrame(width=300)
+    card = subject.create_entities_group_card(
+        root,
+        group_label="NPCs",
+        entities=[{"name": f"E{i}"} for i in range(5)],
+        palette=palette,
+        visible_limit=3,
+    )
+
+    chips_container = card.children[1]
+    toggle = next(widget for widget in chips_container.children if isinstance(widget, _FakeButton))
+
+    collapsed_visible = [child for child in chips_container.children if child.grid_info is not None]
+    assert len(collapsed_visible) == 4  # 3 chips + toggle
+
+    toggle.config["command"]()
+
+    expanded_visible = [child for child in chips_container.children if child.grid_info is not None]
+    assert len(expanded_visible) == 6  # 5 chips + toggle
+    assert toggle.config["text"] == "Show less"


### PR DESCRIPTION
### Motivation
- Improve chip layout so entity chips wrap automatically instead of using `pack(side="left")`, making the UI responsive on narrow viewports.
- Keep the existing `visible_limit` / hidden-entities toggle behaviour while ensuring the `+N more` button remains the last item in the layout.

### Description
- Replace left-packed chips in `modules/scenarios/widgets/scene_body/entities_group_card.py` with a wrapping grid driven by a new `_reflow_chips` handler bound to `<Configure>` and triggered on initial render via `after_idle`.
- Add `_estimate_columns` to compute columns from `chips_container.winfo_width()` and chip `winfo_reqwidth()`; constants `CHIP_GAP_X`, `CHIP_GAP_Y`, and `FALLBACK_CHIP_WIDTH` control spacing and sizing.
- Preserve `visible_limit` logic and hidden entities toggle, implemented so the toggle button (`+N more` / `Show less`) is always appended as the last widget in the visible grid.
- Add a focused widget-level test `tests/scenarios/test_entities_group_card.py` that fakes CTk widgets to validate reflow behaviour and access to hidden entities in narrow viewports.

### Testing
- Added and ran `pytest -q tests/scenarios/test_entities_group_card.py tests/scenarios/test_scene_body_sections.py` which completed successfully.
- Test summary: `5 passed` (all executed tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e660ad606c832b821c8ba79b8b373a)