### PR TITLE
Ajout d'un mode `single_column` explicite pour le layout de détail (spotlight)

### DIFF
--- a/modules/generic/detail_ui/entity_layout.py
+++ b/modules/generic/detail_ui/entity_layout.py
@@ -34,15 +34,24 @@ def _bind_wrap_to_parent_width(label, parent, *, horizontal_padding: int = 32, m
     label.after_idle(_refresh_wrap)
 
 
-def create_detail_split_layout(parent, *, sidebar_width: int = 380, spotlight_primary: bool = False):
+def create_detail_split_layout(
+    parent,
+    *,
+    sidebar_width: int = 380,
+    spotlight_primary: bool = False,
+    single_column: bool = False,
+):
     """Build a 16:9-friendly content split with a main stage and a utility rail."""
 
     palette = get_detail_palette()
     shell = ctk.CTkFrame(parent, fg_color="transparent")
     side_weight = 4 if spotlight_primary else 3
     side_minsize = max(sidebar_width, 460 if spotlight_primary else 380)
-    shell.grid_columnconfigure(0, weight=5)
-    shell.grid_columnconfigure(1, weight=side_weight, minsize=side_minsize)
+    if single_column:
+        shell.grid_columnconfigure(0, weight=1)
+    else:
+        shell.grid_columnconfigure(0, weight=5)
+        shell.grid_columnconfigure(1, weight=side_weight, minsize=side_minsize)
     shell.grid_rowconfigure(0, weight=1)
 
     main_column = ctk.CTkFrame(shell, fg_color="transparent")
@@ -55,10 +64,17 @@ def create_detail_split_layout(parent, *, sidebar_width: int = 380, spotlight_pr
         border_color=palette["muted_border"],
         corner_radius=24,
     )
-    side_column.grid(row=0, column=1, sticky="nsew")
+    if single_column:
+        side_column.grid(row=0, column=0, sticky="nsew")
+    else:
+        side_column.grid(row=0, column=1, sticky="nsew")
 
     side_inner = ctk.CTkFrame(side_column, fg_color="transparent")
     side_inner.pack(fill="both", expand=True, padx=18, pady=18)
+
+    if single_column:
+        main_column.grid_remove()
+        return shell, main_column, side_inner
 
     layout_scheduler = LayoutSettleScheduler(shell)
     layout_probe = {"width": None}

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2374,6 +2374,7 @@ def create_entity_detail_frame(
     shell, main_column, side_column = create_detail_split_layout(
         content_frame,
         spotlight_primary=spotlight_primary,
+        single_column=spotlight_only,
     )
     shell.pack(fill="both", expand=True, padx=10, pady=(0, 6))
 
@@ -2391,11 +2392,6 @@ def create_entity_detail_frame(
     )
 
     if spotlight_only:
-        try:
-            main_column.grid_forget()
-            side_column.master.grid_configure(row=0, column=0, columnspan=2, sticky="nsew")
-        except Exception:
-            pass
         return content_frame
 
     compact_header = ctk.CTkFrame(main_column, fg_color="transparent")


### PR DESCRIPTION
### Motivation

- Éviter les conflits entre la logique responsive pilotée par le `LayoutSettleScheduler` et le rendu « spotlight-only » qui provoquait une bande vide / découpe du panneau portrait lors de redimensionnements.
- Remplacer le hack fragile qui modifiait la grille après-coup pour une solution explicite et prévisible côté layout.

### Description

- Ajout du paramètre `single_column: bool = False` à `create_detail_split_layout` dans `modules/generic/detail_ui/entity_layout.py` pour forcer un shell à une seule colonne lorsque nécessaire.
- En mode `single_column=True`, le code : ne crée ni ne bind le `LayoutSettleScheduler`, configure la grille en une seule colonne (`shell.grid_columnconfigure(0, weight=1)`), place `side_column` en `row=0, column=0, sticky="nsew"` et masque immédiatement `main_column` via `grid_remove()` puis retourne le shell (sans logique responsive).
- Comportement inchangé quand `single_column=False` (scheduler et logique responsive existants conservés).
- Mise à jour de l'appel dans `modules/generic/entity_detail_factory.py` pour transmettre `single_column=spotlight_only` à `create_detail_split_layout` et suppression du bloc hack `if spotlight_only:` (remplacé par un simple `return`).
- Fichiers modifiés : `modules/generic/detail_ui/entity_layout.py` et `modules/generic/entity_detail_factory.py`.

### Testing

- Compilation statique : `python -m compileall modules/generic/detail_ui/entity_layout.py modules/generic/entity_detail_factory.py` réussie.
- Aucune suite de tests automatisés additionnelle exécutée dans cet environnement; vérification UI manuelle recommandée localement avec les étapes : 1) ouvrir une entité depuis GM Table, 2) réduire la fenêtre à la hauteur du spotlight, 3) confirmer qu’il n’y a plus de bande vide en bas et que le spotlight n’est plus coupé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8d8a0004832b86014f3778961b7a)