### PR TITLE
Refactor audio and dice bar layouts into semantic UI zones

### DIFF
--- a/modules/audio/ui/bar/window.py
+++ b/modules/audio/ui/bar/window.py
@@ -26,6 +26,7 @@ from modules.audio.ui.bar.layout import (
 )
 from modules.audio.ui.bar.presenters import build_playlist_lookup, build_search_lookup
 from modules.helpers.logging_helper import log_exception, log_module_import
+from modules.ui.tooltip import ToolTip
 from modules.ui.bars.style_tokens import build_bar_variants, shared_bar_tokens
 
 log_module_import(__name__)
@@ -138,183 +139,260 @@ class AudioBarWindow(ctk.CTkToplevel):
         )
         self._content_grid_options = {"row": 0, "column": 1, "padx": 0, "pady": 0, "sticky": "nsew"}
         content.grid(**self._content_grid_options)
-        content.grid_columnconfigure(0, weight=0)
-        content.grid_columnconfigure(1, weight=1)
-        content.grid_columnconfigure(2, weight=1)
-        content.grid_columnconfigure(3, weight=1)
-        content.grid_columnconfigure(4, weight=1)
-        content.grid_columnconfigure(5, weight=2)
-        content.grid_columnconfigure(14, weight=3)
-        content.grid_columnconfigure(16, weight=2)
+        for index in range(5):
+            content.grid_columnconfigure(index, weight=1)
         self._content_frame = content
 
+        control_font = ctk.CTkFont(size=bar_tokens.font_size_body)
+        dynamic_value_font = ctk.CTkFont(size=bar_tokens.font_size_body, weight="bold")
+        secondary_label_font = ctk.CTkFont(size=bar_tokens.font_size_header)
+        secondary_text_color = tokens.get("text_muted", bar_tokens.emphasis_text_muted)
+
+        def add_separator(column: int) -> None:
+            sep = ctk.CTkFrame(
+                content,
+                width=bar_tokens.border_width_thin,
+                fg_color=tokens.get("button_border", variants["default"].border),
+            )
+            sep.grid(row=0, column=column, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm), pady=bar_tokens.spacing_sm, sticky="ns")
+
+        source_zone = ctk.CTkFrame(content, fg_color="transparent")
+        source_zone.grid(row=0, column=0, padx=(bar_tokens.spacing_xs, bar_tokens.spacing_sm), pady=bar_tokens.spacing_xs, sticky="ew")
+        for index in range(4):
+            source_zone.grid_columnconfigure(index, weight=1)
+
         self.section_toggle_button = ctk.CTkButton(
-            content,
+            source_zone,
             textvariable=self.section_toggle_var,
             command=self._toggle_section,
             width=110,
+            font=control_font,
         )
         self.section_toggle_button.grid(
             row=0,
             column=0,
-            padx=(bar_tokens.spacing_xs, bar_tokens.spacing_md),
-            pady=bar_tokens.spacing_xs,
+            padx=(0, bar_tokens.spacing_xs),
+            pady=0,
             sticky="ew",
         )
+        ToolTip(self.section_toggle_button, "Cycle through source sections: Music, Ambience, and SFX.")
 
         self.search_var = tk.StringVar(value="")
         self.search_entry = ctk.CTkEntry(
-            content,
+            source_zone,
             textvariable=self.search_var,
             placeholder_text="Search",
+            font=control_font,
         )
         self.search_entry.grid(
             row=0,
             column=1,
             padx=bar_tokens.spacing_xs,
-            pady=bar_tokens.spacing_xs,
+            pady=0,
             sticky="ew",
         )
         self.search_entry.bind("<Return>", self._on_search_submitted)
         self.search_entry.bind("<KP_Enter>", self._on_search_submitted)
         self.search_entry.bind("<KeyRelease>", self._on_search_text_changed)
+        ToolTip(self.search_entry, "Search by track title, category, or mood.")
 
         self.category_menu = ctk.CTkOptionMenu(
-            content,
+            source_zone,
             variable=self.category_var,
             values=["Category"],
             command=self._on_category_selected,
             width=170,
+            font=control_font,
         )
         self.category_menu.grid(
             row=0,
             column=2,
             padx=bar_tokens.spacing_xs,
-            pady=bar_tokens.spacing_xs,
+            pady=0,
             sticky="ew",
         )
         self.category_menu.configure(state="disabled")
