### PR TITLE
Add avatar support to scene body briefing NPC column

### DIFF
--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -330,9 +330,12 @@ def _create_description_block(
         elif value:
             scene_places.append(value)
 
+    scene_npc_rows = [{"line": str(item), "avatar": None} for item in scene_npcs]
+    scene_npc_rows = attach_entity_avatars("NPCs", scene_npc_rows, gm_view_ref)
+
     create_scene_briefing_layout(
         description_block,
-        npc_names=[str(item) for item in scene_npcs],
+        npc_names=scene_npc_rows,
         place_names=[str(item) for item in scene_places],
         clue_lines=[str(item) for item in clue_items],
         event_lines=[str(item) for item in event_items],

--- a/modules/scenarios/widgets/scene_briefing_layout.py
+++ b/modules/scenarios/widgets/scene_briefing_layout.py
@@ -15,10 +15,33 @@ def _normalize_lines(values) -> list[str]:
     return items
 
 
-def _create_row(parent, *, line: str, palette: dict, icon: str = "•", emphasized: bool = False) -> ctk.CTkLabel:
+def _normalize_rows(values) -> list[dict]:
+    """Return cleaned rows with optional avatar image."""
+    rows: list[dict] = []
+    for value in values or []:
+        if isinstance(value, dict):
+            line = " ".join(str(value.get("line") or value.get("text") or "").split()).strip()
+            avatar = value.get("avatar")
+        else:
+            line = " ".join(str(value or "").split()).strip()
+            avatar = None
+        if line:
+            rows.append({"line": line, "avatar": avatar})
+    return rows
+
+
+def _create_row(parent, *, line: str, palette: dict, icon: str = "•", emphasized: bool = False, avatar=None) -> ctk.CTkLabel:
     """Create one line row inside a scene briefing column."""
+    row_shell = ctk.CTkFrame(parent, fg_color="transparent")
+    row_shell.pack(fill="x", pady=(0, 6))
+
+    if avatar is not None:
+        avatar_label = ctk.CTkLabel(row_shell, text="", image=avatar)
+        avatar_label.image = avatar
+        avatar_label.pack(side="left", padx=(0, 8), pady=1)
+
     row = ctk.CTkLabel(
-        parent,
+        row_shell,
         text=f"{icon}  {line}",
         anchor="w",
         justify="left",
@@ -26,7 +49,7 @@ def _create_row(parent, *, line: str, palette: dict, icon: str = "•", emphasiz
         font=ctk.CTkFont(size=12, weight="bold" if emphasized else "normal"),
         wraplength=0,
     )
-    row.pack(fill="x", pady=(0, 6))
+    row.pack(side="left", fill="x", expand=True)
     return row
 
 
@@ -55,7 +78,7 @@ def _create_column(
     body = ctk.CTkFrame(col, fg_color="transparent")
     body.pack(fill="both", expand=True)
 
-    rendered = _normalize_lines(lines)[:6]
+    rendered = _normalize_rows(lines)[:6]
     labels = []
 
     if not rendered:
@@ -68,14 +91,15 @@ def _create_column(
             )
         )
     else:
-        for index, line in enumerate(rendered):
+        for index, item in enumerate(rendered):
             labels.append(
                 _create_row(
                     body,
-                    line=line,
+                    line=item["line"],
                     palette=palette,
                     icon=row_icon,
                     emphasized=index == 0,
+                    avatar=item.get("avatar"),
                 )
             )
 
@@ -132,7 +156,7 @@ def create_scene_briefing_layout(
         lines=npc_names,
         palette=palette,
         row_icon="👤",
-        footer_text=f"View all {len(_normalize_lines(npc_names))} NPCs" if npc_names else None,
+        footer_text=f"View all {len(_normalize_rows(npc_names))} NPCs" if npc_names else None,
     )
     _add_vertical_separator(columns, palette)
 

--- a/tests/scenarios/test_scene_briefing_layout.py
+++ b/tests/scenarios/test_scene_briefing_layout.py
@@ -1,0 +1,21 @@
+"""Tests for scene briefing layout row normalization."""
+
+from modules.scenarios.widgets import scene_briefing_layout as subject
+
+
+def test_normalize_rows_accepts_dict_payload_with_avatar():
+    """Verify that normalize rows preserves avatar payload for dict items."""
+    avatar = object()
+    rows = subject._normalize_rows([
+        {"line": "  Aleksander   Lesnik  ", "avatar": avatar},
+        "",
+    ])
+
+    assert rows == [{"line": "Aleksander Lesnik", "avatar": avatar}]
+
+
+def test_normalize_rows_accepts_plain_strings_without_avatar():
+    """Verify that normalize rows keeps plain string entries."""
+    rows = subject._normalize_rows(["  Capitaine du navire "])
+
+    assert rows == [{"line": "Capitaine du navire", "avatar": None}]


### PR DESCRIPTION
### Motivation
- Improve the scene-body briefing board so NPC rows can show mini-portraits beside their names, matching the updated scene entity chips UI.
- Reuse the existing avatar pipeline so NPCs in the briefing use the same portrait resolution/cache as other scene views.

### Description
- Add `_normalize_rows` to accept either plain strings or dict row payloads with optional `avatar`, and switch the briefing code to use it instead of plain string normalization.
- Update `_create_row` to render an optional avatar image to the left of the row text and keep existing styling and wrapping behavior.
- Change `create_scene_briefing_layout` to use `_normalize_rows` and to compute NPC counts from normalized rows.
- Feed NPCs from `scene_body_sections.build_scene_body_sections` through `attach_entity_avatars` to populate avatar thumbnails before passing rows to the briefing layout.
- Add unit tests `tests/scenarios/test_scene_briefing_layout.py` covering row normalization for dict payloads and plain strings.

### Testing
- Ran `pytest -q tests/scenarios/test_scene_briefing_layout.py tests/scenarios/test_scene_entity_portraits.py tests/scenarios/test_scene_body_sections.py` and all tests passed.
- Test run result: `7 passed` (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6994c25f8832b84de1ffbe3dcfda2)