### PR TITLE
Virtualize Ambiance library, lazy thumbnails, batch-add playlist, and robust monitor handling

### DIFF
--- a/modules/scenarios/gm_table/ambiance/page.py
+++ b/modules/scenarios/gm_table/ambiance/page.py
@@ -9,6 +9,9 @@ from tkinter import messagebox, simpledialog
 
 import customtkinter as ctk
 
+from modules.scenarios.gm_table.ambiance.playlist_controller import add_missing_items_to_playlist
+from modules.scenarios.gm_table.ambiance.thumb_loader import AmbianceThumbLoader
+from modules.scenarios.gm_table.ambiance.virtualized_grid import VirtualizedWallpaperGrid
 from modules.ui.ambiance.importer.service import WallpaperImportService
 from modules.ui.ambiance.importer.thumbnailer import WallpaperThumbnailer
 from modules.ui.ambiance.library.models import WallpaperLibraryItem, WallpaperQuery
@@ -28,10 +31,12 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         self._repository = CampaignWallpaperRepository()
         self._import_service = WallpaperImportService(self._repository.store)
         self._thumbnailer = WallpaperThumbnailer(size=(136, 82))
+        self._thumb_loader = AmbianceThumbLoader(self, thumbnailer=self._thumbnailer)
         self._selected_ids: set[str] = set()
         self._playlist: list[dict] = []
         self._drag_index: int | None = None
         self._restoring_ui_state = True
+        self._empty_library_card = None
 
         state = dict(initial_state or {})
         settings = load_ambiance_settings()
@@ -99,7 +104,8 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         ctk.CTkOptionMenu(filters, variable=self._media_var, values=["all", "image", "video"], width=110).grid(row=0, column=2, padx=(0, 8))
         ctk.CTkOptionMenu(filters, variable=self._orientation_var, values=["all", "landscape", "portrait", "square"], width=126).grid(row=0, column=3, padx=(0, 8))
         ctk.CTkOptionMenu(filters, variable=self._sort_var, values=["name", "created_desc", "size_desc"], width=120).grid(row=0, column=4, padx=(0, 8))
-        ctk.CTkButton(filters, text="Add to playlist", width=130, command=self._add_selected_to_playlist).grid(row=0, column=5)
+        ctk.CTkButton(filters, text="Add to playlist", width=130, command=self._add_selected_to_playlist).grid(row=0, column=5, padx=(0, 8))
+        ctk.CTkButton(filters, text="Add all to playlist", width=150, command=self._add_all_to_playlist).grid(row=0, column=6)
 
     def _build_body(self) -> None:
         body = ctk.CTkFrame(self, fg_color="transparent")
@@ -111,6 +117,14 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         self._library_frame = ctk.CTkScrollableFrame(body, fg_color="transparent")
         self._library_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
         self._library_frame.grid_columnconfigure(0, weight=1)
+
+        self._virtual_grid = VirtualizedWallpaperGrid(
+            self._library_frame,
+            row_height=106,
+            overscan_rows=3,
+            create_row=self._create_library_card,
+            bind_row=self._bind_library_card,
+        )
 
         playlist_panel = ctk.CTkFrame(body)
         playlist_panel.grid(row=0, column=1, sticky="nsew")
@@ -160,51 +174,41 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         )
 
     def _render_library(self) -> None:
-        for child in self._library_frame.winfo_children():
-            child.destroy()
         items = self._library_items()
         if not items:
-            card = ctk.CTkFrame(self._library_frame)
-            card.grid(row=0, column=0, sticky="ew", padx=4, pady=6)
-            ctk.CTkLabel(card, text="No wallpapers imported yet", font=ctk.CTkFont(size=14, weight="bold")).pack(anchor="w", padx=10, pady=(10, 2))
-            ctk.CTkLabel(card, text="Import wallpapers into this campaign to build your playlist.", text_color="#9CA3AF").pack(anchor="w", padx=10, pady=(0, 10))
-            ctk.CTkButton(card, text="Open Importer", command=self._open_importer).pack(anchor="w", padx=10, pady=(0, 10))
+            self._virtual_grid.set_items([])
+            if self._empty_library_card is None or not self._empty_library_card.winfo_exists():
+                card = ctk.CTkFrame(self._library_frame)
+                card.grid(row=3, column=0, sticky="ew", padx=4, pady=6)
+                ctk.CTkLabel(card, text="No wallpapers imported yet", font=ctk.CTkFont(size=14, weight="bold")).pack(anchor="w", padx=10, pady=(10, 2))
+                ctk.CTkLabel(card, text="Import wallpapers into this campaign to build your playlist.", text_color="#9CA3AF").pack(anchor="w", padx=10, pady=(0, 10))
+                ctk.CTkButton(card, text="Open Importer", command=self._open_importer).pack(anchor="w", padx=10, pady=(0, 10))
+                self._empty_library_card = card
             return
 
