### PR TITLE
Improve ambiance stop behavior and add playlist clear action

### DIFF
--- a/modules/scenarios/gm_table/ambiance/page.py
+++ b/modules/scenarios/gm_table/ambiance/page.py
@@ -130,6 +130,7 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         playlist_panel.grid(row=0, column=1, sticky="nsew")
         playlist_panel.grid_rowconfigure(1, weight=1)
         playlist_panel.grid_columnconfigure(0, weight=1)
+        playlist_panel.grid_columnconfigure(1, weight=0)
 
         ctk.CTkLabel(playlist_panel, text="Session Playlist", anchor="w", font=ctk.CTkFont(size=14, weight="bold")).grid(
             row=0,
@@ -138,8 +139,16 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             padx=8,
             pady=(8, 6),
         )
+        ctk.CTkButton(
+            playlist_panel,
+            text="Remove all",
+            width=96,
+            fg_color="#B91C1C",
+            hover_color="#991B1B",
+            command=self._remove_all_playlist,
+        ).grid(row=0, column=1, sticky="e", padx=(0, 8), pady=(8, 6))
         self._playlist_frame = ctk.CTkScrollableFrame(playlist_panel, fg_color="transparent")
-        self._playlist_frame.grid(row=1, column=0, sticky="nsew", padx=8, pady=(0, 8))
+        self._playlist_frame.grid(row=1, column=0, columnspan=2, sticky="nsew", padx=8, pady=(0, 8))
 
     def _build_player_controls(self) -> None:
         controls = ctk.CTkFrame(self, fg_color="transparent")
@@ -339,6 +348,14 @@ class GMTableAmbiancePage(ctk.CTkFrame):
             self._playlist.pop(index)
             self._render_playlist()
 
+    def _remove_all_playlist(self) -> None:
+        if not self._playlist:
+            self._toast("Playlist is already empty.")
+            return
+        self._playlist.clear()
+        self._render_playlist()
+        self._toast("Playlist cleared.")
+
     def _adjust_duration(self, index: int, delta: int) -> None:
         if not (0 <= index < len(self._playlist)):
             return
@@ -458,8 +475,8 @@ class GMTableAmbiancePage(ctk.CTkFrame):
         if player is None:
             return
         try:
-            player.stop()
-            self._status_var.set("Playback stopped.")
+            player.stop(close_window=True)
+            self._status_var.set("Playback stopped and window closed.")
         except Exception as exc:
             self._status_var.set(f"Stop failed: {exc}")
 

--- a/modules/ui/ambiance/player.py
+++ b/modules/ui/ambiance/player.py
@@ -98,14 +98,16 @@ class SecondScreenAmbiancePlayer:
         self._state.is_paused = False
         self._render_current()
 
-    def stop(self, *, clear_playlist: bool = False) -> None:
+    def stop(self, *, clear_playlist: bool = False, close_window: bool = False) -> None:
         """Stop playback and clear frame resources."""
         self._cancel_scheduled()
         self._close_video()
         self._state.is_running = False
         self._state.is_paused = False
         self._state.current_index = -1
-        if self._canvas is not None:
+        if close_window:
+            self._destroy_window()
+        elif self._canvas is not None:
             self._canvas.configure(image="", text="Ambiance stoppée", fg="white", bg="black")
         if clear_playlist:
             self._playlist = AmbiancePlaylist()
@@ -183,8 +185,17 @@ class SecondScreenAmbiancePlayer:
         self._canvas = tk.Label(self._window, bg="black", bd=0, highlightthickness=0)
         self._canvas.pack(fill="both", expand=True)
 
-        self._window.bind("<Escape>", lambda _event: self.stop())
-        self._window.protocol("WM_DELETE_WINDOW", self.stop)
+        self._window.bind("<Escape>", lambda _event: self.stop(close_window=True))
+        self._window.protocol("WM_DELETE_WINDOW", lambda: self.stop(close_window=True))
+
+    def _destroy_window(self) -> None:
+        """Close the ambiance render window and release widget references."""
+        window = self._window
+        self._window = None
+        self._canvas = None
+        self._photo_ref = None
+        if window is not None and window.winfo_exists():
+            window.destroy()
 
 
     def consume_last_monitor_warning(self) -> str | None:


### PR DESCRIPTION
## Summary
- make the ambiance player support closing its fullscreen window when stopping playback
- update the ambiance render window shortcuts (`Escape` / close button) to stop and close the window
- update the Ambiance Screen `Stop` action to close the ambiance window instead of leaving a "stopped" message on screen
- add a new **Remove all** button in the Session Playlist panel to clear every wallpaper from the playlist in one click

## Notes
- `stop()` keeps backward-compatible defaults; closing is opt-in via `close_window=True`.
- playlist clearing immediately persists through the existing `_render_playlist()` persistence flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efef0ebef8832b938fe9933145e657)