### PR TITLE
Keep scenario tab active when GM Screen auto-opens Handouts

### DIFF
--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -1256,7 +1256,7 @@ class GMScreenView(ctk.CTkFrame):
         """Seed default startup tabs when no explicit layout is available."""
         if "Handouts" in self.tabs:
             return
-        self.open_handouts_tab("Handouts")
+        self.open_handouts_tab("Handouts", activate=False)
 
     def _initialize_context_menu(self):
         """Internal helper for initialize context menu."""
@@ -2523,7 +2523,7 @@ class GMScreenView(ctk.CTkFrame):
             layout_meta={"kind": "loot_generator"},
         )
 
-    def open_handouts_tab(self, title=None):
+    def open_handouts_tab(self, title=None, activate=True):
         """Open the handouts page inside the GM screen."""
         container = ctk.CTkFrame(self._ensure_rich_host())
         self._make_fullbleed(container)
@@ -2558,6 +2558,7 @@ class GMScreenView(ctk.CTkFrame):
             container,
             content_factory=factory,
             layout_meta={"kind": "handouts", "host": "rich"},
+            activate=activate,
         )
 
     def open_random_tables_tab(self, title=None, initial_state=None):


### PR DESCRIPTION
### Motivation
- When the GM Screen opens without a saved layout the code auto-creates the Handouts tab but also focuses it, whereas the desired behavior is to keep the scenario window displayed while still opening Handouts in the background.

### Description
- Modified `modules/scenarios/gm_screen_view.py` to add an `activate` parameter to `open_handouts_tab` (default `True`) and forward it to `add_tab` so manual opens still activate; changed the startup seeding call in `_seed_default_startup_tabs` to call `open_handouts_tab("Handouts", activate=False)` so Handouts is created but not focused.

### Testing
- Ran `pytest -q tests/test_campaign_overview_launch_layout.py` and it passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e929be7e80832b8d4c606eac4cdc71)