### PR TITLE
Add session dock design tokens and unify audio/dice panel styling

### DIFF
--- a/modules/ui/session_dock/__init__.py
+++ b/modules/ui/session_dock/__init__.py
@@ -1,0 +1,1 @@
+"""Session dock UI package."""

--- a/modules/ui/session_dock/panels/__init__.py
+++ b/modules/ui/session_dock/panels/__init__.py
@@ -1,0 +1,6 @@
+"""Panels for session dock."""
+
+from .audio_panel import AudioPanel
+from .dice_panel import DicePanel
+
+__all__ = ["AudioPanel", "DicePanel"]

--- a/modules/ui/session_dock/panels/audio_panel.py
+++ b/modules/ui/session_dock/panels/audio_panel.py
@@ -1,0 +1,45 @@
+"""Session dock audio panel styled with shared session-dock tokens."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.ui.session_dock.theme.component_styles import (
+    ANIMATION_STYLE,
+    BODY_LABEL_STYLE,
+    PANEL_BASE_STYLE,
+    TITLE_LABEL_STYLE,
+    button_style,
+    icon_style,
+    spacing,
+)
+
+
+class AudioPanel(ctk.CTkFrame):
+    """Compact audio controls for the session dock."""
+
+    def __init__(self, master: ctk.CTkBaseClass, **kwargs) -> None:
+        merged = {**PANEL_BASE_STYLE, **kwargs}
+        super().__init__(master, **merged)
+
+        pad = spacing("md")
+        self.grid_columnconfigure(0, weight=1)
+
+        self.title = ctk.CTkLabel(self, text="Audio", **TITLE_LABEL_STYLE)
+        self.title.grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs")))
+
+        self.subtitle = ctk.CTkLabel(self, text="Ambiance and cues", **BODY_LABEL_STYLE)
+        self.subtitle.grid(row=1, column=0, sticky="w", padx=pad, pady=(0, spacing("sm")))
+
+        self.play_button = ctk.CTkButton(self, text="Play", **button_style("idle"))
+        self.play_button.grid(row=2, column=0, sticky="ew", padx=pad, pady=(0, spacing("xs")))
+
+        self.stop_button = ctk.CTkButton(self, text="Stop", **button_style("critical"))
+        self.stop_button.grid(row=3, column=0, sticky="ew", padx=pad, pady=(0, pad))
+
+        self.icon_token = icon_style("idle")
+        self.timings = ANIMATION_STYLE.copy()
+
+    def get_animation_timings(self) -> dict[str, int]:
+        """Provide animation timings used by panel transitions."""
+        return self.timings.copy()

--- a/modules/ui/session_dock/panels/dice_panel.py
+++ b/modules/ui/session_dock/panels/dice_panel.py
@@ -1,0 +1,45 @@
+"""Session dock dice panel styled with shared session-dock tokens."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.ui.session_dock.theme.component_styles import (
+    ANIMATION_STYLE,
+    BODY_LABEL_STYLE,
+    PANEL_BASE_STYLE,
+    TITLE_LABEL_STYLE,
+    button_style,
+    icon_style,
+    spacing,
+)
+
+
+class DicePanel(ctk.CTkFrame):
+    """Quick dice rolling controls for the session dock."""
+
+    def __init__(self, master: ctk.CTkBaseClass, **kwargs) -> None:
+        merged = {**PANEL_BASE_STYLE, **kwargs}
+        super().__init__(master, **merged)
+
+        pad = spacing("md")
+        self.grid_columnconfigure(0, weight=1)
+
+        self.title = ctk.CTkLabel(self, text="Dice", **TITLE_LABEL_STYLE)
+        self.title.grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs")))
+
+        self.subtitle = ctk.CTkLabel(self, text="Fast checks and rolls", **BODY_LABEL_STYLE)
+        self.subtitle.grid(row=1, column=0, sticky="w", padx=pad, pady=(0, spacing("sm")))
+
+        self.roll_button = ctk.CTkButton(self, text="Roll d20", **button_style("active"))
+        self.roll_button.grid(row=2, column=0, sticky="ew", padx=pad, pady=(0, spacing("xs")))
+
+        self.clear_button = ctk.CTkButton(self, text="Clear", **button_style("idle"))
+        self.clear_button.grid(row=3, column=0, sticky="ew", padx=pad, pady=(0, pad))
+
+        self.icon_token = icon_style("hover")
+        self.timings = ANIMATION_STYLE.copy()
+
+    def get_animation_timings(self) -> dict[str, int]:
+        """Provide animation timings used by panel transitions."""
+        return self.timings.copy()

