### PR TITLE
Add campaign-local wallpaper importer & library and refactor Ambiance page to use it

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -69,6 +69,7 @@ from modules.ui.database_manager_dialog import DatabaseManagerDialog
 from modules.ui.system_manager_dialog import SystemManagerDialog
 from modules.ui.menu_bar import AppMenuBar
 from modules.ui.ambiance import SecondScreenAmbiancePlayer
+from modules.ui.ambiance.importer.dialog import AmbianceWallpaperImporterDialog
 from modules.ui.sidebar.accordion_sections import SidebarAccordion, SidebarItemSpec, SidebarSectionSpec
 from modules.ui.controllers import AIRunWindowController
 from modules.events.ui.dock import CalendarDock
@@ -196,6 +197,7 @@ class MainWindow(ctk.CTk):
         self._image_library_browser_window = None
         self._asset_library_window = None
         self._ambiance_player: SecondScreenAmbiancePlayer | None = None
+        self._wallpaper_importer_window = None
         self._busy_modal = None
         self._system_selector_dialog = None
         self._database_manager_dialog = None
@@ -4600,6 +4602,26 @@ class MainWindow(ctk.CTk):
                 self.current_gm_view.open_ambiance_tab()
         except Exception:
             pass
+
+    def open_wallpaper_importer(self, *, on_complete=None):
+        """Open wallpaper importer dialog bound to the current campaign."""
+        dialog = None
+        try:
+            dialog = self._wallpaper_importer_window
+        except Exception:
+            dialog = None
+
+        if dialog is None or not dialog.winfo_exists():
+            dialog = AmbianceWallpaperImporterDialog(self, on_complete=on_complete)
+            self._wallpaper_importer_window = dialog
+            dialog.bind("<Destroy>", lambda _event: setattr(self, "_wallpaper_importer_window", None))
+            return dialog
+
+        if callable(on_complete):
+            dialog._on_complete = on_complete  # type: ignore[attr-defined]
+        dialog.lift()
+        dialog.focus_force()
+        return dialog
 
     def open_sound_manager(self):
         """Open sound manager."""

