### PR TITLE
Add Ambiance Screen panel to GM Table and GM Screen

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -4576,6 +4576,31 @@ class MainWindow(ctk.CTk):
             self._ambiance_player = SecondScreenAmbiancePlayer(root=self)
         return self._ambiance_player
 
+    def open_ambiance_panel(self):
+        """Open ambiance controls in the active GM workspace."""
+        try:
+            if getattr(self, "current_gm_view", None) is not None and self.current_gm_view.winfo_exists():
+                self.current_gm_view.open_ambiance_tab()
+                return
+        except Exception:
+            pass
+
+        try:
+            if getattr(self, "current_gm_table", None) is not None and self.current_gm_table.winfo_exists():
+                opener = getattr(self.current_gm_table, "open_ambiance_panel", None)
+                if callable(opener):
+                    opener()
+                    return
+        except Exception:
+            pass
+
+        self.open_gm_screen(show_empty_message=True)
+        try:
+            if getattr(self, "current_gm_view", None) is not None and self.current_gm_view.winfo_exists():
+                self.current_gm_view.open_ambiance_tab()
+        except Exception:
+            pass
+
     def open_sound_manager(self):
         """Open sound manager."""
         try:

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -35,6 +35,7 @@ from modules.scenarios.scene_flow_viewer import create_scene_flow_frame, scene_f
 from modules.scenarios.plot_twist_scheduler import PlotTwistScheduler
 from modules.scenarios.plot_twist_panel import PlotTwistPanel, roll_plot_twist
 from modules.scenarios.gm_screen.handouts.panel import create_handouts_panel
+from modules.scenarios.gm_table.ambiance.page import GMTableAmbiancePage
 from modules.scenarios.session_notes import (
     build_scene_snapshot_entry,
     build_session_debrief_entry,
@@ -239,6 +240,7 @@ class GMScreenView(ctk.CTkFrame):
             "Scene Flow",
             "Image Library",
             "Handouts",
+            "Ambiance Screen",
             "Loot Generator",
             "Whiteboard",
             "Random Tables",
@@ -2012,6 +2014,8 @@ class GMScreenView(ctk.CTkFrame):
             self.open_whiteboard_tab(title=title or "Whiteboard")
         elif kind == "handouts":
             self.open_handouts_tab(title=title or "Handouts")
+        elif kind == "ambiance":
+            self.open_ambiance_tab(title=title or "Ambiance Screen")
         elif kind == "puzzle_display":
             # Handle the branch where kind == 'puzzle_display'.
             puzzle_name = tab_def.get("puzzle_name")
@@ -2561,6 +2565,32 @@ class GMScreenView(ctk.CTkFrame):
             activate=activate,
         )
 
+    def open_ambiance_tab(self, title=None, activate=True):
+        """Open the ambiance panel inside the GM screen."""
+        container = ctk.CTkFrame(self._ensure_rich_host())
+        self._make_fullbleed(container)
+        panel = GMTableAmbiancePage(container)
+        panel.pack(fill="both", expand=True)
+        container.ambiance_panel = panel
+
+        def factory(master):
+            """Create ambiance panel content."""
+            host_parent = master if master is not None else self._ensure_rich_host()
+            frame = ctk.CTkFrame(host_parent)
+            self._make_fullbleed(frame)
+            created = GMTableAmbiancePage(frame)
+            created.pack(fill="both", expand=True)
+            frame.ambiance_panel = created
+            return frame
+
+        self.add_tab(
+            title or "Ambiance Screen",
+            container,
+            content_factory=factory,
+            layout_meta={"kind": "ambiance", "host": "rich"},
+            activate=activate,
+        )
+
     def open_random_tables_tab(self, title=None, initial_state=None):
         """Open the random tables panel inside the GM screen."""
 
@@ -3051,6 +3081,9 @@ class GMScreenView(ctk.CTkFrame):
             return
         elif entity_type == "Handouts":
             self.open_handouts_tab()
+            return
+        elif entity_type == "Ambiance Screen":
+            self.open_ambiance_tab()
             return
         elif entity_type == "Loot Generator":
             # Handle the branch where entity_type == 'Loot Generator'.