--- a/modules/ui/session_dock/theme/__init__.py
+++ b/modules/ui/session_dock/theme/__init__.py
@@ -1,0 +1,1 @@
+"""Theme helpers for session dock."""

--- a/modules/ui/session_dock/theme/component_styles.py
+++ b/modules/ui/session_dock/theme/component_styles.py
@@ -1,0 +1,85 @@
+"""Reusable component style maps built from session dock tokens."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .tokens import ANIMATION, COLORS, SPACING, STATES, TYPOGRAPHY
+
+
+BUTTON_VARIANTS: Dict[str, Dict[str, str | int]] = {
+    "idle": {
+        "fg_color": COLORS.background_subtle,
+        "hover_color": STATES.hover,
+        "border_color": COLORS.border_default,
+        "text_color": COLORS.text_primary,
+    },
+    "hover": {
+        "fg_color": STATES.hover,
+        "hover_color": STATES.active,
+        "border_color": COLORS.border_focus,
+        "text_color": COLORS.text_primary,
+    },
+    "active": {
+        "fg_color": STATES.active,
+        "hover_color": STATES.active,
+        "border_color": COLORS.accent_primary,
+        "text_color": COLORS.background_canvas,
+    },
+    "critical": {
+        "fg_color": STATES.critical,
+        "hover_color": "#F0838B",
+        "border_color": "#F4A4AA",
+        "text_color": COLORS.background_canvas,
+    },
+}
+
+
+ICON_VARIANTS: Dict[str, Dict[str, str]] = {
+    "idle": {"fg": STATES.idle, "bg": COLORS.background_surface},
+    "hover": {"fg": STATES.hover, "bg": COLORS.background_subtle},
+    "active": {"fg": STATES.active, "bg": COLORS.accent_primary_soft},
+    "critical": {"fg": STATES.critical, "bg": "#472229"},
+}
+
+
+PANEL_BASE_STYLE: Dict[str, str | int] = {
+    "fg_color": COLORS.background_surface,
+    "corner_radius": 10,
+    "border_width": 1,
+    "border_color": COLORS.border_default,
+}
+
+
+TITLE_LABEL_STYLE: Dict[str, str | int] = {
+    "text_color": COLORS.text_primary,
+    "font": (TYPOGRAPHY.font_family, TYPOGRAPHY.title_size, TYPOGRAPHY.title_weight),
+}
+
+
+BODY_LABEL_STYLE: Dict[str, str | int] = {
+    "text_color": COLORS.text_secondary,
+    "font": (TYPOGRAPHY.font_family, TYPOGRAPHY.body_size, TYPOGRAPHY.body_weight),
+}
+
+
+ANIMATION_STYLE: Dict[str, int] = {
+    "expand_ms": ANIMATION.expand_ms,
+    "collapse_ms": ANIMATION.collapse_ms,
+    "result_highlight_ms": ANIMATION.result_highlight_ms,
+}
+
+
+def button_style(state: str = "idle") -> Dict[str, str | int]:
+    """Return the button style for a given interaction state."""
+    return BUTTON_VARIANTS.get(state, BUTTON_VARIANTS["idle"]).copy()
+
+
+def icon_style(state: str = "idle") -> Dict[str, str]:
+    """Return the icon style for a given interaction state."""
+    return ICON_VARIANTS.get(state, ICON_VARIANTS["idle"]).copy()
+
+
+def spacing(value: str = "md") -> int:
+    """Expose spacing tokens via string keys for panel layout code."""
+    return getattr(SPACING, value, SPACING.md)

--- a/modules/ui/session_dock/theme/tokens.py
+++ b/modules/ui/session_dock/theme/tokens.py
@@ -1,0 +1,70 @@
+"""Design tokens for the session dock UI.
+
+This module centralizes visual primitives so panels can share one cohesive identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpacingScale:
+    none: int = 0
+    xs: int = 4
+    sm: int = 8
+    md: int = 12
+    lg: int = 16
+    xl: int = 24
+    xxl: int = 32
+
+
+@dataclass(frozen=True)
+class TypographyHierarchy:
+    font_family: str = "Inter"
+    title_size: int = 18
+    subtitle_size: int = 14
+    body_size: int = 13
+    caption_size: int = 11
+    title_weight: str = "bold"
+    subtitle_weight: str = "bold"
+    body_weight: str = "normal"
+    caption_weight: str = "normal"
+
+
+@dataclass(frozen=True)
+class ColorRoles:
+    background_canvas: str = "#0E1118"
+    background_surface: str = "#161C27"
+    background_subtle: str = "#1E2634"
+    border_default: str = "#2C374A"
+    border_focus: str = "#4F6FA2"
+    text_primary: str = "#E8ECF4"
+    text_secondary: str = "#B6C1D4"
+    text_muted: str = "#8B98AE"
+    accent_primary: str = "#72A4FF"
+    accent_primary_soft: str = "#3A527B"
+
+
+@dataclass(frozen=True)
+class StateColors:
+    idle: str = "#5C6F91"
+    hover: str = "#7F95BD"
+    active: str = "#8DB3FF"
+    critical: str = "#E66C75"
+    success: str = "#63CB9B"
+    warning: str = "#E6BC6C"
+
+
+@dataclass(frozen=True)
+class AnimationTimings:
+    expand_ms: int = 220
+    collapse_ms: int = 180
+    result_highlight_ms: int = 700
+
+
+SPACING = SpacingScale()
+TYPOGRAPHY = TypographyHierarchy()
+COLORS = ColorRoles()
+STATES = StateColors()
+ANIMATION = AnimationTimings()