+        ToolTip(self.category_menu, "Filter tracks to one library category.")
 
         self.mood_menu = ctk.CTkOptionMenu(
-            content,
+            source_zone,
             variable=self.mood_var,
             values=["Mood"],
             command=self._on_mood_selected,
             width=140,
+            font=control_font,
         )
         self.mood_menu.grid(
             row=0,
             column=3,
-            padx=bar_tokens.spacing_xs,
-            pady=bar_tokens.spacing_xs,
+            padx=(bar_tokens.spacing_xs, 0),
+            pady=0,
             sticky="ew",
         )
         self.mood_menu.configure(state="disabled")
+        ToolTip(self.mood_menu, "Optional mood filter inside the selected category.")
+
+        add_separator(1)
+        queue_zone = ctk.CTkFrame(content, fg_color="transparent")
+        queue_zone.grid(row=0, column=2, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm), pady=bar_tokens.spacing_xs, sticky="ew")
+        queue_zone.grid_columnconfigure(0, weight=1)
+        queue_zone.grid_columnconfigure(1, weight=2)
 
         self._search_results_menu_width = SEARCH_RESULTS_MENU_WIDTH
         self._now_playing_menu_width = NOW_PLAYING_MENU_WIDTH
         self.search_results_var = tk.StringVar(value="No results")
         self.search_results_menu = ctk.CTkOptionMenu(
-            content,
+            queue_zone,
             variable=self.search_results_var,
             values=["No results"],
             command=self._on_search_result_selected,
             width=self._search_results_menu_width,
+            font=control_font,
         )
         self.search_results_menu.grid(
             row=0,
-            column=4,
-            padx=bar_tokens.spacing_xs,
-            pady=bar_tokens.spacing_xs,
+            column=0,
+            padx=(0, bar_tokens.spacing_xs),
+            pady=0,
             sticky="ew",
         )
         self.search_results_menu.configure(state="disabled")
         self.search_results_var.trace_add("write", self._keep_search_dropdown_width)
+        ToolTip(self.search_results_menu, "Select a search result to queue or play.")
 
         self.now_playing_menu = ctk.CTkOptionMenu(
-            content,
+            queue_zone,
             variable=self.now_playing_var,
             values=["No tracks available"],
             command=self._on_track_selected,
             width=self._now_playing_menu_width,
+            font=dynamic_value_font,
         )
         self.now_playing_menu.grid(
             row=0,
-            column=5,
-            padx=bar_tokens.spacing_xs,
-            pady=bar_tokens.spacing_xs,
+            column=1,
+            padx=(bar_tokens.spacing_xs, 0),
+            pady=0,
             sticky="ew",
         )
         self.now_playing_menu.configure(state="disabled")
         self.now_playing_var.trace_add("write", self._keep_now_playing_dropdown_width)
+        ToolTip(self.now_playing_menu, "Current queue / now playing track selector.")
+
+        add_separator(3)
+        transport_zone = ctk.CTkFrame(content, fg_color="transparent")
+        transport_zone.grid(row=0, column=4, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm), pady=bar_tokens.spacing_xs, sticky="w")
+        for index in range(4):
+            transport_zone.grid_columnconfigure(index, weight=0)
 
         self.prev_button = ctk.CTkButton(
-            content, text="Prev", command=self._on_prev_clicked, width=70,
-            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover
+            transport_zone, text="Prev", command=self._on_prev_clicked, width=70,
+            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover, font=control_font
         )
-        self.prev_button.grid(row=0, column=6, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="ew")
+        self.prev_button.grid(row=0, column=0, padx=(0, bar_tokens.spacing_xs), pady=0, sticky="ew")
+        ToolTip(self.prev_button, "Play the previous track in the active playlist.")
 
         self.play_button = ctk.CTkButton(
-            content, text="Play", command=self._on_play_clicked, width=70,
-            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover
+            transport_zone, text="Play", command=self._on_play_clicked, width=70,
+            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover, font=control_font
         )
