### PR TITLE
Add session dock UI foundation with dynamic panel controller

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -73,6 +73,8 @@ from modules.ui.ambiance.control_window import AmbianceControlWindow
 from modules.ui.ambiance.importer.dialog import AmbianceWallpaperImporterDialog
 from modules.ui.sidebar.accordion_sections import SidebarAccordion, SidebarItemSpec, SidebarSectionSpec
 from modules.ui.controllers import AIRunWindowController
+from modules.ui.session_dock import SessionDockController
+from modules.ui.session_dock.panels import AudioPanel, DicePanel
 from modules.events.ui.dock import CalendarDock
 from modules.events.models.event_types import get_event_type
 from modules.events.services.timeline_simulator import CampaignTimelineSimulator
@@ -201,6 +203,7 @@ class MainWindow(ctk.CTk):
         self._ambiance_control_window = None
         self._wallpaper_importer_window = None
         self._busy_modal = None
+        self.session_dock_controller: SessionDockController | None = None
         self._system_selector_dialog = None
         self._database_manager_dialog = None
         self._update_thread = None
@@ -210,6 +213,9 @@ class MainWindow(ctk.CTk):
         root.bind_all("<Control-i>", self._on_ctrl_i)
         root.bind_all("<Control-I>", self._on_ctrl_i)
         self._bind_global_shortcuts()
+        self.session_dock_controller = SessionDockController(self)
+        self.session_dock_controller.mount_panel(AudioPanel.panel_id, AudioPanel)
+        self.session_dock_controller.mount_panel(DicePanel.panel_id, DicePanel)
 
         self._system_listener_unsub = register_system_change_listener(self._on_system_changed)
         # Rebuild colorized UI bits when theme changes
@@ -219,6 +225,18 @@ class MainWindow(ctk.CTk):
         self.after(400, self.open_audio_bar)
         self.after(600, lambda: self._queue_update_check(force=True))
         self.after(800, self._auto_open_campaign_overview)
+
+    def mount_session_dock_panel(self, panel_id: str, panel_cls, **kwargs):
+        """Mount a panel dynamically in the session dock."""
+        if self.session_dock_controller is None:
+            self.session_dock_controller = SessionDockController(self)
+        return self.session_dock_controller.mount_panel(panel_id, panel_cls, **kwargs)
+
+    def unmount_session_dock_panel(self, panel_id: str) -> bool:
+        """Unmount a panel dynamically from the session dock."""
+        if self.session_dock_controller is None:
+            return False
+        return self.session_dock_controller.unmount_panel(panel_id)
 
     def _bind_global_shortcuts(self):
         """Bind global shortcuts."""

--- a/modules/ui/session_dock/__init__.py
+++ b/modules/ui/session_dock/__init__.py
@@ -1,1 +1,5 @@
 """Session dock UI package."""
+
+from .controller import SessionDockController
+
+__all__ = ["SessionDockController"]

--- a/modules/ui/session_dock/controller.py
+++ b/modules/ui/session_dock/controller.py
@@ -1,0 +1,63 @@
+"""Session dock controller that mounts/unmounts panels dynamically."""
+
+from __future__ import annotations
+
+from modules.ui.session_dock.core.dock_shortcuts import DockShortcutManager
+from modules.ui.session_dock.core.dock_state import DockState, DockStateStore
+from modules.ui.session_dock.core.dock_window import DockWindow
+
+
+class SessionDockController:
+    """Owns dock lifecycle and dynamic panel mounting."""
+
+    def __init__(self, root) -> None:
+        self._root = root
+        self._store = DockStateStore()
+        self._state = self._store.load()
+        self._window = DockWindow(root, self._state, on_state_change=self._persist_state)
+        self._shortcuts = DockShortcutManager(root)
+        self._mounted_panels: dict[str, object] = {}
+        self._next_row = 0
+
+        self._shortcuts.bind("<Control-Alt-d>", self.toggle_visibility)
+        self._shortcuts.bind("<Control-Alt-minus>", lambda: self._window.set_mode("compact"))
+        self._shortcuts.bind("<Control-Alt-equal>", lambda: self._window.set_mode("full"))
+
+        if self._state.mode == "hidden":
+            self._window.hide()
+        else:
+            self._window.show()
+
+    def mount_panel(self, panel_id: str, panel_cls, **kwargs):
+        """Instantiate and attach a panel if not already mounted."""
+        if panel_id in self._mounted_panels:
+            return self._mounted_panels[panel_id]
+
+        panel = panel_cls(self._window.container, **kwargs)
+        panel.grid(row=self._next_row, column=0, sticky="ew", padx=4, pady=4)
+        self._mounted_panels[panel_id] = panel
+        self._next_row += 1
+        return panel
+
+    def unmount_panel(self, panel_id: str) -> bool:
+        """Remove a mounted panel by id."""
+        panel = self._mounted_panels.pop(panel_id, None)
+        if panel is None:
+            return False
+        panel.destroy()
+        return True
+
+    def toggle_visibility(self) -> None:
+        """Toggle hidden/full mode quickly."""
+        if self._window.state.mode == "hidden":
+            self._window.set_mode("full")
+        else:
+            self._window.set_mode("hidden")
+
+    def dispose(self) -> None:
+        """Release resources and bindings."""
+        self._shortcuts.clear()
+        self._window.destroy()
+
+    def _persist_state(self, state: DockState) -> None:
+        self._store.save(state)

