### PR TITLE
Add optional random-tables support to asset bundle export/import and GitHub publish

### DIFF
--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -434,7 +434,10 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             messagebox.showinfo("No Selection", "Select at least one asset to export.")
             return
 
-        options_dialog = CheckboxDialog(
+        include_systems = True
+        include_random_tables = False
+
+        systems_dialog = CheckboxDialog(
             self,
             title="Export Options",
             message="Choose optional content to include in this export bundle:",
@@ -443,10 +446,24 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             confirm_label="Continue",
             cancel_label="Cancel",
         )
-        self.wait_window(options_dialog)
-        if options_dialog.result is None:
+        self.wait_window(systems_dialog)
+        if systems_dialog.result is None:
             return
-        include_systems = options_dialog.result
+        include_systems = systems_dialog.result
+
+        random_tables_dialog = CheckboxDialog(
+            self,
+            title="Export Options",
+            message="Do you want to include random tables files in this bundle?",
+            checkbox_label="Include random tables",
+            default=False,
+            confirm_label="Continue",
+            cancel_label="Cancel",
+        )
+        self.wait_window(random_tables_dialog)
+        if random_tables_dialog.result is None:
+            return
+        include_random_tables = random_tables_dialog.result
 
         default_name = f"asset_bundle_{self.selected_campaign.name.replace(' ', '_')}.zip"
         destination = filedialog.asksaveasfilename(
@@ -466,6 +483,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 selections,
                 include_database=False,
                 include_systems=include_systems,
+                include_random_tables=include_random_tables,
                 progress_callback=callback,
             )
 
@@ -533,11 +551,29 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         if description is None:
             return
         description = description.strip()
+
+        include_random_tables = False
+        if not publishing_full_campaign:
+            random_tables_dialog = CheckboxDialog(
+                self,
+                title="Publish Options",
+                message="Do you want to include random tables files from this campaign?",
+                checkbox_label="Include random tables",
+                default=False,
+                confirm_label="Continue",
+                cancel_label="Cancel",
+            )
+            self.wait_window(random_tables_dialog)
+            if random_tables_dialog.result is None:
+                return
+            include_random_tables = bool(random_tables_dialog.result)
+
         self._publish_bundle_to_github(
             selections=selections,
             title=title,
             description=description,
             include_database=publishing_full_campaign,
+            include_random_tables=include_random_tables,
         )
 
     def publish_image_library_to_github(self):
@@ -589,6 +625,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             title=title,
             description=description,
             include_database=False,
+            include_random_tables=False,
             progress_title="Publishing Image Library",
         )
 
@@ -599,6 +636,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         title: str,
         description: str,
         include_database: bool = False,
+        include_random_tables: bool = False,
         progress_title: str = "Publishing Bundle",
     ) -> None:
         """Internal helper for publishing a bundle to GitHub."""
@@ -621,6 +659,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                     selections,
                     include_database=include_database,
                     include_systems=True,
+                    include_random_tables=include_random_tables,
                     progress_callback=callback,
                 )
                 return self.gallery_client.publish_bundle(
@@ -746,7 +785,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 f"Assets skipped: {summary.get('skipped', 0)}\n"
                 f"Systems imported: {summary.get('systems_imported', 0)}\n"
                 f"Systems updated: {summary.get('systems_updated', 0)}\n"
-                f"Systems skipped: {summary.get('systems_skipped', 0)}"
+                f"Systems skipped: {summary.get('systems_skipped', 0)}\n"
+                f"Extra files imported: {summary.get('extra_files_imported', 0)}\n"
+                f"Extra files skipped: {summary.get('extra_files_skipped', 0)}"
             ),
         )
 

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -609,6 +609,7 @@ def export_bundle(
     *,
     include_database: bool = False,
     include_systems: bool = True,
+    include_random_tables: bool = False,
     progress_callback=None,
 ) -> dict:
     """Export bundle."""
