### PR TITLE
Limit GM table entity detail pages to spotlight content only

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -902,14 +902,13 @@ class GMTableView(ctk.CTkFrame):
         """Build an entity detail page."""
         entity_type = state.get("entity_type")
         entity_name = state.get("entity_name")
-        spotlight_only = bool(state.get("spotlight_only", False))
         item = self._load_entity_item(entity_type, entity_name)
         frame = create_entity_detail_frame(
             entity_type,
             item,
             master=host,
             open_entity_callback=self.open_entity_panel,
-            spotlight_only=spotlight_only,
+            spotlight_only=True,
         )
         frame.grid(row=0, column=0, sticky="nsew")
         return frame


### PR DESCRIPTION
## Summary
- reverted the recent GM table detail-page behavior that allowed full entity content
- enforced `spotlight_only=True` when building entity detail frames in `GMTableView`

## Why
The GM table should display only spotlight content, not the full entity detail view.

## Files changed
- `modules/scenarios/gm_table_view.py`

## Validation
- static inspection of the updated call path confirms the GM table detail frame now always requests spotlight-only rendering

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8546c304832b96eca10c48106741)