### PR TITLE
Defer session dock init and default dock to hidden to avoid startup window

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -213,9 +213,7 @@ class MainWindow(ctk.CTk):
         root.bind_all("<Control-i>", self._on_ctrl_i)
         root.bind_all("<Control-I>", self._on_ctrl_i)
         self._bind_global_shortcuts()
-        self.session_dock_controller = SessionDockController(self)
-        self.session_dock_controller.mount_panel(AudioPanel.panel_id, AudioPanel)
-        self.session_dock_controller.mount_panel(DicePanel.panel_id, DicePanel)
+        self.after(1000, self._initialize_session_dock)
 
         self._system_listener_unsub = register_system_change_listener(self._on_system_changed)
         # Rebuild colorized UI bits when theme changes
@@ -229,7 +227,9 @@ class MainWindow(ctk.CTk):
     def mount_session_dock_panel(self, panel_id: str, panel_cls, **kwargs):
         """Mount a panel dynamically in the session dock."""
         if self.session_dock_controller is None:
-            self.session_dock_controller = SessionDockController(self)
+            self._initialize_session_dock()
+        if self.session_dock_controller is None:
+            return None
         return self.session_dock_controller.mount_panel(panel_id, panel_cls, **kwargs)
 
     def unmount_session_dock_panel(self, panel_id: str) -> bool:
@@ -237,6 +237,22 @@ class MainWindow(ctk.CTk):
         if self.session_dock_controller is None:
             return False
         return self.session_dock_controller.unmount_panel(panel_id)
+
+    def _initialize_session_dock(self) -> None:
+        """Initialize session dock without blocking main window startup."""
+        if self.session_dock_controller is not None:
+            return
+
+        try:
+            controller = SessionDockController(self)
+            controller.mount_panel(AudioPanel.panel_id, AudioPanel)
+            controller.mount_panel(DicePanel.panel_id, DicePanel)
+            self.session_dock_controller = controller
+        except Exception as exc:
+            log_exception(
+                f"Session dock initialization skipped: {exc}",
+                func_name="main_window.MainWindow._initialize_session_dock",
+            )
 
     def _bind_global_shortcuts(self):
         """Bind global shortcuts."""

--- a/modules/ui/session_dock/core/dock_state.py
+++ b/modules/ui/session_dock/core/dock_state.py
@@ -15,19 +15,19 @@ DockEdge = Literal["left", "right", "top", "bottom"]
 class DockState:
     """Serializable dock state used across sessions."""
 
-    mode: DockMode = "compact"
+    mode: DockMode = "hidden"
     pinned_edge: DockEdge = "right"
     opacity: float = 0.96
 
     @classmethod
     def from_dict(cls, data: dict) -> "DockState":
         """Build and sanitize state from raw JSON data."""
-        mode = data.get("mode", "compact")
+        mode = data.get("mode", "hidden")
         edge = data.get("pinned_edge", "right")
         opacity = data.get("opacity", 0.96)
 
         if mode not in {"hidden", "compact", "full"}:
-            mode = "compact"
+            mode = "hidden"
         if edge not in {"left", "right", "top", "bottom"}:
             edge = "right"
         try:


### PR DESCRIPTION
### Motivation
- Recent session-dock changes caused a small "Session Dock" window to appear during app startup instead of the main application, so initialization must not block or force-open the dock.
- The dock should remain hidden by default on fresh/invalid state so new installs or corrupted state files don't auto-show the dock.

### Description
- Defer creation of `SessionDockController` until after main window setup by scheduling `self.after(1000, self._initialize_session_dock)` in `main_window.py` and add a guarded `_initialize_session_dock()` initializer that mounts `AudioPanel` and `DicePanel` and logs any exceptions instead of raising them.
- Make panel mounting lazy by calling `_initialize_session_dock()` from `mount_session_dock_panel()` and return early if initialization fails or is skipped.
- Change default `DockState.mode` and the `from_dict` fallback from `"compact"` to `"hidden"` in `modules/ui/session_dock/core/dock_state.py` so the dock does not auto-open on first run or invalid state.
- Files changed: `main_window.py` (deferred initialization, new `_initialize_session_dock`, safer `mount_session_dock_panel`) and `modules/ui/session_dock/core/dock_state.py` (default mode/fallback update).

### Testing
- Ran `python -m py_compile main_window.py modules/ui/session_dock/core/dock_state.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c0442f5c832ba00d5885eb77edb9)