### PR TITLE
Move Highlights card to main detail column

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2452,7 +2452,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
         ).pack(anchor="w")
 
     create_highlight_card(
-        side_column,
+        main_column,
         "Highlights",
         highlight_lines,
         empty_state="Add signature fields like Role, Secret, Powers, or Motivation to surface a punchier overview.",


### PR DESCRIPTION
### Motivation
- The Highlights card belonged in the spotlight/sidebar area but should live with the primary narrative content so the spotlight remains focused on portrait/accent information.

### Description
- Updated `modules/generic/entity_detail_factory.py` to pass `main_column` (instead of `side_column`) as the parent to `create_highlight_card(...)`, moving the Highlights card into the main detail column.

### Testing
- Ran `python -m py_compile modules/generic/entity_detail_factory.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7ff34bf4832ba3f1db305a48d525)