### PR TITLE
Fix NameError from missing `gm_view_ref` in scene description rendering

### DIFF
--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -164,6 +164,7 @@ def _create_description_block(
     description_font_size=13,
     npc_names=None,
     place_names=None,
+    gm_view_ref=None,
 ):
     """Create description block."""
     palette = get_detail_palette()
@@ -567,6 +568,7 @@ def build_scene_body_sections(
         description_font_size=density_style["description_font_size"],
         npc_names=npc_names,
         place_names=place_names,
+        gm_view_ref=gm_view_ref,
     )
     if has_entities or has_maps or has_links:
         _add_subtle_separator(shell)


### PR DESCRIPTION
### Motivation
- Prevent a runtime `NameError` when `attach_entity_avatars(...)` is called from the scene description rendering path by ensuring the GM view reference is available to the description builder.

### Description
- Add an optional `gm_view_ref` parameter to `_create_description_block` and pass the `gm_view_ref` from `build_scene_body_sections` into the call so avatar/map interactions can use the view reference.

### Testing
- Compiled the modified module with `python -m py_compile modules/scenarios/widgets/scene_body_sections.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69ac71264832bb75c4fefad64544a)