### PR DESCRIPTION
### Motivation
- Centralize visual primitives so session-dock panels share a single cohesive UI identity (spacing, typography, color roles, state colors, and animation timings). 
- Provide consistent button and icon variants for interaction states (`idle`, `hover`, `active`, `critical`) so controls behave and look uniform across panels. 
- Make it easy for panels to consume design primitives via a small, readable token + style layer to keep layout and theming consistent and maintainable.

### Description
- Added a token catalog at `modules/ui/session_dock/theme/tokens.py` defining spacing scale, typography hierarchy, color roles, interaction state colors, and animation timings. 
- Added `modules/ui/session_dock/theme/component_styles.py` with `BUTTON_VARIANTS`, `ICON_VARIANTS`, `PANEL_BASE_STYLE`, `TITLE_LABEL_STYLE`, `BODY_LABEL_STYLE`, `ANIMATION_STYLE`, and helpers `button_style`, `icon_style`, and `spacing`. 
- Implemented `AudioPanel` and `DicePanel` in `modules/ui/session_dock/panels/` to consume the token-driven styles and animation timings for a unified look and behavior. 
- Added package `__init__.py` files for `modules/ui/session_dock`, `modules/ui/session_dock/theme`, and `modules/ui/session_dock/panels` to keep the module layout modular and readable.

### Testing
- Ran `python -m compileall modules/ui/session_dock` to validate the new package, and the compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ba9908c4832b92fa50de4fb7f478)