### PR TITLE
Redesign scene display briefing layout for GM Screen and GM Table

### DIFF
--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -5,6 +5,7 @@ from customtkinter import CTkLabel
 from modules.generic.detail_ui import get_detail_palette
 from modules.scenarios.scene_structured_fields import parse_scene_sections_with_structured_fallback
 from modules.scenarios.widgets.scene_body import create_entities_groups_grid, prepare_entities_for_group
+from modules.scenarios.widgets.scene_briefing_layout import create_scene_briefing_layout
 from modules.scenarios.widgets.scene_density import get_scene_density_style
 
 
@@ -154,7 +155,15 @@ def _render_card_bullets(container, items, *, expanded, font_size):
     _refresh_wrap()
 
 
-def _create_description_block(parent, body_text, *, scene_dict=None, description_font_size=13):
+def _create_description_block(
+    parent,
+    body_text,
+    *,
+    scene_dict=None,
+    description_font_size=13,
+    npc_names=None,
+    place_names=None,
+):
     """Create description block."""
     palette = get_detail_palette()
     parsed = parse_scene_sections_with_structured_fallback(scene_dict or {}, body_text)
@@ -258,6 +267,43 @@ def _create_description_block(parent, body_text, *, scene_dict=None, description
                 refresh()
 
             toggle.configure(command=_toggle_section)
+
+    section_lookup = {
+        str(section.get("key") or "").strip().lower(): section
+        for section in (parsed.get("sections") or [])
+    }
+    clue_items = list((section_lookup.get("clues/hooks") or {}).get("items") or [])
+    event_items = []
+    for key in ("conflicts/obstacles", "key beats", "transitions"):
+        # Process each key from ('conflicts/obstacles', 'key beats', 'transitions').
+        event_items.extend((section_lookup.get(key) or {}).get("items") or [])
+
+    scene_npcs = list(npc_names or [])
+    for key in ("SceneNPCs", "NPCs", "npcs"):
+        # Process each key from ('SceneNPCs', 'NPCs', 'npcs').
+        value = (scene_dict or {}).get(key)
+        if isinstance(value, list):
+            scene_npcs.extend(value)
+        elif value:
+            scene_npcs.append(value)
+
+    scene_places = list(place_names or [])
+    for key in ("SceneLocations", "Places", "places"):
+        # Process each key from ('SceneLocations', 'Places', 'places').
+        value = (scene_dict or {}).get(key)
+        if isinstance(value, list):
+            scene_places.extend(value)
+        elif value:
+            scene_places.append(value)
+
+    create_scene_briefing_layout(
+        description_block,
+        npc_names=[str(item) for item in scene_npcs],
+        place_names=[str(item) for item in scene_places],
+        clue_lines=[str(item) for item in clue_items],
+        event_lines=[str(item) for item in event_items],
+        palette=palette,
+    )
 
     def _refresh_hero_wrap(_event=None):
         """Refresh hero wrap."""
@@ -468,6 +514,8 @@ def build_scene_body_sections(
         body_text,
         scene_dict=scene_dict,
         description_font_size=density_style["description_font_size"],
+        npc_names=npc_names,
+        place_names=place_names,
     )
     if has_entities or has_maps or has_links:
         _add_subtle_separator(shell)

--- a/modules/scenarios/widgets/scene_briefing_layout.py
+++ b/modules/scenarios/widgets/scene_briefing_layout.py
@@ -1,0 +1,102 @@
+"""Scene briefing layout widgets used by GM scene cards."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+def _normalize_lines(values) -> list[str]:
+    """Return cleaned non-empty lines."""
+    items: list[str] = []
+    for value in values or []:
+        text = " ".join(str(value or "").split()).strip()
+        if text:
+            items.append(text)
+    return items
+
+
+def _create_column(parent, *, title: str, lines: list[str], palette: dict, empty_text: str = "—") -> None:
+    """Create one briefing column."""
+    col = ctk.CTkFrame(
+        parent,
+        fg_color="transparent",
+        border_width=1,
+        border_color=palette["muted_border"],
+        corner_radius=12,
+    )
+    col.pack(side="left", fill="both", expand=True, padx=4, pady=0)
+
+    ctk.CTkLabel(
+        col,
+        text=title.upper(),
+        anchor="w",
+        text_color=palette["muted_text"],
+        font=ctk.CTkFont(size=10, weight="bold"),
+    ).pack(fill="x", padx=10, pady=(9, 6))
+
+    body = ctk.CTkFrame(col, fg_color="transparent")
+    body.pack(fill="both", expand=True, padx=10, pady=(0, 10))
+
+    rendered = _normalize_lines(lines)[:6]
+    if not rendered:
+        ctk.CTkLabel(
+            body,
+            text=empty_text,
+            anchor="w",
+            justify="left",
+            text_color=palette["muted_text"],
+            font=ctk.CTkFont(size=12, slant="italic"),
+        ).pack(fill="x", pady=(0, 5))
+        return
+
+    labels = []
+    for line in rendered:
+        label = ctk.CTkLabel(
+            body,
+            text=f"• {line}",
+            anchor="w",
+            justify="left",
+            text_color=palette["text"],
+            font=ctk.CTkFont(size=12),
+            wraplength=0,
+        )
+        label.pack(fill="x", pady=(0, 5))
+        labels.append(label)
+
+    def _refresh_wrap(_event=None):
+        """Refresh column wrap lengths."""
+        wrap_px = max(180, int(body.winfo_width()) - 8)
+        for current in labels:
+            current.configure(wraplength=wrap_px)
+
+    body.bind("<Configure>", _refresh_wrap, add="+")
+    _refresh_wrap()
+
+
+def create_scene_briefing_layout(
+    parent,
+    *,
+    npc_names: list[str],
+    place_names: list[str],
+    clue_lines: list[str],
+    event_lines: list[str],
+    palette: dict,
+) -> ctk.CTkFrame:
+    """Create a 4-column scene intel strip inspired by the design mockup."""
+    board = ctk.CTkFrame(
+        parent,
+        fg_color=palette["surface_card"],
+        corner_radius=14,
+        border_width=1,
+        border_color=palette["muted_border"],
+    )
+    board.pack(fill="x", padx=12, pady=(4, 10))
+
+    columns = ctk.CTkFrame(board, fg_color="transparent")
+    columns.pack(fill="x", padx=8, pady=8)
+
+    _create_column(columns, title="NPCs in scene", lines=npc_names, palette=palette)
+    _create_column(columns, title="Places", lines=place_names, palette=palette)
+    _create_column(columns, title="Clues", lines=clue_lines, palette=palette)
+    _create_column(columns, title="Events & triggers", lines=event_lines, palette=palette)
+    return board


### PR DESCRIPTION
## Summary
- added a dedicated `scene_briefing_layout` widget module under `modules/scenarios/widgets/` to keep the scene UI architecture modular
- updated the scene body renderer to insert a new four-column scene briefing strip inspired by the screenshot
- populated the new strip with NPCs, places, clues, and events/triggers derived from structured scene fields and parsed sections
- wired fallback data sources so NPC/place columns still populate from scene-level linked entities

## Why
The scene display in scenario details now more closely matches the requested tactical panel style for both GM Screen and GM Virtual Desk, since both surfaces render scenario scene cards through the shared scene-body widgets.

## Validation
- `python -m py_compile modules/scenarios/widgets/scene_body_sections.py modules/scenarios/widgets/scene_briefing_layout.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66cb2766c832bb93ee785c3390aa0)