### PR TITLE
Display entity name in spotlight panel chip

### DIFF
--- a/modules/generic/detail_ui/entity_layout.py
+++ b/modules/generic/detail_ui/entity_layout.py
@@ -109,7 +109,7 @@ def create_spotlight_panel(
 
     header = ctk.CTkFrame(card, fg_color="transparent")
     header.pack(fill="x", padx=18, pady=(18, 10))
-    create_chip(header, "SPOTLIGHT", accent=True).pack(anchor="w")
+    create_chip(header, title, accent=True).pack(anchor="w")
     ctk.CTkLabel(
         header,
         text=title,


### PR DESCRIPTION
### Motivation
- Replace the static "SPOTLIGHT" chip label with the actual entity title so the spotlight panel reflects context-specific names like `Xenomorph Soldier`.

### Description
- Update `create_spotlight_panel` in `modules/generic/detail_ui/entity_layout.py` to call `create_chip(header, title, accent=True)` instead of the hard-coded `"SPOTLIGHT"` string.

### Testing
- Ran `python -m compileall modules/generic/detail_ui/entity_layout.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6eb6b47c832ba454c7b82a5f47f7)