--- a/modules/scenarios/gm_table/ambiance/page.py
+++ b/modules/scenarios/gm_table/ambiance/page.py
@@ -1,274 +1,332 @@
-"""Ambiance page embedded in GM Table / GM Screen."""
+"""Ambiance page driven by campaign-local wallpaper library."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
 import tkinter as tk
-from tkinter import filedialog
+from tkinter import messagebox, simpledialog
 
 import customtkinter as ctk
 
-from modules.scenarios.gm_table.ambiance.repository import (
-    AmbianceMediaRecord,
-    AmbianceMediaRepository,
-)
-from modules.scenarios.gm_table.ambiance.thumbnail_cache import ThumbnailCache
+from modules.ui.ambiance.importer.service import WallpaperImportService
+from modules.ui.ambiance.importer.thumbnailer import WallpaperThumbnailer
+from modules.ui.ambiance.library.models import WallpaperLibraryItem, WallpaperQuery
+from modules.ui.ambiance.library.repository import CampaignWallpaperRepository
 from modules.ui.ambiance.models import AmbianceItem, AmbiancePlaylist
-from modules.ui.ambiance.settings import (
-    AmbianceSettings,
-    load_ambiance_settings,
-    update_ambiance_settings,
-)
+from modules.ui.ambiance.settings import AmbianceSettings, load_ambiance_settings, update_ambiance_settings
 
 
 class GMTableAmbiancePage(ctk.CTkFrame):
-    """Manage ambiance playlists and control second-screen playback."""
+    """Manage ambiance library selection and playback playlist."""
 
     def __init__(self, master, *, initial_state: dict | None = None) -> None:
         super().__init__(master, fg_color="transparent")
-        self.grid_rowconfigure(3, weight=1)
+        self.grid_rowconfigure(2, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
-        state = dict(initial_state or {})
-        self._repository = AmbianceMediaRepository()
-        self._thumbnail_cache = ThumbnailCache()
-        self._records: list[AmbianceMediaRecord] = []
+        self._repository = CampaignWallpaperRepository()
+        self._import_service = WallpaperImportService(self._repository.store)
+        self._thumbnailer = WallpaperThumbnailer(size=(136, 82))
+        self._selected_ids: set[str] = set()
+        self._playlist: list[dict] = []
+        self._drag_index: int | None = None
         self._restoring_ui_state = True
 
+        state = dict(initial_state or {})
         settings = load_ambiance_settings()
-        preloaded_folder, preloaded_playlist = self._resolve_source_paths(state=state, settings=settings)
+        self._migrate_legacy_sources_if_needed(settings)
+        settings = load_ambiance_settings()
 
-        self._folder_var = tk.StringVar(value=preloaded_folder)
-        self._playlist_var = tk.StringVar(value=preloaded_playlist)
+        self._query_var = tk.StringVar(value="")
+        self._media_var = tk.StringVar(value="all")
+        self._orientation_var = tk.StringVar(value="all")
+        self._sort_var = tk.StringVar(value="name")
         self._status_var = tk.StringVar(value="")
-        duration_value = state.get("image_duration", settings.default_duration_sec)
-        self._duration_var = tk.StringVar(value=str(duration_value if duration_value not in (None, "") else "8"))
+
+        self._duration_var = tk.StringVar(value=str(state.get("image_duration", settings.default_duration_sec or 8)))
         self._loop_var = tk.BooleanVar(value=bool(state.get("loop", settings.loop)))
         self._shuffle_var = tk.BooleanVar(value=bool(state.get("shuffle", settings.shuffle)))
         self._enabled_var = tk.BooleanVar(value=bool(settings.enabled))
         self._transition_var = tk.StringVar(value=settings.transition if settings.transition in {"fade", "cut"} else "fade")
         self._monitor_var = tk.StringVar(value=str(max(0, settings.target_monitor_index)))
 
-        ctk.CTkLabel(
-            self,
-            text="Ambiance Screen",
-            anchor="w",
-            font=ctk.CTkFont(size=16, weight="bold"),
-        ).grid(row=0, column=0, sticky="ew", pady=(0, 6))
+        persisted_entries = list(settings.playlist_entries)
+        state_playlist = state.get("playlist_entries")
+        if isinstance(state_playlist, list):
+            persisted_entries = state_playlist
+        self._playlist = _normalize_playlist_entries(persisted_entries, default_duration=self._safe_duration_value())
 
-        controls = ctk.CTkFrame(self, fg_color="transparent")
-        controls.grid(row=1, column=0, sticky="ew", pady=(0, 6))
-        controls.grid_columnconfigure(1, weight=1)
+        self._build_header()
+        self._build_filters()
+        self._build_body()
+        self._build_player_controls()
 
-        ctk.CTkLabel(controls, text="Folder", width=78, anchor="w").grid(row=0, column=0, sticky="w")
-        ctk.CTkEntry(controls, textvariable=self._folder_var, height=30).grid(
-            row=0, column=1, sticky="ew", padx=6
-        )
-        ctk.CTkButton(controls, text="Browse", width=86, command=self._pick_folder).grid(row=0, column=2, padx=(0, 4))
-        ctk.CTkButton(controls, text="Scan", width=70, command=self._scan_folder).grid(row=0, column=3)
-
-        ctk.CTkLabel(controls, text="Playlist", width=78, anchor="w").grid(row=1, column=0, sticky="w", pady=(6, 0))
-        ctk.CTkEntry(controls, textvariable=self._playlist_var, height=30).grid(
-            row=1, column=1, sticky="ew", padx=6, pady=(6, 0)
-        )
-        ctk.CTkButton(controls, text="Load", width=86, command=self._pick_playlist).grid(row=1, column=2, padx=(0, 4), pady=(6, 0))
-        ctk.CTkButton(controls, text="Refresh", width=70, command=self._refresh_sources).grid(row=1, column=3, pady=(6, 0))
-
-        options = ctk.CTkFrame(self, fg_color="transparent")
-        options.grid(row=2, column=0, sticky="ew", pady=(0, 6))
-        options.grid_columnconfigure(8, weight=1)
-
-        ctk.CTkLabel(options, text="Image duration (s)").grid(row=0, column=0, sticky="w")
-        ctk.CTkEntry(options, textvariable=self._duration_var, width=88, height=30).grid(row=0, column=1, padx=(6, 16), sticky="w")
-        ctk.CTkCheckBox(options, text="Loop", variable=self._loop_var).grid(row=0, column=2, padx=(0, 10))
-        ctk.CTkCheckBox(options, text="Shuffle", variable=self._shuffle_var).grid(row=0, column=3, padx=(0, 10))
-        ctk.CTkLabel(options, text="Transition").grid(row=0, column=4, padx=(0, 6))
-        ctk.CTkOptionMenu(
-            options,
-            variable=self._transition_var,
-            values=["fade", "cut"],
-            width=96,
-            height=30,
-        ).grid(row=0, column=5, padx=(0, 12))
-        ctk.CTkLabel(options, text="Monitor").grid(row=0, column=6, padx=(0, 6))
-        ctk.CTkEntry(options, textvariable=self._monitor_var, width=52, height=30).grid(row=0, column=7, padx=(0, 12), sticky="w")
-        ctk.CTkCheckBox(options, text="Auto resume", variable=self._enabled_var).grid(row=0, column=8, padx=(0, 10))
-
-        ctk.CTkButton(options, text="Start", width=72, command=self._start).grid(row=0, column=9, padx=(0, 6), sticky="e")
-        ctk.CTkButton(options, text="Pause", width=72, command=self._pause_or_resume).grid(row=0, column=10, padx=(0, 6), sticky="e")
-        ctk.CTkButton(options, text="Stop", width=72, command=self._stop).grid(row=0, column=11, padx=(0, 6), sticky="e")
-        ctk.CTkButton(options, text="Next", width=72, command=self._next).grid(row=0, column=12, sticky="e")
-
-        self._list = ctk.CTkScrollableFrame(self, fg_color="transparent")
-        self._list.grid(row=3, column=0, sticky="nsew")
-
-        ctk.CTkLabel(
-            self,
-            textvariable=self._status_var,
-            anchor="w",
-            justify="left",
-            text_color="#F59E0B",
-        ).grid(row=4, column=0, sticky="ew", pady=(6, 0))
+        self._query_var.trace_add("write", lambda *_args: self._render_library())
+        self._media_var.trace_add("write", lambda *_args: self._render_library())
+        self._orientation_var.trace_add("write", lambda *_args: self._render_library())
+        self._sort_var.trace_add("write", lambda *_args: self._render_library())
 
         self._bind_persistence_traces()
-        self._refresh_sources()
+        self._render_library()
+        self._render_playlist()
         self._restoring_ui_state = False
-        if self._enabled_var.get() and self._records:
-            self.after(120, self._start)
 
-    def _resolve_source_paths(self, *, state: dict, settings: AmbianceSettings) -> tuple[str, str]:
-        folder_value = str(state.get("folder") or "")
-        playlist_value = str(state.get("playlist") or "")
-        if folder_value or playlist_value:
-            return folder_value, playlist_value
+    def _build_header(self) -> None:
+        top = ctk.CTkFrame(self, fg_color="transparent")
+        top.grid(row=0, column=0, sticky="ew", pady=(0, 8))
+        top.grid_columnconfigure(0, weight=1)
 
-        folder = ""
-        playlist = ""
-        for raw_path in settings.playlist_paths:
-            path = Path(str(raw_path)).expanduser()
-            if not playlist and path.is_file():
-                playlist = str(path)
-            elif not folder and path.is_dir():
-                folder = str(path)
-        return folder, playlist
+        ctk.CTkLabel(top, text="Ambiance Screen", anchor="w", font=ctk.CTkFont(size=16, weight="bold")).grid(
+            row=0,
+            column=0,
+            sticky="w",
+        )
+        ctk.CTkButton(top, text="Open Importer", width=130, command=self._open_importer).grid(row=0, column=1, padx=(10, 0))
 
-    def _bind_persistence_traces(self) -> None:
-        for variable in (
-            self._folder_var,
-            self._playlist_var,
-            self._duration_var,
-            self._loop_var,
-            self._shuffle_var,
-            self._enabled_var,
-            self._transition_var,
-            self._monitor_var,
-        ):
-            variable.trace_add("write", self._on_setting_changed)
+    def _build_filters(self) -> None:
+        filters = ctk.CTkFrame(self, fg_color="transparent")
+        filters.grid(row=1, column=0, sticky="ew", pady=(0, 8))
+        filters.grid_columnconfigure(1, weight=1)
 
-    def _on_setting_changed(self, *_args) -> None:
-        if self._restoring_ui_state:
-            return
-        self._persist_settings()
+        ctk.CTkLabel(filters, text="Search").grid(row=0, column=0, padx=(0, 6), sticky="w")
+        ctk.CTkEntry(filters, textvariable=self._query_var, height=30, placeholder_text="Filename or tag").grid(
+            row=0,
+            column=1,
+            sticky="ew",
+            padx=(0, 8),
+        )
+        ctk.CTkOptionMenu(filters, variable=self._media_var, values=["all", "image", "video"], width=110).grid(row=0, column=2, padx=(0, 8))
+        ctk.CTkOptionMenu(filters, variable=self._orientation_var, values=["all", "landscape", "portrait", "square"], width=126).grid(row=0, column=3, padx=(0, 8))
+        ctk.CTkOptionMenu(filters, variable=self._sort_var, values=["name", "created_desc", "size_desc"], width=120).grid(row=0, column=4, padx=(0, 8))
+        ctk.CTkButton(filters, text="Add to playlist", width=130, command=self._add_selected_to_playlist).grid(row=0, column=5)
 
-    def _persist_settings(self) -> None:
-        sources = [self._playlist_var.get().strip(), self._folder_var.get().strip()]
-        valid_sources = tuple(path for path in sources if path)
-        update_ambiance_settings(
-            enabled=bool(self._enabled_var.get()),
-            playlist_paths=valid_sources,
-            default_duration_sec=self._safe_duration_value(),
-            transition=(self._transition_var.get().strip().lower() or "fade"),
-            shuffle=bool(self._shuffle_var.get()),
-            loop=bool(self._loop_var.get()),
-            target_monitor_index=self._safe_monitor_index(),
+    def _build_body(self) -> None:
+        body = ctk.CTkFrame(self, fg_color="transparent")
+        body.grid(row=2, column=0, sticky="nsew")
+        body.grid_rowconfigure(0, weight=1)
+        body.grid_columnconfigure(0, weight=2)
+        body.grid_columnconfigure(1, weight=1)
+
+        self._library_frame = ctk.CTkScrollableFrame(body, fg_color="transparent")
+        self._library_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        self._library_frame.grid_columnconfigure(0, weight=1)
+
+        playlist_panel = ctk.CTkFrame(body)
+        playlist_panel.grid(row=0, column=1, sticky="nsew")
+        playlist_panel.grid_rowconfigure(1, weight=1)
+        playlist_panel.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(playlist_panel, text="Session Playlist", anchor="w", font=ctk.CTkFont(size=14, weight="bold")).grid(
+            row=0,
+            column=0,
+            sticky="ew",
+            padx=8,
+            pady=(8, 6),
+        )
+        self._playlist_frame = ctk.CTkScrollableFrame(playlist_panel, fg_color="transparent")
+        self._playlist_frame.grid(row=1, column=0, sticky="nsew", padx=8, pady=(0, 8))
+
+    def _build_player_controls(self) -> None:
+        controls = ctk.CTkFrame(self, fg_color="transparent")
+        controls.grid(row=3, column=0, sticky="ew", pady=(8, 0))
+        controls.grid_columnconfigure(8, weight=1)
+
+        ctk.CTkLabel(controls, text="Image duration (s)").grid(row=0, column=0, sticky="w")
+        ctk.CTkEntry(controls, textvariable=self._duration_var, width=76, height=30).grid(row=0, column=1, padx=(6, 14), sticky="w")
+        ctk.CTkCheckBox(controls, text="Loop", variable=self._loop_var).grid(row=0, column=2, padx=(0, 8))
+        ctk.CTkCheckBox(controls, text="Shuffle", variable=self._shuffle_var).grid(row=0, column=3, padx=(0, 8))
+        ctk.CTkLabel(controls, text="Transition").grid(row=0, column=4, padx=(0, 6))
+        ctk.CTkOptionMenu(controls, variable=self._transition_var, values=["fade", "cut"], width=86).grid(row=0, column=5, padx=(0, 10))
+        ctk.CTkLabel(controls, text="Monitor").grid(row=0, column=6, padx=(0, 6))
+        ctk.CTkEntry(controls, textvariable=self._monitor_var, width=50, height=30).grid(row=0, column=7, padx=(0, 10), sticky="w")
+        ctk.CTkCheckBox(controls, text="Auto resume", variable=self._enabled_var).grid(row=0, column=8, padx=(0, 10), sticky="w")
+
+        ctk.CTkButton(controls, text="Start", width=72, command=self._start).grid(row=0, column=9, padx=(0, 6), sticky="e")
+        ctk.CTkButton(controls, text="Pause", width=72, command=self._pause_or_resume).grid(row=0, column=10, padx=(0, 6), sticky="e")
+        ctk.CTkButton(controls, text="Stop", width=72, command=self._stop).grid(row=0, column=11, padx=(0, 6), sticky="e")
+        ctk.CTkButton(controls, text="Next", width=72, command=self._next).grid(row=0, column=12, sticky="e")
+
+        ctk.CTkLabel(self, textvariable=self._status_var, anchor="w", text_color="#F59E0B").grid(row=4, column=0, sticky="ew", pady=(6, 0))
+
+    def _library_items(self) -> list[WallpaperLibraryItem]:
+        return self._repository.list_items(
+            WallpaperQuery(
+                search=self._query_var.get(),
+                media_type=self._media_var.get(),
+                orientation=self._orientation_var.get(),
+                sort_key=self._sort_var.get(),
+            )
         )
 
-    def _safe_duration_value(self) -> float:
-        try:
-            return max(0.5, float(self._duration_var.get().strip()))
-        except Exception:
-            return 8.0
+    def _render_library(self) -> None:
+        for child in self._library_frame.winfo_children():
+            child.destroy()
+        items = self._library_items()
+        if not items:
+            card = ctk.CTkFrame(self._library_frame)
+            card.grid(row=0, column=0, sticky="ew", padx=4, pady=6)
+            ctk.CTkLabel(card, text="No wallpapers imported yet", font=ctk.CTkFont(size=14, weight="bold")).pack(anchor="w", padx=10, pady=(10, 2))
+            ctk.CTkLabel(card, text="Import wallpapers into this campaign to build your playlist.", text_color="#9CA3AF").pack(anchor="w", padx=10, pady=(0, 10))
+            ctk.CTkButton(card, text="Open Importer", command=self._open_importer).pack(anchor="w", padx=10, pady=(0, 10))
+            return
 
-    def _safe_monitor_index(self) -> int:
-        try:
-            return max(0, int(self._monitor_var.get().strip()))
-        except Exception:
-            return 1
+        for idx, item in enumerate(items):
+            self._render_library_card(item=item, row_idx=idx)
 
-    def _pick_folder(self) -> None:
-        selected = filedialog.askdirectory(title="Select ambiance folder")
-        if selected:
-            self._folder_var.set(selected)
-            self._scan_folder()
+    def _render_library_card(self, *, item: WallpaperLibraryItem, row_idx: int) -> None:
+        card = ctk.CTkFrame(self._library_frame, border_width=1, border_color="#334155")
+        card.grid(row=row_idx, column=0, sticky="ew", padx=4, pady=4)
+        card.grid_columnconfigure(1, weight=1)
 
-    def _pick_playlist(self) -> None:
-        selected = filedialog.askopenfilename(
-            title="Select ambiance playlist",
-            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        abs_path = self._repository.store.absolute_path(item)
+        thumb = self._thumbnailer.get(abs_path, media_type=item.media_type)
+        ctk.CTkLabel(card, text="", image=thumb, width=144).grid(row=0, column=0, rowspan=2, padx=(8, 8), pady=8)
+
+        selected = item.id in self._selected_ids
+        select_button = ctk.CTkCheckBox(
+            card,
+            text=item.filename,
+            onvalue=True,
+            offvalue=False,
+            command=lambda item_id=item.id: self._toggle_select(item_id),
         )
         if selected:
-            self._playlist_var.set(selected)
-            self._load_playlist_file(selected)
+            select_button.select()
+        else:
+            select_button.deselect()
+        select_button.grid(row=0, column=1, sticky="w", pady=(8, 2))
 
-    def _refresh_sources(self) -> None:
-        playlist_path = self._playlist_var.get().strip()
-        folder = self._folder_var.get().strip()
-        if playlist_path:
-            self._load_playlist_file(playlist_path)
-            self._persist_settings()
-            return
-        if folder:
-            self._scan_folder()
-            self._persist_settings()
-            return
-        self._records = []
-        self._render_records()
-        self._persist_settings()
+        details = f"{item.media_type.title()} · {item.width or '—'}x{item.height or '—'} · {_format_size(item.filesize)}"
+        ctk.CTkLabel(card, text=details, text_color="#9CA3AF", anchor="w").grid(row=1, column=1, sticky="w", pady=(0, 8))
 
-    def _scan_folder(self) -> None:
-        folder = self._folder_var.get().strip()
-        if not folder:
-            self._status_var.set("Select a folder before scanning.")
-            return
-        self._records = self._repository.scan_folder(folder)
-        self._status_var.set(f"{len(self._records)} media indexed from folder.")
-        self._render_records()
-        self._persist_settings()
+        quick_actions = ctk.CTkFrame(card, fg_color="transparent")
+        quick_actions.grid(row=0, column=2, rowspan=2, padx=(0, 8))
+        preview_btn = ctk.CTkButton(quick_actions, text="Preview", width=74, command=lambda i=item: self._preview_item(i))
+        add_btn = ctk.CTkButton(quick_actions, text="+ Playlist", width=86, command=lambda i=item: self._add_single_to_playlist(i))
+        tag_btn = ctk.CTkButton(quick_actions, text="Tag", width=54, command=lambda i=item: self._tag_item(i))
 
-    def _load_playlist_file(self, playlist_path: str) -> None:
-        path = Path(playlist_path).expanduser()
-        if not path.is_file():
-            self._status_var.set("Playlist file not found.")
-            return
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            self._status_var.set(f"Unable to read playlist: {exc}")
-            return
+        def _show(_event=None):
+            preview_btn.grid(row=0, column=0, padx=(0, 4), pady=(0, 4))
+            add_btn.grid(row=0, column=1, padx=(0, 4), pady=(0, 4))
+            tag_btn.grid(row=0, column=2, pady=(0, 4))
 
-        media_items = payload.get("items") if isinstance(payload, dict) else []
-        if not isinstance(media_items, list):
-            media_items = []
-        media_paths = [str((item or {}).get("path") or "") for item in media_items if isinstance(item, dict)]
-        self._records = self._repository.build_index(media_paths)
+        def _hide(_event=None):
+            for widget in (preview_btn, add_btn, tag_btn):
+                widget.grid_forget()
 
-        if isinstance(payload, dict):
-            self._loop_var.set(bool(payload.get("loop", self._loop_var.get())))
-            self._shuffle_var.set(bool(payload.get("shuffle", self._shuffle_var.get())))
-            duration = payload.get("default_duration")
-            if duration not in (None, ""):
-                self._duration_var.set(str(duration))
-        self._status_var.set(f"{len(self._records)} media loaded from playlist.")
-        self._render_records()
-        self._persist_settings()
+        card.bind("<Enter>", _show)
+        card.bind("<Leave>", _hide)
 
-    def _render_records(self) -> None:
-        for child in self._list.winfo_children():
+    def _render_playlist(self) -> None:
+        for child in self._playlist_frame.winfo_children():
             child.destroy()
 
-        if not self._records:
-            ctk.CTkLabel(self._list, text="No media detected.", anchor="w").grid(row=0, column=0, sticky="ew", padx=4, pady=4)
+        items = self._repository.find_by_ids([entry["id"] for entry in self._playlist])
+        by_id = {item.id: item for item in items}
+        if not self._playlist:
+            ctk.CTkLabel(self._playlist_frame, text="Playlist is empty.", text_color="#9CA3AF").grid(row=0, column=0, sticky="w", padx=4, pady=6)
+            self._persist_settings()
             return
 
-        self._list.grid_columnconfigure(1, weight=1)
-        for idx, record in enumerate(self._records):
-            row = ctk.CTkFrame(self._list)
+        for idx, entry in enumerate(self._playlist):
+            item = by_id.get(entry["id"])
+            if item is None:
+                continue
+            row = ctk.CTkFrame(self._playlist_frame)
             row.grid(row=idx, column=0, sticky="ew", padx=2, pady=2)
             row.grid_columnconfigure(1, weight=1)
+            row.bind("<ButtonPress-1>", lambda _event, i=idx: self._begin_drag(i))
+            row.bind("<ButtonRelease-1>", lambda _event, i=idx: self._drop_drag(i))
 
-            thumb = self._thumbnail_cache.get(record)
-            ctk.CTkLabel(row, text="", image=thumb, width=116).grid(row=0, column=0, padx=(6, 8), pady=6)
+            ctk.CTkLabel(row, text="☰", width=22, text_color="#94A3B8").grid(row=0, column=0, padx=(6, 6), pady=6)
+            ctk.CTkLabel(row, text=item.filename, anchor="w").grid(row=0, column=1, sticky="ew")
+            chip = ctk.CTkLabel(row, text=f"{float(entry.get('duration', self._safe_duration_value())):.0f}s", width=44, fg_color="#1F2937", corner_radius=10)
+            chip.grid(row=0, column=2, padx=(6, 4), pady=6)
+            ctk.CTkButton(row, text="+", width=26, command=lambda i=idx: self._adjust_duration(i, +1)).grid(row=0, column=3, padx=(0, 4))
+            ctk.CTkButton(row, text="-", width=26, command=lambda i=idx: self._adjust_duration(i, -1)).grid(row=0, column=4, padx=(0, 4))
+            ctk.CTkButton(row, text="×", width=26, fg_color="#B91C1C", hover_color="#991B1B", command=lambda i=idx: self._remove_playlist_index(i)).grid(row=0, column=5, padx=(0, 6))
 
-            details = record.name
-            if record.width and record.height:
-                details = f"{details} · {record.width}x{record.height}"
-            ctk.CTkLabel(row, text=details, anchor="w").grid(row=0, column=1, sticky="ew", padx=(0, 8))
-            ctk.CTkLabel(row, text=record.media_type.title(), text_color="#9CA3AF", width=72).grid(row=0, column=2, padx=(0, 8))
+        self._persist_settings()
+
+    def _begin_drag(self, index: int) -> None:
+        self._drag_index = index
+
+    def _drop_drag(self, target_index: int) -> None:
+        source = self._drag_index
+        self._drag_index = None
+        if source is None or source == target_index:
+            return
+        if source < 0 or source >= len(self._playlist) or target_index < 0 or target_index >= len(self._playlist):
+            return
+        entry = self._playlist.pop(source)
+        self._playlist.insert(target_index, entry)
+        self._render_playlist()
+
+    def _toggle_select(self, item_id: str) -> None:
+        if item_id in self._selected_ids:
+            self._selected_ids.remove(item_id)
+        else:
+            self._selected_ids.add(item_id)
+
+    def _add_selected_to_playlist(self) -> None:
+        selected_items = self._repository.find_by_ids(list(self._selected_ids))
+        if not selected_items:
+            self._toast("No wallpaper selected.")
+            return
+        for item in selected_items:
+            self._playlist.append({"id": item.id, "duration": self._safe_duration_value()})
+        self._render_playlist()
+        self._toast(f"Added {len(selected_items)} item(s) to playlist.")
+
+    def _add_single_to_playlist(self, item: WallpaperLibraryItem) -> None:
+        self._playlist.append({"id": item.id, "duration": self._safe_duration_value()})
+        self._render_playlist()
+        self._toast(f"Added '{item.filename}' to playlist.")
+
+    def _remove_playlist_index(self, index: int) -> None:
+        if 0 <= index < len(self._playlist):
+            self._playlist.pop(index)
+            self._render_playlist()
+
+    def _adjust_duration(self, index: int, delta: int) -> None:
+        if not (0 <= index < len(self._playlist)):
+            return
+        current = float(self._playlist[index].get("duration", self._safe_duration_value()))
+        self._playlist[index]["duration"] = max(1.0, current + float(delta))
+        self._render_playlist()
+
+    def _preview_item(self, item: WallpaperLibraryItem) -> None:
+        messagebox.showinfo("Wallpaper", f"{item.filename}\n{item.width or '—'}x{item.height or '—'}\nTags: {', '.join(item.tags) or 'none'}", parent=self)
+
+    def _tag_item(self, item: WallpaperLibraryItem) -> None:
+        current = ", ".join(item.tags)
+        answer = simpledialog.askstring("Tags", "Comma-separated tags", initialvalue=current, parent=self)
+        if answer is None:
+            return
+        tags = tuple(tag.strip() for tag in answer.split(",") if tag.strip())
+        updated = WallpaperLibraryItem(
+            id=item.id,
+            relative_path=item.relative_path,
+            filename=item.filename,
+            media_type=item.media_type,
+            width=item.width,
+            height=item.height,
+            filesize=item.filesize,
+            created_at=item.created_at,
+            tags=tags,
+        )
+        self._repository.store.upsert(updated)
+        self._render_library()
 
     def _build_playlist(self) -> AmbiancePlaylist | None:
-        if not self._records:
-            self._status_var.set("No media available. Scan folder or load playlist first.")
+        if not self._playlist:
+            self._status_var.set("No media in playlist. Add imported wallpapers first.")
+            return None
+
+        lookup = {item.id: item for item in self._repository.find_by_ids([entry["id"] for entry in self._playlist])}
+        if not lookup:
+            self._status_var.set("Playlist references missing library items.")
             return None
 
         try:
@@ -277,10 +335,15 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             self._status_var.set("Image duration must be a number.")
             return None
 
-        items = [
-            AmbianceItem(path=record.path, media_type=record.media_type, duration=default_duration)
-            for record in self._records
-        ]
+        items: list[AmbianceItem] = []
+        for entry in self._playlist:
+            source = lookup.get(entry["id"])
+            if source is None:
+                continue
+            absolute = self._repository.store.absolute_path(source)
+            duration = float(entry.get("duration") or default_duration)
+            items.append(AmbianceItem(path=absolute, media_type=source.media_type, duration=max(0.5, duration), tags=source.tags))
+
         return AmbiancePlaylist(
             items=items,
             loop=bool(self._loop_var.get()),
@@ -346,3 +409,128 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             self._status_var.set("Skipped to next media.")
         except Exception as exc:
             self._status_var.set(f"Next failed: {exc}")
+
+    def _open_importer(self) -> None:
+        host = self.winfo_toplevel()
+        opener = getattr(host, "open_wallpaper_importer", None)
+        if callable(opener):
+            opener(on_complete=lambda _result: self._on_import_completed())
+            return
+        self._status_var.set("Importer unavailable from this window.")
+
+    def _on_import_completed(self) -> None:
+        self._repository.rebuild()
+        self._render_library()
+        self._toast("Wallpaper library updated.")
+
+    def _bind_persistence_traces(self) -> None:
+        for variable in (
+            self._duration_var,
+            self._loop_var,
+            self._shuffle_var,
+            self._enabled_var,
+            self._transition_var,
+            self._monitor_var,
+        ):
+            variable.trace_add("write", self._on_setting_changed)
+
+    def _on_setting_changed(self, *_args) -> None:
+        if self._restoring_ui_state:
+            return
+        self._persist_settings()
+
+    def _persist_settings(self) -> None:
+        update_ambiance_settings(
+            enabled=bool(self._enabled_var.get()),
+            playlist_paths=(),
+            playlist_item_ids=tuple(entry["id"] for entry in self._playlist),
+            playlist_entries=tuple({"id": entry["id"], "duration": float(entry.get("duration", self._safe_duration_value()))} for entry in self._playlist),
+            default_duration_sec=self._safe_duration_value(),
+            transition=(self._transition_var.get().strip().lower() or "fade"),
+            shuffle=bool(self._shuffle_var.get()),
+            loop=bool(self._loop_var.get()),
+            target_monitor_index=self._safe_monitor_index(),
+        )
+
+    def _safe_duration_value(self) -> float:
+        try:
+            return max(0.5, float(self._duration_var.get().strip()))
+        except Exception:
+            return 8.0
+
+    def _safe_monitor_index(self) -> int:
+        try:
+            return max(0, int(self._monitor_var.get().strip()))
+        except Exception:
+            return 1
+
+    def _toast(self, text: str) -> None:
+        self._status_var.set(text)
+        self.after(3500, lambda: self._status_var.set(""))
+
+    def _migrate_legacy_sources_if_needed(self, settings: AmbianceSettings) -> None:
+        if settings.playlist_entries:
+            return
+        if not settings.playlist_paths:
+            return
+
+        gathered: list[str] = []
+        for raw in settings.playlist_paths:
+            path = Path(str(raw or "")).expanduser()
+            if path.is_dir():
+                gathered.extend(str(candidate) for candidate in sorted(path.rglob("*")) if candidate.is_file())
+                continue
+            if path.is_file() and path.suffix.lower() == ".json":
+                try:
+                    payload = json.loads(path.read_text(encoding="utf-8"))
+                except Exception:
+                    continue
+                items = payload.get("items") if isinstance(payload, dict) else []
+                if isinstance(items, list):
+                    for item in items:
+                        media_path = str((item or {}).get("path") or "") if isinstance(item, dict) else ""
+                        if media_path:
+                            gathered.append(media_path)
+                continue
+            if path.is_file():
+                gathered.append(str(path))
+
+        if not gathered:
+            update_ambiance_settings(playlist_paths=(), playlist_item_ids=(), playlist_entries=())
+            return
+
+        result = self._import_service.import_files(gathered, strategy="skip")
+        if result.imported_items:
+            migrated_entries = tuple({"id": item.id, "duration": settings.default_duration_sec or 8.0} for item in result.imported_items)
+            update_ambiance_settings(
+                playlist_paths=(),
+                playlist_item_ids=tuple(item.id for item in result.imported_items),
+                playlist_entries=migrated_entries,
+            )
+        else:
+            update_ambiance_settings(playlist_paths=(), playlist_item_ids=(), playlist_entries=())
+
+
+def _normalize_playlist_entries(raw_entries: list | tuple, *, default_duration: float) -> list[dict]:
+    normalized: list[dict] = []
+    for raw in raw_entries:
+        if not isinstance(raw, dict):
+            continue
+        item_id = str(raw.get("id") or "").strip()
+        if not item_id:
+            continue
+        try:
+            duration = max(0.5, float(raw.get("duration") or default_duration))
+        except Exception:
+            duration = default_duration
+        normalized.append({"id": item_id, "duration": duration})
+    return normalized
+
+
+def _format_size(size: int) -> str:
+    value = float(max(0, int(size)))
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{size} B"

--- a/modules/ui/ambiance/importer/__init__.py
+++ b/modules/ui/ambiance/importer/__init__.py
@@ -1,0 +1,6 @@
+"""Ambiance wallpaper importer package."""
+
+from modules.ui.ambiance.importer.dialog import AmbianceWallpaperImporterDialog
+from modules.ui.ambiance.importer.service import WallpaperImportService
+
+__all__ = ["AmbianceWallpaperImporterDialog", "WallpaperImportService"]

--- a/modules/ui/ambiance/importer/dialog.py
+++ b/modules/ui/ambiance/importer/dialog.py
@@ -1,0 +1,212 @@
+"""Ambiance wallpaper importer modal dialog."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog
+
+import customtkinter as ctk
+
+from modules.ui.ambiance.importer.models import DuplicateStrategy, ImportCandidate
+from modules.ui.ambiance.importer.service import WallpaperImportService
+from modules.ui.ambiance.importer.thumbnailer import WallpaperThumbnailer
+
+
+class AmbianceWallpaperImporterDialog(ctk.CTkToplevel):
+    """Modal for importing wallpapers into campaign-local library."""
+
+    def __init__(self, master, *, on_complete=None) -> None:
+        super().__init__(master)
+        self.title("Import Ambiance Wallpapers")
+        self.geometry("980x700")
+        self.minsize(860, 580)
+        self.transient(master)
+        self.grab_set()
+
+        self.grid_rowconfigure(3, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        self._service = WallpaperImportService()
+        self._thumbnailer = WallpaperThumbnailer(size=(120, 74))
+        self._on_complete = on_complete
+        self._status_var = tk.StringVar(value="Drop files or click Add files.")
+        self._strategy_var = tk.StringVar(value="skip")
+        self._entries: list[ImportCandidate] = []
+
+        self._build_header()
+        self._build_drop_zone()
+        self._build_controls()
+        self._build_results_list()
+
+        self.lift()
+        self.focus_force()
+
+    def _build_header(self) -> None:
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.grid(row=0, column=0, sticky="ew", padx=16, pady=(14, 8))
+        header.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(
+            header,
+            text="Import Ambiance Wallpapers",
+            font=ctk.CTkFont(size=18, weight="bold"),
+            anchor="w",
+        ).grid(row=0, column=0, sticky="w")
+
+    def _build_drop_zone(self) -> None:
+        zone = ctk.CTkFrame(self, corner_radius=12, border_width=1, border_color="#374151", fg_color="#111827")
+        zone.grid(row=1, column=0, sticky="ew", padx=16)
+        zone.grid_columnconfigure(0, weight=1)
+        self._drop_zone = zone
+
+        ctk.CTkLabel(
+            zone,
+            text="Drag and drop files here",
+            font=ctk.CTkFont(size=15, weight="bold"),
+        ).grid(row=0, column=0, pady=(14, 4), padx=10)
+        ctk.CTkLabel(
+            zone,
+            text="or use Add files to multi-select images/videos",
+            text_color="#9CA3AF",
+        ).grid(row=1, column=0, pady=(0, 14), padx=10)
+
+        zone.bind("<Button-1>", lambda _event: self._choose_files())
+        self._bind_drop_target(zone)
+
+    def _build_controls(self) -> None:
+        controls = ctk.CTkFrame(self, fg_color="transparent")
+        controls.grid(row=2, column=0, sticky="ew", padx=16, pady=8)
+        controls.grid_columnconfigure(5, weight=1)
+
+        ctk.CTkButton(controls, text="Add files", width=120, command=self._choose_files).grid(row=0, column=0, padx=(0, 8))
+        ctk.CTkLabel(controls, text="Duplicates").grid(row=0, column=1, padx=(4, 6))
+        ctk.CTkOptionMenu(
+            controls,
+            variable=self._strategy_var,
+            values=["skip", "replace", "keep_both"],
+            width=130,
+        ).grid(row=0, column=2, padx=(0, 12))
+
+        ctk.CTkButton(controls, text="Import", fg_color="#16A34A", hover_color="#15803D", width=120, command=self._import).grid(
+            row=0,
+            column=3,
+            padx=(0, 8),
+        )
+        ctk.CTkButton(controls, text="Close", width=90, command=self.destroy).grid(row=0, column=4)
+
+        ctk.CTkLabel(controls, textvariable=self._status_var, anchor="w", text_color="#F59E0B").grid(
+            row=1,
+            column=0,
+            columnspan=6,
+            sticky="ew",
+            pady=(8, 0),
+        )
+
+    def _build_results_list(self) -> None:
+        self._list = ctk.CTkScrollableFrame(self, fg_color="transparent")
+        self._list.grid(row=3, column=0, sticky="nsew", padx=16, pady=(0, 16))
+
+    def _choose_files(self) -> None:
+        paths = filedialog.askopenfilenames(
+            title="Select ambiance media",
+            filetypes=[
+                ("Supported media", "*.png *.jpg *.jpeg *.bmp *.gif *.webp *.mp4 *.mov *.mkv *.avi *.webm *.m4v"),
+                ("Images", "*.png *.jpg *.jpeg *.bmp *.gif *.webp"),
+                ("Videos", "*.mp4 *.mov *.mkv *.avi *.webm *.m4v"),
+                ("All files", "*.*"),
+            ],
+            parent=self,
+        )
+        if not paths:
+            return
+        self._set_candidates(list(paths))
+
+    def _set_candidates(self, paths: list[str]) -> None:
+        self._entries = self._service.inspect_candidates(paths)
+        self._render_entries()
+        self._status_var.set(f"{len(self._entries)} file(s) queued for import.")
+
+    def _import(self) -> None:
+        if not self._entries:
+            self._status_var.set("No files selected.")
+            return
+
+        strategy: DuplicateStrategy = self._strategy_var.get().strip().lower() or "skip"  # type: ignore[assignment]
+        result = self._service.import_files([entry.source_path for entry in self._entries], strategy=strategy)
+        self._entries = result.entries
+        self._render_entries()
+        self._show_summary(result.imported_count, result.skipped_count, result.failed_count)
+        callback = self._on_complete
+        if callable(callback):
+            callback(result)
+
+    def _show_summary(self, imported: int, skipped: int, failed: int) -> None:
+        self._status_var.set(
+            f"Import complete · imported: {imported} · skipped: {skipped} · failed: {failed}"
+        )
+        self.after(4000, lambda: self._status_var.set(""))
+
+    def _render_entries(self) -> None:
+        for child in self._list.winfo_children():
+            child.destroy()
+
+        if not self._entries:
+            ctk.CTkLabel(self._list, text="No files selected yet.", anchor="w", text_color="#9CA3AF").grid(
+                row=0,
+                column=0,
+                sticky="w",
+                padx=4,
+                pady=6,
+            )
+            return
+
+        for idx, entry in enumerate(self._entries):
+            row = ctk.CTkFrame(self._list)
+            row.grid(row=idx, column=0, sticky="ew", padx=2, pady=4)
+            row.grid_columnconfigure(1, weight=1)
+
+            thumb = self._thumbnailer.get(entry.source_path, media_type=entry.media_type)
+            ctk.CTkLabel(row, text="", image=thumb, width=128).grid(row=0, column=0, rowspan=2, padx=(6, 8), pady=6)
+
+            dims = f"{entry.width}x{entry.height}" if entry.width and entry.height else "—"
+            size_text = _format_size(entry.filesize)
+            title = f"{entry.filename} · {dims} · {size_text}"
+            ctk.CTkLabel(row, text=title, anchor="w").grid(row=0, column=1, sticky="ew", padx=(0, 8), pady=(8, 2))
+
+            status_color = {
+                "pending": "#9CA3AF",
+                "imported": "#22C55E",
+                "skipped": "#EAB308",
+                "failed": "#EF4444",
+            }.get(entry.status, "#9CA3AF")
+            status_text = entry.message or entry.status.title()
+            ctk.CTkLabel(row, text=status_text, anchor="w", text_color=status_color).grid(
+                row=1,
+                column=1,
+                sticky="ew",
+                padx=(0, 8),
+                pady=(0, 8),
+            )
+
+    def _bind_drop_target(self, widget) -> None:
+        try:
+            widget.drop_target_register("DND_Files")
+            widget.dnd_bind("<<Drop>>", self._on_drop_event)
+        except Exception:
+            return
+
+    def _on_drop_event(self, event) -> None:
+        data = str(getattr(event, "data", "") or "").strip()
+        if not data:
+            return
+        files = self.tk.splitlist(data)
+        self._set_candidates([str(path) for path in files])
+
+
+def _format_size(size: int) -> str:
+    value = float(max(0, int(size)))
+    units = ["B", "KB", "MB", "GB"]
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{size} B"

--- a/modules/ui/ambiance/importer/models.py
+++ b/modules/ui/ambiance/importer/models.py
@@ -1,0 +1,45 @@
+"""Models for ambiance wallpaper import workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
+DuplicateStrategy = Literal["skip", "replace", "keep_both"]
+ImportStatus = Literal["pending", "imported", "skipped", "failed"]
+
+
+@dataclass(slots=True)
+class ImportCandidate:
+    """Single user-selected file candidate."""
+
+    source_path: str
+    filename: str
+    filesize: int = 0
+    width: int | None = None
+    height: int | None = None
+    media_type: str = "unknown"
+    status: ImportStatus = "pending"
+    message: str = ""
+
+
+@dataclass(slots=True)
+class ImportResult:
+    """Summary returned by import service."""
+
+    entries: list[ImportCandidate] = field(default_factory=list)
+    imported_items: list[WallpaperLibraryItem] = field(default_factory=list)
+
+    @property
+    def imported_count(self) -> int:
+        return sum(1 for entry in self.entries if entry.status == "imported")
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for entry in self.entries if entry.status == "skipped")
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for entry in self.entries if entry.status == "failed")

--- a/modules/ui/ambiance/importer/service.py
+++ b/modules/ui/ambiance/importer/service.py
@@ -1,0 +1,175 @@
+"""Import logic for campaign-local ambiance wallpapers."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+from PIL import Image
+
+from modules.ui.ambiance.importer.models import DuplicateStrategy, ImportCandidate, ImportResult
+from modules.ui.ambiance.library.index_store import CampaignWallpaperIndexStore
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"}
+_VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"}
+_MEDIA_EXTENSIONS = _IMAGE_EXTENSIONS | _VIDEO_EXTENSIONS
+_NAME_SANITIZE_PATTERN = re.compile(r"[^a-zA-Z0-9._\- ]+")
+
+
+class WallpaperImportService:
+    """Validate and copy user-selected files into campaign wallpaper storage."""
+
+    def __init__(self, index_store: CampaignWallpaperIndexStore | None = None) -> None:
+        self._store = index_store or CampaignWallpaperIndexStore()
+
+    def inspect_candidates(self, paths: list[str] | tuple[str, ...]) -> list[ImportCandidate]:
+        candidates: list[ImportCandidate] = []
+        for raw in paths:
+            path = Path(str(raw or "")).expanduser()
+            if not path.exists() or not path.is_file():
+                candidates.append(
+                    ImportCandidate(
+                        source_path=str(path),
+                        filename=path.name or str(path),
+                        status="failed",
+                        message="File not found.",
+                    )
+                )
+                continue
+
+            media_type = _infer_media_type(path)
+            if media_type is None:
+                candidates.append(
+                    ImportCandidate(
+                        source_path=str(path),
+                        filename=path.name,
+                        filesize=int(path.stat().st_size),
+                        status="failed",
+                        message="Unsupported file type.",
+                    )
+                )
+                continue
+
+            width = None
+            height = None
+            if media_type == "image":
+                try:
+                    with Image.open(path) as image:
+                        width, height = image.size
+                except Exception:
+                    width = None
+                    height = None
+
+            candidates.append(
+                ImportCandidate(
+                    source_path=str(path.resolve()),
+                    filename=path.name,
+                    filesize=int(path.stat().st_size),
+                    width=width,
+                    height=height,
+                    media_type=media_type,
+                    status="pending",
+                )
+            )
+        return candidates
+
+    def import_files(self, paths: list[str] | tuple[str, ...], *, strategy: DuplicateStrategy = "skip") -> ImportResult:
+        entries = self.inspect_candidates(paths)
+        existing = self._store.load()
+        by_filename = {item.filename.casefold(): item for item in existing}
+        imported_items: list[WallpaperLibraryItem] = []
+
+        for entry in entries:
+            if entry.status == "failed":
+                continue
+            source = Path(entry.source_path)
+            if not source.exists() or not source.is_file():
+                entry.status = "failed"
+                entry.message = "Source file missing."
+                continue
+
+            safe_name = sanitize_filename(entry.filename)
+            duplicate = by_filename.get(safe_name.casefold())
+            destination = self._store.wallpapers_dir / safe_name
+
+            if duplicate and strategy == "skip":
+                entry.status = "skipped"
+                entry.message = "Skipped (duplicate filename)."
+                continue
+
+            if duplicate and strategy == "keep_both":
+                destination = self._store.next_unique_path(safe_name)
+                safe_name = destination.name
+                duplicate = None
+
+            try:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination)
+            except Exception as exc:
+                entry.status = "failed"
+                entry.message = f"Copy failed: {exc}"
+                continue
+
+            library_item = _build_item(destination, source_media_type=entry.media_type, previous=duplicate)
+            imported_items.append(library_item)
+            by_filename[library_item.filename.casefold()] = library_item
+            entry.filename = library_item.filename
+            entry.filesize = library_item.filesize
+            entry.width = library_item.width
+            entry.height = library_item.height
+            entry.media_type = library_item.media_type
+            entry.status = "imported"
+            entry.message = "Imported"
+
+        self._store.upsert_many(imported_items)
+        return ImportResult(entries=entries, imported_items=imported_items)
+
+
+def sanitize_filename(name: str) -> str:
+    """Normalize imported filenames to safe local asset names."""
+    original = Path(name).name.strip() or "wallpaper"
+    cleaned = _NAME_SANITIZE_PATTERN.sub("_", original)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip(" .")
+    if not cleaned:
+        cleaned = "wallpaper"
+    if "." not in cleaned:
+        cleaned = f"{cleaned}.png"
+    return cleaned
+
+
+def _infer_media_type(path: Path) -> str | None:
+    suffix = path.suffix.lower()
+    if suffix in _IMAGE_EXTENSIONS:
+        return "image"
+    if suffix in _VIDEO_EXTENSIONS:
+        return "video"
+    return None
+
+
+def _build_item(destination: Path, *, source_media_type: str, previous: WallpaperLibraryItem | None) -> WallpaperLibraryItem:
+    stat = destination.stat()
+    media_type = source_media_type if source_media_type in {"image", "video"} else (_infer_media_type(destination) or "image")
+    width = None
+    height = None
+    if media_type == "image":
+        try:
+            with Image.open(destination) as image:
+                width, height = image.size
+        except Exception:
+            width = None
+            height = None
+
+    return WallpaperLibraryItem(
+        id=(previous.id if previous else uuid4().hex),
+        relative_path=destination.name,
+        filename=destination.name,
+        media_type=("video" if media_type == "video" else "image"),
+        width=width,
+        height=height,
+        filesize=int(stat.st_size),
+        created_at=float(stat.st_mtime),
+        tags=(previous.tags if previous else ()),
+    )

