### PR TITLE
Display mini portraits for scene body entities when available

### DIFF
--- a/modules/scenarios/widgets/scene_body/entity_portraits.py
+++ b/modules/scenarios/widgets/scene_body/entity_portraits.py
@@ -1,0 +1,124 @@
+"""Avatar loading helpers for scene body entity chips."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import customtkinter as ctk
+from PIL import Image
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.portrait_helper import parse_portrait_value, resolve_portrait_candidate
+
+
+GROUP_TO_ENTITY_TYPE = {
+    "NPCs": "NPCs",
+    "Villains": "Villains",
+    "Creatures": "Creatures",
+    "Places": "Places",
+}
+
+_AVATAR_SIZE = (24, 24)
+
+
+def attach_entity_avatars(group_label: str, entities: Iterable[dict], gm_view_ref):
+    """Attach a mini avatar image to each entity payload when possible."""
+    if gm_view_ref is None:
+        return list(entities or [])
+
+    entity_type = GROUP_TO_ENTITY_TYPE.get(group_label)
+    if not entity_type:
+        return list(entities or [])
+
+    wrapper = _resolve_wrapper(gm_view_ref, entity_type)
+    if wrapper is None:
+        return list(entities or [])
+
+    records_by_name = _load_records_by_name(wrapper)
+    prepared = []
+    for payload in entities or []:
+        updated = dict(payload)
+        entity_name = str(updated.get("name") or "").strip()
+        record = records_by_name.get(entity_name)
+        updated["avatar"] = _build_avatar(gm_view_ref, entity_type, entity_name, record)
+        prepared.append(updated)
+
+    return prepared
+
+
+def _resolve_wrapper(gm_view_ref, entity_type: str):
+    wrappers = getattr(gm_view_ref, "wrappers", None)
+    if isinstance(wrappers, dict):
+        return wrappers.get(entity_type)
+    return None
+
+
+def _load_records_by_name(wrapper) -> dict:
+    try:
+        items = wrapper.load_items() if wrapper else []
+    except Exception:
+        return {}
+
+    records = {}
+    for item in items or []:
+        name = str(item.get("Name") or item.get("name") or "").strip()
+        if name:
+            records[name] = item
+    return records
+
+
+def _build_avatar(gm_view_ref, entity_type: str, entity_name: str, record: dict | None):
+    if not entity_name or not record:
+        return None
+
+    cache = _avatar_cache(gm_view_ref)
+    cache_key = (entity_type, entity_name, _AVATAR_SIZE)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    image_path = _resolve_record_image_path(record)
+    if not image_path:
+        cache[cache_key] = None
+        return None
+
+    try:
+        with Image.open(image_path) as image_obj:
+            image_obj = image_obj.convert("RGBA")
+            image_obj.thumbnail(_AVATAR_SIZE, Image.Resampling.LANCZOS)
+            width = max(1, int(image_obj.width))
+            height = max(1, int(image_obj.height))
+            avatar = ctk.CTkImage(light_image=image_obj.copy(), dark_image=image_obj.copy(), size=(width, height))
+    except Exception:
+        avatar = None
+
+    cache[cache_key] = avatar
+    return avatar
+
+
+def _avatar_cache(gm_view_ref) -> dict:
+    cache = getattr(gm_view_ref, "_scene_entity_avatar_cache", None)
+    if isinstance(cache, dict):
+        return cache
+    cache = {}
+    setattr(gm_view_ref, "_scene_entity_avatar_cache", cache)
+    return cache
+
+
+def _resolve_record_image_path(record: dict) -> str | None:
+    candidates = []
+
+    portrait_values = parse_portrait_value(record.get("Portrait") or record.get("portrait"))
+    candidates.extend(portrait_values)
+
+    for key in ("Image", "image"):
+        value = str(record.get(key) or "").strip()
+        if value:
+            candidates.append(value)
+
+    for candidate in candidates:
+        resolved = resolve_portrait_candidate(candidate, ConfigHelper.get_campaign_dir())
+        if resolved:
+            return str(Path(resolved))
+
+    return None

--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -5,6 +5,7 @@ from customtkinter import CTkLabel
 from modules.generic.detail_ui import get_detail_palette
 from modules.scenarios.scene_structured_fields import parse_scene_sections_with_structured_fallback
 from modules.scenarios.widgets.scene_body import create_entities_groups_grid, prepare_entities_for_group
+from modules.scenarios.widgets.scene_body.entity_portraits import attach_entity_avatars
 from modules.scenarios.widgets.scene_briefing_layout import create_scene_briefing_layout
 from modules.scenarios.widgets.scene_density import get_scene_density_style
 
@@ -349,7 +350,15 @@ def _create_description_block(
     return description_block, description_label
 
 
-def _create_entities_block(parent, npc_names, villain_names, creature_names, place_names, open_entity_callback=None):
+def _create_entities_block(
+    parent,
+    npc_names,
+    villain_names,
+    creature_names,
+    place_names,
+    open_entity_callback=None,
+    gm_view_ref=None,
+):
     """Create entities block."""
     palette = get_detail_palette()
     has_entities = bool(npc_names or villain_names or creature_names or place_names)
@@ -360,14 +369,20 @@ def _create_entities_block(parent, npc_names, villain_names, creature_names, pla
     entities_block.pack(fill="x", padx=12, pady=(0, 0))
     _create_section_title(entities_block, "Entities")
 
+    groups = (
+        ("NPCs", prepare_entities_for_group(npc_names or [])),
+        ("Villains", prepare_entities_for_group(villain_names or [])),
+        ("Creatures", prepare_entities_for_group(creature_names or [])),
+        ("Places", prepare_entities_for_group(place_names or [])),
+    )
+    groups_with_avatars = [
+        (group_label, attach_entity_avatars(group_label, entities, gm_view_ref))
+        for group_label, entities in groups
+    ]
+
     create_entities_groups_grid(
         entities_block,
-        groups=(
-            ("NPCs", prepare_entities_for_group(npc_names or [])),
-            ("Villains", prepare_entities_for_group(villain_names or [])),
-            ("Creatures", prepare_entities_for_group(creature_names or [])),
-            ("Places", prepare_entities_for_group(place_names or [])),
-        ),
+        groups=groups_with_avatars,
         palette=palette,
         open_entity_callback=open_entity_callback,
         visible_limit=6,
@@ -560,6 +575,7 @@ def build_scene_body_sections(
         creature_names,
         place_names,
         open_entity_callback=open_entity_callback,
+        gm_view_ref=gm_view_ref,
     )
     if entities_block is not None and (has_maps or has_links):
         _add_subtle_separator(shell)

--- a/tests/scenarios/test_scene_entity_portraits.py
+++ b/tests/scenarios/test_scene_entity_portraits.py
@@ -1,0 +1,104 @@
+"""Tests for scene body entity portraits."""
+
+from __future__ import annotations
+
+from modules.scenarios.widgets.scene_body import entity_portraits as subject
+
+
+class _FakeWrapper:
+    def __init__(self, items):
+        self._items = items
+
+    def load_items(self):
+        return self._items
+
+
+class _FakeGMView:
+    def __init__(self, wrappers):
+        self.wrappers = wrappers
+
+
+class _FakeCTkImage:
+    def __init__(self, light_image=None, dark_image=None, size=None):
+        self.light_image = light_image
+        self.dark_image = dark_image
+        self.size = size
+
+
+class _FakeImageObj:
+    def __init__(self):
+        self.width = 64
+        self.height = 64
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def convert(self, _mode):
+        return self
+
+    def thumbnail(self, size, _resample):
+        self.width, self.height = size
+
+    def copy(self):
+        return self
+
+
+def test_attach_entity_avatars_adds_avatar_from_portrait_field(tmp_path, monkeypatch):
+    portrait_path = tmp_path / "npc_portrait.png"
+    portrait_path.write_bytes(b"not-an-image")
+
+    monkeypatch.setattr(subject.ctk, "CTkImage", _FakeCTkImage)
+    monkeypatch.setattr(subject.ConfigHelper, "get_campaign_dir", staticmethod(lambda: str(tmp_path)))
+    monkeypatch.setattr(subject.Image, "open", lambda _path: _FakeImageObj())
+
+    gm_view = _FakeGMView(
+        wrappers={
+            "NPCs": _FakeWrapper(
+                [
+                    {"Name": "Avery", "Portrait": str(portrait_path)},
+                ]
+            )
+        }
+    )
+
+    entities = [{"name": "Avery", "role": "Guide"}]
+    prepared = subject.attach_entity_avatars("NPCs", entities, gm_view)
+
+    assert prepared[0]["avatar"] is not None
+    assert prepared[0]["avatar"].size == (24, 24)
+
+
+def test_attach_entity_avatars_uses_cache_for_same_entity(tmp_path, monkeypatch):
+    portrait_path = tmp_path / "villain_portrait.png"
+    portrait_path.write_bytes(b"not-an-image")
+
+    monkeypatch.setattr(subject.ctk, "CTkImage", _FakeCTkImage)
+    monkeypatch.setattr(subject.ConfigHelper, "get_campaign_dir", staticmethod(lambda: str(tmp_path)))
+
+    open_calls = {"count": 0}
+
+    def _fake_open(_path):
+        open_calls["count"] += 1
+        return _FakeImageObj()
+
+    monkeypatch.setattr(subject.Image, "open", _fake_open)
+
+    gm_view = _FakeGMView(
+        wrappers={
+            "Villains": _FakeWrapper(
+                [
+                    {"Name": "Mordrek", "Portrait": str(portrait_path)},
+                ]
+            )
+        }
+    )
+
+    entities = [{"name": "Mordrek"}]
+    first = subject.attach_entity_avatars("Villains", entities, gm_view)
+    second = subject.attach_entity_avatars("Villains", entities, gm_view)
+
+    assert first[0]["avatar"] is second[0]["avatar"]
+    assert open_calls["count"] == 1


### PR DESCRIPTION
### Motivation
- Improve scene body entity chips by showing a mini portrait/avatar when an entity has an image, making entities easier to scan visually.
- Avoid repeated image work by caching generated avatars on the GM view.

### Description
- Added `modules/scenarios/widgets/scene_body/entity_portraits.py` which resolves `Portrait`/`Image` fields, builds 24×24 avatar `CTkImage` objects, and caches them on the provided `gm_view_ref` for reuse.
- Updated `modules/scenarios/widgets/scene_body_sections.py` to call `attach_entity_avatars(...)` and pass `gm_view_ref` so groups are enriched with `avatar` entries before rendering chips.
- Added unit tests in `tests/scenarios/test_scene_entity_portraits.py` that validate avatar attachment and cache reuse behavior.

### Testing
- Ran `pytest -q tests/scenarios/test_scene_entity_portraits.py tests/scenarios/test_entities_group_card.py tests/scenarios/test_scene_body_sections.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69761e100832ba1b1e78fe70349ea)