### PR TITLE
Fix CustomTkinter button callback errors during teardown

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -31,6 +31,7 @@ from PIL import Image
 # Modular helper imports
 from modules.helpers.window_helper import position_window_at_top
 from modules.helpers import theme_manager
+from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch
 from modules.helpers.template_loader import (
     load_template,
     load_entity_definitions,
@@ -118,6 +119,7 @@ log_module_import(__name__)
 
 def configure_ui_defaults() -> None:
     """Apply global CustomTkinter defaults explicitly at app startup."""
+    apply_ctk_button_after_cleanup_patch(ctk)
     ctk.set_appearance_mode("Dark")
     theme_manager.apply_theme(theme_manager.get_theme())
 
@@ -4536,6 +4538,7 @@ class MainWindow(ctk.CTk):
         try:
             # Keep reload active campaign system resilient if this step fails.
             from modules.helpers import theme_manager
+from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch
             theme_key = theme_manager.get_theme()
             theme_manager.apply_theme(theme_key)
             self._on_theme_changed(theme_key)

--- a/modules/helpers/customtkinter_compat.py
+++ b/modules/helpers/customtkinter_compat.py
@@ -1,0 +1,63 @@
+"""Compatibility patches for CustomTkinter widgets used by the app."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from modules.helpers.logging_helper import log_debug, log_module_import
+
+log_module_import(__name__)
+
+
+def apply_ctk_button_after_cleanup_patch(ctk_module: Any) -> None:
+    """Ensure ``CTkButton`` cancels pending ``after`` callbacks on destroy.
+
+    Some CustomTkinter builds can emit Tcl errors like
+    ``invalid command name "..._click_animation"`` when a button is destroyed
+    while a click animation callback is still queued. This patch tracks callback
+    IDs created via ``after`` on each button instance and cancels them during
+    ``destroy``.
+    """
+
+    button_cls = getattr(ctk_module, "CTkButton", None)
+    if button_cls is None:
+        return
+    if getattr(button_cls, "_gm_after_cleanup_patch", False):
+        return
+
+    original_after = button_cls.after
+    original_after_cancel = button_cls.after_cancel
+    original_destroy = button_cls.destroy
+
+    def _tracked_after(self: Any, ms: int, callback: Any = None, *args: Any) -> Any:
+        callback_id = original_after(self, ms, callback, *args)
+        if callback is not None and callback_id:
+            tracked = getattr(self, "_gm_tracked_after_ids", None)
+            if tracked is None:
+                tracked = set()
+                setattr(self, "_gm_tracked_after_ids", tracked)
+            tracked.add(callback_id)
+        return callback_id
+
+    def _tracked_after_cancel(self: Any, callback_id: Any) -> None:
+        tracked = getattr(self, "_gm_tracked_after_ids", None)
+        if tracked is not None:
+            tracked.discard(callback_id)
+        original_after_cancel(self, callback_id)
+
+    def _safe_destroy(self: Any) -> Any:
+        tracked = tuple(getattr(self, "_gm_tracked_after_ids", ()))
+        for callback_id in tracked:
+            try:
+                original_after_cancel(self, callback_id)
+            except Exception:
+                pass
+        if hasattr(self, "_gm_tracked_after_ids"):
+            self._gm_tracked_after_ids.clear()
+        return original_destroy(self)
+
+    button_cls.after = _tracked_after
+    button_cls.after_cancel = _tracked_after_cancel
+    button_cls.destroy = _safe_destroy
+    button_cls._gm_after_cleanup_patch = True
+    log_debug("Applied CTkButton after-cleanup compatibility patch")

--- a/tests/helpers/test_customtkinter_compat.py
+++ b/tests/helpers/test_customtkinter_compat.py
@@ -1,0 +1,50 @@
+from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch
+
+
+class _FakeButton:
+    def __init__(self):
+        self.after_calls = []
+        self.after_cancel_calls = []
+        self.destroy_calls = 0
+
+    def after(self, ms, callback=None, *args):
+        callback_id = f"after-{len(self.after_calls) + 1}"
+        self.after_calls.append((ms, callback, args, callback_id))
+        return callback_id
+
+    def after_cancel(self, callback_id):
+        self.after_cancel_calls.append(callback_id)
+
+    def destroy(self):
+        self.destroy_calls += 1
+        return "destroyed"
+
+
+class _FakeCTK:
+    CTkButton = _FakeButton
+
+
+def test_patch_cancels_pending_after_callbacks_on_destroy():
+    apply_ctk_button_after_cleanup_patch(_FakeCTK)
+
+    button = _FakeCTK.CTkButton()
+    callback_id_1 = button.after(40, lambda: None)
+    callback_id_2 = button.after(10, lambda: None)
+
+    result = button.destroy()
+
+    assert result == "destroyed"
+    assert button.destroy_calls == 1
+    assert callback_id_1 in button.after_cancel_calls
+    assert callback_id_2 in button.after_cancel_calls
+
+
+def test_patch_is_idempotent():
+    apply_ctk_button_after_cleanup_patch(_FakeCTK)
+    apply_ctk_button_after_cleanup_patch(_FakeCTK)
+
+    button = _FakeCTK.CTkButton()
+    callback_id = button.after(5, lambda: None)
+    button.after_cancel(callback_id)
+
+    assert button.after_cancel_calls.count(callback_id) == 1


### PR DESCRIPTION
### Motivation
- Prevent Tcl errors like `invalid command name "..._click_animation"` that occur when a `CTkButton` is destroyed while a queued `after` callback (e.g. click animation) is still pending.

### Description
- Add `modules/helpers/customtkinter_compat.py` with `apply_ctk_button_after_cleanup_patch` that wraps `CTkButton.after`, `after_cancel`, and `destroy` to track and cancel pending callback IDs on teardown.
- Apply the compatibility patch at startup by calling `apply_ctk_button_after_cleanup_patch(ctk)` from `configure_ui_defaults()` in `main_window.py` so the behavior is active globally.
- Add focused unit tests in `tests/helpers/test_customtkinter_compat.py` that verify pending callbacks are canceled on `destroy` and that the patch is idempotent.

### Testing
- Ran `pytest -q tests/helpers/test_customtkinter_compat.py` which succeeded with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c7e6cb44832b97d8f9bff6b9c07c)