### PR TITLE
Fix DockWindow state collision with CTkToplevel

### DIFF
--- a/modules/ui/session_dock/controller.py
+++ b/modules/ui/session_dock/controller.py
@@ -49,7 +49,7 @@ class SessionDockController:
 
     def toggle_visibility(self) -> None:
         """Toggle hidden/full mode quickly."""
-        if self._window.state.mode == "hidden":
+        if self._window.dock_state.mode == "hidden":
             self._window.set_mode("full")
         else:
             self._window.set_mode("hidden")

--- a/modules/ui/session_dock/core/dock_window.py
+++ b/modules/ui/session_dock/core/dock_window.py
@@ -37,7 +37,8 @@ class DockWindow(ctk.CTkToplevel):
         self._apply_state_geometry()
 
     @property
-    def state(self) -> DockState:
+    def dock_state(self) -> DockState:
+        """Return persisted dock state without shadowing Tk's ``state()`` API."""
         return self._state
 
     def show(self) -> None:


### PR DESCRIPTION
### Motivation
- Prevent an initialization crash where `CTkToplevel.__init__()` calls `state()` and a `@property state` on `DockWindow` shadowed the expected callable, causing an `AttributeError` when `_state` was not yet set.

### Description
- Renamed the `DockWindow.state` property to `DockWindow.dock_state` and added a short docstring clarifying it avoids shadowing Tk's `state()` API.
- Updated `SessionDockController.toggle_visibility()` to reference `self._window.dock_state.mode` instead of the old property.

### Testing
- Ran `python -m py_compile modules/ui/session_dock/core/dock_window.py modules/ui/session_dock/controller.py` and it completed successfully.
- Searched the session dock sources with `rg` for remaining `def state(` or `.state` usages to verify no remaining collision and found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bf41e89c832ba4f4c816f46a668b)