--- a/modules/ui/ambiance/importer/thumbnailer.py
+++ b/modules/ui/ambiance/importer/thumbnailer.py
@@ -1,0 +1,59 @@
+"""Thumbnail cache used by importer and campaign library list."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+
+import customtkinter as ctk
+from PIL import Image, ImageOps
+
+_DEFAULT_SIZE = (140, 84)
+
+
+class WallpaperThumbnailer:
+    """Generate and cache CTk thumbnails for local media files."""
+
+    def __init__(self, *, size: tuple[int, int] = _DEFAULT_SIZE, max_items: int = 250) -> None:
+        self._size = (max(32, int(size[0])), max(24, int(size[1])))
+        self._max_items = max(40, int(max_items))
+        self._cache: OrderedDict[str, tuple[float, ctk.CTkImage]] = OrderedDict()
+        self._placeholder = self._build_placeholder()
+
+    def get(self, path: str, *, media_type: str = "image") -> ctk.CTkImage:
+        file_path = Path(path)
+        if media_type != "image":
+            return self._placeholder
+        try:
+            mtime = file_path.stat().st_mtime
+        except OSError:
+            return self._placeholder
+
+        key = str(file_path.resolve())
+        cached = self._cache.get(key)
+        if cached is not None and cached[0] == mtime:
+            self._cache.move_to_end(key)
+            return cached[1]
+
+        image = self._load_image(file_path)
+        self._cache[key] = (mtime, image)
+        self._cache.move_to_end(key)
+        while len(self._cache) > self._max_items:
+            self._cache.popitem(last=False)
+        return image
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def _load_image(self, path: Path) -> ctk.CTkImage:
+        try:
+            with Image.open(path) as source:
+                render = source.convert("RGB")
+                fitted = ImageOps.fit(render, self._size, Image.Resampling.LANCZOS)
+        except Exception:
+            return self._placeholder
+        return ctk.CTkImage(light_image=fitted, dark_image=fitted, size=self._size)
+
+    def _build_placeholder(self) -> ctk.CTkImage:
+        image = Image.new("RGB", self._size, color="#1F2937")
+        return ctk.CTkImage(light_image=image, dark_image=image, size=self._size)

--- a/modules/ui/ambiance/library/__init__.py
+++ b/modules/ui/ambiance/library/__init__.py
@@ -1,0 +1,6 @@
+"""Campaign ambiance wallpaper library package."""
+
+from modules.ui.ambiance.library.index_store import CampaignWallpaperIndexStore
+from modules.ui.ambiance.library.repository import CampaignWallpaperRepository
+
+__all__ = ["CampaignWallpaperIndexStore", "CampaignWallpaperRepository"]

--- a/modules/ui/ambiance/library/index_store.py
+++ b/modules/ui/ambiance/library/index_store.py
@@ -1,0 +1,181 @@
+"""Campaign-local persistence for ambiance wallpaper index metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+from PIL import Image
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"}
+_VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"}
+_MEDIA_EXTENSIONS = _IMAGE_EXTENSIONS | _VIDEO_EXTENSIONS
+
+
+class CampaignWallpaperIndexStore:
+    """Read/write wallpaper index in active campaign folder."""
+
+    def __init__(self, campaign_dir: str | None = None) -> None:
+        base = Path(campaign_dir or ConfigHelper.get_campaign_dir())
+        self._campaign_dir = base
+        self._wallpapers_dir = base / "assets" / "ambiance" / "wallpapers"
+        self._index_path = self._wallpapers_dir / "index.json"
+
+    @property
+    def wallpapers_dir(self) -> Path:
+        self._wallpapers_dir.mkdir(parents=True, exist_ok=True)
+        return self._wallpapers_dir
+
+    @property
+    def index_path(self) -> Path:
+        self.wallpapers_dir.mkdir(parents=True, exist_ok=True)
+        return self._index_path
+
+    def load(self) -> list[WallpaperLibraryItem]:
+        path = self.index_path
+        if not path.exists():
+            return []
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+        raw_items = payload.get("items") if isinstance(payload, dict) else []
+        if not isinstance(raw_items, list):
+            return []
+
+        rows: list[WallpaperLibraryItem] = []
+        for raw in raw_items:
+            if not isinstance(raw, dict):
+                continue
+            row = WallpaperLibraryItem(
+                id=str(raw.get("id") or uuid4().hex),
+                relative_path=str(raw.get("relative_path") or "").replace("\\", "/"),
+                filename=str(raw.get("filename") or ""),
+                media_type=("video" if str(raw.get("media_type") or "").lower() == "video" else "image"),
+                width=_to_int(raw.get("width")),
+                height=_to_int(raw.get("height")),
+                filesize=max(0, _to_int(raw.get("filesize"), 0) or 0),
+                created_at=float(raw.get("created_at") or 0.0),
+                tags=tuple(_clean_tags(raw.get("tags"))),
+            )
+            if row.relative_path and row.filename:
+                rows.append(row)
+        return rows
+
+    def save(self, items: list[WallpaperLibraryItem]) -> None:
+        payload = {
+            "version": 1,
+            "items": [
+                {
+                    "id": item.id,
+                    "relative_path": item.relative_path,
+                    "filename": item.filename,
+                    "media_type": item.media_type,
+                    "width": item.width,
+                    "height": item.height,
+                    "filesize": item.filesize,
+                    "created_at": item.created_at,
+                    "tags": list(item.tags),
+                }
+                for item in items
+            ],
+        }
+        path = self.index_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def upsert(self, item: WallpaperLibraryItem) -> WallpaperLibraryItem:
+        rows = self.load()
+        by_id = {row.id: row for row in rows}
+        by_id[item.id] = item
+        self.save(list(by_id.values()))
+        return item
+
+    def upsert_many(self, items: list[WallpaperLibraryItem]) -> list[WallpaperLibraryItem]:
+        if not items:
+            return []
+        rows = self.load()
+        by_id = {row.id: row for row in rows}
+        for item in items:
+            by_id[item.id] = item
+        merged = list(by_id.values())
+        self.save(merged)
+        return items
+
+    def rebuild(self) -> list[WallpaperLibraryItem]:
+        indexed_by_rel = {item.relative_path: item for item in self.load()}
+        rebuilt: list[WallpaperLibraryItem] = []
+        for candidate in sorted(self.wallpapers_dir.rglob("*")):
+            if not candidate.is_file() or candidate.name == "index.json":
+                continue
+            suffix = candidate.suffix.lower()
+            if suffix not in _MEDIA_EXTENSIONS:
+                continue
+            rel = candidate.relative_to(self.wallpapers_dir).as_posix()
+            stat = candidate.stat()
+            media_type = "image" if suffix in _IMAGE_EXTENSIONS else "video"
+            width = None
+            height = None
+            if media_type == "image":
+                try:
+                    with Image.open(candidate) as image:
+                        width, height = image.size
+                except Exception:
+                    width = None
+                    height = None
+            previous = indexed_by_rel.get(rel)
+            rebuilt.append(
+                WallpaperLibraryItem(
+                    id=(previous.id if previous else uuid4().hex),
+                    relative_path=rel,
+                    filename=candidate.name,
+                    media_type=media_type,
+                    width=width,
+                    height=height,
+                    filesize=int(stat.st_size),
+                    created_at=float(stat.st_mtime),
+                    tags=(previous.tags if previous else ()),
+                )
+            )
+        self.save(rebuilt)
+        return rebuilt
+
+    def absolute_path(self, item: WallpaperLibraryItem) -> str:
+        return str((self.wallpapers_dir / item.relative_path).resolve())
+
+    def next_unique_path(self, filename: str) -> Path:
+        target = self.wallpapers_dir / filename
+        if not target.exists():
+            return target
+
+        stem = target.stem
+        suffix = target.suffix
+        counter = 2
+        while True:
+            candidate = target.with_name(f"{stem}-{counter}{suffix}")
+            if not candidate.exists():
+                return candidate
+            counter += 1
+
+
+def _to_int(value, default: int | None = None) -> int | None:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _clean_tags(raw_tags) -> tuple[str, ...]:
+    if not isinstance(raw_tags, (list, tuple)):
+        return ()
+    cleaned: list[str] = []
+    for tag in raw_tags:
+        text = str(tag or "").strip()
+        if text:
+            cleaned.append(text)
+    return tuple(cleaned)

