### PR TITLE
Enhance spotlight layout for portrait-driven entities

### DIFF
--- a/modules/generic/detail_ui/entity_layout.py
+++ b/modules/generic/detail_ui/entity_layout.py
@@ -14,13 +14,15 @@ from .theme import create_chip, create_section_card, get_detail_palette
 LAYOUT_BREAKPOINT = 1180
 
 
-def create_detail_split_layout(parent, *, sidebar_width: int = 380):
+def create_detail_split_layout(parent, *, sidebar_width: int = 380, spotlight_primary: bool = False):
     """Build a 16:9-friendly content split with a main stage and a utility rail."""
 
     palette = get_detail_palette()
     shell = ctk.CTkFrame(parent, fg_color="transparent")
+    side_weight = 4 if spotlight_primary else 3
+    side_minsize = max(sidebar_width, 460 if spotlight_primary else 380)
     shell.grid_columnconfigure(0, weight=5)
-    shell.grid_columnconfigure(1, weight=3, minsize=sidebar_width)
+    shell.grid_columnconfigure(1, weight=side_weight, minsize=side_minsize)
     shell.grid_rowconfigure(0, weight=1)
 
     main_column = ctk.CTkFrame(shell, fg_color="transparent")
@@ -88,14 +90,19 @@ def create_spotlight_panel(
     portrait_builder=None,
     fallback_text: str = "No portrait linked yet.",
     accent_lines: Iterable[str] | None = None,
+    prominent: bool = False,
 ):
     """Create spotlight panel."""
     palette = get_detail_palette()
+    title_size = 20 if prominent else 18
+    portrait_height = 520 if prominent else 430
+    accent_border = palette["accent"] if prominent else palette["pill_border"]
+    accent_border_width = 2 if prominent else 1
     card = ctk.CTkFrame(
         parent,
         fg_color=palette["surface_overlay"],
-        border_width=1,
-        border_color=palette["pill_border"],
+        border_width=accent_border_width,
+        border_color=accent_border,
         corner_radius=22,
     )
     card.pack(fill="x", pady=(0, 14))
@@ -106,7 +113,7 @@ def create_spotlight_panel(
     ctk.CTkLabel(
         header,
         text=title,
-        font=ctk.CTkFont(size=18, weight="bold"),
+        font=ctk.CTkFont(size=title_size, weight="bold"),
         text_color=palette["text"],
         justify="left",
         wraplength=280,
@@ -127,7 +134,7 @@ def create_spotlight_panel(
         border_width=1,
         border_color=palette["muted_border"],
         corner_radius=20,
-        height=430,
+        height=portrait_height,
     )
     portrait_shell.pack(fill="x", padx=18, pady=(0, 16))
     portrait_shell.pack_propagate(False)
@@ -158,7 +165,7 @@ def create_spotlight_panel(
             text="Add art to turn this panel into a full-height character spotlight.",
             font=ctk.CTkFont(size=12),
             text_color=palette["muted_text"],
-            wraplength=240,
+            wraplength=260 if prominent else 240,
             justify="center",
         ).pack()
 

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -69,6 +69,7 @@ log_module_import(__name__)
 PORTRAIT_SIZE = (320, 420)
 DEFAULT_PORTRAIT_PLACEMENT = "spotlight"
 _open_entity_windows = {}
+SPOTLIGHT_PRIMARY_ENTITY_TYPES = {"NPCs", "Villains", "Creatures", "Places"}
 
 
 def _portrait_debug(entity_type, entity, message):
@@ -2309,7 +2310,11 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
 
     highlight_lines = _collect_highlight_lines(entity_type, entity)
 
-    shell, main_column, side_column = create_detail_split_layout(content_frame)
+    spotlight_primary = entity_type in SPOTLIGHT_PRIMARY_ENTITY_TYPES
+    shell, main_column, side_column = create_detail_split_layout(
+        content_frame,
+        spotlight_primary=spotlight_primary,
+    )
     shell.pack(fill="both", expand=True, padx=10, pady=(0, 6))
 
     category_label = entity_type[:-1] if entity_type.endswith("s") else entity_type
@@ -2320,6 +2325,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
         portrait_builder=_make_spotlight_portrait if DEFAULT_PORTRAIT_PLACEMENT in {"spotlight", "both"} else None,
         fallback_text=_spotlight_fallback(entity_type),
         accent_lines=highlight_lines[:3],
+        prominent=spotlight_primary,
     )
 
     compact_header = ctk.CTkFrame(main_column, fg_color="transparent")


### PR DESCRIPTION
### Motivation

- Make portrait-led entity detail views more visually prominent so character-driven entries read like storytelling panels on wide screens.
- Provide an additive, opt-in way to increase the right-rail footprint and visual weight without changing default layouts for other entity types.
- Keep small-screen stacked behavior and the existing no-portrait fallback composition intact for balance and accessibility.

### Description

- Added a `spotlight_primary` flag to `create_detail_split_layout(...)` and use it to increase the side column weight and minimum size (`weight=4`, `minsize>=460`) when enabled while preserving the legacy defaults otherwise.
- Extended `create_spotlight_panel(...)` with a `prominent` boolean (default `False`) that increases the title font size, raises the portrait shell height to `520`, and applies a slightly stronger accent border treatment when `True`.
- Introduced `SPOTLIGHT_PRIMARY_ENTITY_TYPES = {"NPCs","Villains","Creatures","Places"}` and enabled `spotlight_primary` / `prominent` for those entity types in the generic entity detail composition.
- Preserved small-screen stacking behavior (existing breakpoint logic unchanged) and retained the no-portrait fallback structure with only minor wrap-length tuning for prominent mode.

### Testing

- Ran `python -m compileall modules/generic/detail_ui/entity_layout.py modules/generic/entity_detail_factory.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6c60e148832bbf889aaf1d0652ec)