### PR TITLE
Attach scene place avatars to briefing layout rows

### DIFF
--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -341,10 +341,20 @@ def _create_description_block(
     ]
     scene_npc_rows = attach_entity_avatars("NPCs", scene_npc_rows, gm_view_ref)
 
+    scene_place_rows = [
+        {
+            "name": str(item),
+            "line": str(item),
+            "avatar": None,
+        }
+        for item in scene_places
+    ]
+    scene_place_rows = attach_entity_avatars("Places", scene_place_rows, gm_view_ref)
+
     create_scene_briefing_layout(
         description_block,
         npc_names=scene_npc_rows,
-        place_names=[str(item) for item in scene_places],
+        place_names=scene_place_rows,
         clue_lines=[str(item) for item in clue_items],
         event_lines=[str(item) for item in event_items],
         palette=palette,

--- a/tests/scenarios/test_scene_body_sections_briefing_places.py
+++ b/tests/scenarios/test_scene_body_sections_briefing_places.py
@@ -1,0 +1,115 @@
+"""Tests ensuring place avatars are attached for scene briefing data."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from modules.scenarios.widgets import scene_body_sections as subject
+
+
+class _DummyWidget:
+    """Tiny stand-in for CTk widgets."""
+
+    def __init__(self, *_, **__):
+        self._children = []
+        self.config = {}
+
+    def pack(self, *_, **__):
+        return None
+
+    def grid(self, *_, **__):
+        return None
+
+    def grid_columnconfigure(self, *_, **__):
+        return None
+
+    def pack_forget(self, *_, **__):
+        return None
+
+    def bind(self, *_, **__):
+        return None
+
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+    def winfo_width(self):
+        return 500
+
+    def winfo_children(self):
+        return list(self._children)
+
+    def destroy(self):
+        return None
+
+
+class _DummyBoolVar:
+    """Simple bool var for toggles in tests."""
+
+    def __init__(self, master=None, value=False):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+def _patch_minimal_ctk(monkeypatch):
+    dummy_ctk = SimpleNamespace(
+        CTkFrame=_DummyWidget,
+        CTkLabel=_DummyWidget,
+        CTkButton=_DummyWidget,
+        CTkFont=lambda *a, **k: None,
+        BooleanVar=_DummyBoolVar,
+    )
+    monkeypatch.setattr(subject, "ctk", dummy_ctk)
+
+
+def test_create_description_block_attaches_place_avatars_for_briefing(monkeypatch):
+    """Scene briefing data should call attach avatars for Places in description block."""
+    _patch_minimal_ctk(monkeypatch)
+
+    monkeypatch.setattr(
+        subject,
+        "parse_scene_sections_with_structured_fallback",
+        lambda *_a, **_k: {
+            "has_sections": True,
+            "intro_text": "Intro",
+            "sections": [{"key": "clues/hooks", "title": "Clues", "items": ["clue"]}],
+        },
+    )
+
+    calls = []
+
+    def _fake_attach(group, rows, _gm_view_ref):
+        calls.append((group, rows))
+        return rows
+
+    monkeypatch.setattr(subject, "attach_entity_avatars", _fake_attach)
+
+    captured_brief = {}
+
+    def _fake_briefing_layout(_parent, **kwargs):
+        captured_brief.update(kwargs)
+        return _DummyWidget()
+
+    monkeypatch.setattr(subject, "create_scene_briefing_layout", _fake_briefing_layout)
+
+    subject._create_description_block(
+        _DummyWidget(),
+        "Body",
+        scene_dict={"SceneLocations": ["Dock 9"], "SceneNPCs": ["Ilya"]},
+        npc_names=["Nina"],
+        place_names=["Old Quarter"],
+        gm_view_ref=object(),
+    )
+
+    called_groups = [group for group, _rows in calls]
+    assert "NPCs" in called_groups
+    assert "Places" in called_groups
+
+    assert captured_brief["place_names"] == [
+        {"name": "Old Quarter", "line": "Old Quarter", "avatar": None},
+        {"name": "Dock 9", "line": "Dock 9", "avatar": None},
+    ]

--- a/tests/scenarios/test_scene_briefing_layout.py
+++ b/tests/scenarios/test_scene_briefing_layout.py
@@ -19,3 +19,83 @@ def test_normalize_rows_accepts_plain_strings_without_avatar():
     rows = subject._normalize_rows(["  Capitaine du navire "])
 
     assert rows == [{"line": "Capitaine du navire", "avatar": None}]
+
+
+
+def test_create_scene_briefing_layout_passes_place_dict_rows_with_avatar(monkeypatch):
+    """Place dict rows should keep avatar payload in the Places column call path."""
+    captured = []
+
+    class _DummyFrame:
+        def __init__(self, *_, **__):
+            pass
+
+        def pack(self, *_, **__):
+            return None
+
+    monkeypatch.setattr(subject.ctk, "CTkFrame", _DummyFrame)
+    monkeypatch.setattr(subject, "_add_vertical_separator", lambda *_, **__: None)
+
+    def _capture_column(_parent, *, title, lines, **kwargs):
+        captured.append((title, lines, kwargs))
+
+    monkeypatch.setattr(subject, "_create_column", _capture_column)
+
+    avatar = object()
+    place_rows = [{"line": "Clocktower", "avatar": avatar}]
+    subject.create_scene_briefing_layout(
+        _DummyFrame(),
+        npc_names=["Nina"],
+        place_names=place_rows,
+        clue_lines=[],
+        event_lines=[],
+        palette={
+            "surface_card": "#111",
+            "muted_border": "#222",
+            "muted_text": "#aaa",
+            "text": "#fff",
+            "accent": "#0bf",
+        },
+    )
+
+    places_column = next(item for item in captured if item[0] == "Places")
+    assert places_column[1] == place_rows
+
+
+
+def test_create_scene_briefing_layout_keeps_plain_string_places_backward_compatible(monkeypatch):
+    """Plain string place names should still flow to the Places column."""
+    captured = []
+
+    class _DummyFrame:
+        def __init__(self, *_, **__):
+            pass
+
+        def pack(self, *_, **__):
+            return None
+
+    monkeypatch.setattr(subject.ctk, "CTkFrame", _DummyFrame)
+    monkeypatch.setattr(subject, "_add_vertical_separator", lambda *_, **__: None)
+    monkeypatch.setattr(
+        subject,
+        "_create_column",
+        lambda _parent, *, title, lines, **kwargs: captured.append((title, lines)),
+    )
+
+    place_names = ["Harbor", "Undercity"]
+    subject.create_scene_briefing_layout(
+        _DummyFrame(),
+        npc_names=[],
+        place_names=place_names,
+        clue_lines=[],
+        event_lines=[],
+        palette={
+            "surface_card": "#111",
+            "muted_border": "#222",
+            "muted_text": "#aaa",
+            "text": "#fff",
+            "accent": "#0bf",
+        },
+    )
+
+    assert next(lines for title, lines in captured if title == "Places") == place_names


### PR DESCRIPTION
### Motivation

- Briefing columns should preserve avatar payloads for Places the same way they do for NPCs so place portraits appear in the briefing UI.
- The scene description builder previously converted places to plain strings before the briefing layout, which dropped avatar data attached by `attach_entity_avatars`.
- Keep the existing `create_scene_briefing_layout` API stable while making briefing data avatar-aware for Places.

### Description

- In `_create_description_block` build `scene_place_rows` from `scene_places` using the same dict payload shape used for NPCs (`{"name": str(item), "line": str(item), "avatar": None}`) and call `attach_entity_avatars("Places", scene_place_rows, gm_view_ref)` before rendering the briefing layout.
- Pass `scene_place_rows` to `create_scene_briefing_layout(..., place_names=...)` instead of converting places to plain strings, preserving avatar fields without changing the layout function signature.
- Added a new regression test `tests/scenarios/test_scene_body_sections_briefing_places.py` which asserts `attach_entity_avatars("Places", ...)` is invoked and the briefing payload contains place dict rows.
- Extended `tests/scenarios/test_scene_briefing_layout.py` with two tests: one validating dict rows with `avatar` are forwarded to the Places column, and one ensuring plain string place inputs remain backward-compatible.

### Testing

- Ran `pytest -q tests/scenarios/test_scene_briefing_layout.py tests/scenarios/test_scene_body_sections_briefing_places.py tests/scenarios/test_scene_body_sections.py` and all tests passed (`8 passed`).
- Unit tests cover `scene_briefing_layout` normalization, dict-based place rows with avatars, backward compatibility for string place names, and a higher-level assertion that `attach_entity_avatars("Places", ...)` is called by `_create_description_block`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70b34970c832b8c26e28f10961cd6)