### PR TITLE
Store campaign custom random tables in campaign root and include in asset bundles

### DIFF
--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 
 _RANDOM_TABLE_FILE = Path("static/data/random_tables.json")
 _RANDOM_TABLE_DIR = Path("static/data/random_tables")
+_CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE = Path("campaign_custom_tables.json")
 _INTERNAL_RANDOM_TABLE_CUSTOM_FILE = Path("_internal/static/data/random_tables/campaign_custom_tables.json")
 _GM_LAYOUTS_FILE = Path("gm_layouts.json")
 _GM_TABLE_MARKS_FILES = (
@@ -37,6 +38,10 @@ def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, s
                 continue
             relative_path = file_path.relative_to(root).as_posix()
             collected.append((file_path.resolve(), relative_path))
+
+    campaign_custom_tables = (root / _CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE).resolve()
+    if campaign_custom_tables.exists() and campaign_custom_tables.is_file():
+        collected.append((campaign_custom_tables, _CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE.as_posix()))
 
     internal_custom_tables = (root / _INTERNAL_RANDOM_TABLE_CUSTOM_FILE).resolve()
     if internal_custom_tables.exists() and internal_custom_tables.is_file():

--- a/modules/helpers/random_table_loader.py
+++ b/modules/helpers/random_table_loader.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from modules.helpers.config_helper import ConfigHelper
@@ -11,6 +12,7 @@ log_module_import(__name__)
 
 
 PLOT_TWIST_TABLE_ID = "universal_plot_twists"
+CAMPAIGN_CUSTOM_TABLES_FILE = "campaign_custom_tables.json"
 
 
 class RandomTableLoader:
@@ -55,7 +57,17 @@ class RandomTableLoader:
         self.categories = []
         self.tables = {}
 
-        for source in self._iter_sources(self.base_path):
+        sources = list(self._iter_sources(self.base_path))
+        campaign_custom_tables = self.campaign_custom_tables_path()
+        if os.path.exists(campaign_custom_tables):
+            sources.append(campaign_custom_tables)
+
+        seen_sources = set()
+        for source in sources:
+            normalized_source = str(Path(source).resolve())
+            if normalized_source in seen_sources:
+                continue
+            seen_sources.add(normalized_source)
             # Process each source from _iter_sources(base_path).
             data = self._read_source(source)
             if not data:
@@ -211,6 +223,12 @@ class RandomTableLoader:
             return None
         text = str(value).strip()
         return text or None
+
+    @staticmethod
+    def campaign_custom_tables_path() -> str:
+        """Return campaign-specific custom random table file path."""
+        campaign_dir = ConfigHelper.get_campaign_dir()
+        return os.path.join(campaign_dir, CAMPAIGN_CUSTOM_TABLES_FILE)
 
 
 def plot_twist_data_path() -> str:

--- a/modules/scenarios/random_tables_editor.py
+++ b/modules/scenarios/random_tables_editor.py
@@ -10,7 +10,7 @@ import tkinter as tk
 from tkinter import messagebox
 
 from modules.helpers.config_helper import ConfigHelper
-from modules.helpers.random_table_loader import RandomTableLoader
+from modules.helpers.random_table_loader import CAMPAIGN_CUSTOM_TABLES_FILE, RandomTableLoader
 from modules.helpers.logging_helper import log_exception, log_module_import
 from modules.scenarios.dialogs.random_table_import_dialog import RandomTableImportDialog
 from modules.scenarios.random_tables_panel import RandomTablesPanel
@@ -318,27 +318,25 @@ class RandomTableEditorDialog(ctk.CTkToplevel):
 
     def _resolve_base_path(self) -> str:
         """Resolve base path."""
-        base_path = RandomTableLoader.default_data_path()
-        campaign_dir = os.path.join(ConfigHelper.get_campaign_dir(), "static", "data", "random_tables")
-        campaign_file = os.path.join(ConfigHelper.get_campaign_dir(), "static", "data", "random_tables.json")
-
-        if os.path.isdir(campaign_dir):
-            base_path = campaign_dir
-        elif os.path.exists(campaign_file):
-            base_path = campaign_file
-
-        return base_path
+        return RandomTableLoader.default_data_path()
 
     def _resolve_target_file(self, base_path: str, source_path: Optional[str]) -> str:
         """Resolve target file."""
+        campaign_custom_path = os.path.join(ConfigHelper.get_campaign_dir(), CAMPAIGN_CUSTOM_TABLES_FILE)
+
         if source_path and os.path.exists(source_path):
+            normalized_source = os.path.abspath(source_path)
+            normalized_campaign_custom = os.path.abspath(campaign_custom_path)
+            if normalized_source == normalized_campaign_custom:
+                os.makedirs(os.path.dirname(source_path) or ".", exist_ok=True)
+                return source_path
             os.makedirs(os.path.dirname(source_path) or ".", exist_ok=True)
-            return source_path
+            return campaign_custom_path
         if os.path.isdir(base_path):
-            os.makedirs(base_path, exist_ok=True)
-            return os.path.join(base_path, "campaign_custom_tables.json")
-        os.makedirs(os.path.dirname(base_path) or ".", exist_ok=True)
-        return base_path
+            os.makedirs(os.path.dirname(campaign_custom_path) or ".", exist_ok=True)
+            return campaign_custom_path
+        os.makedirs(os.path.dirname(campaign_custom_path) or ".", exist_ok=True)
+        return campaign_custom_path
 
     def _load_existing_tables(self, target_file: str) -> dict:
         """Load existing tables."""

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -142,36 +142,28 @@ def test_install_full_campaign_bundle_restores_random_tables_files(tmp_path):
     assert restored_random_table.read_text(encoding="utf-8") == '{"categories": []}'
 
 
-def test_install_full_campaign_bundle_restores_internal_custom_random_tables_file(tmp_path):
-    """Installing a full campaign bundle should restore internal custom random tables JSON."""
+def test_install_full_campaign_bundle_restores_campaign_custom_random_tables_file(tmp_path):
+    """Installing a full campaign bundle should restore campaign custom random tables JSON."""
     source_root = tmp_path / "source"
     source_root.mkdir(parents=True, exist_ok=True)
     db_path = source_root / "campaign.db"
     sqlite3.connect(db_path).close()
 
-    internal_custom_file = (
-        source_root / "_internal" / "static" / "data" / "random_tables" / "campaign_custom_tables.json"
-    )
-    internal_custom_file.parent.mkdir(parents=True, exist_ok=True)
-    internal_custom_file.write_text('{"tables": []}', encoding="utf-8")
+    campaign_custom_file = source_root / "campaign_custom_tables.json"
+    campaign_custom_file.write_text('{"tables": []}', encoding="utf-8")
 
     source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
     bundle_path = tmp_path / "full_bundle.zip"
     manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
     extra_files = manifest.get("extra_files") or []
-    assert any(
-        entry.get("relative_path") == "_internal/static/data/random_tables/campaign_custom_tables.json"
-        for entry in extra_files
-    )
+    assert any(entry.get("relative_path") == "campaign_custom_tables.json" for entry in extra_files)
 
     target_root = tmp_path / "installed_campaign"
     installed = install_full_campaign_bundle(bundle_path, target_root)
 
-    restored_internal_custom = (
-        installed.root / "_internal" / "static" / "data" / "random_tables" / "campaign_custom_tables.json"
-    )
-    assert restored_internal_custom.exists()
-    assert restored_internal_custom.read_text(encoding="utf-8") == '{"tables": []}'
+    restored_campaign_custom = installed.root / "campaign_custom_tables.json"
+    assert restored_campaign_custom.exists()
+    assert restored_campaign_custom.read_text(encoding="utf-8") == '{"tables": []}'
 
 
 def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_path):


