### PR TITLE
Defer toolbar repaint after map display initialization

### DIFF
--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -268,6 +268,37 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
     self._build_toolbar()
     self._build_canvas()
 
+    def _refresh_toolbar_after_map():
+        """Force a lightweight toolbar repaint after parent frame mapping/sizing."""
+        parent = getattr(self, "parent", None)
+        if parent is None or not parent.winfo_exists():
+            return
+        try:
+            parent.update_idletasks()
+        except Exception:
+            return
+
+        toolbar = getattr(self, "_toolbar_scrollable", None)
+        if toolbar is None or not toolbar.winfo_exists():
+            return
+        xview = getattr(toolbar, "xview", None)
+        if not callable(xview):
+            return
+        try:
+            current_left = float(xview()[0])
+        except Exception:
+            current_left = 0.0
+        try:
+            toolbar.xview_moveto(0)
+            toolbar.xview_moveto(current_left)
+        except Exception:
+            pass
+
+    try:
+        self.parent.after(10, _refresh_toolbar_after_map)
+    except Exception:
+        pass
+
     # 3) Load base image + fog mask (supports static image or video)
     image_path = (item.get("Image", "") or "").strip()
     full_image_path = _resolve_campaign_path(image_path)

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -69,7 +69,7 @@ def _build_toolbar(self):
     # Main toolbar container that fills the width and holds the scrollable area
     toolbar_container = ctk.CTkFrame(self.parent)
     toolbar_container.pack(side="top", fill="x", pady=(0,2)) # Added small pady for visual separation
-    # Expose on controller for downstream layout sizing
+    # Expose explicit references on controller for downstream layout hooks
     try:
         self._toolbar_container = toolbar_container
     except Exception:
@@ -81,6 +81,10 @@ def _build_toolbar(self):
     toolbar_height = 65 # Adjust as needed for your icon/widget sizes
     toolbar = ctk.CTkScrollableFrame(toolbar_container, orientation="horizontal", height=toolbar_height)
     toolbar.pack(fill="x", expand=True) # Make the scrollable area fill the container
+    try:
+        self._toolbar_scrollable = toolbar
+    except Exception:
+        pass
 
     # Load icons
     icons = {


### PR DESCRIPTION
### Motivation
- Ensure the horizontal toolbar is painted correctly on first display of a map when the host frame is still being mapped/sized. 
- Make the toolbar repaint deterministic by exposing explicit references to the toolbar widgets so a deferred refresh can target them reliably.
- Avoid Tk errors when deferred callbacks run after the tab/frame has been closed.

### Description
- Expose the scrollable toolbar frame as `self._toolbar_scrollable` (and keep `self._toolbar_container`) in `_build_toolbar` so callers can reliably access the horizontal scrollable area. 
- Add a deferred helper `_refresh_toolbar_after_map` inside `_on_display_map` that calls `parent.update_idletasks()`, checks `winfo_exists()`, and performs a no-op horizontal scroll refresh via `xview_moveto(0)` then restoring the previous position to force a repaint. 
- Schedule the helper with `self.parent.after(10, ...)` immediately after `_build_toolbar()` and `_build_canvas()` so it runs once the host frame is mapped and sized. 
- Guard all operations with existence checks and `try/except` to avoid errors when tabs or frames close during the deferred callback.

### Testing
- Ran Python byte-compile on the modified modules with `python -m py_compile modules/maps/views/map_selector.py modules/maps/views/toolbar_view.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ed3b2e68832b9e87904f6e998b13)