### PR TITLE
Add Ambiance campaign settings module and auto-restore flow

### DIFF
--- a/modules/scenarios/gm_table/ambiance/page.py
+++ b/modules/scenarios/gm_table/ambiance/page.py
@@ -15,6 +15,11 @@ from modules.scenarios.gm_table.ambiance.repository import (
 )
 from modules.scenarios.gm_table.ambiance.thumbnail_cache import ThumbnailCache
 from modules.ui.ambiance.models import AmbianceItem, AmbiancePlaylist
+from modules.ui.ambiance.settings import (
+    AmbianceSettings,
+    load_ambiance_settings,
+    update_ambiance_settings,
+)
 
 
 class GMTableAmbiancePage(ctk.CTkFrame):
@@ -29,13 +34,21 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         self._repository = AmbianceMediaRepository()
         self._thumbnail_cache = ThumbnailCache()
         self._records: list[AmbianceMediaRecord] = []
+        self._restoring_ui_state = True
 
-        self._folder_var = tk.StringVar(value=str(state.get("folder") or ""))
-        self._playlist_var = tk.StringVar(value=str(state.get("playlist") or ""))
+        settings = load_ambiance_settings()
+        preloaded_folder, preloaded_playlist = self._resolve_source_paths(state=state, settings=settings)
+
+        self._folder_var = tk.StringVar(value=preloaded_folder)
+        self._playlist_var = tk.StringVar(value=preloaded_playlist)
         self._status_var = tk.StringVar(value="")
-        self._duration_var = tk.StringVar(value=str(state.get("image_duration") or "8"))
-        self._loop_var = tk.BooleanVar(value=bool(state.get("loop", True)))
-        self._shuffle_var = tk.BooleanVar(value=bool(state.get("shuffle", False)))
+        duration_value = state.get("image_duration", settings.default_duration_sec)
+        self._duration_var = tk.StringVar(value=str(duration_value if duration_value not in (None, "") else "8"))
+        self._loop_var = tk.BooleanVar(value=bool(state.get("loop", settings.loop)))
+        self._shuffle_var = tk.BooleanVar(value=bool(state.get("shuffle", settings.shuffle)))
+        self._enabled_var = tk.BooleanVar(value=bool(settings.enabled))
+        self._transition_var = tk.StringVar(value=settings.transition if settings.transition in {"fade", "cut"} else "fade")
+        self._monitor_var = tk.StringVar(value=str(max(0, settings.target_monitor_index)))
 
         ctk.CTkLabel(
             self,
@@ -64,17 +77,28 @@ class GMTableAmbiancePage(ctk.CTkFrame):
 
         options = ctk.CTkFrame(self, fg_color="transparent")
         options.grid(row=2, column=0, sticky="ew", pady=(0, 6))
-        options.grid_columnconfigure(5, weight=1)
+        options.grid_columnconfigure(8, weight=1)
 
         ctk.CTkLabel(options, text="Image duration (s)").grid(row=0, column=0, sticky="w")
         ctk.CTkEntry(options, textvariable=self._duration_var, width=88, height=30).grid(row=0, column=1, padx=(6, 16), sticky="w")
         ctk.CTkCheckBox(options, text="Loop", variable=self._loop_var).grid(row=0, column=2, padx=(0, 10))
         ctk.CTkCheckBox(options, text="Shuffle", variable=self._shuffle_var).grid(row=0, column=3, padx=(0, 10))
+        ctk.CTkLabel(options, text="Transition").grid(row=0, column=4, padx=(0, 6))
+        ctk.CTkOptionMenu(
+            options,
+            variable=self._transition_var,
+            values=["fade", "cut"],
+            width=96,
+            height=30,
+        ).grid(row=0, column=5, padx=(0, 12))
+        ctk.CTkLabel(options, text="Monitor").grid(row=0, column=6, padx=(0, 6))
+        ctk.CTkEntry(options, textvariable=self._monitor_var, width=52, height=30).grid(row=0, column=7, padx=(0, 12), sticky="w")
+        ctk.CTkCheckBox(options, text="Auto resume", variable=self._enabled_var).grid(row=0, column=8, padx=(0, 10))
 
-        ctk.CTkButton(options, text="Start", width=72, command=self._start).grid(row=0, column=6, padx=(0, 6), sticky="e")
-        ctk.CTkButton(options, text="Pause", width=72, command=self._pause_or_resume).grid(row=0, column=7, padx=(0, 6), sticky="e")
-        ctk.CTkButton(options, text="Stop", width=72, command=self._stop).grid(row=0, column=8, padx=(0, 6), sticky="e")
-        ctk.CTkButton(options, text="Next", width=72, command=self._next).grid(row=0, column=9, sticky="e")
+        ctk.CTkButton(options, text="Start", width=72, command=self._start).grid(row=0, column=9, padx=(0, 6), sticky="e")
+        ctk.CTkButton(options, text="Pause", width=72, command=self._pause_or_resume).grid(row=0, column=10, padx=(0, 6), sticky="e")
+        ctk.CTkButton(options, text="Stop", width=72, command=self._stop).grid(row=0, column=11, padx=(0, 6), sticky="e")
+        ctk.CTkButton(options, text="Next", width=72, command=self._next).grid(row=0, column=12, sticky="e")
 
         self._list = ctk.CTkScrollableFrame(self, fg_color="transparent")
         self._list.grid(row=3, column=0, sticky="nsew")
@@ -87,7 +111,70 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             text_color="#F59E0B",
         ).grid(row=4, column=0, sticky="ew", pady=(6, 0))
 
