### PR TITLE
Decouple Ambiance controls into standalone top-bar window

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -69,6 +69,7 @@ from modules.ui.database_manager_dialog import DatabaseManagerDialog
 from modules.ui.system_manager_dialog import SystemManagerDialog
 from modules.ui.menu_bar import AppMenuBar
 from modules.ui.ambiance import SecondScreenAmbiancePlayer
+from modules.ui.ambiance.control_window import AmbianceControlWindow
 from modules.ui.ambiance.importer.dialog import AmbianceWallpaperImporterDialog
 from modules.ui.sidebar.accordion_sections import SidebarAccordion, SidebarItemSpec, SidebarSectionSpec
 from modules.ui.controllers import AIRunWindowController
@@ -197,6 +198,7 @@ class MainWindow(ctk.CTk):
         self._image_library_browser_window = None
         self._asset_library_window = None
         self._ambiance_player: SecondScreenAmbiancePlayer | None = None
+        self._ambiance_control_window = None
         self._wallpaper_importer_window = None
         self._busy_modal = None
         self._system_selector_dialog = None
@@ -4579,29 +4581,19 @@ class MainWindow(ctk.CTk):
         return self._ambiance_player
 
     def open_ambiance_panel(self):
-        """Open ambiance controls in the active GM workspace."""
-        try:
-            if getattr(self, "current_gm_view", None) is not None and self.current_gm_view.winfo_exists():
-                self.current_gm_view.open_ambiance_tab()
-                return
-        except Exception:
-            pass
-
-        try:
-            if getattr(self, "current_gm_table", None) is not None and self.current_gm_table.winfo_exists():
-                opener = getattr(self.current_gm_table, "open_ambiance_panel", None)
-                if callable(opener):
-                    opener()
-                    return
-        except Exception:
-            pass
-
-        self.open_gm_screen(show_empty_message=True)
-        try:
-            if getattr(self, "current_gm_view", None) is not None and self.current_gm_view.winfo_exists():
-                self.current_gm_view.open_ambiance_tab()
-        except Exception:
-            pass
+        """Open or focus standalone ambiance controls."""
+        window = getattr(self, "_ambiance_control_window", None)
+        if window is None or not window.winfo_exists():
+            window = AmbianceControlWindow(self)
+            self._ambiance_control_window = window
+            window.bind(
+                "<Destroy>",
+                lambda _event: setattr(self, "_ambiance_control_window", None),
+            )
+            return window
+        window.lift()
+        window.focus_force()
+        return window
 
     def open_wallpaper_importer(self, *, on_complete=None):
         """Open wallpaper importer dialog bound to the current campaign."""

--- a/modules/scenarios/gm_screen_view.py
+++ b/modules/scenarios/gm_screen_view.py
@@ -35,7 +35,6 @@ from modules.scenarios.scene_flow_viewer import create_scene_flow_frame, scene_f
 from modules.scenarios.plot_twist_scheduler import PlotTwistScheduler
 from modules.scenarios.plot_twist_panel import PlotTwistPanel, roll_plot_twist
 from modules.scenarios.gm_screen.handouts.panel import create_handouts_panel
-from modules.scenarios.gm_table.ambiance.page import GMTableAmbiancePage
 from modules.scenarios.session_notes import (
     build_scene_snapshot_entry,
     build_session_debrief_entry,
@@ -240,7 +239,6 @@ class GMScreenView(ctk.CTkFrame):
             "Scene Flow",
             "Image Library",
             "Handouts",
-            "Ambiance Screen",
             "Loot Generator",
             "Whiteboard",
             "Random Tables",
@@ -2014,8 +2012,6 @@ class GMScreenView(ctk.CTkFrame):
             self.open_whiteboard_tab(title=title or "Whiteboard")
         elif kind == "handouts":
             self.open_handouts_tab(title=title or "Handouts")
-        elif kind == "ambiance":
-            self.open_ambiance_tab(title=title or "Ambiance Screen")
         elif kind == "puzzle_display":
             # Handle the branch where kind == 'puzzle_display'.
             puzzle_name = tab_def.get("puzzle_name")
@@ -2565,32 +2561,6 @@ class GMScreenView(ctk.CTkFrame):
             activate=activate,
         )
 
-    def open_ambiance_tab(self, title=None, activate=True):
-        """Open the ambiance panel inside the GM screen."""
-        container = ctk.CTkFrame(self._ensure_rich_host())
-        self._make_fullbleed(container)
-        panel = GMTableAmbiancePage(container)
-        panel.pack(fill="both", expand=True)
-        container.ambiance_panel = panel
-
-        def factory(master):
-            """Create ambiance panel content."""
-            host_parent = master if master is not None else self._ensure_rich_host()
-            frame = ctk.CTkFrame(host_parent)
-            self._make_fullbleed(frame)
-            created = GMTableAmbiancePage(frame)
-            created.pack(fill="both", expand=True)
-            frame.ambiance_panel = created
-            return frame
-
-        self.add_tab(
-            title or "Ambiance Screen",
-            container,
-            content_factory=factory,
-            layout_meta={"kind": "ambiance", "host": "rich"},
-            activate=activate,
-        )
-
     def open_random_tables_tab(self, title=None, initial_state=None):
         """Open the random tables panel inside the GM screen."""
 
