### PR TITLE
Include internal custom random tables in full campaign bundles

### DIFF
--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 
 _RANDOM_TABLE_FILE = Path("static/data/random_tables.json")
 _RANDOM_TABLE_DIR = Path("static/data/random_tables")
+_INTERNAL_RANDOM_TABLE_CUSTOM_FILE = Path("_internal/static/data/random_tables/campaign_custom_tables.json")
 _GM_LAYOUTS_FILE = Path("gm_layouts.json")
 _GM_TABLE_MARKS_FILES = (
     Path("data/save/clue_positions.json"),
@@ -36,6 +37,10 @@ def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, s
                 continue
             relative_path = file_path.relative_to(root).as_posix()
             collected.append((file_path.resolve(), relative_path))
+
+    internal_custom_tables = (root / _INTERNAL_RANDOM_TABLE_CUSTOM_FILE).resolve()
+    if internal_custom_tables.exists() and internal_custom_tables.is_file():
+        collected.append((internal_custom_tables, _INTERNAL_RANDOM_TABLE_CUSTOM_FILE.as_posix()))
 
     gm_layouts_file = (root / _GM_LAYOUTS_FILE).resolve()
     if gm_layouts_file.exists() and gm_layouts_file.is_file():

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -142,6 +142,38 @@ def test_install_full_campaign_bundle_restores_random_tables_files(tmp_path):
     assert restored_random_table.read_text(encoding="utf-8") == '{"categories": []}'
 
 
+def test_install_full_campaign_bundle_restores_internal_custom_random_tables_file(tmp_path):
+    """Installing a full campaign bundle should restore internal custom random tables JSON."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    internal_custom_file = (
+        source_root / "_internal" / "static" / "data" / "random_tables" / "campaign_custom_tables.json"
+    )
+    internal_custom_file.parent.mkdir(parents=True, exist_ok=True)
+    internal_custom_file.write_text('{"tables": []}', encoding="utf-8")
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "full_bundle.zip"
+    manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+    extra_files = manifest.get("extra_files") or []
+    assert any(
+        entry.get("relative_path") == "_internal/static/data/random_tables/campaign_custom_tables.json"
+        for entry in extra_files
+    )
+
+    target_root = tmp_path / "installed_campaign"
+    installed = install_full_campaign_bundle(bundle_path, target_root)
+
+    restored_internal_custom = (
+        installed.root / "_internal" / "static" / "data" / "random_tables" / "campaign_custom_tables.json"
+    )
+    assert restored_internal_custom.exists()
+    assert restored_internal_custom.read_text(encoding="utf-8") == '{"tables": []}'
+
+
 def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_path):
     """Installing a full campaign bundle should restore maptools + GM table extra files."""
     source_root = tmp_path / "source"


### PR DESCRIPTION
### Motivation
- Ensure custom random tables stored under the internal path are included when publishing or exporting a full campaign bundle so Git-based database exports/imports preserve user-provided tables.

### Description
- Add `_internal/static/data/random_tables/campaign_custom_tables.json` as an extra-file candidate in `collect_full_campaign_extra_files` by introducing `_INTERNAL_RANDOM_TABLE_CUSTOM_FILE` and appending it when present in the campaign root (`modules/generic/cross_campaign_bundle_extras.py`).
- Add a regression test to verify the internal custom file is present in the bundle manifest and is restored by `install_full_campaign_bundle` (`tests/test_cross_campaign_asset_service.py`).
- Changes are localized to the extra-file collection logic and test coverage, keeping export/install flow unchanged otherwise.

### Testing
- Ran `pytest -q tests/test_cross_campaign_asset_service.py -k "internal_custom_random_tables_file or restores_random_tables_files"` and both targeted tests passed (2 passed, 7 deselected) with only a deprecation warning unrelated to this change.
- Test assertions verify the file appears in `manifest["extra_files"]` and that the file is restored under the `_internal` path after installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc407f164832b9599440d2a4143b9)