--- a/modules/scenarios/gm_table/ambiance/__init__.py
+++ b/modules/scenarios/gm_table/ambiance/__init__.py
@@ -1,0 +1,12 @@
+"""GM Table ambiance modules."""
+
+from .page import GMTableAmbiancePage
+from .repository import AmbianceMediaRecord, AmbianceMediaRepository
+from .thumbnail_cache import ThumbnailCache
+
+__all__ = [
+    "AmbianceMediaRecord",
+    "AmbianceMediaRepository",
+    "GMTableAmbiancePage",
+    "ThumbnailCache",
+]

--- a/modules/scenarios/gm_table/ambiance/page.py
+++ b/modules/scenarios/gm_table/ambiance/page.py
@@ -1,0 +1,251 @@
+"""Ambiance page embedded in GM Table / GM Screen."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tkinter as tk
+from tkinter import filedialog
+
+import customtkinter as ctk
+
+from modules.scenarios.gm_table.ambiance.repository import (
+    AmbianceMediaRecord,
+    AmbianceMediaRepository,
+)
+from modules.scenarios.gm_table.ambiance.thumbnail_cache import ThumbnailCache
+from modules.ui.ambiance.models import AmbianceItem, AmbiancePlaylist
+
+
+class GMTableAmbiancePage(ctk.CTkFrame):
+    """Manage ambiance playlists and control second-screen playback."""
+
+    def __init__(self, master, *, initial_state: dict | None = None) -> None:
+        super().__init__(master, fg_color="transparent")
+        self.grid_rowconfigure(3, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        state = dict(initial_state or {})
+        self._repository = AmbianceMediaRepository()
+        self._thumbnail_cache = ThumbnailCache()
+        self._records: list[AmbianceMediaRecord] = []
+
+        self._folder_var = tk.StringVar(value=str(state.get("folder") or ""))
+        self._playlist_var = tk.StringVar(value=str(state.get("playlist") or ""))
+        self._status_var = tk.StringVar(value="")
+        self._duration_var = tk.StringVar(value=str(state.get("image_duration") or "8"))
+        self._loop_var = tk.BooleanVar(value=bool(state.get("loop", True)))
+        self._shuffle_var = tk.BooleanVar(value=bool(state.get("shuffle", False)))
+
+        ctk.CTkLabel(
+            self,
+            text="Ambiance Screen",
+            anchor="w",
+            font=ctk.CTkFont(size=16, weight="bold"),
+        ).grid(row=0, column=0, sticky="ew", pady=(0, 6))
+
+        controls = ctk.CTkFrame(self, fg_color="transparent")
+        controls.grid(row=1, column=0, sticky="ew", pady=(0, 6))
+        controls.grid_columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(controls, text="Folder", width=78, anchor="w").grid(row=0, column=0, sticky="w")
+        ctk.CTkEntry(controls, textvariable=self._folder_var, height=30).grid(
+            row=0, column=1, sticky="ew", padx=6
+        )
+        ctk.CTkButton(controls, text="Browse", width=86, command=self._pick_folder).grid(row=0, column=2, padx=(0, 4))
+        ctk.CTkButton(controls, text="Scan", width=70, command=self._scan_folder).grid(row=0, column=3)
+
+        ctk.CTkLabel(controls, text="Playlist", width=78, anchor="w").grid(row=1, column=0, sticky="w", pady=(6, 0))
+        ctk.CTkEntry(controls, textvariable=self._playlist_var, height=30).grid(
+            row=1, column=1, sticky="ew", padx=6, pady=(6, 0)
+        )
+        ctk.CTkButton(controls, text="Load", width=86, command=self._pick_playlist).grid(row=1, column=2, padx=(0, 4), pady=(6, 0))
+        ctk.CTkButton(controls, text="Refresh", width=70, command=self._refresh_sources).grid(row=1, column=3, pady=(6, 0))
+
+        options = ctk.CTkFrame(self, fg_color="transparent")
+        options.grid(row=2, column=0, sticky="ew", pady=(0, 6))
+        options.grid_columnconfigure(5, weight=1)
+
+        ctk.CTkLabel(options, text="Image duration (s)").grid(row=0, column=0, sticky="w")
+        ctk.CTkEntry(options, textvariable=self._duration_var, width=88, height=30).grid(row=0, column=1, padx=(6, 16), sticky="w")
+        ctk.CTkCheckBox(options, text="Loop", variable=self._loop_var).grid(row=0, column=2, padx=(0, 10))
+        ctk.CTkCheckBox(options, text="Shuffle", variable=self._shuffle_var).grid(row=0, column=3, padx=(0, 10))
+
+        ctk.CTkButton(options, text="Start", width=72, command=self._start).grid(row=0, column=6, padx=(0, 6), sticky="e")
+        ctk.CTkButton(options, text="Pause", width=72, command=self._pause_or_resume).grid(row=0, column=7, padx=(0, 6), sticky="e")
+        ctk.CTkButton(options, text="Stop", width=72, command=self._stop).grid(row=0, column=8, padx=(0, 6), sticky="e")
+        ctk.CTkButton(options, text="Next", width=72, command=self._next).grid(row=0, column=9, sticky="e")
+
+        self._list = ctk.CTkScrollableFrame(self, fg_color="transparent")
+        self._list.grid(row=3, column=0, sticky="nsew")
+
+        ctk.CTkLabel(
+            self,
+            textvariable=self._status_var,
+            anchor="w",
+            justify="left",
+            text_color="#F59E0B",
+        ).grid(row=4, column=0, sticky="ew", pady=(6, 0))
+
+        self._refresh_sources()
+
+    def _pick_folder(self) -> None:
+        selected = filedialog.askdirectory(title="Select ambiance folder")
+        if selected:
+            self._folder_var.set(selected)
+            self._scan_folder()
+
+    def _pick_playlist(self) -> None:
+        selected = filedialog.askopenfilename(
+            title="Select ambiance playlist",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        if selected:
+            self._playlist_var.set(selected)
+            self._load_playlist_file(selected)
+
+    def _refresh_sources(self) -> None:
+        playlist_path = self._playlist_var.get().strip()
+        folder = self._folder_var.get().strip()
+        if playlist_path:
+            self._load_playlist_file(playlist_path)
+            return
+        if folder:
+            self._scan_folder()
+            return
+        self._records = []
+        self._render_records()
+
+    def _scan_folder(self) -> None:
+        folder = self._folder_var.get().strip()
+        if not folder:
+            self._status_var.set("Select a folder before scanning.")
+            return
+        self._records = self._repository.scan_folder(folder)
+        self._status_var.set(f"{len(self._records)} media indexed from folder.")
+        self._render_records()
+
+    def _load_playlist_file(self, playlist_path: str) -> None:
+        path = Path(playlist_path).expanduser()
+        if not path.is_file():
+            self._status_var.set("Playlist file not found.")
+            return
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            self._status_var.set(f"Unable to read playlist: {exc}")
+            return
+
+        media_items = payload.get("items") if isinstance(payload, dict) else []
+        if not isinstance(media_items, list):
+            media_items = []
+        media_paths = [str((item or {}).get("path") or "") for item in media_items if isinstance(item, dict)]
+        self._records = self._repository.build_index(media_paths)
+
+        if isinstance(payload, dict):
+            self._loop_var.set(bool(payload.get("loop", self._loop_var.get())))
+            self._shuffle_var.set(bool(payload.get("shuffle", self._shuffle_var.get())))
+            duration = payload.get("default_duration")
+            if duration not in (None, ""):
+                self._duration_var.set(str(duration))
+        self._status_var.set(f"{len(self._records)} media loaded from playlist.")
+        self._render_records()
+
+    def _render_records(self) -> None:
+        for child in self._list.winfo_children():
+            child.destroy()
+
+        if not self._records:
+            ctk.CTkLabel(self._list, text="No media detected.", anchor="w").grid(row=0, column=0, sticky="ew", padx=4, pady=4)
+            return
+
+        self._list.grid_columnconfigure(1, weight=1)
+        for idx, record in enumerate(self._records):
+            row = ctk.CTkFrame(self._list)
+            row.grid(row=idx, column=0, sticky="ew", padx=2, pady=2)
+            row.grid_columnconfigure(1, weight=1)
+
+            thumb = self._thumbnail_cache.get(record)
+            ctk.CTkLabel(row, text="", image=thumb, width=116).grid(row=0, column=0, padx=(6, 8), pady=6)
+
+            details = record.name
+            if record.width and record.height:
+                details = f"{details} · {record.width}x{record.height}"
+            ctk.CTkLabel(row, text=details, anchor="w").grid(row=0, column=1, sticky="ew", padx=(0, 8))
+            ctk.CTkLabel(row, text=record.media_type.title(), text_color="#9CA3AF", width=72).grid(row=0, column=2, padx=(0, 8))
+
+    def _build_playlist(self) -> AmbiancePlaylist | None:
+        if not self._records:
+            self._status_var.set("No media available. Scan folder or load playlist first.")
+            return None
+
+        try:
+            default_duration = max(0.5, float(self._duration_var.get().strip()))
+        except Exception:
+            self._status_var.set("Image duration must be a number.")
+            return None
+
+        items = [
+            AmbianceItem(path=record.path, media_type=record.media_type, duration=default_duration)
+            for record in self._records
+        ]
+        return AmbiancePlaylist(
+            items=items,
+            loop=bool(self._loop_var.get()),
+            shuffle=bool(self._shuffle_var.get()),
+            default_duration=default_duration,
+        )
+
+    def _resolve_player(self):
+        host = self.winfo_toplevel()
+        getter = getattr(host, "get_ambiance_player", None)
+        if callable(getter):
+            return getter()
+        self._status_var.set("Ambiance player unavailable from this window.")
+        return None
+
+    def _start(self) -> None:
+        player = self._resolve_player()
+        playlist = self._build_playlist()
+        if player is None or playlist is None:
+            return
+        try:
+            player.start(playlist)
+            self._status_var.set(f"Playback started ({len(playlist.items)} media).")
+        except Exception as exc:
+            self._status_var.set(f"Start failed: {exc}")
+
+    def _pause_or_resume(self) -> None:
+        player = self._resolve_player()
+        if player is None:
+            return
+        try:
+            state = getattr(player, "_state", None)
+            if state is not None and getattr(state, "is_paused", False):
+                player.resume()
+                self._status_var.set("Playback resumed.")
+            else:
+                player.pause()
+                self._status_var.set("Playback paused.")
+        except Exception as exc:
+            self._status_var.set(f"Pause failed: {exc}")
+
+    def _stop(self) -> None:
+        player = self._resolve_player()
+        if player is None:
+            return
+        try:
+            player.stop()
+            self._status_var.set("Playback stopped.")
+        except Exception as exc:
+            self._status_var.set(f"Stop failed: {exc}")
+
+    def _next(self) -> None:
+        player = self._resolve_player()
+        if player is None:
+            return
+        try:
+            player.next()
+            self._status_var.set("Skipped to next media.")
+        except Exception as exc:
+            self._status_var.set(f"Next failed: {exc}")

--- a/modules/scenarios/gm_table/ambiance/repository.py
+++ b/modules/scenarios/gm_table/ambiance/repository.py
@@ -1,0 +1,86 @@
+"""Media repository for the GM Table ambiance workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from PIL import Image
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"}
+_VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"}
+_MEDIA_EXTENSIONS = _IMAGE_EXTENSIONS | _VIDEO_EXTENSIONS
+
+
+@dataclass(slots=True)
+class AmbianceMediaRecord:
+    """Single indexed media entry."""
+
+    path: str
+    name: str
+    media_type: str
+    modified_at: float
+    size_bytes: int
+    width: int | None = None
+    height: int | None = None
+
+
+class AmbianceMediaRepository:
+    """Build a local media index from folders or explicit paths."""
+
+    def scan_folder(self, folder_path: str) -> list[AmbianceMediaRecord]:
+        """Scan a folder recursively and return indexed media entries."""
+        base = Path(folder_path).expanduser()
+        if not base.is_dir():
+            return []
+
+        records: list[AmbianceMediaRecord] = []
+        for candidate in sorted(base.rglob("*")):
+            if not candidate.is_file() or candidate.suffix.lower() not in _MEDIA_EXTENSIONS:
+                continue
+            record = self._build_record(candidate)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def build_index(self, media_paths: Iterable[str]) -> list[AmbianceMediaRecord]:
+        """Create metadata records from an explicit list of media paths."""
+        records: list[AmbianceMediaRecord] = []
+        for raw_path in media_paths:
+            path = Path(str(raw_path or "")).expanduser()
+            if not path.is_file() or path.suffix.lower() not in _MEDIA_EXTENSIONS:
+                continue
+            record = self._build_record(path)
+            if record is not None:
+                records.append(record)
+        return sorted(records, key=lambda entry: entry.name.casefold())
+
+    def _build_record(self, path: Path) -> AmbianceMediaRecord | None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+
+        extension = path.suffix.lower()
+        media_type = "image" if extension in _IMAGE_EXTENSIONS else "video"
+        width = None
+        height = None
+
+        if media_type == "image":
+            try:
+                with Image.open(path) as image:
+                    width, height = image.size
+            except Exception:
+                width = None
+                height = None
+
+        return AmbianceMediaRecord(
+            path=str(path.resolve()),
+            name=path.name,
+            media_type=media_type,
+            modified_at=float(stat.st_mtime),
+            size_bytes=int(stat.st_size),
+            width=width,
+            height=height,
+        )