### PR DESCRIPTION
### Motivation
- Campaign-specific random-table edits should live in the campaign directory rather than under the app `static` tree so each campaign can carry its own custom tables. 
- When exporting/importing full-campaign or global asset bundles those campaign-specific custom tables must be included so they are preserved across installs.

### Description
- Random table loader now automatically includes a campaign-level file returned by `RandomTableLoader.campaign_custom_tables_path()` (`campaign_custom_tables.json` at campaign root) and deduplicates sources to avoid double-loading the same file, implemented in `modules/helpers/random_table_loader.py`.
- Random table editor persistence was changed to target the campaign root `campaign_custom_tables.json` instead of `static/data/random_tables/...`, and the editor resolves the target file to the campaign-level path when saving, implemented in `modules/scenarios/random_tables_editor.py`.
- Full-campaign extra-file collection now includes `campaign_custom_tables.json` at the campaign root so the file is exported/imported with bundles, implemented in `modules/generic/cross_campaign_bundle_extras.py`.
- Updated regression tests in `tests/test_cross_campaign_asset_service.py` to assert that `campaign_custom_tables.json` is added to bundle `extra_files` and restored on install.

### Testing
- Ran `pytest -q tests/test_cross_campaign_asset_service.py` which executed the updated regression tests and the suite passed with `9 passed` and no failures (plus some benign deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcbddba40832b89420bcd3330966a)