### PR TITLE
Hide duplicate `Type` field when primary type chip is shown

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2417,6 +2417,8 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
         field_type = field["type"]
         if field_name in {"Portrait", "Name", "Title"}:
             continue
+        if field_name == "Type" and primary_type:
+            continue
         if field_type == "list" and not field.get("linked_type"):
             continue
         render_fields.append(field)


### PR DESCRIPTION
### Motivation
- Remove redundant `Type: ...` text in entity detail views when a primary `Type` chip is already displayed in the compact header to avoid duplicate information.

### Description
- Skip the `Type` field when building `render_fields` if a `primary_type` chip exists by adding `if field_name == "Type" and primary_type: continue` in `modules/generic/entity_detail_factory.py` within the template field iteration.

### Testing
- Ran `python -m py_compile modules/generic/entity_detail_factory.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec79ab4e2c832b9e0305c06704d134)