--- a/modules/scenarios/gm_table/ambiance/thumbnail_cache.py
+++ b/modules/scenarios/gm_table/ambiance/thumbnail_cache.py
@@ -1,0 +1,59 @@
+"""Thumbnail cache for GM Table ambiance media lists."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+
+import customtkinter as ctk
+from PIL import Image, ImageOps
+
+from modules.scenarios.gm_table.ambiance.repository import AmbianceMediaRecord
+
+_THUMBNAIL_SIZE = (116, 66)
+
+
+class ThumbnailCache:
+    """Small in-memory LRU cache of CTk thumbnails."""
+
+    def __init__(self, *, max_items: int = 220) -> None:
+        self._max_items = max(40, int(max_items))
+        self._cache: OrderedDict[str, tuple[float, ctk.CTkImage]] = OrderedDict()
+        self._placeholder = self._build_placeholder()
+
+    def get(self, record: AmbianceMediaRecord) -> ctk.CTkImage:
+        """Return a thumbnail for a media record."""
+        key = record.path
+        cached = self._cache.get(key)
+        if cached is not None and cached[0] == record.modified_at:
+            self._cache.move_to_end(key)
+            return cached[1]
+
+        image = self._load(record)
+        self._cache[key] = (record.modified_at, image)
+        self._cache.move_to_end(key)
+        while len(self._cache) > self._max_items:
+            self._cache.popitem(last=False)
+        return image
+
+    def clear(self) -> None:
+        """Drop all cached thumbnails."""
+        self._cache.clear()
+
+    def _load(self, record: AmbianceMediaRecord) -> ctk.CTkImage:
+        if record.media_type != "image":
+            return self._placeholder
+
+        path = Path(record.path)
+        try:
+            with Image.open(path) as source:
+                render = source.convert("RGB")
+                fitted = ImageOps.fit(render, _THUMBNAIL_SIZE, Image.Resampling.LANCZOS)
+        except Exception:
+            return self._placeholder
+        return ctk.CTkImage(light_image=fitted, dark_image=fitted, size=_THUMBNAIL_SIZE)
+
+    @staticmethod
+    def _build_placeholder() -> ctk.CTkImage:
+        image = Image.new("RGB", _THUMBNAIL_SIZE, color="#1F2937")
+        return ctk.CTkImage(light_image=image, dark_image=image, size=_THUMBNAIL_SIZE)

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -39,6 +39,7 @@ DEFAULT_PANEL_SIZES = {
     "scene_flow": (860, 600),
     "image_library": (860, 580),
     "handouts": (760, 560),
+    "ambiance": (820, 580),
     "loot_generator": (620, 520),
     "whiteboard": (900, 640),
     "random_tables": (680, 560),

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -21,6 +21,7 @@ from modules.objects.loot_generator_panel import LootGeneratorPanel
 from modules.puzzles.puzzle_display_window import create_puzzle_display_frame
 from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
+from modules.scenarios.gm_table.ambiance.page import GMTableAmbiancePage
 from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
 from modules.scenarios.gm_table.pages import (
     GMTableHostedPage,
@@ -124,6 +125,7 @@ class GMTableView(ctk.CTkFrame):
             "Scene Flow",
             "Image Library",
             "Handouts",
+            "Ambiance Screen",
             "Loot Generator",
             "Whiteboard",
             "Random Tables",
@@ -671,6 +673,9 @@ class GMTableView(ctk.CTkFrame):
                 "handouts", "Handouts", {"scenario_name": self.scenario_name}
             )
             return
+        if option == "Ambiance Screen":
+            self.open_ambiance_panel()
+            return
         if option == "Loot Generator":
             self._create_panel("loot_generator", "Loot Generator", {})
             return
@@ -757,6 +762,8 @@ class GMTableView(ctk.CTkFrame):
                     map_wrapper=self.map_wrapper,
                     initial_state=definition.state,
                 )
+            if kind == "ambiance":
+                return GMTableAmbiancePage(parent, initial_state=definition.state)
             if kind == "loot_generator":
                 return GMTableHostedPage(
                     parent,
@@ -1078,6 +1085,15 @@ class GMTableView(ctk.CTkFrame):
             _open_selected,
         )
         view.pack(fill="both", expand=True)
+
+    def open_ambiance_panel(self) -> None:
+        """Focus an existing ambiance panel or create one."""
+        records = self.workspace.list_panels(kinds={"ambiance"}, include_minimized=True)
+        if records:
+            panel_id = str(records[-1]["panel_id"])
+            self.workspace.bring_to_front(panel_id)
+            return
+        self._create_panel("ambiance", "Ambiance Screen", {})
 
     def open_chatbot(self, event=None) -> None:
         """Open the shared chatbot from the tabletop."""

--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -173,6 +173,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                         _command("Dice", app.open_dice_roller, shortcut="F8", icon_key="dice_roller"),
                         _command("Sound & Music", app.open_sound_manager, shortcut="F7", icon_key="audio_controls"),
                         _command("Session Timers", app.open_timer_window, icon_key="session_timers"),
+                        _command("Ambiance Screen", app.open_ambiance_panel, icon_key="audio_controls"),
                         _command("Character Creation", app.open_character_creation),
                     ],
                 ),


### PR DESCRIPTION
### Motivation
- Fournir un panneau d'« Ambiance » pour piloter la lecture d'images/vidéos sur un second écran depuis l'espace GM.
- Réutiliser le player second-screen existant et offrir une UI pour charger un dossier ou une playlist, configurer la durée, le loop/shuffle et les contrôles de lecture.
- Améliorer la fluidité UI avec des miniatures mises en cache pour éviter les blocages lors du rendu de listes média.

### Description
- Ajout du nouveau module `modules/scenarios/gm_table/ambiance/` contenant `page.py` (UI `GMTableAmbiancePage`), `repository.py` (`AmbianceMediaRepository` et `AmbianceMediaRecord`) et `thumbnail_cache.py` (`ThumbnailCache`) pour l'indexation et le cache des miniatures.
- `GMTableAmbiancePage` propose la sélection de dossier/playlist, l'affichage des médias indexés, le réglage de la durée par image, les options `loop`/`shuffle` et les boutons `Start`/`Pause`/`Stop`/`Next` qui contrôlent le player via `get_ambiance_player`.
- Intégration dans les flux existants : prise en charge de `kind == "ambiance"` dans la création de panels, méthode `open_ambiance_panel` ajoutée à la vue GM Table, méthode `open_ambiance_tab` ajoutée à la GM Screen, et menu “Ambiance Screen” ajouté dans `modules/ui/menu/menu_sections.py`.
- Mise à jour de la taille par défaut des panels (`DEFAULT_PANEL_SIZES`) pour inclure la clé `"ambiance"`.

### Testing
- Compilation statique: exécuté `python -m py_compile` sur les fichiers modifiés (`modules/scenarios/gm_table/ambiance/*.py`, `modules/scenarios/gm_table_view.py`, `modules/scenarios/gm_screen_view.py`, `modules/ui/menu/menu_sections.py`, `main_window.py`, `modules/scenarios/gm_table/workspace.py`) et la commande s'est terminée sans erreur de syntaxe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd5d49c54832b9e39f3ad1ae01ebb)