### PR TITLE
Avoid duplicate Type line in spotlight card accents

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -292,6 +292,31 @@ def _resolve_primary_type_chip(entity: dict) -> str:
     return ""
 
 
+def _build_spotlight_accent_lines(highlight_lines, primary_type: str):
+    """Return spotlight accent lines without repeating the primary type chip."""
+    if not highlight_lines:
+        return []
+    normalized_primary = str(primary_type or "").strip().lower()
+    if not normalized_primary:
+        return highlight_lines[:3]
+
+    filtered_lines = []
+    for line in highlight_lines:
+        # Process each line from highlight_lines.
+        text = str(line or "").strip()
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered.startswith("type:"):
+            value = text.split(":", 1)[1].strip().lower() if ":" in text else ""
+            if value == normalized_primary:
+                continue
+        filtered_lines.append(text)
+        if len(filtered_lines) >= 3:
+            break
+    return filtered_lines
+
+
 def _build_portrait_widget(parent, entity_type, entity, *, size):
     """Build portrait widget."""
     portrait_sources = (
@@ -2330,12 +2355,15 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
     shell.pack(fill="both", expand=True, padx=10, pady=(0, 6))
 
     category_label = entity_type[:-1] if entity_type.endswith("s") else entity_type
+    primary_type = _resolve_primary_type_chip(entity)
+    spotlight_accent_lines = _build_spotlight_accent_lines(highlight_lines, primary_type)
+
     create_spotlight_panel(
         side_column,
         title=str(entity_label),
         portrait_builder=_make_spotlight_portrait if DEFAULT_PORTRAIT_PLACEMENT in {"spotlight", "both"} else None,
         fallback_text=_spotlight_fallback(entity_type),
-        accent_lines=highlight_lines[:3],
+        accent_lines=spotlight_accent_lines,
         prominent=spotlight_primary,
     )
 
@@ -2355,7 +2383,6 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
     chip_row.pack(fill="x", pady=(8, 0))
     create_chip(chip_row, str(entity_label), accent=True).pack(side="left", padx=(0, 8))
 
-    primary_type = _resolve_primary_type_chip(entity)
     if primary_type:
         create_chip(chip_row, primary_type).pack(side="left", padx=(0, 8))
 


### PR DESCRIPTION
### Motivation
- The spotlight card could display a `Type: ...` highlight line that repeated the same value already shown as the primary type chip, producing a redundant UI line.
- The change aims to keep spotlight accent lines informative without repeating the primary chip value.

### Description
- Added a helper `def _build_spotlight_accent_lines(highlight_lines, primary_type: str)` which filters the collected highlight lines to avoid repeating the primary `Type` value.
- `create_entity_detail_frame` now computes `primary_type` once and passes deduplicated `accent_lines` into `create_spotlight_panel` instead of slicing `highlight_lines` directly.
- The chip row logic and existing `Type` deduplication for column fields are preserved so the type still appears as the primary chip but is omitted from spotlight accents when duplicated.
- File changed: `modules/generic/entity_detail_factory.py`.

### Testing
- Ran `python -m compileall modules/generic/entity_detail_factory.py` which completed successfully with no syntax errors.
- Verified the module diff and ensured code compiles cleanly (no additional automated tests were executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7b665f18832b82907e38c2fb34ee)