--- a/modules/ui/session_dock/core/__init__.py
+++ b/modules/ui/session_dock/core/__init__.py
@@ -1,0 +1,7 @@
+"""Core session dock primitives (state, window, shortcuts)."""
+
+from .dock_shortcuts import DockShortcutManager
+from .dock_state import DockState, DockStateStore
+from .dock_window import DockWindow
+
+__all__ = ["DockShortcutManager", "DockState", "DockStateStore", "DockWindow"]

--- a/modules/ui/session_dock/core/dock_shortcuts.py
+++ b/modules/ui/session_dock/core/dock_shortcuts.py
@@ -1,0 +1,29 @@
+"""Keyboard shortcut wiring for the session dock."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import customtkinter as ctk
+
+
+class DockShortcutManager:
+    """Manage bind/unbind lifecycle of dock shortcuts."""
+
+    def __init__(self, root: ctk.CTkBaseClass) -> None:
+        self._root = root
+        self._bindings: list[tuple[str, str]] = []
+
+    def bind(self, sequence: str, callback: Callable[[], None]) -> None:
+        """Register a global sequence on the application root."""
+        bind_id = self._root.bind_all(sequence, lambda _event: callback(), add="+")
+        self._bindings.append((sequence, bind_id))
+
+    def clear(self) -> None:
+        """Remove all registered bindings."""
+        for sequence, bind_id in self._bindings:
+            self._root.unbind_all(sequence)
+            if bind_id:
+                # Tk does not support selective unbind_all by id; kept for future updates.
+                _ = bind_id
+        self._bindings.clear()

--- a/modules/ui/session_dock/core/dock_state.py
+++ b/modules/ui/session_dock/core/dock_state.py
@@ -1,0 +1,71 @@
+"""State model and persistence helpers for the session dock."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Literal
+
+DockMode = Literal["hidden", "compact", "full"]
+DockEdge = Literal["left", "right", "top", "bottom"]
+
+
+@dataclass(slots=True)
+class DockState:
+    """Serializable dock state used across sessions."""
+
+    mode: DockMode = "compact"
+    pinned_edge: DockEdge = "right"
+    opacity: float = 0.96
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DockState":
+        """Build and sanitize state from raw JSON data."""
+        mode = data.get("mode", "compact")
+        edge = data.get("pinned_edge", "right")
+        opacity = data.get("opacity", 0.96)
+
+        if mode not in {"hidden", "compact", "full"}:
+            mode = "compact"
+        if edge not in {"left", "right", "top", "bottom"}:
+            edge = "right"
+        try:
+            normalized_opacity = float(opacity)
+        except (TypeError, ValueError):
+            normalized_opacity = 0.96
+        normalized_opacity = max(0.35, min(1.0, normalized_opacity))
+
+        return cls(mode=mode, pinned_edge=edge, opacity=normalized_opacity)
+
+    def to_dict(self) -> dict:
+        """Return plain JSON-safe representation."""
+        return asdict(self)
+
+
+class DockStateStore:
+    """Disk-backed state persistence for dock configuration."""
+
+    def __init__(self, state_file: Path | None = None) -> None:
+        default_dir = Path.home() / ".gmcampaigndesigner"
+        self._state_file = state_file or (default_dir / "session_dock_state.json")
+
+    def load(self) -> DockState:
+        """Load persisted state or return defaults."""
+        if not self._state_file.exists():
+            return DockState()
+
+        try:
+            raw = json.loads(self._state_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return DockState()
+
+        return DockState.from_dict(raw if isinstance(raw, dict) else {})
+
+    def save(self, state: DockState) -> None:
+        """Persist state to disk."""
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
+        self._state_file.write_text(
+            json.dumps(state.to_dict(), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )

--- a/modules/ui/session_dock/core/dock_window.py
+++ b/modules/ui/session_dock/core/dock_window.py
@@ -1,0 +1,109 @@
+"""Top-level dock window for mounting session panels."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import customtkinter as ctk
+
+from modules.ui.session_dock.core.dock_state import DockMode, DockState
+
+
+class DockWindow(ctk.CTkToplevel):
+    """Dedicated floating window with pinning and display modes."""
+
+    def __init__(
+        self,
+        master: ctk.CTk,
+        state: DockState,
+        on_state_change: Callable[[DockState], None],
+    ) -> None:
+        super().__init__(master)
+        self.withdraw()
+        self.title("Session Dock")
+        self.attributes("-topmost", True)
+        self.resizable(False, False)
+
+        self._master = master
+        self._state = state
+        self._on_state_change = on_state_change
+
+        self.container = ctk.CTkFrame(self, fg_color="transparent")
+        self.container.pack(fill="both", expand=True, padx=8, pady=8)
+
+        self.protocol("WM_DELETE_WINDOW", self.hide)
+        self.bind("<Configure>", self._on_parent_configure, add="+")
+
+        self._apply_state_geometry()
+
+    @property
+    def state(self) -> DockState:
+        return self._state
+
+    def show(self) -> None:
+        """Show and raise the dock."""
+        self._state.mode = "full" if self._state.mode == "hidden" else self._state.mode
+        self.deiconify()
+        self.lift()
+        self._apply_state_geometry()
+        self._notify()
+
+    def hide(self) -> None:
+        """Hide the dock and persist hidden state."""
+        self.withdraw()
+        self._state.mode = "hidden"
+        self._notify()
+
+    def set_mode(self, mode: DockMode) -> None:
+        """Switch between hidden, compact and full layouts."""
+        self._state.mode = mode
+        if mode == "hidden":
+            self.withdraw()
+        else:
+            self.deiconify()
+            self._apply_state_geometry()
+        self._notify()
+
+    def pin_to_edge(self, edge: str) -> None:
+        """Pin dock window to one edge of the main window."""
+        self._state.pinned_edge = edge  # type: ignore[assignment]
+        if self._state.mode != "hidden":
+            self._apply_state_geometry()
+        self._notify()
+
+    def set_opacity(self, opacity: float) -> None:
+        """Apply opacity and persist value."""
+        normalized = max(0.35, min(1.0, float(opacity)))
+        self._state.opacity = normalized
+        self.attributes("-alpha", normalized)
+        self._notify()
+
+    def _notify(self) -> None:
+        self._on_state_change(self._state)
+
+    def _on_parent_configure(self, _event=None) -> None:
+        if self._state.mode != "hidden":
+            self._apply_state_geometry()
+
+    def _apply_state_geometry(self) -> None:
+        self.attributes("-alpha", self._state.opacity)
+        self.update_idletasks()
+
+        master_x = self._master.winfo_rootx()
+        master_y = self._master.winfo_rooty()
+        master_w = self._master.winfo_width()
+        master_h = self._master.winfo_height()
+
+        width = 320 if self._state.mode == "full" else 220
+        height = 400 if self._state.mode == "full" else 240
+
+        if self._state.pinned_edge == "left":
+            x, y = master_x, master_y + 64
+        elif self._state.pinned_edge == "top":
+            x, y = master_x + 64, master_y
+        elif self._state.pinned_edge == "bottom":
+            x, y = master_x + 64, master_y + max(0, master_h - height)
+        else:
+            x, y = master_x + max(0, master_w - width), master_y + 64
+
+        self.geometry(f"{width}x{height}+{x}+{y}")

--- a/modules/ui/session_dock/panels/audio_panel.py
+++ b/modules/ui/session_dock/panels/audio_panel.py
@@ -1,45 +1,35 @@
-"""Session dock audio panel styled with shared session-dock tokens."""
+"""Audio panel rendered inside the session dock container."""
 
 from __future__ import annotations
 
 import customtkinter as ctk
 
-from modules.ui.session_dock.theme.component_styles import (
-    ANIMATION_STYLE,
-    BODY_LABEL_STYLE,
-    PANEL_BASE_STYLE,
-    TITLE_LABEL_STYLE,
-    button_style,
-    icon_style,
-    spacing,
-)
+from modules.ui.session_dock.theme.component_styles import BODY_LABEL_STYLE, PANEL_BASE_STYLE, TITLE_LABEL_STYLE, spacing
+from modules.ui.session_dock.widgets import DockIconButton, StatusPill, attach_tooltip
 
 
 class AudioPanel(ctk.CTkFrame):
-    """Compact audio controls for the session dock."""
+    """Compact audio controls for ambiance and cues."""
+
+    panel_id = "audio"
 
     def __init__(self, master: ctk.CTkBaseClass, **kwargs) -> None:
-        merged = {**PANEL_BASE_STYLE, **kwargs}
-        super().__init__(master, **merged)
-
+        super().__init__(master, **{**PANEL_BASE_STYLE, **kwargs})
         pad = spacing("md")
-        self.grid_columnconfigure(0, weight=1)
 
-        self.title = ctk.CTkLabel(self, text="Audio", **TITLE_LABEL_STYLE)
-        self.title.grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs")))
+        self.grid_columnconfigure(1, weight=1)
 
-        self.subtitle = ctk.CTkLabel(self, text="Ambiance and cues", **BODY_LABEL_STYLE)
-        self.subtitle.grid(row=1, column=0, sticky="w", padx=pad, pady=(0, spacing("sm")))
+        ctk.CTkLabel(self, text="Audio", **TITLE_LABEL_STYLE).grid(
+            row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs"))
+        )
+        StatusPill(self, text="Idle", tone="idle").grid(row=0, column=1, sticky="e", padx=pad, pady=(pad, spacing("xs")))
+        ctk.CTkLabel(self, text="Ambiance and cues", **BODY_LABEL_STYLE).grid(
+            row=1, column=0, columnspan=2, sticky="w", padx=pad, pady=(0, spacing("sm"))
+        )
 
-        self.play_button = ctk.CTkButton(self, text="Play", **button_style("idle"))
-        self.play_button.grid(row=2, column=0, sticky="ew", padx=pad, pady=(0, spacing("xs")))
-
-        self.stop_button = ctk.CTkButton(self, text="Stop", **button_style("critical"))
-        self.stop_button.grid(row=3, column=0, sticky="ew", padx=pad, pady=(0, pad))
-
-        self.icon_token = icon_style("idle")
-        self.timings = ANIMATION_STYLE.copy()
-
-    def get_animation_timings(self) -> dict[str, int]:
-        """Provide animation timings used by panel transitions."""
-        return self.timings.copy()
+        play = DockIconButton(self, text="▶")
+        stop = DockIconButton(self, text="■", state="critical")
+        play.grid(row=2, column=0, sticky="w", padx=(pad, spacing("xs")), pady=(0, pad))
+        stop.grid(row=2, column=1, sticky="w", padx=(0, pad), pady=(0, pad))
+        attach_tooltip(play, "Play ambiance")
+        attach_tooltip(stop, "Stop ambiance")

--- a/modules/ui/session_dock/panels/dice_panel.py
+++ b/modules/ui/session_dock/panels/dice_panel.py
@@ -1,45 +1,39 @@
-"""Session dock dice panel styled with shared session-dock tokens."""
+"""Dice panel rendered inside the session dock container."""
 
 from __future__ import annotations
 
 import customtkinter as ctk
 
-from modules.ui.session_dock.theme.component_styles import (
-    ANIMATION_STYLE,
-    BODY_LABEL_STYLE,
-    PANEL_BASE_STYLE,
-    TITLE_LABEL_STYLE,
-    button_style,
-    icon_style,
-    spacing,
-)
+from modules.ui.session_dock.theme.component_styles import BODY_LABEL_STYLE, PANEL_BASE_STYLE, TITLE_LABEL_STYLE, spacing
+from modules.ui.session_dock.widgets import DockIconButton, DockSegmentedControl, StatusPill, attach_tooltip
 
 
 class DicePanel(ctk.CTkFrame):
-    """Quick dice rolling controls for the session dock."""
+    """Quick roll controls for table actions."""
+
+    panel_id = "dice"
 
     def __init__(self, master: ctk.CTkBaseClass, **kwargs) -> None:
-        merged = {**PANEL_BASE_STYLE, **kwargs}
-        super().__init__(master, **merged)
-
+        super().__init__(master, **{**PANEL_BASE_STYLE, **kwargs})
         pad = spacing("md")
-        self.grid_columnconfigure(0, weight=1)
 
-        self.title = ctk.CTkLabel(self, text="Dice", **TITLE_LABEL_STYLE)
-        self.title.grid(row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs")))
+        self.grid_columnconfigure(1, weight=1)
 
-        self.subtitle = ctk.CTkLabel(self, text="Fast checks and rolls", **BODY_LABEL_STYLE)
-        self.subtitle.grid(row=1, column=0, sticky="w", padx=pad, pady=(0, spacing("sm")))
+        ctk.CTkLabel(self, text="Dice", **TITLE_LABEL_STYLE).grid(
+            row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs"))
+        )
+        StatusPill(self, text="Ready", tone="success").grid(row=0, column=1, sticky="e", padx=pad, pady=(pad, spacing("xs")))
+        ctk.CTkLabel(self, text="Fast checks and rolls", **BODY_LABEL_STYLE).grid(
+            row=1, column=0, columnspan=2, sticky="w", padx=pad, pady=(0, spacing("sm"))
+        )
 
-        self.roll_button = ctk.CTkButton(self, text="Roll d20", **button_style("active"))
-        self.roll_button.grid(row=2, column=0, sticky="ew", padx=pad, pady=(0, spacing("xs")))
+        modes = DockSegmentedControl(self, values=["d20", "d12", "d6"])
+        modes.set("d20")
+        modes.grid(row=2, column=0, columnspan=2, sticky="ew", padx=pad, pady=(0, spacing("sm")))
 
-        self.clear_button = ctk.CTkButton(self, text="Clear", **button_style("idle"))
-        self.clear_button.grid(row=3, column=0, sticky="ew", padx=pad, pady=(0, pad))
-
-        self.icon_token = icon_style("hover")
-        self.timings = ANIMATION_STYLE.copy()
-
-    def get_animation_timings(self) -> dict[str, int]:
-        """Provide animation timings used by panel transitions."""
-        return self.timings.copy()
+        roll = DockIconButton(self, text="🎲", state="active")
+        clear = DockIconButton(self, text="⟲")
+        roll.grid(row=3, column=0, sticky="w", padx=(pad, spacing("xs")), pady=(0, pad))
+        clear.grid(row=3, column=1, sticky="w", padx=(0, pad), pady=(0, pad))
+        attach_tooltip(roll, "Roll selected die")
+        attach_tooltip(clear, "Clear result")

--- a/modules/ui/session_dock/widgets/__init__.py
+++ b/modules/ui/session_dock/widgets/__init__.py
@@ -1,0 +1,13 @@
+"""Shared widgets for session dock UI elements."""
+
+from .icon_button import DockIconButton
+from .segmented_controls import DockSegmentedControl
+from .status_pill import StatusPill
+from .tooltip_helpers import attach_tooltip
+
+__all__ = [
+    "DockIconButton",
+    "DockSegmentedControl",
+    "StatusPill",
+    "attach_tooltip",
+]

--- a/modules/ui/session_dock/widgets/icon_button.py
+++ b/modules/ui/session_dock/widgets/icon_button.py
@@ -1,0 +1,23 @@
+"""Shared icon button wrapper for session dock controls."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.ui.session_dock.theme.component_styles import button_style
+
+
+class DockIconButton(ctk.CTkButton):
+    """Small icon-like button with consistent dock styling."""
+
+    def __init__(self, master: ctk.CTkBaseClass, text: str, command=None, state: str = "idle") -> None:
+        super().__init__(
+            master,
+            text=text,
+            width=34,
+            height=30,
+            corner_radius=8,
+            border_width=1,
+            command=command,
+            **button_style(state),
+        )

--- a/modules/ui/session_dock/widgets/segmented_controls.py
+++ b/modules/ui/session_dock/widgets/segmented_controls.py
@@ -1,0 +1,24 @@
+"""Segmented controls used by dock headers and panel filters."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.ui.session_dock.theme.tokens import COLORS
+
+
+class DockSegmentedControl(ctk.CTkSegmentedButton):
+    """Themed segmented button preset."""
+
+    def __init__(self, master: ctk.CTkBaseClass, values: list[str], command=None) -> None:
+        super().__init__(
+            master,
+            values=values,
+            command=command,
+            fg_color=COLORS.background_subtle,
+            selected_color=COLORS.accent_primary,
+            selected_hover_color=COLORS.accent_primary_soft,
+            unselected_color=COLORS.background_surface,
+            unselected_hover_color=COLORS.background_subtle,
+            text_color=COLORS.text_primary,
+        )

--- a/modules/ui/session_dock/widgets/status_pill.py
+++ b/modules/ui/session_dock/widgets/status_pill.py
@@ -1,0 +1,30 @@
+"""Tiny status pills for panel and service indicators."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.ui.session_dock.theme.tokens import COLORS, STATES, TYPOGRAPHY
+
+_COLORS = {
+    "idle": STATES.idle,
+    "success": STATES.success,
+    "warning": STATES.warning,
+    "critical": STATES.critical,
+}
+
+
+class StatusPill(ctk.CTkLabel):
+    """Compact visual status token."""
+
+    def __init__(self, master: ctk.CTkBaseClass, text: str, tone: str = "idle") -> None:
+        super().__init__(
+            master,
+            text=text,
+            corner_radius=999,
+            fg_color=_COLORS.get(tone, STATES.idle),
+            text_color=COLORS.background_canvas,
+            font=(TYPOGRAPHY.font_family, TYPOGRAPHY.caption_size, TYPOGRAPHY.caption_weight),
+            padx=8,
+            pady=2,
+        )

--- a/modules/ui/session_dock/widgets/tooltip_helpers.py
+++ b/modules/ui/session_dock/widgets/tooltip_helpers.py
@@ -1,0 +1,10 @@
+"""Thin wrapper to keep tooltip usage consistent in dock widgets."""
+
+from __future__ import annotations
+
+from modules.ui.tooltip import ToolTip
+
+
+def attach_tooltip(widget, text: str, delay: int = 350) -> ToolTip:
+    """Attach a shared tooltip implementation to any widget."""
+    return ToolTip(widget, text=text, delay=delay)


### PR DESCRIPTION
### Motivation
- Provide a reusable UI foundation for a floating session dock that can host multiple small panels (audio, dice, etc.) and be mounted/unmounted at runtime. 
- Keep panel visuals consistent by centralizing tokens, styles and small shared widgets to simplify future panel development. 
- Persist user preferences (visibility mode, pinned edge, opacity) and expose global keyboard shortcuts for quick access.

### Description
- Added core dock primitives under `modules/ui/session_dock/core/`: `dock_window.py` (CTkToplevel with pinning, geometry and opacity handling), `dock_state.py` (serializable `DockState` and `DockStateStore` persisting to `~/.gmcampaigndesigner/session_dock_state.json`), and `dock_shortcuts.py` (shortcut bind/clear manager).
- Added shared dock widgets under `modules/ui/session_dock/widgets/`: `DockIconButton`, `DockSegmentedControl`, `StatusPill`, and `attach_tooltip` to standardize small control building blocks.
- Updated existing panels to use the new primitives in `modules/ui/session_dock/panels/` and expose `panel_id` values (`audio`, `dice`) for dynamic mounting.
- Introduced `SessionDockController` (`modules/ui/session_dock/controller.py`) to own dock lifecycle, shortcut wiring (`Ctrl+Alt+D`, `Ctrl+Alt+-`, `Ctrl+Alt+=`) and dynamic `mount_panel`/`unmount_panel` operations.
- Exposed and wired the controller in `main_window.py` to initialize the dock at startup, mount default audio/dice panels, and provide `mount_session_dock_panel(...)` and `unmount_session_dock_panel(...)` methods for dynamic use.

### Testing
- Ran a bytecode/compile check with `python -m compileall modules/ui/session_dock main_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bcefa800832ba0826cc2bb6b9434)