-        for idx, item in enumerate(items):
-            self._render_library_card(item=item, row_idx=idx)
+        if self._empty_library_card is not None and self._empty_library_card.winfo_exists():
+            self._empty_library_card.destroy()
+            self._empty_library_card = None
+        self._virtual_grid.set_items(items)
 
-    def _render_library_card(self, *, item: WallpaperLibraryItem, row_idx: int) -> None:
-        card = ctk.CTkFrame(self._library_frame, border_width=1, border_color="#334155")
-        card.grid(row=row_idx, column=0, sticky="ew", padx=4, pady=4)
+    def _create_library_card(self, parent):
+        card = ctk.CTkFrame(parent, border_width=1, border_color="#334155")
         card.grid_columnconfigure(1, weight=1)
 
-        abs_path = self._repository.store.absolute_path(item)
-        thumb = self._thumbnailer.get(abs_path, media_type=item.media_type)
-        ctk.CTkLabel(card, text="", image=thumb, width=144).grid(row=0, column=0, rowspan=2, padx=(8, 8), pady=8)
+        thumbnail_label = ctk.CTkLabel(card, text="", width=144)
+        thumbnail_label.grid(row=0, column=0, rowspan=2, padx=(8, 8), pady=8)
 
-        selected = item.id in self._selected_ids
-        select_button = ctk.CTkCheckBox(
-            card,
-            text=item.filename,
-            onvalue=True,
-            offvalue=False,
-            command=lambda item_id=item.id: self._toggle_select(item_id),
-        )
-        if selected:
-            select_button.select()
-        else:
-            select_button.deselect()
+        select_button = ctk.CTkCheckBox(card, text="", onvalue=True, offvalue=False)
         select_button.grid(row=0, column=1, sticky="w", pady=(8, 2))
 
-        details = f"{item.media_type.title()} · {item.width or '—'}x{item.height or '—'} · {_format_size(item.filesize)}"
-        ctk.CTkLabel(card, text=details, text_color="#9CA3AF", anchor="w").grid(row=1, column=1, sticky="w", pady=(0, 8))
+        details_label = ctk.CTkLabel(card, text="", text_color="#9CA3AF", anchor="w")
+        details_label.grid(row=1, column=1, sticky="w", pady=(0, 8))
 
         quick_actions = ctk.CTkFrame(card, fg_color="transparent")
         quick_actions.grid(row=0, column=2, rowspan=2, padx=(0, 8))
-        preview_btn = ctk.CTkButton(quick_actions, text="Preview", width=74, command=lambda i=item: self._preview_item(i))
-        add_btn = ctk.CTkButton(quick_actions, text="+ Playlist", width=86, command=lambda i=item: self._add_single_to_playlist(i))
-        tag_btn = ctk.CTkButton(quick_actions, text="Tag", width=54, command=lambda i=item: self._tag_item(i))
+        preview_btn = ctk.CTkButton(quick_actions, text="Preview", width=74)
+        add_btn = ctk.CTkButton(quick_actions, text="+ Playlist", width=86)
+        tag_btn = ctk.CTkButton(quick_actions, text="Tag", width=54)
 
         def _show(_event=None):
             preview_btn.grid(row=0, column=0, padx=(0, 4), pady=(0, 4))
@@ -217,6 +221,43 @@ class GMTableAmbiancePage(ctk.CTkFrame):
 
         card.bind("<Enter>", _show)
         card.bind("<Leave>", _hide)
