### PR TITLE
Remove duplicate entity title in spotlight header

### DIFF
--- a/modules/generic/detail_ui/entity_layout.py
+++ b/modules/generic/detail_ui/entity_layout.py
@@ -94,7 +94,6 @@ def create_spotlight_panel(
 ):
     """Create spotlight panel."""
     palette = get_detail_palette()
-    title_size = 20 if prominent else 18
     portrait_height = 520 if prominent else 430
     accent_border = palette["accent"] if prominent else palette["pill_border"]
     accent_border_width = 2 if prominent else 1
@@ -110,14 +109,6 @@ def create_spotlight_panel(
     header = ctk.CTkFrame(card, fg_color="transparent")
     header.pack(fill="x", padx=18, pady=(18, 10))
     create_chip(header, title, accent=True).pack(anchor="w")
-    ctk.CTkLabel(
-        header,
-        text=title,
-        font=ctk.CTkFont(size=title_size, weight="bold"),
-        text_color=palette["text"],
-        justify="left",
-        wraplength=280,
-    ).pack(anchor="w", pady=(12, 4))
     if subtitle:
         ctk.CTkLabel(
             header,
@@ -126,7 +117,7 @@ def create_spotlight_panel(
             text_color=palette["muted_text"],
             justify="left",
             wraplength=280,
-        ).pack(anchor="w")
+        ).pack(anchor="w", pady=(8, 0))
 
     portrait_shell = ctk.CTkFrame(
         card,


### PR DESCRIPTION
### Motivation
- The spotlight header duplicated the entity name (chip plus a second-line label), producing redundant UI; the change keeps the chip as the single name display and preserves header spacing.

### Description
- Removed the duplicated second-line title label and the now-unused `title_size` variable in `create_spotlight_panel` in `modules/generic/detail_ui/entity_layout.py`, and adjusted the subtitle `pack` padding so subtitle text aligns cleanly under the chip.

### Testing
- Ran `pytest -q tests/generic/test_entity_detail_factory_window_focus.py`, which passed (`4 passed`).
- Running `pytest -q tests/scenarios/gm_table/test_gm_table_view.py tests/generic/test_entity_detail_factory_window_focus.py` aborted during collection due to an environment `ImportError` for `PIL.ImageFont` unrelated to this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec70646448832bb6b385fd35978817)