### PR TITLE
Deduplicate and merge NPC/Place name sources with preserved casing

### DIFF
--- a/modules/scenarios/widgets/scene_body/entity_lists.py
+++ b/modules/scenarios/widgets/scene_body/entity_lists.py
@@ -1,0 +1,24 @@
+"""Entity list merge helpers for scene body widgets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def merge_unique_entity_names(*sources: Any) -> list[str]:
+    """Merge entity name sources while preserving first-seen display casing."""
+    merged: list[str] = []
+    seen: set[str] = set()
+
+    for source in sources:
+        for item in source or []:
+            text = str(item or "").strip()
+            if not text:
+                continue
+            key = text.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(text)
+
+    return merged

--- a/modules/scenarios/widgets/scene_body_sections.py
+++ b/modules/scenarios/widgets/scene_body_sections.py
@@ -5,6 +5,7 @@ from customtkinter import CTkLabel
 from modules.generic.detail_ui import get_detail_palette
 from modules.scenarios.scene_structured_fields import parse_scene_sections_with_structured_fallback
 from modules.scenarios.widgets.scene_body import create_entities_groups_grid, prepare_entities_for_group
+from modules.scenarios.widgets.scene_body.entity_lists import merge_unique_entity_names
 from modules.scenarios.widgets.scene_body.entity_portraits import attach_entity_avatars
 from modules.scenarios.widgets.scene_briefing_layout import create_scene_briefing_layout
 from modules.scenarios.widgets.scene_density import get_scene_density_style
@@ -313,23 +314,25 @@ def _create_description_block(
         # Process each key from ('conflicts/obstacles', 'key beats', 'transitions').
         event_items.extend((section_lookup.get(key) or {}).get("items") or [])
 
-    scene_npcs = list(npc_names or [])
+    scene_npc_sources = [npc_names or []]
     for key in ("SceneNPCs", "NPCs", "npcs"):
         # Process each key from ('SceneNPCs', 'NPCs', 'npcs').
         value = (scene_dict or {}).get(key)
         if isinstance(value, list):
-            scene_npcs.extend(value)
+            scene_npc_sources.append(value)
         elif value:
-            scene_npcs.append(value)
+            scene_npc_sources.append([value])
+    scene_npcs = merge_unique_entity_names(*scene_npc_sources)
 
-    scene_places = list(place_names or [])
+    scene_place_sources = [place_names or []]
     for key in ("SceneLocations", "Places", "places"):
         # Process each key from ('SceneLocations', 'Places', 'places').
         value = (scene_dict or {}).get(key)
         if isinstance(value, list):
-            scene_places.extend(value)
+            scene_place_sources.append(value)
         elif value:
-            scene_places.append(value)
+            scene_place_sources.append([value])
+    scene_places = merge_unique_entity_names(*scene_place_sources)
 
     scene_npc_rows = [
         {


### PR DESCRIPTION
### Motivation
- Ensure entity name lists collected from multiple scene fields are merged without duplicates and preserve the first-seen display casing.
- Consolidate merging logic into a reusable helper to avoid repeated ad-hoc concatenation and deduplication patterns.
- Improve robustness when scene dictionaries provide single values or lists under different keys for NPCs and Places.

### Description
- Add `merge_unique_entity_names` helper in `modules/scenarios/widgets/scene_body/entity_lists.py` that merges multiple sources, strips/ignores empty entries, deduplicates case-insensitively, and preserves first-seen casing.
- Refactor `modules/scenarios/widgets/scene_body_sections.py` to collect NPC and Place sources into lists and call `merge_unique_entity_names` to produce `scene_npcs` and `scene_places` respectively.
- Rename intermediate variables to clarify source collection and keep existing downstream behavior (row creation and `attach_entity_avatars`) unchanged.

### Testing
- Ran the test suite with `pytest -q` and the scenario widget tests, and they completed successfully.
- Ran static checks/linting (project linters) with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70d1447b8832ba24e6ae0220cbcbd)