### PR TITLE
Restyle scene body entity briefing to match mockup

### DIFF
--- a/modules/scenarios/widgets/scene_briefing_layout.py
+++ b/modules/scenarios/widgets/scene_briefing_layout.py
@@ -15,16 +15,34 @@ def _normalize_lines(values) -> list[str]:
     return items
 
 
-def _create_column(parent, *, title: str, lines: list[str], palette: dict, empty_text: str = "—") -> None:
-    """Create one briefing column."""
-    col = ctk.CTkFrame(
+def _create_row(parent, *, line: str, palette: dict, icon: str = "•", emphasized: bool = False) -> ctk.CTkLabel:
+    """Create one line row inside a scene briefing column."""
+    row = ctk.CTkLabel(
         parent,
-        fg_color="transparent",
-        border_width=1,
-        border_color=palette["muted_border"],
-        corner_radius=12,
+        text=f"{icon}  {line}",
+        anchor="w",
+        justify="left",
+        text_color=palette["text"] if emphasized else palette["muted_text"],
+        font=ctk.CTkFont(size=12, weight="bold" if emphasized else "normal"),
+        wraplength=0,
     )
-    col.pack(side="left", fill="both", expand=True, padx=4, pady=0)
+    row.pack(fill="x", pady=(0, 6))
+    return row
+
+
+def _create_column(
+    parent,
+    *,
+    title: str,
+    lines: list[str],
+    palette: dict,
+    empty_text: str = "—",
+    row_icon: str = "•",
+    footer_text: str | None = None,
+) -> None:
+    """Create one briefing column."""
+    col = ctk.CTkFrame(parent, fg_color="transparent")
+    col.pack(side="left", fill="both", expand=True, padx=12, pady=0)
 
     ctk.CTkLabel(
         col,
@@ -32,45 +50,58 @@ def _create_column(parent, *, title: str, lines: list[str], palette: dict, empty
         anchor="w",
         text_color=palette["muted_text"],
         font=ctk.CTkFont(size=10, weight="bold"),
-    ).pack(fill="x", padx=10, pady=(9, 6))
+    ).pack(fill="x", pady=(2, 10))
 
     body = ctk.CTkFrame(col, fg_color="transparent")
-    body.pack(fill="both", expand=True, padx=10, pady=(0, 10))
+    body.pack(fill="both", expand=True)
 
     rendered = _normalize_lines(lines)[:6]
-    if not rendered:
-        ctk.CTkLabel(
-            body,
-            text=empty_text,
-            anchor="w",
-            justify="left",
-            text_color=palette["muted_text"],
-            font=ctk.CTkFont(size=12, slant="italic"),
-        ).pack(fill="x", pady=(0, 5))
-        return
-
     labels = []
-    for line in rendered:
-        label = ctk.CTkLabel(
-            body,
-            text=f"• {line}",
-            anchor="w",
-            justify="left",
-            text_color=palette["text"],
-            font=ctk.CTkFont(size=12),
-            wraplength=0,
+
+    if not rendered:
+        labels.append(
+            _create_row(
+                body,
+                line=empty_text,
+                palette=palette,
+                icon="",
+            )
         )
-        label.pack(fill="x", pady=(0, 5))
-        labels.append(label)
+    else:
+        for index, line in enumerate(rendered):
+            labels.append(
+                _create_row(
+                    body,
+                    line=line,
+                    palette=palette,
+                    icon=row_icon,
+                    emphasized=index == 0,
+                )
+            )
+
+    if footer_text:
+        ctk.CTkLabel(
+            col,
+            text=footer_text,
+            anchor="w",
+            text_color=palette["accent"],
+            font=ctk.CTkFont(size=11, weight="bold"),
+            cursor="hand2",
+        ).pack(fill="x", pady=(4, 0))
 
     def _refresh_wrap(_event=None):
         """Refresh column wrap lengths."""
-        wrap_px = max(180, int(body.winfo_width()) - 8)
+        wrap_px = max(140, int(body.winfo_width()) - 8)
         for current in labels:
             current.configure(wraplength=wrap_px)
 
     body.bind("<Configure>", _refresh_wrap, add="+")
     _refresh_wrap()
+
+
+def _add_vertical_separator(parent, palette: dict) -> None:
+    """Add a thin separator between columns."""
+    ctk.CTkFrame(parent, width=1, fg_color=palette["muted_border"]).pack(side="left", fill="y", pady=6)
 
 
 def create_scene_briefing_layout(
@@ -95,8 +126,42 @@ def create_scene_briefing_layout(
     columns = ctk.CTkFrame(board, fg_color="transparent")
     columns.pack(fill="x", padx=8, pady=8)
 
-    _create_column(columns, title="NPCs in scene", lines=npc_names, palette=palette)
-    _create_column(columns, title="Places", lines=place_names, palette=palette)
-    _create_column(columns, title="Clues", lines=clue_lines, palette=palette)
-    _create_column(columns, title="Events & triggers", lines=event_lines, palette=palette)
+    _create_column(
+        columns,
+        title="NPCs in scene",
+        lines=npc_names,
+        palette=palette,
+        row_icon="👤",
+        footer_text=f"View all {len(_normalize_lines(npc_names))} NPCs" if npc_names else None,
+    )
+    _add_vertical_separator(columns, palette)
+
+    _create_column(
+        columns,
+        title="Places",
+        lines=place_names,
+        palette=palette,
+        row_icon="📍",
+        footer_text="View on map" if place_names else None,
+    )
+    _add_vertical_separator(columns, palette)
+
+    _create_column(
+        columns,
+        title="Clues",
+        lines=clue_lines,
+        palette=palette,
+        row_icon="☑",
+        footer_text="Manage clues" if clue_lines else None,
+    )
+    _add_vertical_separator(columns, palette)
+
+    _create_column(
+        columns,
+        title="Events & triggers",
+        lines=event_lines,
+        palette=palette,
+        row_icon="⚙",
+        footer_text=f"View all events ({len(_normalize_lines(event_lines))})" if event_lines else None,
+    )
     return board


### PR DESCRIPTION
### Motivation
- Present scene-linked entities (NPCs, Places, Clues, Events) in a compact, dashboard-style 4-column strip that matches the provided screenshot layout.
- Improve readability and hierarchy so the most relevant item is emphasized and columns have consistent wrapping and spacing.

### Description
- Reworked `modules/scenarios/widgets/scene_briefing_layout.py` to add a reusable `_create_row` helper and refactor the column renderer into `_create_column` for cleaner per-item rendering and emphasis of the first item.
- Added section-specific icons, optional footer action text per column (e.g. `View on map`, `Manage clues`, counts), and thin vertical separators between columns to mirror the mockup.
- Tuned padding and wrap logic (`wraplength` calculations) for tighter layout and consistent multi-line behavior.
- Kept the public API `create_scene_briefing_layout` but changed its internal rendering to build the new 4-column board.

### Testing
- Ran `python -m compileall modules/scenarios/widgets/scene_briefing_layout.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e694580db0832ba2d7429242e4581d)