+        self._bind_persistence_traces()
         self._refresh_sources()
+        self._restoring_ui_state = False
+        if self._enabled_var.get() and self._records:
+            self.after(120, self._start)
+
+    def _resolve_source_paths(self, *, state: dict, settings: AmbianceSettings) -> tuple[str, str]:
+        folder_value = str(state.get("folder") or "")
+        playlist_value = str(state.get("playlist") or "")
+        if folder_value or playlist_value:
+            return folder_value, playlist_value
+
+        folder = ""
+        playlist = ""
+        for raw_path in settings.playlist_paths:
+            path = Path(str(raw_path)).expanduser()
+            if not playlist and path.is_file():
+                playlist = str(path)
+            elif not folder and path.is_dir():
+                folder = str(path)
+        return folder, playlist
+
+    def _bind_persistence_traces(self) -> None:
+        for variable in (
+            self._folder_var,
+            self._playlist_var,
+            self._duration_var,
+            self._loop_var,
+            self._shuffle_var,
+            self._enabled_var,
+            self._transition_var,
+            self._monitor_var,
+        ):
+            variable.trace_add("write", self._on_setting_changed)
+
+    def _on_setting_changed(self, *_args) -> None:
+        if self._restoring_ui_state:
+            return
+        self._persist_settings()
+
+    def _persist_settings(self) -> None:
+        sources = [self._playlist_var.get().strip(), self._folder_var.get().strip()]
+        valid_sources = tuple(path for path in sources if path)
+        update_ambiance_settings(
+            enabled=bool(self._enabled_var.get()),
+            playlist_paths=valid_sources,
+            default_duration_sec=self._safe_duration_value(),
+            transition=(self._transition_var.get().strip().lower() or "fade"),
+            shuffle=bool(self._shuffle_var.get()),
+            loop=bool(self._loop_var.get()),
+            target_monitor_index=self._safe_monitor_index(),
+        )
+
+    def _safe_duration_value(self) -> float:
+        try:
+            return max(0.5, float(self._duration_var.get().strip()))
+        except Exception:
+            return 8.0
+
+    def _safe_monitor_index(self) -> int:
+        try:
+            return max(0, int(self._monitor_var.get().strip()))
+        except Exception:
+            return 1
 
     def _pick_folder(self) -> None:
         selected = filedialog.askdirectory(title="Select ambiance folder")
@@ -109,12 +196,15 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         folder = self._folder_var.get().strip()
         if playlist_path:
             self._load_playlist_file(playlist_path)
+            self._persist_settings()
             return
         if folder:
             self._scan_folder()
+            self._persist_settings()
             return
         self._records = []
         self._render_records()
+        self._persist_settings()
 
     def _scan_folder(self) -> None:
         folder = self._folder_var.get().strip()
@@ -124,6 +214,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         self._records = self._repository.scan_folder(folder)
         self._status_var.set(f"{len(self._records)} media indexed from folder.")
         self._render_records()
+        self._persist_settings()
 
     def _load_playlist_file(self, playlist_path: str) -> None:
         path = Path(playlist_path).expanduser()
@@ -150,6 +241,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
                 self._duration_var.set(str(duration))
         self._status_var.set(f"{len(self._records)} media loaded from playlist.")
         self._render_records()
+        self._persist_settings()
 
     def _render_records(self) -> None:
         for child in self._list.winfo_children():
