### PR TITLE
Remove redundant Name/Title cards from entity detail view

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2401,7 +2401,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
         # Process each field from template['fields'].
         field_name = field["name"]
         field_type = field["type"]
-        if field_name == "Portrait":
+        if field_name in {"Portrait", "Name", "Title"}:
             continue
         if field_type == "list" and not field.get("linked_type"):
             continue


### PR DESCRIPTION
### Motivation
- Remove the redundant “Name” card from entity detail pages because the hero/synopsis header already displays the entity name, reducing visual duplication and noise in the detail UI.

### Description
- Skip `Portrait`, `Name`, and `Title` fields when building the generic detail cards in `modules/generic/entity_detail_factory.py` so those fields are not emitted as separate section cards.
- This preserves the existing hero/header and spotlight portrait behavior while preventing a second name/title card from appearing in the main columns.

### Testing
- Ran `python -m py_compile modules/generic/entity_detail_factory.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec67de3a5c832bbfa7d0ffd4356fa6)