### PR TITLE
Add `name` to scene briefing NPC rows so avatars resolve

### DIFF
--- a/modules/scenarios/widgets/scene_body/entity_portraits.py
+++ b/modules/scenarios/widgets/scene_body/entity_portraits.py
@@ -39,7 +39,7 @@ def attach_entity_avatars(group_label: str, entities: Iterable[dict], gm_view_re
     prepared = []
     for payload in entities or []:
         updated = dict(payload)
-        entity_name = str(updated.get("name") or "").strip()
+        entity_name = str(updated.get("name") or updated.get("line") or "").strip()
         record = records_by_name.get(entity_name)
         updated["avatar"] = _build_avatar(gm_view_ref, entity_type, entity_name, record)
         prepared.append(updated)

--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -331,7 +331,14 @@ def _create_description_block(
         elif value:
             scene_places.append(value)
 
-    scene_npc_rows = [{"line": str(item), "avatar": None} for item in scene_npcs]
+    scene_npc_rows = [
+        {
+            "name": str(item),
+            "line": str(item),
+            "avatar": None,
+        }
+        for item in scene_npcs
+    ]
     scene_npc_rows = attach_entity_avatars("NPCs", scene_npc_rows, gm_view_ref)
 
     create_scene_briefing_layout(

--- a/tests/scenarios/test_scene_entity_portraits.py
+++ b/tests/scenarios/test_scene_entity_portraits.py
@@ -102,3 +102,28 @@ def test_attach_entity_avatars_uses_cache_for_same_entity(tmp_path, monkeypatch)
 
     assert first[0]["avatar"] is second[0]["avatar"]
     assert open_calls["count"] == 1
+
+
+def test_attach_entity_avatars_uses_line_when_name_missing(tmp_path, monkeypatch):
+    portrait_path = tmp_path / "npc_briefing_portrait.png"
+    portrait_path.write_bytes(b"not-an-image")
+
+    monkeypatch.setattr(subject.ctk, "CTkImage", _FakeCTkImage)
+    monkeypatch.setattr(subject.ConfigHelper, "get_campaign_dir", staticmethod(lambda: str(tmp_path)))
+    monkeypatch.setattr(subject.Image, "open", lambda _path: _FakeImageObj())
+
+    gm_view = _FakeGMView(
+        wrappers={
+            "NPCs": _FakeWrapper(
+                [
+                    {"Name": "Avery", "Portrait": str(portrait_path)},
+                ]
+            )
+        }
+    )
+
+    briefing_rows = [{"line": "Avery", "avatar": None}]
+    prepared = subject.attach_entity_avatars("NPCs", briefing_rows, gm_view)
+
+    assert prepared[0]["avatar"] is not None
+    assert prepared[0]["avatar"].size == (24, 24)


### PR DESCRIPTION
### Motivation
- Scene briefing NPC rows were only providing `line`, which prevented `attach_entity_avatars` from reliably resolving portraits by name while `create_scene_briefing_layout` still needs `line` to render.
- Make avatar attachment resilient to mixed payloads so briefing-style rows and full entity payloads both get avatars when a matching portrait exists.

### Description
- Updated `_create_description_block` in `modules/scenarios/widgets/scene_body_sections.py` to build briefing rows as `{"name": str(item), "line": str(item), "avatar": None}` before calling `attach_entity_avatars`.
- Hardened `attach_entity_avatars` in `modules/scenarios/widgets/scene_body/entity_portraits.py` to fall back to `line` when `name` is missing by using `updated.get("name") or updated.get("line")` for lookup.
- Added a regression test `test_attach_entity_avatars_uses_line_when_name_missing` in `tests/scenarios/test_scene_entity_portraits.py` that exercises briefing-style rows and asserts an avatar is attached when a matching portrait record exists.

### Testing
- Ran `pytest -q tests/scenarios/test_scene_entity_portraits.py` and the test suite passed with `3 passed`.
- The existing avatar-related tests continued to pass after the change, confirming caching and avatar construction behavior remained correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69c865f58832b9c2b043de9b9d163)