### PR TITLE
feat(gm-table): show spotlight-only entity panels

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2237,7 +2237,14 @@ def EditWindow(self, item, template, model_wrapper, creation_mode=False, on_save
 
 
 @log_function
-def create_entity_detail_frame(entity_type, entity, master, open_entity_callback=None):
+def create_entity_detail_frame(
+    entity_type,
+    entity,
+    master,
+    open_entity_callback=None,
+    *,
+    spotlight_only: bool = False,
+):
     """
     Routes Scenarios through our custom header/body and
     everything else through the generic detail path.
@@ -2266,6 +2273,7 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
                 item,
                 parent,
                 open_entity_callback,
+                spotlight_only=spotlight_only,
             ),
         )
 
@@ -2381,6 +2389,14 @@ def create_entity_detail_frame(entity_type, entity, master, open_entity_callback
         accent_lines=spotlight_accent_lines,
         prominent=spotlight_primary,
     )
+
+    if spotlight_only:
+        try:
+            main_column.grid_forget()
+            side_column.master.grid_configure(row=0, column=0, columnspan=2, sticky="nsew")
+        except Exception:
+            pass
+        return content_frame
 
     compact_header = ctk.CTkFrame(main_column, fg_color="transparent")
     compact_header.pack(fill="x", pady=(0, 14))

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -908,6 +908,7 @@ class GMTableView(ctk.CTkFrame):
             item,
             master=host,
             open_entity_callback=self.open_entity_panel,
+            spotlight_only=True,
         )
         frame.grid(row=0, column=0, sticky="nsew")
         return frame


### PR DESCRIPTION
### Motivation
- GM Table entity windows should be simplified to show only the spotlight rail (portrait/accent lines) and hide the rest of the detail cards/fields when opened from the GM virtual table.

### Description
- Added a `spotlight_only: bool` parameter to `create_entity_detail_frame` so callers can request rendering only the spotlight area.
- Preserved `spotlight_only` during in-place rebuilds by passing the flag into the rebuild callback used after edits.
- In spotlight-only mode the main content column is removed and the spotlight rail is reconfigured to occupy the full area (grid adjustments guarded by a try/except).
- Updated the GM Table entity panel builder to call `create_entity_detail_frame(..., spotlight_only=True)` so GM Table panels show only the spotlight.

### Testing
- Ran `python -m compileall modules/generic/entity_detail_factory.py modules/scenarios/gm_table_view.py` and compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec81877b54832ba9ae1d8156bee8aa)