@@ -3081,9 +3051,6 @@ class GMScreenView(ctk.CTkFrame):
             return
         elif entity_type == "Handouts":
             self.open_handouts_tab()
-            return
-        elif entity_type == "Ambiance Screen":
-            self.open_ambiance_tab()
             return
         elif entity_type == "Loot Generator":
             # Handle the branch where entity_type == 'Loot Generator'.

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -21,7 +21,6 @@ from modules.objects.loot_generator_panel import LootGeneratorPanel
 from modules.puzzles.puzzle_display_window import create_puzzle_display_frame
 from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
-from modules.scenarios.gm_table.ambiance.page import GMTableAmbiancePage
 from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
 from modules.scenarios.gm_table.pages import (
     GMTableHostedPage,
@@ -125,7 +124,6 @@ class GMTableView(ctk.CTkFrame):
             "Scene Flow",
             "Image Library",
             "Handouts",
-            "Ambiance Screen",
             "Loot Generator",
             "Whiteboard",
             "Random Tables",
@@ -673,9 +671,6 @@ class GMTableView(ctk.CTkFrame):
                 "handouts", "Handouts", {"scenario_name": self.scenario_name}
             )
             return
-        if option == "Ambiance Screen":
-            self.open_ambiance_panel()
-            return
         if option == "Loot Generator":
             self._create_panel("loot_generator", "Loot Generator", {})
             return
@@ -762,8 +757,6 @@ class GMTableView(ctk.CTkFrame):
                     map_wrapper=self.map_wrapper,
                     initial_state=definition.state,
                 )
-            if kind == "ambiance":
-                return GMTableAmbiancePage(parent, initial_state=definition.state)
             if kind == "loot_generator":
                 return GMTableHostedPage(
                     parent,
@@ -1085,15 +1078,6 @@ class GMTableView(ctk.CTkFrame):
             _open_selected,
         )
         view.pack(fill="both", expand=True)
-
-    def open_ambiance_panel(self) -> None:
-        """Focus an existing ambiance panel or create one."""
-        records = self.workspace.list_panels(kinds={"ambiance"}, include_minimized=True)
-        if records:
-            panel_id = str(records[-1]["panel_id"])
-            self.workspace.bring_to_front(panel_id)
-            return
-        self._create_panel("ambiance", "Ambiance Screen", {})
 
     def open_chatbot(self, event=None) -> None:
         """Open the shared chatbot from the tabletop."""

