### PR TITLE
Include map records and mask files in full-campaign export bundles

### DIFF
--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -629,6 +629,16 @@ def export_bundle(
                 f"Unable to include image library records for full campaign export: {exc}",
                 func_name="modules.generic.cross_campaign_asset_service.export_bundle",
             )
+    if include_database and "maps" not in selected_for_bundle:
+        # Full-campaign exports should always include map records so fog-mask
+        # files and token/marker media can be discovered and bundled.
+        try:
+            selected_for_bundle["maps"] = load_entities("maps", source_campaign.db_path)
+        except Exception as exc:
+            log_warning(
+                f"Unable to include map records for full campaign export: {exc}",
+                func_name="modules.generic.cross_campaign_asset_service.export_bundle",
+            )
 
     data_dir = Path(tempfile.mkdtemp(prefix="asset_export_"))
     temp_root = Path(data_dir)

--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -14,6 +14,7 @@ _GM_TABLE_MARKS_FILES = (
     Path("data/save/clue_links.json"),
 )
 _MAPTOOLS_INFO_FILE = Path("world_maps/world_map_data.json")
+_MAP_MASKS_DIR = Path("masks")
 
 
 def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, str]]:
@@ -49,5 +50,13 @@ def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, s
     maptools_info_file = (root / _MAPTOOLS_INFO_FILE).resolve()
     if maptools_info_file.exists() and maptools_info_file.is_file():
         collected.append((maptools_info_file, _MAPTOOLS_INFO_FILE.as_posix()))
+
+    map_masks_dir = (root / _MAP_MASKS_DIR).resolve()
+    if map_masks_dir.exists() and map_masks_dir.is_dir():
+        for file_path in sorted(map_masks_dir.rglob("*")):
+            if not file_path.is_file():
+                continue
+            relative_path = file_path.relative_to(root).as_posix()
+            collected.append((file_path.resolve(), relative_path))
 
     return collected


### PR DESCRIPTION
### Motivation

- Ensure full-campaign exports always include map records so fog-mask files and token/marker media can be discovered and bundled.
- Ensure map mask files stored under the `masks` directory are collected and included with full-campaign bundles.

### Description

- When `include_database` is true and `maps` are not already selected, load `maps` entities from the source campaign database and append them to `selected_for_bundle`, with warning logging on failure.
- Add `_MAP_MASKS_DIR = Path("masks")` and include all files under the `masks` directory in `collect_full_campaign_extra_files` so they are returned as extra files to be packaged.

### Testing

- Ran the existing automated test suite with `pytest` and confirmed the test run completed successfully (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9ef824f4832b9878bb20220e0efa)