### PR TITLE
Include random tables and image library in full campaign bundles

### DIFF
--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from modules.audio.entity_audio import normalize_audio_reference
+from modules.generic.cross_campaign_bundle_extras import collect_full_campaign_extra_files
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.portrait_helper import parse_portrait_value, serialize_portrait_value
@@ -616,6 +617,19 @@ def export_bundle(
 
     _call_progress(progress_callback, "Collecting records...", 0.05)
 
+    if include_database and not source_campaign.db_path.exists():
+        raise FileNotFoundError(source_campaign.db_path)
+
+    selected_for_bundle = {entity: list(records) for entity, records in selected_records.items()}
+    if include_database and "image_assets" not in selected_for_bundle:
+        try:
+            selected_for_bundle["image_assets"] = load_entities("image_assets", source_campaign.db_path)
+        except Exception as exc:
+            log_warning(
+                f"Unable to include image library records for full campaign export: {exc}",
+                func_name="modules.generic.cross_campaign_asset_service.export_bundle",
+            )
+
     data_dir = Path(tempfile.mkdtemp(prefix="asset_export_"))
     temp_root = Path(data_dir)
     manifest: dict = {
@@ -638,7 +652,7 @@ def export_bundle(
     try:
         # Keep bundle resilient if this step fails.
         (temp_root / "data").mkdir(parents=True, exist_ok=True)
-        for entity_type, records in selected_records.items():
+        for entity_type, records in selected_for_bundle.items():
             # Process each (entity_type, records) from selected_records.items().
             if not records:
                 continue
@@ -678,6 +692,29 @@ def export_bundle(
 
             if entity_type == "maps":
                 bundled_world_maps.update(_collect_world_map_entries(records, source_campaign.root))
+
+        if include_database:
+            extra_files = collect_full_campaign_extra_files(source_campaign.root)
+            if extra_files:
+                manifest["extra_files"] = []
+            for absolute_path, relative_path in extra_files:
+                bundle_path = Path("extras") / Path(relative_path)
+                bundle_abs = temp_root / bundle_path
+                bundle_abs.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    shutil.copy2(absolute_path, bundle_abs)
+                except Exception as exc:
+                    log_warning(
+                        f"Unable to bundle extra campaign file {absolute_path}: {exc}",
+                        func_name="modules.generic.cross_campaign_asset_service.export_bundle",
+                    )
+                    continue
+                manifest["extra_files"].append(
+                    {
+                        "relative_path": relative_path,
+                        "bundle_path": bundle_path.as_posix(),
+                    }
+                )
 
         if include_systems:
             # Continue with this path when include systems is set.
@@ -1201,7 +1238,8 @@ def install_full_campaign_bundle(
         shutil.copy2(db_source, db_destination)
 
         assets = manifest.get("assets") or []
-        total_steps = max(len(assets) + 1, 1)
+        extra_files = manifest.get("extra_files") or []
+        total_steps = max(len(assets) + len(extra_files) + 1, 1)
         _call_progress(progress_callback, "Copying database", 1 / total_steps)
 
         target_root = target_dir.resolve()
@@ -1239,6 +1277,41 @@ def install_full_campaign_bundle(
                 progress_callback,
                 f"Copying assets ({index}/{len(assets)})",
                 min((index + 1) / total_steps, 1.0),
+            )
+
+        extra_offset = len(assets)
+        for index, extra_entry in enumerate(extra_files, start=1):
+            bundle_rel = str(extra_entry.get("bundle_path") or "").strip()
+            relative_path = str(extra_entry.get("relative_path") or "").replace("\\", "/").strip()
+            if not bundle_rel or not relative_path:
+                continue
+            source_extra = (temp_dir / bundle_rel).resolve()
+            if not source_extra.exists():
+                log_warning(
+                    f"Missing extra file in bundle: {bundle_rel}",
+                    func_name="modules.generic.cross_campaign_asset_service.install_full_campaign_bundle",
+                )
+                continue
+            destination = (target_root / relative_path).resolve()
+            if not str(destination).startswith(str(target_root)):
+                log_warning(
+                    f"Skipping extra file with unsafe destination path: {relative_path}",
+                    func_name="modules.generic.cross_campaign_asset_service.install_full_campaign_bundle",
+                )
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(source_extra, destination)
+            except Exception as exc:
+                log_warning(
+                    f"Failed to copy extra file {source_extra}: {exc}",
+                    func_name="modules.generic.cross_campaign_asset_service.install_full_campaign_bundle",
+                )
+                continue
+            _call_progress(
+                progress_callback,
+                f"Copying extra files ({index}/{len(extra_files)})",
+                min((extra_offset + index + 1) / total_steps, 1.0),
             )
 
         campaign_name = str(manifest.get("source_campaign", {}).get("name") or target_dir.name)

--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -1,0 +1,33 @@
+"""Helpers for exporting/restoring non-entity campaign bundle files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+
+_RANDOM_TABLE_FILE = Path("static/data/random_tables.json")
+_RANDOM_TABLE_DIR = Path("static/data/random_tables")
+
+
+def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, str]]:
+    """Collect extra files that must travel with full-campaign bundles.
+
+    Returns tuples of (absolute_path, relative_path_posix).
+    """
+    root = Path(campaign_root).resolve()
+    collected: List[Tuple[Path, str]] = []
+
+    random_tables_file = (root / _RANDOM_TABLE_FILE).resolve()
+    if random_tables_file.exists() and random_tables_file.is_file():
+        collected.append((random_tables_file, _RANDOM_TABLE_FILE.as_posix()))
+
+    random_tables_dir = (root / _RANDOM_TABLE_DIR).resolve()
+    if random_tables_dir.exists() and random_tables_dir.is_dir():
+        for file_path in sorted(random_tables_dir.rglob("*.json")):
+            if not file_path.is_file():
+                continue
+            relative_path = file_path.relative_to(root).as_posix()
+            collected.append((file_path.resolve(), relative_path))
+
+    return collected

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -2,6 +2,7 @@
 
 import sys
 import types
+import sqlite3
 
 import pytest
 
@@ -23,6 +24,7 @@ from modules.generic.cross_campaign_asset_service import (
     _rewrite_record_paths,
     collect_assets,
     export_bundle,
+    install_full_campaign_bundle,
 )
 
 
@@ -88,3 +90,51 @@ def test_rewrite_record_paths_updates_image_library_fields(tmp_path):
     assert updated["RelativePath"] == replacement
     assert updated["Path"] == str((target_campaign_root / replacement).resolve())
     assert updated["SourceRoot"] == str(target_campaign_root)
+
+
+def test_export_bundle_full_campaign_includes_image_assets_even_without_selection(tmp_path, monkeypatch):
+    """Full campaign exports should still include image library records/assets."""
+    campaign_root = tmp_path / "source_campaign"
+    campaign_root.mkdir(parents=True, exist_ok=True)
+    db_path = campaign_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    image_file = campaign_root / "assets" / "image_library" / "tiles" / "forest.png"
+    image_file.parent.mkdir(parents=True, exist_ok=True)
+    image_file.write_bytes(b"forest-bytes")
+
+    source_campaign = CampaignDatabase(name="Source", root=campaign_root, db_path=db_path)
+    destination = tmp_path / "bundle.zip"
+
+    def fake_load_entities(entity_type, _db_path):
+        if entity_type == "image_assets":
+            return [{"Name": "Forest Tile", "RelativePath": "assets/image_library/tiles/forest.png"}]
+        return []
+
+    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+
+    manifest = export_bundle(destination, source_campaign, selected_records={}, include_database=True)
+
+    assert manifest["entities"]["image_assets"]["count"] == 1
+    assert any(asset.get("asset_type") == "image_library" for asset in manifest["assets"])
+
+
+def test_install_full_campaign_bundle_restores_random_tables_files(tmp_path):
+    """Installing a full campaign bundle should restore random table JSON files."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    random_tables_file = source_root / "static" / "data" / "random_tables" / "encounters.json"
+    random_tables_file.parent.mkdir(parents=True, exist_ok=True)
+    random_tables_file.write_text('{"categories": []}', encoding="utf-8")
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "full_bundle.zip"
+    export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+
+    target_root = tmp_path / "installed_campaign"
+    installed = install_full_campaign_bundle(bundle_path, target_root)
+
+    restored_random_table = installed.root / "static" / "data" / "random_tables" / "encounters.json"
+    assert restored_random_table.exists()
+    assert restored_random_table.read_text(encoding="utf-8") == '{"categories": []}'


### PR DESCRIPTION
## Summary
- ensure full campaign exports automatically include `image_assets` records/files even when not selected in the asset tabs
- include random table JSON files (`static/data/random_tables.json` and `static/data/random_tables/**/*.json`) in full campaign bundles
- restore those extra random-table files during full campaign install from GitHub/downloaded bundle
- add regression tests for full campaign export/import coverage of image library + random tables

## Details
- Added `modules/generic/cross_campaign_bundle_extras.py` to keep bundle-extra file discovery isolated and readable.
- Updated `export_bundle` in `cross_campaign_asset_service` to:
  - fail fast when `include_database=True` and DB is missing (preserves prior behavior)
  - auto-include `image_assets` records for full campaign bundles
  - package full-campaign extra files into `manifest["extra_files"]`
- Updated `install_full_campaign_bundle` to restore `extra_files` into the target campaign directory with path safety checks.
- Extended `tests/test_cross_campaign_asset_service.py` with:
  - coverage that full-campaign export includes image assets without explicit tab selections
  - coverage that full-campaign install restores random table files

## Validation
- `pytest -q tests/test_cross_campaign_asset_service.py` passed (5 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec982eae00832bb2c47214edbe0709)