--- a/modules/ui/ambiance/library/models.py
+++ b/modules/ui/ambiance/library/models.py
@@ -1,0 +1,35 @@
+"""Models for campaign-local ambiance wallpaper library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+MediaType = Literal["image", "video"]
+SortKey = Literal["name", "created_desc", "created_asc", "size_desc", "size_asc"]
+
+
+@dataclass(slots=True)
+class WallpaperLibraryItem:
+    """Persisted library record for a single campaign media item."""
+
+    id: str
+    relative_path: str
+    filename: str
+    media_type: MediaType
+    width: int | None
+    height: int | None
+    filesize: int
+    created_at: float
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(slots=True)
+class WallpaperQuery:
+    """Library query options used by the ambiance page."""
+
+    search: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    orientation: str = "all"
+    media_type: str = "all"
+    sort_key: SortKey = "name"

--- a/modules/ui/ambiance/library/repository.py
+++ b/modules/ui/ambiance/library/repository.py
@@ -1,0 +1,78 @@
+"""Read/query facade over the campaign wallpaper index."""
+
+from __future__ import annotations
+
+from modules.ui.ambiance.library.index_store import CampaignWallpaperIndexStore
+from modules.ui.ambiance.library.models import WallpaperLibraryItem, WallpaperQuery
+
+
+class CampaignWallpaperRepository:
+    """Query helpers used by ambiance UI."""
+
+    def __init__(self, index_store: CampaignWallpaperIndexStore | None = None) -> None:
+        self._store = index_store or CampaignWallpaperIndexStore()
+
+    @property
+    def store(self) -> CampaignWallpaperIndexStore:
+        return self._store
+
+    def list_items(self, query: WallpaperQuery | None = None) -> list[WallpaperLibraryItem]:
+        query = query or WallpaperQuery()
+        rows = self._store.load()
+
+        search = query.search.strip().lower()
+        tag_filter = {tag.strip().lower() for tag in query.tags if tag.strip()}
+        media_type = query.media_type.strip().lower()
+        orientation = query.orientation.strip().lower()
+
+        filtered: list[WallpaperLibraryItem] = []
+        for item in rows:
+            if search and search not in item.filename.lower() and all(search not in tag.lower() for tag in item.tags):
+                continue
+            if media_type in {"image", "video"} and item.media_type != media_type:
+                continue
+            if tag_filter and not tag_filter.intersection({tag.lower() for tag in item.tags}):
+                continue
+            if orientation in {"landscape", "portrait", "square"} and not _matches_orientation(item, orientation):
+                continue
+            filtered.append(item)
+
+        return _sort_items(filtered, query.sort_key)
+
+    def find_by_ids(self, item_ids: list[str] | tuple[str, ...]) -> list[WallpaperLibraryItem]:
+        if not item_ids:
+            return []
+        by_id = {item.id: item for item in self._store.load()}
+        result: list[WallpaperLibraryItem] = []
+        for item_id in item_ids:
+            item = by_id.get(str(item_id))
+            if item is not None:
+                result.append(item)
+        return result
+
+    def rebuild(self) -> list[WallpaperLibraryItem]:
+        return self._store.rebuild()
+
+
+def _matches_orientation(item: WallpaperLibraryItem, orientation: str) -> bool:
+    if not item.width or not item.height:
+        return False
+    if orientation == "landscape":
+        return item.width > item.height
+    if orientation == "portrait":
+        return item.height > item.width
+    if orientation == "square":
+        return item.width == item.height
+    return True
+
+
+def _sort_items(items: list[WallpaperLibraryItem], sort_key: str) -> list[WallpaperLibraryItem]:
+    if sort_key == "created_desc":
+        return sorted(items, key=lambda item: item.created_at, reverse=True)
+    if sort_key == "created_asc":
+        return sorted(items, key=lambda item: item.created_at)
+    if sort_key == "size_desc":
+        return sorted(items, key=lambda item: item.filesize, reverse=True)
+    if sort_key == "size_asc":
+        return sorted(items, key=lambda item: item.filesize)
+    return sorted(items, key=lambda item: item.filename.casefold())

--- a/modules/ui/ambiance/settings.py
+++ b/modules/ui/ambiance/settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import configparser
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from modules.helpers.config_helper import ConfigHelper
@@ -19,6 +19,8 @@ class AmbianceSettings:
 
     enabled: bool = False
     playlist_paths: tuple[str, ...] = ()
+    playlist_item_ids: tuple[str, ...] = ()
+    playlist_entries: tuple[dict, ...] = field(default_factory=tuple)
     default_duration_sec: float = _DEFAULT_DURATION_SEC
     transition: str = "fade"
     shuffle: bool = False
@@ -32,12 +34,18 @@ def load_ambiance_settings() -> AmbianceSettings:
     if not cfg.has_section(_SECTION):
         return AmbianceSettings()
 
-    playlist_paths_raw = cfg.get(_SECTION, "playlist_paths", fallback="[]")
-    playlist_paths = _parse_playlist_paths(playlist_paths_raw)
+    playlist_paths = _parse_json_string_list(cfg.get(_SECTION, "playlist_paths", fallback="[]"))
+    playlist_item_ids = _parse_json_string_list(cfg.get(_SECTION, "playlist_item_ids", fallback="[]"))
+    playlist_entries = _parse_json_object_list(cfg.get(_SECTION, "playlist_entries", fallback="[]"))
+
+    if playlist_item_ids and not playlist_entries:
+        playlist_entries = [{"id": item_id, "duration": _DEFAULT_DURATION_SEC} for item_id in playlist_item_ids]
 
     return AmbianceSettings(
         enabled=_to_bool(cfg.get(_SECTION, "enabled", fallback=False), False),
         playlist_paths=playlist_paths,
+        playlist_item_ids=playlist_item_ids,
+        playlist_entries=tuple(playlist_entries),
         default_duration_sec=_to_float(
             cfg.get(_SECTION, "default_duration_sec", fallback=_DEFAULT_DURATION_SEC),
             _DEFAULT_DURATION_SEC,
@@ -61,6 +69,8 @@ def save_ambiance_settings(settings: AmbianceSettings) -> None:
 
     payload = asdict(settings)
     payload["playlist_paths"] = json.dumps(list(settings.playlist_paths), ensure_ascii=False)
+    payload["playlist_item_ids"] = json.dumps(list(settings.playlist_item_ids), ensure_ascii=False)
+    payload["playlist_entries"] = json.dumps(list(settings.playlist_entries), ensure_ascii=False)
     for key, value in payload.items():
         cfg.set(_SECTION, key, str(value))
 
@@ -78,25 +88,40 @@ def update_ambiance_settings(**changes) -> AmbianceSettings:
     merged = AmbianceSettings(**(asdict(current) | changes))
     if isinstance(merged.playlist_paths, list):
         merged.playlist_paths = tuple(merged.playlist_paths)
+    if isinstance(merged.playlist_item_ids, list):
+        merged.playlist_item_ids = tuple(merged.playlist_item_ids)
+    if isinstance(merged.playlist_entries, list):
+        merged.playlist_entries = tuple(merged.playlist_entries)
     save_ambiance_settings(merged)
     return merged
 
 
-def _parse_playlist_paths(raw_value) -> tuple[str, ...]:
+def _parse_json_string_list(raw_value) -> tuple[str, ...]:
     if isinstance(raw_value, (list, tuple)):
         return tuple(str(item).strip() for item in raw_value if str(item).strip())
-    if raw_value is None:
-        return ()
-    text = str(raw_value).strip()
+    text = str(raw_value or "").strip()
     if not text:
         return ()
     try:
         decoded = json.loads(text)
     except Exception:
         return (text,)
-    if isinstance(decoded, list):
-        return tuple(str(item).strip() for item in decoded if str(item).strip())
-    return ()
+    if not isinstance(decoded, list):
+        return ()
+    return tuple(str(item).strip() for item in decoded if str(item).strip())
+
+
+def _parse_json_object_list(raw_value) -> list[dict]:
+    text = str(raw_value or "").strip()
+    if not text:
+        return []
+    try:
+        decoded = json.loads(text)
+    except Exception:
+        return []
+    if not isinstance(decoded, list):
+        return []
+    return [item for item in decoded if isinstance(item, dict)]
 
 
 def _to_bool(value, default: bool) -> bool:

--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -174,6 +174,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                         _command("Sound & Music", app.open_sound_manager, shortcut="F7", icon_key="audio_controls"),
                         _command("Session Timers", app.open_timer_window, icon_key="session_timers"),
                         _command("Ambiance Screen", app.open_ambiance_panel, icon_key="audio_controls"),
+                        _command("Import Ambiance Wallpapers", app.open_wallpaper_importer, icon_key="audio_controls"),
                         _command("Character Creation", app.open_character_creation),
                     ],
                 ),

--- a/tests/ui/ambiance/test_wallpaper_import_flow.py
+++ b/tests/ui/ambiance/test_wallpaper_import_flow.py
@@ -1,0 +1,101 @@
+"""Tests for campaign-local ambiance wallpaper import and index."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from modules.ui.ambiance.importer.service import WallpaperImportService
+from modules.ui.ambiance.library.index_store import CampaignWallpaperIndexStore
+from modules.ui.ambiance.library.models import WallpaperQuery
+from modules.ui.ambiance.library.repository import CampaignWallpaperRepository
+
+
+def _write_image(path: Path, *, size: tuple[int, int] = (128, 72)) -> None:
+    _ = size
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tiny_png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7YH0oAAAAASUVORK5CYII="
+    )
+    path.write_bytes(tiny_png)
+
+
+def test_import_copies_files_into_campaign_wallpaper_folder(tmp_path: Path) -> None:
+    source_dir = tmp_path / "external"
+    campaign_dir = tmp_path / "campaign"
+    source = source_dir / "my.wallpaper.png"
+    _write_image(source)
+
+    store = CampaignWallpaperIndexStore(str(campaign_dir))
+    service = WallpaperImportService(store)
+
+    result = service.import_files([str(source)], strategy="skip")
+
+    assert result.imported_count == 1
+    saved = store.load()
+    assert len(saved) == 1
+    copied_path = store.wallpapers_dir / saved[0].relative_path
+    assert copied_path.exists()
+    assert copied_path.parent == store.wallpapers_dir
+
+
+def test_import_duplicate_behaviors_skip_replace_keep_both(tmp_path: Path) -> None:
+    campaign_dir = tmp_path / "campaign"
+    source_a = tmp_path / "a.png"
+    source_b = tmp_path / "b.png"
+    source_same_name = tmp_path / "folder" / "a.png"
+    _write_image(source_a, size=(128, 72))
+    _write_image(source_b, size=(192, 108))
+    _write_image(source_same_name, size=(192, 108))
+
+    store = CampaignWallpaperIndexStore(str(campaign_dir))
+    service = WallpaperImportService(store)
+
+    service.import_files([str(source_a)], strategy="skip")
+    skip_result = service.import_files([str(source_a)], strategy="skip")
+    assert skip_result.skipped_count == 1
+
+    replace_result = service.import_files([str(source_same_name)], strategy="replace")
+    assert replace_result.imported_count == 1
+
+    keep_both_result = service.import_files([str(source_a)], strategy="keep_both")
+    assert keep_both_result.imported_count == 1
+    assert len(store.load()) == 2
+
+
+def test_repository_filters_and_rebuild(tmp_path: Path, monkeypatch) -> None:
+    campaign_dir = tmp_path / "campaign"
+    store = CampaignWallpaperIndexStore(str(campaign_dir))
+    wall_dir = store.wallpapers_dir
+    _write_image(wall_dir / "landscape.png", size=(1920, 1080))
+    _write_image(wall_dir / "portrait.png", size=(900, 1600))
+    
+    class _ImageStub:
+        def __init__(self, size):
+            self.size = size
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _fake_open(path):
+        filename = Path(path).name
+        return _ImageStub((1920, 1080) if filename == "landscape.png" else (900, 1600))
+
+    monkeypatch.setattr("modules.ui.ambiance.library.index_store.Image.open", _fake_open)
+
+    rebuilt = store.rebuild()
+    payload = json.loads(store.index_path.read_text(encoding="utf-8"))
+
+    assert len(rebuilt) == 2
+    assert payload["version"] == 1
+
+    repository = CampaignWallpaperRepository(store)
+    landscape = repository.list_items(WallpaperQuery(orientation="landscape"))
+    portrait = repository.list_items(WallpaperQuery(orientation="portrait"))
+
+    assert [item.filename for item in landscape] == ["landscape.png"]
+    assert [item.filename for item in portrait] == ["portrait.png"]