@@ -194,6 +286,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             loop=bool(self._loop_var.get()),
             shuffle=bool(self._shuffle_var.get()),
             default_duration=default_duration,
+            transition_ms=0 if self._transition_var.get().strip().lower() == "cut" else 380,
         )
 
     def _resolve_player(self):
@@ -210,8 +303,12 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         if player is None or playlist is None:
             return
         try:
+            setter = getattr(player, "set_target_monitor_index", None)
+            if callable(setter):
+                setter(self._safe_monitor_index())
             player.start(playlist)
             self._status_var.set(f"Playback started ({len(playlist.items)} media).")
+            self._persist_settings()
         except Exception as exc:
             self._status_var.set(f"Start failed: {exc}")
 

--- a/modules/ui/ambiance/monitor.py
+++ b/modules/ui/ambiance/monitor.py
@@ -22,7 +22,11 @@ class MonitorSelectionError(RuntimeError):
     """Raised when no monitor can be selected for ambiance playback."""
 
 
-def select_target_monitor(*, allow_single_screen_fallback: bool = True) -> MonitorBounds:
+def select_target_monitor(
+    *,
+    allow_single_screen_fallback: bool = True,
+    preferred_index: int | None = None,
+) -> MonitorBounds:
     """Resolve monitor bounds for ambiance playback.
 
     If two monitors are available, the second one is selected.
@@ -33,6 +37,16 @@ def select_target_monitor(*, allow_single_screen_fallback: bool = True) -> Monit
     monitors = _get_monitors()
     if not monitors:
         raise MonitorSelectionError("Aucun écran détecté pour l'ambiance.")
+
+    if isinstance(preferred_index, int) and 0 <= preferred_index < len(monitors):
+        x, y, width, height = monitors[preferred_index]
+        return MonitorBounds(
+            int(x),
+            int(y),
+            int(width),
+            int(height),
+            preferred_index > 0,
+        )
 
     if len(monitors) > 1:
         x, y, width, height = monitors[1]

--- a/modules/ui/ambiance/player.py
+++ b/modules/ui/ambiance/player.py
@@ -39,6 +39,7 @@ class SecondScreenAmbiancePlayer:
         self._runtime_items: list[AmbianceItem] = []
         self._order: list[int] = []
         self._state = AmbianceState()
+        self._target_monitor_index: int | None = None
         self._photo_ref = None
         self._video = None
 
@@ -55,6 +56,16 @@ class SecondScreenAmbiancePlayer:
         self._build_order()
         if self._state.current_index >= len(self._order):
             self._state.current_index = -1
+
+    def set_target_monitor_index(self, monitor_index: int | None) -> None:
+        """Set preferred monitor index used on next window creation."""
+        if monitor_index is None:
+            self._target_monitor_index = None
+            return
+        try:
+            self._target_monitor_index = max(0, int(monitor_index))
+        except Exception:
+            self._target_monitor_index = None
 
     def start(self, playlist: AmbiancePlaylist | None = None) -> None:
         """Start ambiance playback."""
@@ -137,7 +148,8 @@ class SecondScreenAmbiancePlayer:
         if self._window is not None and self._window.winfo_exists() and self._canvas is not None:
             return
         monitor = select_target_monitor(
-            allow_single_screen_fallback=self._allow_single_screen_fallback
+            allow_single_screen_fallback=self._allow_single_screen_fallback,
+            preferred_index=self._target_monitor_index,
         )
 
         self._window = ctk.CTkToplevel(self._root)

--- a/modules/ui/ambiance/settings.py
+++ b/modules/ui/ambiance/settings.py
@@ -1,0 +1,126 @@
+"""Campaign-local persistence helpers for Ambiance UI settings."""
+
+from __future__ import annotations
+
+import configparser
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from modules.helpers.config_helper import ConfigHelper
+
+_SECTION = "Ambiance"
+_DEFAULT_DURATION_SEC = 8.0
+
+
+@dataclass(slots=True)
+class AmbianceSettings:
+    """Serializable settings used by the Ambiance panel."""
+
+    enabled: bool = False
+    playlist_paths: tuple[str, ...] = ()
+    default_duration_sec: float = _DEFAULT_DURATION_SEC
+    transition: str = "fade"
+    shuffle: bool = False
+    loop: bool = True
+    target_monitor_index: int = 1
+
+
+def load_ambiance_settings() -> AmbianceSettings:
+    """Load [Ambiance] settings from campaign-local settings.ini."""
+    cfg = ConfigHelper.load_campaign_config()
+    if not cfg.has_section(_SECTION):
+        return AmbianceSettings()
+
+    playlist_paths_raw = cfg.get(_SECTION, "playlist_paths", fallback="[]")
+    playlist_paths = _parse_playlist_paths(playlist_paths_raw)
+
+    return AmbianceSettings(
+        enabled=_to_bool(cfg.get(_SECTION, "enabled", fallback=False), False),
+        playlist_paths=playlist_paths,
+        default_duration_sec=_to_float(
+            cfg.get(_SECTION, "default_duration_sec", fallback=_DEFAULT_DURATION_SEC),
+            _DEFAULT_DURATION_SEC,
+        ),
+        transition=(cfg.get(_SECTION, "transition", fallback="fade") or "fade").strip().lower(),
+        shuffle=_to_bool(cfg.get(_SECTION, "shuffle", fallback=False), False),
+        loop=_to_bool(cfg.get(_SECTION, "loop", fallback=True), True),
+        target_monitor_index=_to_int(cfg.get(_SECTION, "target_monitor_index", fallback=1), 1),
+    )
+
+
+def save_ambiance_settings(settings: AmbianceSettings) -> None:
+    """Persist settings in the campaign-local settings.ini file."""
+    path = Path(ConfigHelper.get_campaign_settings_path())
+    cfg = configparser.ConfigParser()
+    if path.exists():
+        cfg.read(path, encoding="utf-8")
+
+    if not cfg.has_section(_SECTION):
+        cfg.add_section(_SECTION)
+
+    payload = asdict(settings)
+    payload["playlist_paths"] = json.dumps(list(settings.playlist_paths), ensure_ascii=False)
+    for key, value in payload.items():
+        cfg.set(_SECTION, key, str(value))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        cfg.write(handle)
+
+    ConfigHelper._campaign_config = cfg
+    ConfigHelper._campaign_mtime = path.stat().st_mtime
+
+
+def update_ambiance_settings(**changes) -> AmbianceSettings:
+    """Load current settings, apply partial updates and persist immediately."""
+    current = load_ambiance_settings()
+    merged = AmbianceSettings(**(asdict(current) | changes))
+    if isinstance(merged.playlist_paths, list):
+        merged.playlist_paths = tuple(merged.playlist_paths)
+    save_ambiance_settings(merged)
+    return merged
+
+
+def _parse_playlist_paths(raw_value) -> tuple[str, ...]:
+    if isinstance(raw_value, (list, tuple)):
+        return tuple(str(item).strip() for item in raw_value if str(item).strip())
+    if raw_value is None:
+        return ()
+    text = str(raw_value).strip()
+    if not text:
+        return ()
+    try:
+        decoded = json.loads(text)
+    except Exception:
+        return (text,)
+    if isinstance(decoded, list):
+        return tuple(str(item).strip() for item in decoded if str(item).strip())
+    return ()
+
+
+def _to_bool(value, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "yes", "true", "on"}:
+        return True
+    if normalized in {"0", "no", "false", "off"}:
+        return False
+    return default
+
+
+def _to_float(value, default: float) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _to_int(value, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default

--- a/tests/ui/ambiance/test_monitor.py
+++ b/tests/ui/ambiance/test_monitor.py
@@ -19,3 +19,16 @@ def test_select_target_monitor_single_screen_without_fallback(monkeypatch):
         assert "un seul écran" in str(exc)
     else:
         raise AssertionError("Expected MonitorSelectionError")
+
+
+def test_select_target_monitor_uses_preferred_index(monkeypatch):
+    monkeypatch.setattr(
+        monitor,
+        "_get_monitors",
+        lambda: [(0, 0, 1920, 1080), (1920, 0, 1280, 1024), (3200, 0, 1600, 900)],
+    )
+
+    selected = monitor.select_target_monitor(preferred_index=2)
+
+    assert (selected.x, selected.y, selected.width, selected.height) == (3200, 0, 1600, 900)
+    assert selected.is_secondary is True

--- a/tests/ui/ambiance/test_settings.py
+++ b/tests/ui/ambiance/test_settings.py
@@ -1,0 +1,74 @@
+import configparser
+
+from modules.ui.ambiance.settings import (
+    AmbianceSettings,
+    load_ambiance_settings,
+    save_ambiance_settings,
+    update_ambiance_settings,
+)
+
+
+def test_save_and_load_ambiance_settings(tmp_path, monkeypatch):
+    settings_path = tmp_path / "settings.ini"
+    monkeypatch.setattr(
+        "modules.ui.ambiance.settings.ConfigHelper.get_campaign_settings_path",
+        staticmethod(lambda: str(settings_path)),
+    )
+    monkeypatch.setattr(
+        "modules.ui.ambiance.settings.ConfigHelper.load_campaign_config",
+        staticmethod(lambda: configparser.ConfigParser()),
+    )
+
+    save_ambiance_settings(
+        AmbianceSettings(
+            enabled=True,
+            playlist_paths=("a.json", "/tmp/media"),
+            default_duration_sec=12.5,
+            transition="cut",
+            shuffle=True,
+            loop=False,
+            target_monitor_index=2,
+        )
+    )
+
+    cfg = configparser.ConfigParser()
+    cfg.read(settings_path, encoding="utf-8")
+    monkeypatch.setattr(
+        "modules.ui.ambiance.settings.ConfigHelper.load_campaign_config",
+        staticmethod(lambda: cfg),
+    )
+
+    loaded = load_ambiance_settings()
+    assert loaded.enabled is True
+    assert loaded.playlist_paths == ("a.json", "/tmp/media")
+    assert loaded.default_duration_sec == 12.5
+    assert loaded.transition == "cut"
+    assert loaded.shuffle is True
+    assert loaded.loop is False
+    assert loaded.target_monitor_index == 2
+
+
+def test_update_ambiance_settings_partial_update(tmp_path, monkeypatch):
+    settings_path = tmp_path / "settings.ini"
+    monkeypatch.setattr(
+        "modules.ui.ambiance.settings.ConfigHelper.get_campaign_settings_path",
+        staticmethod(lambda: str(settings_path)),
+    )
+
+    cfg = configparser.ConfigParser()
+    monkeypatch.setattr(
+        "modules.ui.ambiance.settings.ConfigHelper.load_campaign_config",
+        staticmethod(lambda: cfg),
+    )
+    save_ambiance_settings(AmbianceSettings(enabled=False, loop=True))
+
+    cfg = configparser.ConfigParser()
+    cfg.read(settings_path, encoding="utf-8")
+    monkeypatch.setattr(
+        "modules.ui.ambiance.settings.ConfigHelper.load_campaign_config",
+        staticmethod(lambda: cfg),
+    )
+    updated = update_ambiance_settings(enabled=True, playlist_paths=["x.json"])
+
+    assert updated.enabled is True
+    assert updated.playlist_paths == ("x.json",)


### PR DESCRIPTION
### Motivation
- Persist per-campaign Ambiance UI preferences (sources, durations, playback options, monitor) next to the DB so user preferences follow the campaign. 
- Prefill the Ambiance UI at panel creation and optionally resume playback automatically when a campaign is opened. 
- Keep persistence logic out of the view and centralize read/write operations behind a helper.

### Description
- Add `modules/ui/ambiance/settings.py` which uses `ConfigHelper.get_campaign_settings_path()` to read/write a new `[Ambiance]` section and exposes `load_ambiance_settings`, `save_ambiance_settings` and `update_ambiance_settings` plus the `AmbianceSettings` dataclass with keys `enabled`, `playlist_paths`, `default_duration_sec`, `transition`, `shuffle`, `loop`, `target_monitor_index`.
- Wire the Ambiance page to load campaign settings on init, prefill controls (`folder`, `playlist`, `image_duration`, `loop`, `shuffle`, `transition`, `monitor`, `auto resume`) and fall back to `initial_state` when present.
- Persist immediately on significant UI changes by tracing Tk variables and calling `update_ambiance_settings` (no INI logic in the view). 
- Auto-start playback shortly after init when `enabled=true` and media are available.
- Add `transition` and `monitor` controls to the UI and apply `transition_ms` to the built `AmbiancePlaylist`; add `set_target_monitor_index` on the player and pass the chosen monitor index before starting playback.
- Extend monitor selection to accept a `preferred_index` (`modules/ui/ambiance/monitor.py`) so a saved index can be honored.
- Tests: add `tests/ui/ambiance/test_settings.py` for settings save/load/update and extend `tests/ui/ambiance/test_monitor.py` to assert preferred-index behavior.

### Testing
- Ran `pytest -q tests/ui/ambiance/test_monitor.py tests/ui/ambiance/test_settings.py` and all tests passed.
- Result: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd74e9c6c832b9ec6191afcbbcf5b)