### PR TITLE
Make dock height adaptive and constrain to master; fix 'ambience' spelling in audio panel

### DIFF
--- a/modules/ui/session_dock/core/dock_window.py
+++ b/modules/ui/session_dock/core/dock_window.py
@@ -100,7 +100,10 @@ class DockWindow(ctk.CTkToplevel):
         master_h = self._master.winfo_height()
 
         width = 320 if self._state.mode == "full" else 220
-        height = 400 if self._state.mode == "full" else 240
+        base_height = 400 if self._state.mode == "full" else 240
+        content_height = self.container.winfo_reqheight() + 16
+        max_height = max(220, master_h - 24)
+        height = max(base_height, min(content_height, max_height))
 
         if self._state.pinned_edge == "left":
             x, y = master_x, master_y + 64

--- a/modules/ui/session_dock/panels/audio_panel.py
+++ b/modules/ui/session_dock/panels/audio_panel.py
@@ -9,7 +9,7 @@ from modules.ui.session_dock.widgets import DockIconButton, StatusPill, attach_t
 
 
 class AudioPanel(ctk.CTkFrame):
-    """Compact audio controls for ambiance and cues."""
+    """Compact audio controls for ambience and cues."""
 
     panel_id = "audio"
 
@@ -23,7 +23,7 @@ class AudioPanel(ctk.CTkFrame):
             row=0, column=0, sticky="w", padx=pad, pady=(pad, spacing("xs"))
         )
         StatusPill(self, text="Idle", tone="idle").grid(row=0, column=1, sticky="e", padx=pad, pady=(pad, spacing("xs")))
-        ctk.CTkLabel(self, text="Ambiance and cues", **BODY_LABEL_STYLE).grid(
+        ctk.CTkLabel(self, text="Ambience and cues", **BODY_LABEL_STYLE).grid(
             row=1, column=0, columnspan=2, sticky="w", padx=pad, pady=(0, spacing("sm"))
         )
 
@@ -31,5 +31,5 @@ class AudioPanel(ctk.CTkFrame):
         stop = DockIconButton(self, text="■", state="critical")
         play.grid(row=2, column=0, sticky="w", padx=(pad, spacing("xs")), pady=(0, pad))
         stop.grid(row=2, column=1, sticky="w", padx=(0, pad), pady=(0, pad))
-        attach_tooltip(play, "Play ambiance")
-        attach_tooltip(stop, "Stop ambiance")
+        attach_tooltip(play, "Play ambience")
+        attach_tooltip(stop, "Stop ambience")


### PR DESCRIPTION
### Motivation
- Ensure the dock window height adapts to its content while staying within the host/master window bounds to avoid clipping or excessive empty space.
- Preserve a sensible minimum and base size for the dock in both `full` and compact modes so layout remains consistent.
- Correct spelling and UI text for the audio panel to use a consistent "ambience" label and tooltips.

### Description
- Update `_apply_state_geometry` to compute `content_height` via `container.winfo_reqheight()` and clamp the final `height` between a `base_height` and a `max_height` derived from the master window size.
- Keep the existing base sizes (`400` for `full`, `240` for compact) and ensure the final height is at least the base but not larger than the available space minus margins.
- Minor text changes in `audio_panel.py`: update the class docstring and UI strings from "Ambiance" to "Ambience" and adjust the tooltip texts accordingly.

### Testing
- Ran the project's unit test suite with `pytest` and all tests completed successfully.
- Ran code style checks with `flake8` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c4066450832b890ba2ef43d816d8)