-        self.play_button.grid(row=0, column=7, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="ew")
+        self.play_button.grid(row=0, column=1, padx=bar_tokens.spacing_xs, pady=0, sticky="ew")
 
         #self.pause_button = ctk.CTkButton(content, text="Pause", command=self._on_pause_clicked, width=70)
         #self.pause_button.grid(row=0, column=6, padx=4, pady=4, sticky="ew")
 
         self.stop_button = ctk.CTkButton(
-            content, text="Stop", command=self._on_stop_clicked, width=70,
-            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover
+            transport_zone, text="Stop", command=self._on_stop_clicked, width=70,
+            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover, font=control_font
         )
-        self.stop_button.grid(row=0, column=8, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="ew")
+        self.stop_button.grid(row=0, column=2, padx=bar_tokens.spacing_xs, pady=0, sticky="ew")
 
         self.next_button = ctk.CTkButton(
-            content, text="Next", command=self._on_next_clicked, width=70,
-            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover
+            transport_zone, text="Next", command=self._on_next_clicked, width=70,
+            fg_color=variants["accent"].fg, hover_color=variants["accent"].hover, font=control_font
         )
-        self.next_button.grid(row=0, column=9, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="ew")
+        self.next_button.grid(row=0, column=3, padx=(bar_tokens.spacing_xs, 0), pady=0, sticky="ew")
+        ToolTip(self.next_button, "Skip to the next track in the active playlist.")
+
+        add_separator(5)
+        playback_zone = ctk.CTkFrame(content, fg_color="transparent")
+        playback_zone.grid(row=0, column=6, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm), pady=bar_tokens.spacing_xs, sticky="w")
 
         self.shuffle_checkbox = ctk.CTkCheckBox(
-            content,
-            text="Shuffle",
+            playback_zone,
+            text="Shuf",
             variable=self.shuffle_var,
             command=self._on_shuffle_toggle,
+            font=control_font,
+            checkbox_width=16,
+            checkbox_height=16,
         )
-        self.shuffle_checkbox.grid(row=0, column=10, padx=(2, 0), pady=4, sticky="w")
+        self.shuffle_checkbox.grid(row=0, column=0, padx=(0, bar_tokens.spacing_sm), pady=0, sticky="w")
+        ToolTip(self.shuffle_checkbox, "Shuffle playback order.")
 
         self.loop_checkbox = ctk.CTkCheckBox(
-            content,
+            playback_zone,
             text="Loop",
             variable=self.loop_var,
             command=self._on_loop_toggle,
+            font=control_font,
+            checkbox_width=16,
+            checkbox_height=16,
         )
-        self.loop_checkbox.grid(row=0, column=11, padx=(2, 0), pady=4, sticky="w")
+        self.loop_checkbox.grid(row=0, column=1, padx=(0, bar_tokens.spacing_sm), pady=0, sticky="w")
+        ToolTip(self.loop_checkbox, "Repeat the current track when it ends.")
 
         self.continue_checkbox = ctk.CTkCheckBox(
-            content,
-            text="Continue",
+            playback_zone,
+            text="Auto",
             variable=self.continue_var,
             command=self._on_continue_toggle,
+            font=control_font,
+            checkbox_width=16,
+            checkbox_height=16,
         )
-        self.continue_checkbox.grid(row=0, column=12, padx=(2, 4), pady=4, sticky="w")
+        self.continue_checkbox.grid(row=0, column=2, padx=0, pady=0, sticky="w")
+        ToolTip(self.continue_checkbox, "Automatically continue to the next track.")
 
-        volume_label = ctk.CTkLabel(content, text="Volume")
-        volume_label.grid(row=0, column=13, padx=(12, 4), pady=4, sticky="e")
+        add_separator(7)
+        output_zone = ctk.CTkFrame(content, fg_color="transparent")
+        output_zone.grid(row=0, column=8, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_xs), pady=bar_tokens.spacing_xs, sticky="ew")
+        output_zone.grid_columnconfigure(3, weight=1)
+
+        volume_label = ctk.CTkLabel(
+            output_zone,
+            text="Vol",
+            font=secondary_label_font,
+            text_color=secondary_text_color,
+        )
+        volume_label.grid(row=0, column=0, padx=(0, bar_tokens.spacing_xs), pady=0, sticky="e")
+        ToolTip(volume_label, "Master playback volume.")
 
         self.volume_slider = ctk.CTkSlider(
-            content,
+            output_zone,
             from_=0,
             to=100,
             command=self._on_volume_changed,
         )
