### PR TITLE
Allow GM Table entity panels to use full detail layout by default

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -902,13 +902,14 @@ class GMTableView(ctk.CTkFrame):
         """Build an entity detail page."""
         entity_type = state.get("entity_type")
         entity_name = state.get("entity_name")
+        spotlight_only = bool(state.get("spotlight_only", False))
         item = self._load_entity_item(entity_type, entity_name)
         frame = create_entity_detail_frame(
             entity_type,
             item,
             master=host,
             open_entity_callback=self.open_entity_panel,
-            spotlight_only=True,
+            spotlight_only=spotlight_only,
         )
         frame.grid(row=0, column=0, sticky="nsew")
         return frame


### PR DESCRIPTION
### Motivation
- Make GM Table entity panels show the full entity detail (synopsis, highlights, and generic fields) by default while still allowing a compact "spotlight-only" mode per panel via state.

### Description
- Update `GMTableView._build_entity_content` to read `spotlight_only = bool(state.get("spotlight_only", False))` and pass it to `create_entity_detail_frame` instead of forcing `spotlight_only=True`, enabling the non-spotlight branch by default.
- No changes required to `modules/generic/entity_detail_factory.py` because the factory already renders the full detail when `spotlight_only` is `False` (the branch after `if spotlight_only:`).

### Testing
- Ran `rg -n "spotlight_only"` to verify the flag is wired and ran `python -m compileall modules/scenarios/gm_table_view.py modules/generic/entity_detail_factory.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec83cda0b0832b8df3be46e5694ac0)