### PR TITLE
Move synopsis section into main entity card layout

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2382,8 +2382,34 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
         prominent=spotlight_primary,
     )
 
+    compact_header = ctk.CTkFrame(main_column, fg_color="transparent")
+    compact_header.pack(fill="x", pady=(0, 14))
+    compact_title = ctk.CTkLabel(
+        compact_header,
+        text=f"{entity_label} · {category_label}",
+        font=ctk.CTkFont(size=17, weight="bold"),
+        text_color=palette["text"],
+        anchor="w",
+        justify="left",
+    )
+    compact_title.pack(fill="x", anchor="w")
+
+    chip_row = ctk.CTkFrame(compact_header, fg_color="transparent")
+    chip_row.pack(fill="x", pady=(8, 0))
+    create_chip(chip_row, str(entity_label), accent=True).pack(side="left", padx=(0, 8))
+
+    if primary_type:
+        create_chip(chip_row, primary_type).pack(side="left", padx=(0, 8))
+
+    create_chip(chip_row, category_label.upper()).pack(side="left", padx=(0, 8))
+    for item in meta_items[:3]:
+        # Process each item from meta_items[:3].
+        if primary_type and str(item).strip() == primary_type:
+            continue
+        create_chip(chip_row, item).pack(side="left", padx=(0, 8))
+
     synopsis_card, synopsis_body = create_section_card(
-        side_column,
+        main_column,
         "Synopsis",
         "Narrative context pulled from the best available summary field.",
         compact=True,
@@ -2410,7 +2436,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
                 text=synopsis_text,
                 justify="left",
                 anchor="w",
-                wraplength=360,
+                wraplength=720,
                 text_color=palette["muted_text"],
                 font=ctk.CTkFont(size=13),
             )
@@ -2424,32 +2450,6 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
             text_color=palette["muted_text"],
             font=ctk.CTkFont(size=13),
         ).pack(anchor="w")
-
-    compact_header = ctk.CTkFrame(main_column, fg_color="transparent")
-    compact_header.pack(fill="x", pady=(0, 14))
-    compact_title = ctk.CTkLabel(
-        compact_header,
-        text=f"{entity_label} · {category_label}",
-        font=ctk.CTkFont(size=17, weight="bold"),
-        text_color=palette["text"],
-        anchor="w",
-        justify="left",
-    )
-    compact_title.pack(fill="x", anchor="w")
-
-    chip_row = ctk.CTkFrame(compact_header, fg_color="transparent")
-    chip_row.pack(fill="x", pady=(8, 0))
-    create_chip(chip_row, str(entity_label), accent=True).pack(side="left", padx=(0, 8))
-
-    if primary_type:
-        create_chip(chip_row, primary_type).pack(side="left", padx=(0, 8))
-
-    create_chip(chip_row, category_label.upper()).pack(side="left", padx=(0, 8))
-    for item in meta_items[:3]:
-        # Process each item from meta_items[:3].
-        if primary_type and str(item).strip() == primary_type:
-            continue
-        create_chip(chip_row, item).pack(side="left", padx=(0, 8))
 
     create_highlight_card(
         side_column,


### PR DESCRIPTION
### Motivation
- The synopsis was placed in the spotlight/sidebar but should live in the main detail card to improve readability and match the intended UI focus.
- Preserve existing synopsis selection and rendering behavior while making the synopsis more prominent in the primary content flow.

### Description
- Moved the `Synopsis` `create_section_card` from the `side_column` into the `main_column` in `modules/generic/entity_detail_factory.py`.
- Kept the existing logic that picks the best summary field and auto-switches between a read-only `CTkTextbox` and a `CTkLabel` for long vs short synopsis texts.
- Increased the synopsis label `wraplength` from `360` to `720` to better fit the wider main column.
- Placed the compact header and chip row above the synopsis in the main column so the synopsis appears in the main card flow.

### Testing
- Ran `python -m py_compile modules/generic/entity_detail_factory.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7e09c390832bb0e1d2d89b00e771)