-        self.volume_slider.grid(row=0, column=14, padx=4, pady=4, sticky="ew")
+        self.volume_slider.grid(row=0, column=1, padx=bar_tokens.spacing_xs, pady=0, sticky="ew")
+        ToolTip(self.volume_slider, "Adjust master volume for the active section.")
 
-        self.volume_value_label = ctk.CTkLabel(content, textvariable=self.volume_value_var, width=60)
-        self.volume_value_label.grid(row=0, column=15, padx=(4, 12), pady=4, sticky="e")
+        self.volume_value_label = ctk.CTkLabel(
+            output_zone,
+            textvariable=self.volume_value_var,
+            width=52,
+            font=dynamic_value_font,
+        )
+        self.volume_value_label.grid(row=0, column=2, padx=(bar_tokens.spacing_xs, bar_tokens.spacing_md), pady=0, sticky="e")
 
-        self.status_label = ctk.CTkLabel(content, textvariable=self.status_var, anchor="w")
-        self.status_label.grid(row=0, column=16, padx=(8, 4), pady=4, sticky="ew")
+        self.status_label = ctk.CTkLabel(
+            output_zone,
+            textvariable=self.status_var,
+            anchor="w",
+            font=secondary_label_font,
+            text_color=secondary_text_color,
+        )
+        self.status_label.grid(row=0, column=3, padx=(bar_tokens.spacing_sm, 0), pady=0, sticky="ew")
 
         self._building_ui = False
         self._update_collapse_button()

--- a/modules/dice/ui/bar/window.py
+++ b/modules/dice/ui/bar/window.py
@@ -16,6 +16,7 @@ from modules.dice.ui.bar.geometry import HEIGHT_PADDING, INTER_BAR_GAP
 from modules.dice.ui.bar.layout import CLEAR_BUTTON_WIDTH, FORMULA_ENTRY_WIDTH, ROLL_BUTTON_WIDTH
 from modules.helpers.logging_helper import log_module_import
 from modules.ui.bars.style_tokens import build_bar_variants, shared_bar_tokens
+from modules.ui.tooltip import ToolTip
 
 log_module_import(__name__)
 
@@ -122,83 +123,157 @@ class DiceBarWindow(ctk.CTkToplevel):
         )
         self._content_grid_options = {"row": 0, "column": 1, "padx": 0, "pady": 0, "sticky": "nsew"}
         content.grid(**self._content_grid_options)
-        content.grid_columnconfigure(0, weight=0)
-        content.grid_columnconfigure(1, weight=0)
-        content.grid_columnconfigure(2, weight=0)
-        content.grid_columnconfigure(3, weight=0)
-        content.grid_columnconfigure(4, weight=0)
-        content.grid_columnconfigure(5, weight=0)
-        content.grid_columnconfigure(6, weight=1)
-        content.grid_columnconfigure(7, weight=0)
+        content.grid_columnconfigure(0, weight=0)  # Formula
+        content.grid_columnconfigure(1, weight=0)  # Separator
+        content.grid_columnconfigure(2, weight=0)  # Options
+        content.grid_columnconfigure(3, weight=0)  # Separator
+        content.grid_columnconfigure(4, weight=0)  # Presets
+        content.grid_columnconfigure(5, weight=0)  # Separator
+        content.grid_columnconfigure(6, weight=1)  # Results
         content.grid_rowconfigure(0, weight=1)
         self._content_frame = content
 