@@ -703,7 +704,7 @@ def export_bundle(
             if entity_type == "maps":
                 bundled_world_maps.update(_collect_world_map_entries(records, source_campaign.root))
 
-        if include_database:
+        if include_database or include_random_tables:
             extra_files = collect_full_campaign_extra_files(source_campaign.root)
             if extra_files:
                 manifest["extra_files"] = []
@@ -1141,6 +1142,49 @@ def apply_import(
                     summary["imported"] += 1
 
             save_entities(entity_type, target_campaign.db_path, list(merged.values()), replace=False)
+
+        imported_extra_files = 0
+        skipped_extra_files = 0
+        for extra_entry in analysis.manifest.get("extra_files") or []:
+            relative_path = str(extra_entry.get("relative_path") or "").replace("\\", "/").strip()
+            bundle_rel = str(extra_entry.get("bundle_path") or "").strip()
+            if not relative_path or not bundle_rel:
+                continue
+
+            source_extra = (assets_dir / bundle_rel).resolve()
+            if not source_extra.exists():
+                log_warning(
+                    f"Bundle extra file missing: {bundle_rel}",
+                    func_name="modules.generic.cross_campaign_asset_service.apply_import",
+                )
+                continue
+
+            destination = (target_campaign.root / relative_path).resolve()
+            if not str(destination).startswith(str(target_campaign.root.resolve())):
+                log_warning(
+                    f"Skipping extra file with unsafe destination path: {relative_path}",
+                    func_name="modules.generic.cross_campaign_asset_service.apply_import",
+                )
+                continue
+
+            if destination.exists() and not overwrite:
+                skipped_extra_files += 1
+                continue
+
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(source_extra, destination)
+                imported_extra_files += 1
+            except Exception as exc:
+                log_warning(
+                    f"Failed to copy extra file {source_extra}: {exc}",
+                    func_name="modules.generic.cross_campaign_asset_service.apply_import",
+                )
+
+        if imported_extra_files:
+            summary["extra_files_imported"] = imported_extra_files
+        if skipped_extra_files:
+            summary["extra_files_skipped"] = skipped_extra_files
 
         if analysis.systems:
             # Continue with this path when systems is set.

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -25,6 +25,8 @@ from modules.generic.cross_campaign_asset_service import (
     collect_assets,
     export_bundle,
     install_full_campaign_bundle,
+    analyze_bundle,
+    apply_import,
 )
 
 
@@ -181,3 +183,64 @@ def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_p
     assert restored_clue_links.read_text(encoding="utf-8") == '[{"source": "A", "target": "B"}]'
     assert restored_world_map_data.exists()
     assert restored_world_map_data.read_text(encoding="utf-8") == '{"maps": {"City": {"tokens": []}}}'
+
+
+def test_export_bundle_asset_mode_can_include_random_tables_files(tmp_path):
+    """Asset bundle exports can optionally include random-table files."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    random_tables_file = source_root / "static" / "data" / "random_tables" / "encounters.json"
+    random_tables_file.parent.mkdir(parents=True, exist_ok=True)
+    random_tables_file.write_text('{"categories": []}', encoding="utf-8")
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "asset_bundle.zip"
+    manifest = export_bundle(
+        bundle_path,
+        source_campaign,
+        selected_records={},
+        include_database=False,
+        include_random_tables=True,
+    )
+
+    extra_files = manifest.get("extra_files") or []
+    assert any(entry.get("relative_path") == "static/data/random_tables/encounters.json" for entry in extra_files)
+
+
+def test_apply_import_restores_extra_files_for_asset_bundle(tmp_path):
+    """Regular bundle imports should copy bundled extra files like random tables."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    random_tables_file = source_root / "static" / "data" / "random_tables" / "encounters.json"
+    random_tables_file.parent.mkdir(parents=True, exist_ok=True)
+    random_tables_file.write_text('{"categories": []}', encoding="utf-8")
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "asset_bundle.zip"
+    export_bundle(
+        bundle_path,
+        source_campaign,
+        selected_records={},
+        include_database=False,
+        include_random_tables=True,
+    )
+
+    target_root = tmp_path / "target"
+    target_root.mkdir(parents=True, exist_ok=True)
+    target_db = target_root / "campaign.db"
+    sqlite3.connect(target_db).close()
+    target_campaign = CampaignDatabase(name="Target", root=target_root, db_path=target_db)
+
+    analysis = analyze_bundle(bundle_path, target_campaign.db_path)
+    summary = apply_import(analysis, target_campaign, overwrite=True)
+
+    restored = target_root / "static" / "data" / "random_tables" / "encounters.json"
+    assert restored.exists()
+    assert restored.read_text(encoding="utf-8") == '{"categories": []}'
+    assert summary.get("extra_files_imported", 0) >= 1


### PR DESCRIPTION
### Motivation
- Allow users to include campaign random-table JSON files when exporting or publishing asset bundles without requiring a full database export.
- Ensure that asset-bundle imports restore bundled extra files (like random tables) into the target campaign safely and with overwrite-aware behaviour.

### Description
- Added an `include_random_tables: bool = False` parameter to `export_bundle` and wired it into the extra-files collection so asset bundles can include random-table files even when `include_database` is false (modules/generic/cross_campaign_asset_service.py).
- Updated `apply_import` to copy `manifest["extra_files"]` entries into the target campaign with safety checks for destination paths and counters for imported/skipped extra files (summary keys `extra_files_imported` / `extra_files_skipped`).
- Extended the Cross-Campaign Asset Library UI to prompt the user for random-table inclusion during export and GitHub publish flows and to report extra-file import counts in the import-complete dialog (modules/generic/cross_campaign_asset_library.py).
- Added regression tests covering exporting an asset bundle with random tables and importing it to restore random-table files (tests/test_cross_campaign_asset_service.py).

### Testing
- Ran `pytest -q tests/test_cross_campaign_asset_service.py` and all tests passed (`8 passed, 0 failed`).
- Verified syntax with `python -m py_compile modules/generic/cross_campaign_asset_service.py modules/generic/cross_campaign_asset_library.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca86ea55c832ba84075ee5f6d4d24)