--- a/modules/ui/ambiance/control_window.py
+++ b/modules/ui/ambiance/control_window.py
@@ -1,0 +1,23 @@
+"""Standalone ambiance control window."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.scenarios.gm_table.ambiance.page import GMTableAmbiancePage
+
+
+class AmbianceControlWindow(ctk.CTkToplevel):
+    """Top-level standalone window hosting ambiance controls."""
+
+    def __init__(self, master) -> None:
+        super().__init__(master)
+        self.title("Ambiance Control")
+        self.geometry("1320x860")
+        self.minsize(980, 620)
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        panel = GMTableAmbiancePage(self)
+        panel.grid(row=0, column=0, sticky="nsew")
+        self.panel = panel

--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -173,7 +173,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                         _command("Dice", app.open_dice_roller, shortcut="F8", icon_key="dice_roller"),
                         _command("Sound & Music", app.open_sound_manager, shortcut="F7", icon_key="audio_controls"),
                         _command("Session Timers", app.open_timer_window, icon_key="session_timers"),
-                        _command("Ambiance Screen", app.open_ambiance_panel, icon_key="audio_controls"),
+                        _command("Ambiance Control", app.open_ambiance_panel, icon_key="audio_controls"),
                         _command("Import Ambiance Wallpapers", app.open_wallpaper_importer, icon_key="audio_controls"),
                         _command("Character Creation", app.open_character_creation),
                     ],

--- a/tests/scenarios/test_ambiance_decoupled_from_workspaces.py
+++ b/tests/scenarios/test_ambiance_decoupled_from_workspaces.py
@@ -1,0 +1,20 @@
+"""Regression checks for ambiance decoupling from workspace add menus."""
+
+from pathlib import Path
+
+
+def test_gm_screen_add_menu_and_routing_no_longer_reference_ambiance() -> None:
+    """GM Screen should not expose workspace-coupled ambiance entries."""
+    source = Path("modules/scenarios/gm_screen_view.py").read_text(encoding="utf-8")
+
+    assert "Ambiance Screen" not in source
+    assert "open_ambiance_tab" not in source
+
+
+def test_gm_table_add_menu_and_panel_builder_no_longer_reference_ambiance() -> None:
+    """GM Table should not expose ambiance as an add-panel option anymore."""
+    source = Path("modules/scenarios/gm_table_view.py").read_text(encoding="utf-8")
+
+    assert "Ambiance Screen" not in source
+    assert 'kind == "ambiance"' not in source
+    assert "def open_ambiance_panel" not in source

--- a/tests/test_main_window_ambiance_control.py
+++ b/tests/test_main_window_ambiance_control.py
@@ -1,0 +1,36 @@
+"""Static regression checks for MainWindow ambiance entrypoint wiring."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _get_open_ambiance_panel_source() -> str:
+    source = Path("main_window.py").read_text(encoding="utf-8-sig")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "MainWindow":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "open_ambiance_panel":
+                    return ast.get_source_segment(source, item) or ""
+    raise AssertionError("MainWindow.open_ambiance_panel not found")
+
+
+def test_open_ambiance_panel_uses_standalone_control_window() -> None:
+    """Entrypoint should only manage a standalone ambiance toplevel."""
+    method_source = _get_open_ambiance_panel_source()
+
+    assert "AmbianceControlWindow(self)" in method_source
+    assert "_ambiance_control_window" in method_source
+    assert "window.lift()" in method_source
+    assert "window.focus_force()" in method_source
+
+
+def test_open_ambiance_panel_no_longer_routes_to_workspace_views() -> None:
+    """MainWindow entrypoint should not depend on GM Screen/Table instances."""
+    method_source = _get_open_ambiance_panel_source()
+
+    assert "current_gm_view" not in method_source
+    assert "current_gm_table" not in method_source
+    assert "open_gm_screen" not in method_source

--- a/tests/ui/test_menu_sections_image_commands.py
+++ b/tests/ui/test_menu_sections_image_commands.py
@@ -70,4 +70,6 @@ def test_menu_sections_expose_image_library_commands() -> None:
     assert "GM Table" in table_labels
     assert "Import Image Directories…" in labels
     assert "Open Image Library" in labels
+    assert "Ambiance Control" in live_labels
+    assert "Ambiance Screen" not in live_labels
     assert "Import Ambiance Wallpapers" in live_labels


### PR DESCRIPTION
### Motivation
- Remove workspace-coupled Ambiance UI (GM Screen / GM Table) and expose Ambiance only as a dedicated top-bar tool to simplify lifecycle and reduce coupling.
- Preserve existing Ambiance playback/settings/import functionality by reusing the existing Ambiance page widget instead of duplicating logic.
- Keep window lifecycle consistent with other tool windows using a single-instance + destroy-binding pattern.

### Description
- Added a new standalone toplevel `AmbianceControlWindow` at `modules/ui/ambiance/control_window.py` that composes the existing `GMTableAmbiancePage` for UI and behavior reuse.
- Refactored `MainWindow.open_ambiance_panel()` to always open/focus the standalone `AmbianceControlWindow` and added an `_ambiance_control_window` lifecycle field with a `<Destroy>` binding to clear the reference (changes in `main_window.py`).
- Removed workspace-coupled Ambiance references and handlers from `modules/scenarios/gm_screen_view.py` and `modules/scenarios/gm_table_view.py`, including add-menu entries, routing branches, tab/panel builder branches, and `open_ambiance_tab`/`open_ambiance_panel` helpers.
- Updated top-bar wording from "Ambiance Screen" to "Ambiance Control" while keeping the command binding to `app.open_ambiance_panel` in `modules/ui/menu/menu_sections.py`.
- Added/updated tests: `tests/ui/test_menu_sections_image_commands.py` now expects the new label, `tests/test_main_window_ambiance_control.py` checks the `MainWindow.open_ambiance_panel` implementation (static AST checks), and `tests/scenarios/test_ambiance_decoupled_from_workspaces.py` verifies GM Screen/GM Table sources no longer reference workspace ambiance hooks.

### Testing
- Ran focused test suite with `pytest -q tests/ui/test_menu_sections_image_commands.py tests/test_main_window_ambiance_control.py tests/scenarios/test_ambiance_decoupled_from_workspaces.py` which completed with all tests passing (`5 passed`).
- An initial broader run that included many UI tests encountered unrelated environment import errors for PIL submodules during collection, so targeted tests were executed to validate the new wiring and they passed.
- Tests assert that the top menu exposes the Ambiance action with the new label, `MainWindow.open_ambiance_panel()` manages a standalone window, and GM Screen / GM Table no longer expose Ambiance workspace options.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b605d7ac832b8403c27891daa1d7)