### PR TITLE
Default scene description to compact mode and add details toggle

### DIFF
--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -195,8 +195,24 @@ def _create_description_block(
     )
     description_label.pack(fill="x", padx=12, pady=(10, 10))
 
+    full_view_visible = ctk.BooleanVar(master=description_block, value=False)
+
+    detail_toggle = ctk.CTkButton(
+        description_block,
+        text="Voir le détail",
+        height=26,
+        corner_radius=8,
+        fg_color="transparent",
+        hover_color=palette["surface_overlay"],
+        text_color=palette["accent"],
+        border_width=1,
+        border_color=palette["pill_border"],
+    )
+    detail_toggle.pack(anchor="w", padx=12, pady=(0, 8))
+
     cards_grid = ctk.CTkFrame(description_block, fg_color="transparent")
     cards_grid.pack(fill="x", padx=12, pady=(0, 10))
+    cards_grid.pack_forget()
     cards_grid.grid_columnconfigure(0, weight=1)
     cards_grid.grid_columnconfigure(1, weight=1)
 
@@ -267,6 +283,23 @@ def _create_description_block(
                 refresh()
 
             toggle.configure(command=_toggle_section)
+
+    def _sync_full_view():
+        """Sync full view visibility."""
+        if full_view_visible.get():
+            cards_grid.pack(fill="x", padx=12, pady=(0, 10))
+            detail_toggle.configure(text="Masquer le détail")
+        else:
+            cards_grid.pack_forget()
+            detail_toggle.configure(text="Voir le détail")
+
+    def _toggle_full_view():
+        """Toggle full view visibility."""
+        full_view_visible.set(not full_view_visible.get())
+        _sync_full_view()
+
+    detail_toggle.configure(command=_toggle_full_view)
+    _sync_full_view()
 
     section_lookup = {
         str(section.get("key") or "").strip().lower(): section


### PR DESCRIPTION
### Motivation
- The scene description should present a compact hero/strip first and keep the detailed cards hidden by default to reduce visual clutter.
- The change only affects presentation/default visibility while preserving existing parsing and section extraction behavior.

### Description
- Introduced a local UI state variable `full_view_visible = ctk.BooleanVar(master=description_block, value=False)` to track compact vs full presentation.
- Added a `detail_toggle` button and `_toggle_full_view` / `_sync_full_view` functions to show/hide the detailed `cards_grid` and update the button label accordingly.
- Hid the `cards_grid` on initial render with `cards_grid.pack_forget()` and left `parse_scene_sections_with_structured_fallback` and all parsing logic unchanged.

### Testing
- Ran `python -m py_compile modules/scenarios/widgets/scene_body_sections.py`, which succeeded.
- Committed the change with a descriptive message, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e679efb538832bbe80d8bc4548eb8f)