-        entry = ctk.CTkEntry(content, textvariable=self.formula_var, width=FORMULA_ENTRY_WIDTH, height=30)
+        control_font = ctk.CTkFont(size=bar_tokens.font_size_body)
+        secondary_label_font = ctk.CTkFont(size=bar_tokens.font_size_header)
+        secondary_text_color = tokens.get("text_muted", bar_tokens.emphasis_text_muted)
+
+        def add_separator(column: int) -> None:
+            sep = ctk.CTkFrame(
+                content,
+                width=bar_tokens.border_width_thin,
+                fg_color=tokens.get("button_border", variants["default"].border),
+            )
+            sep.grid(row=0, column=column, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm), pady=bar_tokens.spacing_sm, sticky="ns")
+
+        formula_zone = ctk.CTkFrame(content, fg_color="transparent")
+        formula_zone.grid(row=0, column=0, padx=(bar_tokens.spacing_xs, bar_tokens.spacing_sm), pady=bar_tokens.spacing_xs, sticky="nw")
+        formula_zone.grid_columnconfigure(0, weight=0)
+        formula_zone.grid_columnconfigure(1, weight=0)
+
+        formula_label = ctk.CTkLabel(
+            formula_zone,
+            text="Expr",
+            font=secondary_label_font,
+            text_color=secondary_text_color,
+        )
+        formula_label.grid(row=0, column=0, padx=(0, bar_tokens.spacing_xs), pady=0, sticky="w")
+        ToolTip(formula_label, "Dice formula expression, for example: 2d20kh1 + 4.")
+
+        entry = ctk.CTkEntry(formula_zone, textvariable=self.formula_var, width=FORMULA_ENTRY_WIDTH, height=30, font=control_font)
         entry.grid(
             row=0,
-            column=0,
-            padx=(bar_tokens.spacing_xs, bar_tokens.spacing_sm),
-            pady=bar_tokens.spacing_xs,
+            column=1,
+            padx=0,
+            pady=0,
             sticky="new",
         )
         entry.bind("<Return>", lambda _event: self.roll())
         self._formula_entry = entry
+        ToolTip(entry, "Type a dice formula and press Enter to roll.")
 
+        add_separator(1)
+        options_zone = ctk.CTkFrame(content, fg_color="transparent")
+        options_zone.grid(row=0, column=2, padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm), pady=bar_tokens.spacing_xs, sticky="nw")
         explode_box = ctk.CTkCheckBox(
-            content,
-            text="Explode",
+            options_zone,
+            text="Exp",
             variable=self.exploding_var,
             checkbox_height=18,
+            font=control_font,
         )
-        explode_box.grid(row=0, column=1, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="nw")
+        explode_box.grid(row=0, column=0, padx=(0, bar_tokens.spacing_sm), pady=0, sticky="nw")
+        ToolTip(explode_box, "Exploding dice: reroll and add when max face is rolled.")
 
         separate_box = ctk.CTkCheckBox(
-            content,
-            text="Separate",
+            options_zone,
+            text="Sep",
             variable=self.separate_var,
             checkbox_height=18,
+            font=control_font,
         )
-        separate_box.grid(row=0, column=2, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="nw")
+        separate_box.grid(row=0, column=1, padx=(0, bar_tokens.spacing_sm), pady=0, sticky="nw")
+        ToolTip(separate_box, "Show grouped roll details for each dice term.")
 
         roll_button = ctk.CTkButton(
-            content,
+            options_zone,
             text="Roll",
             width=ROLL_BUTTON_WIDTH,
             height=32,
             command=self.roll,
             fg_color=variants["success"].fg,
             hover_color=variants["success"].hover,
-            font=("Segoe UI", bar_tokens.font_size_body, "bold"),
+            font=control_font,
         )
-        roll_button.grid(row=0, column=3, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="new")
+        roll_button.grid(row=0, column=2, padx=(0, bar_tokens.spacing_xs), pady=0, sticky="new")
 
         clear_button = ctk.CTkButton(
-            content,
+            options_zone,
             text="Clear",
             width=CLEAR_BUTTON_WIDTH,
             height=32,
             command=self._clear_formula,
             fg_color=variants["default"].fg,
             hover_color=variants["default"].hover,
+            font=control_font,
         )
-        clear_button.grid(row=0, column=4, padx=bar_tokens.spacing_xs, pady=bar_tokens.spacing_xs, sticky="new")
+        clear_button.grid(row=0, column=3, padx=0, pady=0, sticky="new")
+        ToolTip(clear_button, "Reset the formula input.")
 
