### PR TITLE
Export/import maptools and GM table metadata in full campaign bundles

### DIFF
--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -8,6 +8,12 @@ from typing import List, Tuple
 
 _RANDOM_TABLE_FILE = Path("static/data/random_tables.json")
 _RANDOM_TABLE_DIR = Path("static/data/random_tables")
+_GM_LAYOUTS_FILE = Path("gm_layouts.json")
+_GM_TABLE_MARKS_FILES = (
+    Path("data/save/clue_positions.json"),
+    Path("data/save/clue_links.json"),
+)
+_MAPTOOLS_INFO_FILE = Path("world_maps/world_map_data.json")
 
 
 def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, str]]:
@@ -29,5 +35,19 @@ def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, s
                 continue
             relative_path = file_path.relative_to(root).as_posix()
             collected.append((file_path.resolve(), relative_path))
+
+    gm_layouts_file = (root / _GM_LAYOUTS_FILE).resolve()
+    if gm_layouts_file.exists() and gm_layouts_file.is_file():
+        collected.append((gm_layouts_file, _GM_LAYOUTS_FILE.as_posix()))
+
+    for relative in _GM_TABLE_MARKS_FILES:
+        marks_file = (root / relative).resolve()
+        if not marks_file.exists() or not marks_file.is_file():
+            continue
+        collected.append((marks_file, relative.as_posix()))
+
+    maptools_info_file = (root / _MAPTOOLS_INFO_FILE).resolve()
+    if maptools_info_file.exists() and maptools_info_file.is_file():
+        collected.append((maptools_info_file, _MAPTOOLS_INFO_FILE.as_posix()))
 
     return collected

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -138,3 +138,46 @@ def test_install_full_campaign_bundle_restores_random_tables_files(tmp_path):
     restored_random_table = installed.root / "static" / "data" / "random_tables" / "encounters.json"
     assert restored_random_table.exists()
     assert restored_random_table.read_text(encoding="utf-8") == '{"categories": []}'
+
+
+def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_path):
+    """Installing a full campaign bundle should restore maptools + GM table extra files."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    gm_layouts = source_root / "gm_layouts.json"
+    gm_layouts.write_text('{"layouts": {"Default": {"tabs": []}}}', encoding="utf-8")
+
+    clue_positions = source_root / "data" / "save" / "clue_positions.json"
+    clue_positions.parent.mkdir(parents=True, exist_ok=True)
+    clue_positions.write_text('{"Clue A": {"x": 10, "y": 20}}', encoding="utf-8")
+
+    clue_links = source_root / "data" / "save" / "clue_links.json"
+    clue_links.write_text('[{"source": "A", "target": "B"}]', encoding="utf-8")
+
+    world_map_data = source_root / "world_maps" / "world_map_data.json"
+    world_map_data.parent.mkdir(parents=True, exist_ok=True)
+    world_map_data.write_text('{"maps": {"City": {"tokens": []}}}', encoding="utf-8")
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "full_bundle.zip"
+    export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+
+    target_root = tmp_path / "installed_campaign"
+    installed = install_full_campaign_bundle(bundle_path, target_root)
+
+    restored_gm_layouts = installed.root / "gm_layouts.json"
+    restored_clue_positions = installed.root / "data" / "save" / "clue_positions.json"
+    restored_clue_links = installed.root / "data" / "save" / "clue_links.json"
+    restored_world_map_data = installed.root / "world_maps" / "world_map_data.json"
+
+    assert restored_gm_layouts.exists()
+    assert restored_gm_layouts.read_text(encoding="utf-8") == '{"layouts": {"Default": {"tabs": []}}}'
+    assert restored_clue_positions.exists()
+    assert restored_clue_positions.read_text(encoding="utf-8") == '{"Clue A": {"x": 10, "y": 20}}'
+    assert restored_clue_links.exists()
+    assert restored_clue_links.read_text(encoding="utf-8") == '[{"source": "A", "target": "B"}]'
+    assert restored_world_map_data.exists()
+    assert restored_world_map_data.read_text(encoding="utf-8") == '{"maps": {"City": {"tokens": []}}}'


### PR DESCRIPTION
### Motivation
- Full-campaign bundles did not include campaign-level map and GM-table files, so maptools metadata and GM table marks were lost when exporting/importing a DB bundle (including the GitHub full-bundle import flow). This change ensures those campaign-level files travel with the bundle.

### Description
- Added constants for extra files: `gm_layouts.json`, `data/save/clue_positions.json`, `data/save/clue_links.json`, and `world_maps/world_map_data.json` in `modules/generic/cross_campaign_bundle_extras.py`.
- Extended `collect_full_campaign_extra_files` to include the above files (returns tuples of `(absolute_path, relative_path)` so they are bundled with full-campaign exports).
- Added a regression test `test_install_full_campaign_bundle_restores_maptools_and_gm_table_files` in `tests/test_cross_campaign_asset_service.py` that exports a full bundle and asserts the listed files are restored on install.
- No changes required to the existing install/import codepath because installed `extra_files` are already copied by `install_full_campaign_bundle`, so GitHub-based imports use the same restore behavior.

### Testing
- Ran `pytest -q tests/test_cross_campaign_asset_service.py` and all tests passed (`6 passed`, `3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9cdc716c832b8e9bfebbdf12c059)