### PR TITLE
Fix SyntaxError in main_window.py campaign system reload

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -4538,7 +4538,6 @@ class MainWindow(ctk.CTk):
         try:
             # Keep reload active campaign system resilient if this step fails.
             from modules.helpers import theme_manager
-from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch
             theme_key = theme_manager.get_theme()
             theme_manager.apply_theme(theme_key)
             self._on_theme_changed(theme_key)


### PR DESCRIPTION
### Motivation
- Resolve a `SyntaxError` caused by an unintended unindented import inside `_reload_active_campaign_system` that broke the `try`/`except` block and prevented the module from importing.

### Description
- Remove the stray `from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch` line inside `_reload_active_campaign_system` in `main_window.py` so the `try` block parses correctly and theme reload behavior is preserved.

### Testing
- Ran `python -m py_compile main_window.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cff3729c832b9b9bc473ae83d021)