-        preset_frame = ctk.CTkFrame(content, fg_color="transparent")
-        preset_frame.grid(
+        add_separator(3)
+        preset_zone = ctk.CTkFrame(content, fg_color="transparent")
+        preset_zone.grid(
             row=0,
-            column=5,
-            padx=(bar_tokens.spacing_sm, bar_tokens.spacing_xs),
+            column=4,
+            padx=(bar_tokens.spacing_sm, bar_tokens.spacing_sm),
             pady=bar_tokens.spacing_xs,
+            sticky="nw",
+        )
+        preset_zone.grid_columnconfigure(0, weight=0)
+        preset_label = ctk.CTkLabel(
+            preset_zone,
+            text="Quick",
+            font=secondary_label_font,
+            text_color=secondary_text_color,
+        )
+        preset_label.grid(row=0, column=0, padx=(0, 0), pady=(0, bar_tokens.spacing_2xs), sticky="w")
+        ToolTip(preset_label, "Quick-add common dice to the current expression.")
+
+        preset_frame = ctk.CTkFrame(preset_zone, fg_color="transparent")
+        preset_frame.grid(
+            row=1,
+            column=0,
+            padx=0,
+            pady=0,
             sticky="nw",
         )
         self._preset_frame = preset_frame
 
-        result_frame = ctk.CTkFrame(content, fg_color="transparent")
-        result_frame.grid(
+        add_separator(5)
+        result_zone = ctk.CTkFrame(content, fg_color="transparent")
+        result_zone.grid(
             row=0,
             column=6,
             padx=(bar_tokens.spacing_sm, bar_tokens.spacing_xs),
             pady=bar_tokens.spacing_xs,
+            sticky="new",
+        )
+        result_zone.grid_columnconfigure(0, weight=1)
+
+        result_label = ctk.CTkLabel(
+            result_zone,
+            text="Result",
+            font=secondary_label_font,
+            text_color=secondary_text_color,
+        )
+        result_label.grid(row=0, column=0, padx=0, pady=(0, bar_tokens.spacing_2xs), sticky="w")
+        ToolTip(result_label, "Outcome details and total value.")
+
+        result_frame = ctk.CTkFrame(result_zone, fg_color="transparent")
+        result_frame.grid(
+            row=1,
+            column=0,
+            padx=0,
+            pady=0,
             sticky="new",
         )
         result_frame.grid_columnconfigure(0, weight=1)
@@ -218,10 +293,11 @@ class DiceBarWindow(ctk.CTkToplevel):
 
         total_prefix = ctk.CTkLabel(
             total_container,
-            text="Total",
+            text="Σ",
             font=self._result_normal_font,
             anchor="ne",
             justify="right",
+            text_color=secondary_text_color,
         )
         total_prefix.grid(row=0, column=0, padx=(0, 6), sticky="ne")
         self._register_drag_target(total_prefix)


### PR DESCRIPTION
### Motivation
- Reduce visual noise and improve discoverability by grouping compact bar controls into semantic zones and using subtle separators instead of heavy borders.
- Apply a clear typographic hierarchy so static labels are secondary, controls use medium weight, and only dynamic values (track title, total) are bold.
- Preserve existing behavior and callbacks while shortening static labels and providing tooltips for full explanations.

### Description
- Reorganized `AudioBarWindow._build_ui` into Source (section/search/filter), Queue (results/now playing), Transport (prev/play/stop/next), Playback options (shuffle/loop/continue), and Volume/Status zones using transparent zone frames and thin separator frames; added concise labels (`Shuf`, `Auto`, `Vol`) and tooltips.
- Reorganized `DiceBarWindow._build_ui` into Formula input, Roll options, Quick presets, and Results zones with separators and short static captions (`Expr`, `Exp`, `Sep`, `Quick`, `Σ`) and tooltips; kept total label emphasized.
- Introduced semantic fonts and minor layout/grid adjustments (control/secondary/dynamic fonts, grid column configuration and weights) and imported `ToolTip` to attach explanatory hover text without changing runtime logic.
- No changes to controller or dice-engine logic; this is a UI/layout and labeling refactor limited to `modules/audio/ui/bar/window.py` and `modules/dice/ui/bar/window.py`.

### Testing
- Compiled the modified modules with `python -m compileall modules/audio/ui/bar/window.py modules/dice/ui/bar/window.py`, which completed successfully.
- Ran `pytest -q tests/audio/test_filter_selection_resolver.py tests/test_dice_preferences.py`, which returned `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0dc910cb0832bb0cedd85a01eecc4)