### PR TITLE
Fix session dock configure recursion causing startup freeze

### DIFF
--- a/modules/ui/session_dock/core/dock_window.py
+++ b/modules/ui/session_dock/core/dock_window.py
@@ -32,7 +32,11 @@ class DockWindow(ctk.CTkToplevel):
         self.container.pack(fill="both", expand=True, padx=8, pady=8)
 
         self.protocol("WM_DELETE_WINDOW", self.hide)
-        self.bind("<Configure>", self._on_parent_configure, add="+")
+        self._parent_configure_bind_id = master.bind(
+            "<Configure>",
+            self._on_parent_configure,
+            add="+",
+        )
 
         self._apply_state_geometry()
 
@@ -108,3 +112,10 @@ class DockWindow(ctk.CTkToplevel):
             x, y = master_x + max(0, master_w - width), master_y + 64
 
         self.geometry(f"{width}x{height}+{x}+{y}")
+
+    def destroy(self) -> None:
+        """Unbind parent listeners before destroying the dock window."""
+        if self._parent_configure_bind_id is not None:
+            self._master.unbind("<Configure>", self._parent_configure_bind_id)
+            self._parent_configure_bind_id = None
+        super().destroy()


### PR DESCRIPTION
### Motivation
- Prevent a startup freeze where a blank "Session Dock" window could appear and block interaction by eliminating a self-triggered configure/geometry recursion loop.

### Description
- Change the configure binding to listen on the main window via `master.bind("<Configure>", ...)` instead of binding to the dock itself to avoid self-notification loops.
- Store the bind identifier in `_parent_configure_bind_id` so the callback can be unbound safely later.
- Add `DockWindow.destroy()` to unbind the parent `<Configure>` listener before destroying the dock to avoid stale bindings and lifecycle side effects.
- Keep existing show/hide/geometry logic intact while ensuring the dock no longer causes recursive resize/configure events.

### Testing
- Ran `python -m compileall modules/ui/session_dock/core/dock_window.py` which succeeded.
- Ran `pytest -q tests/test_main_window_launch_defaults.py tests/test_main_window_update.py` which did not complete because test collection failed due to an environment import error (`PIL.ImageEnhance` unavailable), preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c29e7df0832ba29c1be5b9e37afa)