### PR TITLE
Fix overlay dice/audio bars using fullscreen width in expanded mode

### DIFF
--- a/modules/audio/ui/bar/window.py
+++ b/modules/audio/ui/bar/window.py
@@ -988,13 +988,16 @@ class AudioBarWindow(ctk.CTkToplevel):
         try:
             # Keep geometry resilient if this step fails.
             self.update_idletasks()
+            screen_width = self.winfo_screenwidth()
             if self._is_collapsed:
                 target = self._collapse_button or self
                 width = max(40, int(target.winfo_reqwidth() + 8))
                 height_source = target
             else:
-                width = self.winfo_screenwidth()
                 height_source = self._bar_frame or self
+                requested_width = int(height_source.winfo_reqwidth() if height_source is not None else 0)
+                width = max(40, requested_width + 2)
+            width = min(width, screen_width)
             height = max(36, int((height_source.winfo_reqheight() if height_source else 36) + 16))
             y = self.winfo_screenheight() - height
             self.geometry(f"{width}x{height}+0+{max(0, y)}")

--- a/modules/dice/ui/bar/window.py
+++ b/modules/dice/ui/bar/window.py
@@ -446,6 +446,7 @@ class DiceBarWindow(ctk.CTkToplevel):
         try:
             # Keep geometry resilient if this step fails.
             self.update_idletasks()
+            screen_width = self.winfo_screenwidth()
             if self._is_collapsed:
                 # Continue with this path when is collapsed is set.
                 target = self._collapse_button or self
@@ -460,8 +461,9 @@ class DiceBarWindow(ctk.CTkToplevel):
                     if measured:
                         self._collapsed_height_hint = measured
             else:
-                width = self.winfo_screenwidth()
                 height_source = self._bar_frame or self
+                requested_width = int(height_source.winfo_reqwidth() if height_source is not None else 0)
+                width = max(40, requested_width + 2)
                 if self._expanded_height_hint is None and height_source is not None:
                     # Handle the branch where expanded height hint is missing and height source is available.
                     try:
@@ -470,6 +472,7 @@ class DiceBarWindow(ctk.CTkToplevel):
                         measured = 0
                     if measured:
                         self._expanded_height_hint = measured
+            width = min(width, screen_width)
             if self._is_collapsed:
                 base_height = self._collapsed_height_hint
             else:


### PR DESCRIPTION
## Summary
- fixed `AudioBarWindow._apply_geometry()` to size expanded mode from the bar's requested width instead of forcing fullscreen width
- fixed `DiceBarWindow._apply_geometry()` with the same behavior so both bars use consistent sizing
- kept a screen-width clamp to avoid off-screen overflow on smaller displays

## Why
The recent refactor made both bars use `winfo_screenwidth()` in expanded mode. That stretches the bars unnecessarily and can hide or clip fields depending on monitor size/scaling.

## Scope
- `modules/audio/ui/bar/window.py`
- `modules/dice/ui/bar/window.py`

## Validation
- static diff review of geometry logic (no runtime tests executed in this environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e3e53578832b858796a9bc96add2)