+
+        card._thumb_label = thumbnail_label  # type: ignore[attr-defined]
+        card._select_button = select_button  # type: ignore[attr-defined]
+        card._details_label = details_label  # type: ignore[attr-defined]
+        card._preview_btn = preview_btn  # type: ignore[attr-defined]
+        card._add_btn = add_btn  # type: ignore[attr-defined]
+        card._tag_btn = tag_btn  # type: ignore[attr-defined]
+        return card
+
+    def _bind_library_card(self, card, item: WallpaperLibraryItem, _index: int) -> None:
+        card_key = str(id(card))
+        select_button = card._select_button  # type: ignore[attr-defined]
+        select_button.configure(text=item.filename, command=lambda item_id=item.id: self._toggle_select(item_id))
+        if item.id in self._selected_ids:
+            select_button.select()
+        else:
+            select_button.deselect()
+
+        details = f"{item.media_type.title()} · {item.width or '—'}x{item.height or '—'} · {_format_size(item.filesize)}"
+        card._details_label.configure(text=details)  # type: ignore[attr-defined]
+        card._preview_btn.configure(command=lambda i=item: self._preview_item(i))  # type: ignore[attr-defined]
+        card._add_btn.configure(command=lambda i=item: self._add_single_to_playlist(i))  # type: ignore[attr-defined]
+        card._tag_btn.configure(command=lambda i=item: self._tag_item(i))  # type: ignore[attr-defined]
+
+        abs_path = self._repository.store.absolute_path(item)
+        thumb_key = f"{item.id}:{item.media_type}:{abs_path}"
+
+        def _set_thumb(image):
+            card._thumb_label.configure(image=image)  # type: ignore[attr-defined]
+
+        self._thumb_loader.request(
+            card_key=card_key,
+            thumb_key=thumb_key,
+            absolute_path=abs_path,
+            media_type=item.media_type,
+            on_ready=_set_thumb,
+        )
 
     def _render_playlist(self) -> None:
         for child in self._playlist_frame.winfo_children():
@@ -275,12 +316,21 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             self._toast("No wallpaper selected.")
             return
         for item in selected_items:
-            self._playlist.append({"id": item.id, "duration": self._safe_duration_value()})
+            self._playlist.append({"id": item.id, "path": item.relative_path, "duration": self._safe_duration_value()})
         self._render_playlist()
         self._toast(f"Added {len(selected_items)} item(s) to playlist.")
 
+    def _add_all_to_playlist(self) -> None:
+        result = add_missing_items_to_playlist(
+            playlist_entries=self._playlist,
+            library_items=self._library_items(),
+            default_duration=self._safe_duration_value(),
+        )
+        self._render_playlist()
+        self._toast(f"{result.added_count} added, {result.already_present_count} already present.")
+
     def _add_single_to_playlist(self, item: WallpaperLibraryItem) -> None:
-        self._playlist.append({"id": item.id, "duration": self._safe_duration_value()})
+        self._playlist.append({"id": item.id, "path": item.relative_path, "duration": self._safe_duration_value()})
         self._render_playlist()
         self._toast(f"Added '{item.filename}' to playlist.")
 
@@ -357,7 +407,15 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         getter = getattr(host, "get_ambiance_player", None)
         if callable(getter):
             return getter()
-        self._status_var.set("Ambiance player unavailable from this window.")
+
+        parent = self.master
+        while parent is not None:
+            getter = getattr(parent, "get_ambiance_player", None)
+            if callable(getter):
+                return getter()
+            parent = getattr(parent, "master", None)
+
+        self._status_var.set("Unable to resolve ambiance player in this window context.")
         return None
 
     def _start(self) -> None:
@@ -370,7 +428,12 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             if callable(setter):
                 setter(self._safe_monitor_index())
             player.start(playlist)
-            self._status_var.set(f"Playback started ({len(playlist.items)} media).")
+            consume_warning = getattr(player, "consume_last_monitor_warning", None)
+            monitor_warning = consume_warning() if callable(consume_warning) else None
+            if monitor_warning:
+                self._toast(monitor_warning)
+            else:
+                self._status_var.set(f"Playback started ({len(playlist.items)} media).")
             self._persist_settings()
         except Exception as exc:
             self._status_var.set(f"Start failed: {exc}")
@@ -420,6 +483,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
 
     def _on_import_completed(self) -> None:
         self._repository.rebuild()
+        self._thumb_loader.clear()
         self._render_library()
         self._toast("Wallpaper library updated.")
 
