### PR TITLE
Clamp audio and dice bar heights to two-line layout

### DIFF
--- a/modules/audio/ui/bar/window.py
+++ b/modules/audio/ui/bar/window.py
@@ -998,7 +998,8 @@ class AudioBarWindow(ctk.CTkToplevel):
                 requested_width = int(height_source.winfo_reqwidth() if height_source is not None else 0)
                 width = max(40, requested_width + 2)
             width = min(width, screen_width)
-            height = max(36, int((height_source.winfo_reqheight() if height_source else 36) + 16))
+            requested_height = int((height_source.winfo_reqheight() if height_source else 36) + 16)
+            height = max(36, min(requested_height, 96))
             y = self.winfo_screenheight() - height
             self.geometry(f"{width}x{height}+0+{max(0, y)}")
             dice_window = getattr(self.master, "dice_bar_window", None)

--- a/modules/dice/ui/bar/window.py
+++ b/modules/dice/ui/bar/window.py
@@ -479,7 +479,7 @@ class DiceBarWindow(ctk.CTkToplevel):
                 base_height = self._expanded_height_hint
             if not base_height:
                 base_height = height_source.winfo_reqheight() if height_source else 36
-            height = max(36, int(base_height + HEIGHT_PADDING))
+            height = max(36, min(int(base_height + HEIGHT_PADDING), 96))
             screen_height = self.winfo_screenheight()
             y = screen_height - height
 


### PR DESCRIPTION
### Motivation
- Recent layout refactors caused the audio/dice bars to grow taller than intended, breaking the compact two-line presentation.
- The UI should keep the bars visually tight (two lines) while preserving the width/anchoring fixes introduced earlier.

### Description
- Limit the expanded audio bar height by computing `requested_height` and clamping it with `height = max(36, min(requested_height, 96))` in `modules/audio/ui/bar/window.py`.
- Apply the same clamp to the dice bar by changing its computed height to `height = max(36, min(int(base_height + HEIGHT_PADDING), 96))` in `modules/dice/ui/bar/window.py`.
- Preserve the existing width calculation and inter-bar anchoring logic introduced by prior commits; this change only bounds the vertical size.

### Testing
- Ran `python -m py_compile modules/audio/ui/bar/window.py modules/dice/ui/bar/window.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e6e6ce78832b8b248faa66fda36f)