--- a/tests/ui/test_menu_sections_image_commands.py
+++ b/tests/ui/test_menu_sections_image_commands.py
@@ -50,6 +50,8 @@ def test_menu_sections_expose_image_library_commands() -> None:
         open_dice_roller=lambda: None,
         open_sound_manager=lambda: None,
         open_timer_window=lambda: None,
+        open_ambiance_panel=lambda: None,
+        open_wallpaper_importer=lambda: None,
         open_character_creation=lambda: None,
         open_audio_bar=lambda: None,
         open_dice_bar=lambda: None,
@@ -62,7 +64,10 @@ def test_menu_sections_expose_image_library_commands() -> None:
     gm_tools = next(menu for menu in specs if menu.label == "GM Tools")
     imports_group = next(group for group in gm_tools.groups if group.title == "Imports & Media")
     labels = [item.label for item in imports_group.items]
+    live_tools = next(group for group in gm_tools.groups if group.title == "Live Table Tools")
+    live_labels = [item.label for item in live_tools.items]
 
     assert "GM Table" in table_labels
     assert "Import Image Directories…" in labels
     assert "Open Image Library" in labels
+    assert "Import Ambiance Wallpapers" in live_labels


### PR DESCRIPTION
### Motivation
- Replace ad-hoc folder/playlist browsing in the Ambiance page with a campaign-local wallpaper library and a dedicated importer to ensure assets are copied into the campaign and referenced safely.
- Provide a clear UX for importing wallpapers (drag-and-drop, multi-select, duplicate strategies and preview) so Ambiance playlists only use campaign-local files.
- Persist searchable metadata and enable rebuild/migration so existing campaigns upgrade gracefully to the index-backed model.
- Expose an app-level entry point to open the importer from menus and keep the Ambiance playback flow unchanged.