@@ -444,7 +508,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             enabled=bool(self._enabled_var.get()),
             playlist_paths=(),
             playlist_item_ids=tuple(entry["id"] for entry in self._playlist),
-            playlist_entries=tuple({"id": entry["id"], "duration": float(entry.get("duration", self._safe_duration_value()))} for entry in self._playlist),
+            playlist_entries=tuple({"id": entry["id"], "path": str(entry.get("path") or ""), "duration": float(entry.get("duration", self._safe_duration_value()))} for entry in self._playlist),
             default_duration_sec=self._safe_duration_value(),
             transition=(self._transition_var.get().strip().lower() or "fade"),
             shuffle=bool(self._shuffle_var.get()),
@@ -460,9 +524,9 @@ class GMTableAmbiancePage(ctk.CTkFrame):
 
     def _safe_monitor_index(self) -> int:
         try:
-            return max(0, int(self._monitor_var.get().strip()))
+            return int(self._monitor_var.get().strip())
         except Exception:
-            return 1
+            return 0
 
     def _toast(self, text: str) -> None:
         self._status_var.set(text)
@@ -501,7 +565,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
 
         result = self._import_service.import_files(gathered, strategy="skip")
         if result.imported_items:
-            migrated_entries = tuple({"id": item.id, "duration": settings.default_duration_sec or 8.0} for item in result.imported_items)
+            migrated_entries = tuple({"id": item.id, "path": item.relative_path, "duration": settings.default_duration_sec or 8.0} for item in result.imported_items)
             update_ambiance_settings(
                 playlist_paths=(),
                 playlist_item_ids=tuple(item.id for item in result.imported_items),
@@ -519,11 +583,12 @@ def _normalize_playlist_entries(raw_entries: list | tuple, *, default_duration: 
         item_id = str(raw.get("id") or "").strip()
         if not item_id:
             continue
+        path = str(raw.get("path") or "").strip()
         try:
             duration = max(0.5, float(raw.get("duration") or default_duration))
         except Exception:
             duration = default_duration
-        normalized.append({"id": item_id, "duration": duration})
+        normalized.append({"id": item_id, "path": path, "duration": duration})
     return normalized
 
 

--- a/modules/scenarios/gm_table/ambiance/playlist_controller.py
+++ b/modules/scenarios/gm_table/ambiance/playlist_controller.py
@@ -1,0 +1,49 @@
+"""Playlist mutation helpers for GM Table ambiance page."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
+
+@dataclass(frozen=True, slots=True)
+class AddAllResult:
+    """Result metadata for batch playlist append actions."""
+
+    added_count: int
+    already_present_count: int
+
+
+def add_missing_items_to_playlist(
+    *,
+    playlist_entries: list[dict],
+    library_items: list[WallpaperLibraryItem],
+    default_duration: float,
+) -> AddAllResult:
+    """Append items to playlist while keeping order and preventing duplicates."""
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+
+    for entry in playlist_entries:
+        item_id = str((entry or {}).get("id") or "").strip()
+        if item_id:
+            seen_ids.add(item_id)
+        raw_path = str((entry or {}).get("path") or "").strip()
+        if raw_path:
+            seen_paths.add(raw_path)
+
+    added = 0
+    skipped = 0
+    for item in library_items:
+        path_key = str(item.relative_path or "").strip()
+        if item.id in seen_ids or (path_key and path_key in seen_paths):
+            skipped += 1
+            continue
+        playlist_entries.append({"id": item.id, "path": path_key, "duration": float(default_duration)})
+        seen_ids.add(item.id)
+        if path_key:
+            seen_paths.add(path_key)
+        added += 1
+
+    return AddAllResult(added_count=added, already_present_count=skipped)

--- a/modules/scenarios/gm_table/ambiance/thumb_loader.py
+++ b/modules/scenarios/gm_table/ambiance/thumb_loader.py
@@ -1,0 +1,60 @@
+"""Lazy thumbnail scheduling with cache and stale-job protection."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import customtkinter as ctk
+
+
+class AmbianceThumbLoader:
+    """Load thumbnails lazily for currently visible cards only."""
+
+    def __init__(self, host: ctk.CTkBaseClass, *, thumbnailer, cache_size: int = 180) -> None:
+        self._host = host
+        self._thumbnailer = thumbnailer
+        self._cache_size = max(32, int(cache_size))
+        self._cache: OrderedDict[str, ctk.CTkImage] = OrderedDict()
+        self._active_card_jobs: dict[str, tuple[int, str]] = {}
+        self._next_token = 1
+
+    def request(
+        self,
+        *,
+        card_key: str,
+        thumb_key: str,
+        absolute_path: str,
+        media_type: str,
+        on_ready,
+    ) -> None:
+        cached = self._cache.get(thumb_key)
+        if cached is not None:
+            self._cache.move_to_end(thumb_key)
+            on_ready(cached)
+            return
+
+        token = self._next_token
+        self._next_token += 1
+        self._active_card_jobs[card_key] = (token, thumb_key)
+
+        def _load_later() -> None:
+            current = self._active_card_jobs.get(card_key)
+            if current != (token, thumb_key):
+                return
+            image = self._thumbnailer.get(absolute_path, media_type=media_type)
+            self._cache[thumb_key] = image
+            self._cache.move_to_end(thumb_key)
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
+            current = self._active_card_jobs.get(card_key)
+            if current == (token, thumb_key):
+                on_ready(image)
+
+        self._host.after(0, _load_later)
+
+    def invalidate_card(self, card_key: str) -> None:
+        self._active_card_jobs.pop(card_key, None)
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._active_card_jobs.clear()

--- a/modules/scenarios/gm_table/ambiance/virtualized_grid.py
+++ b/modules/scenarios/gm_table/ambiance/virtualized_grid.py
@@ -1,0 +1,116 @@
+"""Viewport-based virtualized list rendering for ambiance library cards."""
+
+from __future__ import annotations
+
+import math
+
+import customtkinter as ctk
+
+
+class VirtualizedWallpaperGrid:
+    """Render only visible rows in a scrollable container and recycle widgets."""
+
+    def __init__(
+        self,
+        scrollable: ctk.CTkScrollableFrame,
+        *,
+        row_height: int,
+        overscan_rows: int,
+        create_row,
+        bind_row,
+    ) -> None:
+        self._scrollable = scrollable
+        self._row_height = max(60, int(row_height))
+        self._overscan_rows = max(1, int(overscan_rows))
+        self._create_row = create_row
+        self._bind_row = bind_row
+
+        self._items: list = []
+        self._pool: list[ctk.CTkFrame] = []
+        self._virtual_job: str | None = None
+        self._bound_canvas = None
+
+        self._top_spacer = ctk.CTkFrame(scrollable, height=1, fg_color="transparent")
+        self._top_spacer.grid(row=0, column=0, sticky="ew")
+        self._top_spacer.grid_propagate(False)
+
+        self._rows_frame = ctk.CTkFrame(scrollable, fg_color="transparent")
+        self._rows_frame.grid(row=1, column=0, sticky="nsew")
+        self._rows_frame.grid_columnconfigure(0, weight=1)
+
+        self._bottom_spacer = ctk.CTkFrame(scrollable, height=1, fg_color="transparent")
+        self._bottom_spacer.grid(row=2, column=0, sticky="ew")
+        self._bottom_spacer.grid_propagate(False)
+
+        self._bind_scroll_events()
+
+    def set_items(self, items: list) -> None:
+        self._items = list(items)
+        self.refresh(force=True)
+
+    def refresh(self, *, force: bool = False) -> None:
+        if self._virtual_job:
+            try:
+                self._scrollable.after_cancel(self._virtual_job)
+            except Exception:
+                pass
+            self._virtual_job = None
+        delay = 0 if force else 20
+        self._virtual_job = self._scrollable.after(delay, self._render_visible)
+
+    def _bind_scroll_events(self) -> None:
+        canvas = getattr(self._scrollable, "_parent_canvas", None)
+        if canvas is None:
+            self._scrollable.after(50, self._bind_scroll_events)
+            return
+        if self._bound_canvas is canvas:
+            return
+        self._bound_canvas = canvas
+        canvas.bind("<Configure>", lambda _event: self.refresh(), add="+")
+        canvas.bind("<MouseWheel>", lambda _event: self.refresh(), add="+")
+        canvas.bind("<Button-4>", lambda _event: self.refresh(), add="+")
+        canvas.bind("<Button-5>", lambda _event: self.refresh(), add="+")
+        scrollbar = getattr(self._scrollable, "_scrollbar", None)
+        if scrollbar is not None:
+            scrollbar.bind("<B1-Motion>", lambda _event: self.refresh(), add="+")
+            scrollbar.bind("<ButtonRelease-1>", lambda _event: self.refresh(force=True), add="+")
+
+    def _render_visible(self) -> None:
+        self._virtual_job = None
+        total_rows = len(self._items)
+        if total_rows <= 0:
+            self._top_spacer.configure(height=1)
+            self._bottom_spacer.configure(height=1)
+            for card in self._pool:
+                card.grid_remove()
+            return
+
+        canvas = getattr(self._scrollable, "_parent_canvas", None)
+        viewport_height = 860
+        scroll_top = 0.0
+        if canvas is not None:
+            viewport_height = max(80, int(canvas.winfo_height()))
+            y0, _y1 = canvas.yview()
+            total_height = total_rows * self._row_height
+            scroll_top = max(0.0, float(y0) * float(total_height))
+
+        first_visible = int(scroll_top // self._row_height)
+        visible_rows = max(1, int(math.ceil(viewport_height / self._row_height)))
+        start = max(0, first_visible - self._overscan_rows)
+        end = min(total_rows, first_visible + visible_rows + self._overscan_rows)
+
+        self._top_spacer.configure(height=max(1, start * self._row_height))
+        self._bottom_spacer.configure(height=max(1, (total_rows - end) * self._row_height))
+
+        needed = max(0, end - start)
+        while len(self._pool) < needed:
+            row = self._create_row(self._rows_frame)
+            self._pool.append(row)
+
+        for slot, card in enumerate(self._pool):
+            if slot >= needed:
+                card.grid_remove()
+                continue
+            item_index = start + slot
+            card.grid(row=slot, column=0, sticky="ew", padx=4, pady=4)
+            self._bind_row(card, self._items[item_index], item_index)

--- a/modules/ui/ambiance/monitor_selector.py
+++ b/modules/ui/ambiance/monitor_selector.py
@@ -1,0 +1,28 @@
+"""Monitor index normalization and fallback policy for ambiance playback."""
+
+from __future__ import annotations
+
+
+def normalize_target_monitor(requested_index: int | None, monitor_count: int) -> tuple[int, str | None]:
+    """Resolve requested monitor index to a safe target and optional user warning."""
+    if monitor_count <= 0:
+        return 0, "No monitor detected, using primary monitor."
+
+    if requested_index is None:
+        return (1, None) if monitor_count > 1 else (0, None)
+
+    try:
+        index = int(requested_index)
+    except Exception:
+        return 0, "Invalid monitor index, using primary monitor."
+
+    if index < 0:
+        return 0, "Invalid monitor index, using primary monitor."
+
+    if index == 1 and monitor_count < 2:
+        return 0, "Secondary monitor not detected, using primary monitor."
+
+    if index >= monitor_count:
+        return 0, "Invalid monitor index, using primary monitor."
+
+    return index, None

--- a/modules/ui/ambiance/player.py
+++ b/modules/ui/ambiance/player.py
@@ -14,6 +14,7 @@ from modules.helpers.logging_helper import log_info, log_warning
 from modules.ui.ambiance.media_loader import load_image, load_video, normalize_item
 from modules.ui.ambiance.models import AmbianceItem, AmbiancePlaylist, AmbianceState
 from modules.ui.ambiance.monitor import MonitorSelectionError, select_target_monitor
+from modules.ui.ambiance.monitor_selector import normalize_target_monitor
 
 _RESAMPLING = getattr(Image, "Resampling", Image)
 _RESAMPLE_MODE = getattr(_RESAMPLING, "LANCZOS", Image.LANCZOS)
@@ -39,7 +40,8 @@ class SecondScreenAmbiancePlayer:
         self._runtime_items: list[AmbianceItem] = []
         self._order: list[int] = []
         self._state = AmbianceState()
-        self._target_monitor_index: int | None = None
+        self._target_monitor_index: int | None = 0
+        self._last_monitor_warning: str | None = None
         self._photo_ref = None
         self._video = None
 
@@ -147,9 +149,17 @@ class SecondScreenAmbiancePlayer:
     def _ensure_window(self) -> None:
         if self._window is not None and self._window.winfo_exists() and self._canvas is not None:
             return
+
+        from modules.ui.image_viewer import _get_monitors
+
+        requested_index = self._target_monitor_index if self._target_monitor_index is not None else 0
+        monitor_count = len(_get_monitors())
+        target_index, warning_message = normalize_target_monitor(requested_index, monitor_count)
+        self._last_monitor_warning = warning_message
+
         monitor = select_target_monitor(
             allow_single_screen_fallback=self._allow_single_screen_fallback,
-            preferred_index=self._target_monitor_index,
+            preferred_index=target_index,
         )
 
         self._window = ctk.CTkToplevel(self._root)
@@ -175,6 +185,13 @@ class SecondScreenAmbiancePlayer:
 
         self._window.bind("<Escape>", lambda _event: self.stop())
         self._window.protocol("WM_DELETE_WINDOW", self.stop)
+
+
+    def consume_last_monitor_warning(self) -> str | None:
+        """Return and clear the latest monitor fallback warning."""
+        warning = self._last_monitor_warning
+        self._last_monitor_warning = None
+        return warning
 
     def _render_current(self) -> None:
         if self._state.is_paused or not self._state.is_running:

--- a/modules/ui/ambiance/settings.py
+++ b/modules/ui/ambiance/settings.py
@@ -25,7 +25,7 @@ class AmbianceSettings:
     transition: str = "fade"
     shuffle: bool = False
     loop: bool = True
-    target_monitor_index: int = 1
+    target_monitor_index: int = 0
 
 
 def load_ambiance_settings() -> AmbianceSettings:
@@ -53,8 +53,24 @@ def load_ambiance_settings() -> AmbianceSettings:
         transition=(cfg.get(_SECTION, "transition", fallback="fade") or "fade").strip().lower(),
         shuffle=_to_bool(cfg.get(_SECTION, "shuffle", fallback=False), False),
         loop=_to_bool(cfg.get(_SECTION, "loop", fallback=True), True),
-        target_monitor_index=_to_int(cfg.get(_SECTION, "target_monitor_index", fallback=1), 1),
+        target_monitor_index=_read_target_monitor_index(cfg),
     )
+
+
+def _read_target_monitor_index(cfg: configparser.ConfigParser) -> int:
+    """Load monitor index with backward compatibility for legacy 1-based values."""
+    raw_index = _to_int(cfg.get(_SECTION, "target_monitor_index", fallback=0), 0)
+    base_mode = (cfg.get(_SECTION, "target_monitor_index_base", fallback="") or "").strip().lower()
+
+    if base_mode == "one_based":
+        return max(0, raw_index - 1)
+    if base_mode == "zero_based":
+        return max(0, raw_index)
+
+    # Legacy fallback: previous builds persisted 1-based monitor indices.
+    if raw_index >= 1:
+        return raw_index - 1
+    return 0
 
 
 def save_ambiance_settings(settings: AmbianceSettings) -> None:
@@ -71,6 +87,7 @@ def save_ambiance_settings(settings: AmbianceSettings) -> None:
     payload["playlist_paths"] = json.dumps(list(settings.playlist_paths), ensure_ascii=False)
     payload["playlist_item_ids"] = json.dumps(list(settings.playlist_item_ids), ensure_ascii=False)
     payload["playlist_entries"] = json.dumps(list(settings.playlist_entries), ensure_ascii=False)
+    payload["target_monitor_index_base"] = "zero_based"
     for key, value in payload.items():
         cfg.set(_SECTION, key, str(value))
 

--- a/tests/test_ambiance_monitor_selector.py
+++ b/tests/test_ambiance_monitor_selector.py
@@ -1,0 +1,19 @@
+from modules.ui.ambiance.monitor_selector import normalize_target_monitor
+
+
+def test_primary_monitor_index_zero_is_valid() -> None:
+    target, warning = normalize_target_monitor(0, 1)
+    assert target == 0
+    assert warning is None
+
+
+def test_secondary_falls_back_when_unavailable() -> None:
+    target, warning = normalize_target_monitor(1, 1)
+    assert target == 0
+    assert warning == "Secondary monitor not detected, using primary monitor."
+
+
+def test_invalid_index_falls_back_to_primary() -> None:
+    target, warning = normalize_target_monitor(-3, 2)
+    assert target == 0
+    assert warning == "Invalid monitor index, using primary monitor."

--- a/tests/test_ambiance_playlist_controller.py
+++ b/tests/test_ambiance_playlist_controller.py
@@ -1,0 +1,31 @@
+from modules.scenarios.gm_table.ambiance.playlist_controller import add_missing_items_to_playlist
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
+
+def _item(item_id: str, path: str) -> WallpaperLibraryItem:
+    return WallpaperLibraryItem(
+        id=item_id,
+        relative_path=path,
+        filename=f"{item_id}.jpg",
+        media_type="image",
+        width=100,
+        height=80,
+        filesize=1024,
+        created_at=1.0,
+        tags=(),
+    )
+
+
+def test_add_missing_items_preserves_order_and_skips_duplicates() -> None:
+    playlist = [{"id": "a", "path": "a.jpg", "duration": 8.0}]
+    items = [_item("a", "a.jpg"), _item("b", "b.jpg"), _item("c", "c.jpg")]
+
+    result = add_missing_items_to_playlist(
+        playlist_entries=playlist,
+        library_items=items,
+        default_duration=10.0,
+    )
+
+    assert result.added_count == 2
+    assert result.already_present_count == 1
+    assert [entry["id"] for entry in playlist] == ["a", "b", "c"]


### PR DESCRIPTION
### Motivation
- Reduce Ambiance page startup time and memory by avoiding eager creation of all wallpaper cards and only painting the first viewport.
- Prevent blank/stale thumbnails and heavy I/O during fast scrolling by loading thumbnails lazily with cancellation and caching.
- Provide a convenient bulk action to append the visible/filtered library to the session playlist while avoiding duplicates.
- Fix ambiguous/incorrect Start errors when monitor index is `0` or `1` and make monitor fallback/user feedback explicit and consistent with persisted settings.

### Description
- Replaced eager library rendering in `modules/scenarios/gm_table/ambiance/page.py` with a viewport-driven renderer and recycled card widgets via the new `VirtualizedWallpaperGrid` helper in `modules/scenarios/gm_table/ambiance/virtualized_grid.py`.
- Added `AmbianceThumbLoader` (`modules/scenarios/gm_table/ambiance/thumb_loader.py`) that schedules thumbnail creation via Tk `after`, keeps a small in-memory LRU cache, and ignores stale jobs for recycled cards so fast scrolling doesn't produce wrong/stale images.
- Introduced `Add all to playlist` UI action and extracted batch-append logic into `modules/scenarios/gm_table/ambiance/playlist_controller.py` which appends missing library items in current order while preventing duplicates (id/path-based) and returns counts for feedback.
- Hardened player startup and monitor selection: added `modules/ui/ambiance/monitor_selector.py` to centralize normalization/fallback (`0` primary, `1` secondary when present, invalid → fallback + concise warning), updated `SecondScreenAmbiancePlayer` to consume that policy and expose a consumable warning via `consume_last_monitor_warning`, and removed the unhelpful generic "player unavailable" message in page resolution logic.
- Added persistence/migration support in `modules/ui/ambiance/settings.py` so legacy 1-based monitor indices are interpreted safely and new saves mark `target_monitor_index_base = "zero_based"` to avoid regressions; playlist entries now persist `path` consistently.
- Kept architecture modular by introducing dedicated submodules and minimal invasive changes to the page and player wiring to surface non-blocking user feedback (toasts/status) when fallback occurs.

### Testing
- Unit tests: ran `pytest -q tests/test_ambiance_monitor_selector.py tests/test_ambiance_playlist_controller.py` and all tests passed (`4 passed`).
- Static validation: compiled modified modules with `python -m py_compile` for `modules/scenarios/gm_table/ambiance/page.py`, `virtualized_grid.py`, `thumb_loader.py`, `playlist_controller.py`, `modules/ui/ambiance/player.py`, `modules/ui/ambiance/settings.py`, and `modules/ui/ambiance/monitor_selector.py` with no syntax errors.
- Notes: manual dual-monitor GUI validation is still recommended on real single/dual-monitor setups to confirm runtime fallback/toast behavior and visual thumbnail loading under heavy scroll.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe8e5ff64832b9e51aa1a3a9a5058)