### PR TITLE
Reattach top-right utility buttons after menu bar rebuild

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -2530,6 +2530,9 @@ class MainWindow(ctk.CTk):
         self.init_wrappers()
         if getattr(self, "menu_bar", None) is not None:
             self.menu_bar.rebuild()
+            self.create_exit_button()
+            if getattr(self, "ai_run_window_controller", None) is not None:
+                self.ai_run_window_controller.reattach_button(self.menu_bar)
 
 
     def open_faction_graph_editor(self):

--- a/modules/ui/controllers/ai_run_window_controller.py
+++ b/modules/ui/controllers/ai_run_window_controller.py
@@ -41,6 +41,15 @@ class AIRunWindowController:
         ai_pipeline_events.subscribe("*", self._on_pipeline_event)
         ai_request_state.subscribe(self._on_state_changed)
 
+    def reattach_button(self, new_menu_bar) -> None:
+        """Reattach the AI run button to a rebuilt menu bar."""
+        self.menu_bar = new_menu_bar
+        self._open_button = self.menu_bar.create_action_button(
+            text="AI Run*" if ai_request_state.state.active else "AI Run",
+            command=self.open_window,
+            width=80,
+        )
+
     def new_request_id(self) -> str:
         """Handle new request ID."""
         return uuid4().hex


### PR DESCRIPTION
### Motivation
- `menu_bar.rebuild()` recreates menu internals and detaches top-right action buttons, so they must be re-registered when the menu is rebuilt (e.g., on refresh / database switch).

### Description
- In `MainWindow.refresh_entities()` call `self.create_exit_button()` immediately after `self.menu_bar.rebuild()` and, if present, call `self.ai_run_window_controller.reattach_button(self.menu_bar)` to re-register the AI Run button.
- Added `AIRunWindowController.reattach_button(new_menu_bar)` which recreates the controller's `AI Run` action button and preserves the active-state label (`"AI Run*"` when active).
- Left the original `create_exit_button()` usage in `__init__` unchanged to avoid duplicate buttons on first load.

### Testing
- Ran `python -m py_compile main_window.py modules/ui/controllers/ai_run_window_controller.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8882582e8832b9a82f3ad3417cdab)