### PR TITLE
Handle missing database configuration at startup

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -109,6 +109,7 @@ from modules.campaigns.services import (
 from modules.dice.dice_roller_window import DiceRollerWindow
 from modules.dice.dice_bar_window import DiceBarWindow
 from modules.audio.audio_controller import get_audio_controller
+from modules.startup import ensure_database_configured_for_startup
 
 initialize_logging()
 install_global_exception_hooks()
@@ -4751,5 +4752,6 @@ if __name__ == "__main__":
 
         _apply_update.main()
     else:
-        app = MainWindow()
-        app.mainloop()
+        if ensure_database_configured_for_startup():
+            app = MainWindow()
+            app.mainloop()

--- a/modules/events/services/campaign_date_service.py
+++ b/modules/events/services/campaign_date_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import date, datetime
 from typing import Any
 
@@ -17,7 +18,10 @@ class CampaignDateService:
     @classmethod
     def get_today(cls) -> date:
         """Return today."""
-        stored = get_campaign_setting(_CAMPAIGN_DATE_KEY)
+        try:
+            stored = get_campaign_setting(_CAMPAIGN_DATE_KEY)
+        except sqlite3.OperationalError:
+            return date.today()
         return cls.parse(stored) or date.today()
 
     @classmethod

--- a/modules/startup/__init__.py
+++ b/modules/startup/__init__.py
@@ -1,0 +1,5 @@
+"""Startup orchestration helpers."""
+
+from .database_bootstrap import ensure_database_configured_for_startup
+
+__all__ = ["ensure_database_configured_for_startup"]

--- a/modules/startup/database_bootstrap.py
+++ b/modules/startup/database_bootstrap.py
@@ -1,0 +1,91 @@
+"""Startup helpers that ensure a valid campaign database is configured."""
+
+from __future__ import annotations
+
+import sqlite3
+import tkinter as tk
+from pathlib import Path
+
+from modules.campaigns.services import (
+    ensure_campaign_directory,
+    normalize_campaign_db_path,
+    seed_default_templates,
+)
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.logging_helper import log_exception, log_info, log_module_import
+from modules.ui.database_manager_dialog import DatabaseManagerDialog
+
+log_module_import(__name__)
+
+
+def ensure_database_configured_for_startup() -> bool:
+    """Ensure startup can reach a campaign database, prompting the user if needed."""
+    current_path = ConfigHelper.get("Database", "path", fallback="") or ""
+
+    if _is_database_path_usable(current_path):
+        return True
+
+    selection = _prompt_database_selection(current_path)
+    if selection is None:
+        log_info(
+            "Startup database selection cancelled by user.",
+            func_name="database_bootstrap.ensure_database_configured_for_startup",
+        )
+        return False
+
+    selected_path, is_new_database = selection
+    normalized_path = normalize_campaign_db_path(selected_path)
+    normalized_path = ensure_campaign_directory(normalized_path)
+    ConfigHelper.set("Database", "path", normalized_path)
+
+    if is_new_database:
+        try:
+            seed_default_templates(normalized_path)
+        except Exception:
+            log_exception(
+                "Failed to seed default templates during startup database bootstrap.",
+                func_name="database_bootstrap.ensure_database_configured_for_startup",
+            )
+
+    return True
+
+
+def _is_database_path_usable(path: str) -> bool:
+    """Return whether ``path`` can be opened by sqlite."""
+    normalized_path = str(path or "").strip()
+    if not normalized_path:
+        return False
+
+    normalized_path = normalize_campaign_db_path(normalized_path)
+    try:
+        with sqlite3.connect(normalized_path):
+            pass
+    except sqlite3.OperationalError:
+        return False
+    except Exception:
+        return False
+
+    return True
+
+
+def _prompt_database_selection(current_path: str):
+    """Open the database selector dialog and return the chosen path and creation flag."""
+    root = tk.Tk()
+    root.withdraw()
+
+    selection = {"value": None}
+
+    def _on_selected(path: str, is_new: bool) -> None:
+        selection["value"] = (path, is_new)
+
+    dialog = DatabaseManagerDialog(
+        root,
+        current_path=current_path or None,
+        on_selected=_on_selected,
+        on_cancelled=lambda: None,
+    )
+
+    root.wait_window(dialog)
+    root.destroy()
+
+    return selection["value"]


### PR DESCRIPTION
## Summary
- Added a dedicated startup bootstrap module (`modules/startup/database_bootstrap.py`) to validate whether the configured SQLite database path is usable before creating `MainWindow`.
- If the configured path is invalid/missing (e.g., Campaign folder does not exist), the app now opens the existing `DatabaseManagerDialog` so the user can create/select a first database inside `Campaigns`.
- Persisted the selected database path back to `config.ini`, ensured campaign directory creation, and seeded default templates for newly created databases.
- Updated startup flow in `main_window.py` to gate app launch on successful database configuration.
- Added a defensive fallback in `CampaignDateService.get_today()` to avoid hard crashes on `sqlite3.OperationalError` and return system date instead.

## Why
This prevents the startup traceback `sqlite3.OperationalError: unable to open database file` when no campaign directory/database exists, and provides a user-facing first-run recovery path instead of crashing.

## Notes
- No runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b80705c0832b97f53f51366a2113)