### Description
- Added a modular importer under `modules/ui/ambiance/importer/` with `dialog.py`, `service.py`, `models.py`, and `thumbnailer.py` to present a modal UI and implement validation, filename sanitization, duplicate handling (`skip`/`replace`/`keep_both`) and campaign-local copying.
- Added a campaign wallpaper library under `modules/ui/ambiance/library/` with `index_store.py` (persists `assets/ambiance/wallpapers/index.json`), `repository.py` (search/filter/sort, id lookup) and `models.py` (item/query dataclasses), plus a rebuild utility.
- Refactored `modules/scenarios/gm_table/ambiance/page.py` to remove folder/playlist browsing and consume only the new library: searchable thumbnail grid, multi-select, hover quick actions (preview/add/tag), playlist assembly with per-item duration chips and drag-and-drop reordering, and an empty-state CTA to open the importer.
- Extended `modules/ui/ambiance/settings.py` to persist library-backed `playlist_item_ids`/`playlist_entries` while remaining compatible with legacy `playlist_paths`; added `MainWindow.open_wallpaper_importer()` and a menu entry `Import Ambiance Wallpapers` wired in `modules/ui/menu/menu_sections.py`.

### Testing
- Ran unit/flow tests: `pytest -q tests/ui/ambiance/test_settings.py tests/ui/ambiance/test_wallpaper_import_flow.py tests/ui/test_menu_sections_image_commands.py` and all tests passed (`6 passed`).
- Performed quick sanity compile: `python -m py_compile modules/scenarios/gm_table/ambiance/page.py modules/ui/ambiance/importer/dialog.py modules/ui/ambiance/importer/service.py modules/ui/ambiance/library/index_store.py modules/ui/ambiance/library/repository.py modules/ui/ambiance/settings.py` completed without errors.
- Verified created files and commit recorded as `Implement campaign-local ambiance wallpaper import and library flow` in repository history.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe3473618832ba741eb25f89b8f8c)