### PR TITLE
Restore full-width bottom bars and stabilize audio bar layout

### DIFF
--- a/modules/audio/ui/bar/window.py
+++ b/modules/audio/ui/bar/window.py
@@ -995,8 +995,7 @@ class AudioBarWindow(ctk.CTkToplevel):
                 height_source = target
             else:
                 height_source = self._bar_frame or self
-                requested_width = int(height_source.winfo_reqwidth() if height_source is not None else 0)
-                width = max(40, requested_width + 2)
+                width = screen_width
             width = min(width, screen_width)
             requested_height = int((height_source.winfo_reqheight() if height_source else 36) + 16)
             height = max(36, min(requested_height, 96))
@@ -1052,6 +1051,7 @@ class AudioBarWindow(ctk.CTkToplevel):
             self.lift()
             self.focus_force()
             self.attributes("-topmost", True)
+            self.after(250, self._apply_geometry)
         except Exception:
             pass
 

--- a/modules/dice/ui/bar/window.py
+++ b/modules/dice/ui/bar/window.py
@@ -462,8 +462,7 @@ class DiceBarWindow(ctk.CTkToplevel):
                         self._collapsed_height_hint = measured
             else:
                 height_source = self._bar_frame or self
-                requested_width = int(height_source.winfo_reqwidth() if height_source is not None else 0)
-                width = max(40, requested_width + 2)
+                width = screen_width
                 if self._expanded_height_hint is None and height_source is not None:
                     # Handle the branch where expanded height hint is missing and height source is available.
                     try:


### PR DESCRIPTION
### Motivation
- The expanded dice and audio bars were sizing to `winfo_reqwidth()` (content-requested width) which could make the dice bar not span the full screen and occasionally produce an apparently empty audio bar on first render. 
- The audio bar's initial geometry could run before child widgets were fully realized, causing a first-frame under-layout.

### Description
- Reverted expanded-width behavior to use the screen width by setting `width = screen_width` in `modules/dice/ui/bar/window.py` and `modules/audio/ui/bar/window.py` for the non-collapsed path. 
- Added a delayed second geometry pass `self.after(250, self._apply_geometry)` to `AudioBarWindow.show()` to reflow layout after widgets are realized. 
- Changes are limited to `modules/dice/ui/bar/window.py` and `modules/audio/ui/bar/window.py` and only affect expanded-width and audio show timing.

### Testing
- Ran `pytest -q`; test collection failed due to unrelated environment/import issues (PIL imports and test module name collisions) and not because of the two modified files. 
- No automated test failures were observed that can be attributed to the changes in `modules/dice/ui/bar/window.py` and `modules/audio/ui/bar/window.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e87bcd88832bbf9481700b1d8885)