### PR TITLE
Add shared compact bar style and restyle dice/audio bars

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 
 import customtkinter as ctk
 from modules.helpers import theme_manager
+from modules.ui.styles.compact_bar_style import build_compact_bar_style
 
 from modules.audio.audio_constants import DEFAULT_SECTION, SECTION_TITLES
 from modules.audio.audio_controller import AudioController, get_audio_controller
@@ -84,7 +85,14 @@ class AudioBarWindow(ctk.CTkToplevel):
         self.grid_columnconfigure(0, weight=1)
 
         tokens = theme_manager.get_tokens()
-        bar = ctk.CTkFrame(self, corner_radius=0, fg_color=tokens.get("panel_bg"))
+        style = build_compact_bar_style(tokens)
+        bar = ctk.CTkFrame(
+            self,
+            corner_radius=14,
+            fg_color=style.shell_bg,
+            border_width=style.border_width,
+            border_color=style.panel_border,
+        )
         bar.grid(row=0, column=0, sticky="nsew", padx=8, pady=8)
         bar.grid_columnconfigure(0, weight=0)
         bar.grid_columnconfigure(1, weight=1)
@@ -94,12 +102,20 @@ class AudioBarWindow(ctk.CTkToplevel):
             bar,
             text="◀",
             width=16,
-            fg_color=tokens.get("button_fg"),
+            fg_color=style.accent_soft,
+            hover_color=style.accent_hover,
+            corner_radius=style.button_radius,
             command=self._toggle_collapsed,
         )
         self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")
 
-        content = ctk.CTkFrame(bar, corner_radius=0, fg_color=tokens.get("panel_alt_bg"))
+        content = ctk.CTkFrame(
+            bar,
+            corner_radius=12,
+            fg_color=style.content_bg,
+            border_width=1,
+            border_color=style.panel_border,
+        )
         self._content_grid_options = {"row": 0, "column": 1, "padx": 0, "pady": 0, "sticky": "nsew"}
         content.grid(**self._content_grid_options)
         for column in range(10):
@@ -114,9 +130,9 @@ class AudioBarWindow(ctk.CTkToplevel):
             content,
             text="DISCOVER",
             font=("Segoe UI", 10, "bold"),
-            corner_radius=8,
-            fg_color=tokens.get("sidebar_active_bg"),
-            text_color=tokens.get("sidebar_active_fg"),
+            corner_radius=style.pill_radius,
+            fg_color=style.badge_fg,
+            text_color=style.badge_text,
             padx=10,
             pady=2,
         )
@@ -126,9 +142,9 @@ class AudioBarWindow(ctk.CTkToplevel):
             content,
             text="PLAYBACK",
             font=("Segoe UI", 10, "bold"),
-            corner_radius=8,
-            fg_color=tokens.get("sidebar_hover_bg"),
-            text_color=tokens.get("text_primary"),
+            corner_radius=style.pill_radius,
+            fg_color=style.accent_soft,
+            text_color=style.badge_text,
             padx=10,
             pady=2,
         )
@@ -200,13 +216,15 @@ class AudioBarWindow(ctk.CTkToplevel):
 
         self.prev_button = ctk.CTkButton(
             content, text="Prev", command=self._on_prev_clicked, width=70,
-            fg_color=tokens.get("accent_button_fg"), hover_color=tokens.get("accent_button_hover")
+            fg_color=style.accent_soft, hover_color=style.accent_hover, text_color=style.button_text,
+            corner_radius=style.button_radius,
         )
         self.prev_button.grid(row=1, column=6, padx=4, pady=(0, 6), sticky="ew")
 
         self.play_button = ctk.CTkButton(
             content, text="Play", command=self._on_play_clicked, width=70,
-            fg_color=tokens.get("accent_button_fg"), hover_color=tokens.get("accent_button_hover")
+            fg_color=style.accent_strong, hover_color=style.accent_hover, text_color=style.button_text,
+            corner_radius=style.button_radius,
         )
         self.play_button.grid(row=1, column=7, padx=4, pady=(0, 6), sticky="ew")
 
@@ -215,13 +233,15 @@ class AudioBarWindow(ctk.CTkToplevel):
 
         self.stop_button = ctk.CTkButton(
             content, text="Stop", command=self._on_stop_clicked, width=70,
-            fg_color=tokens.get("accent_button_fg"), hover_color=tokens.get("accent_button_hover")
+            fg_color=style.accent_soft, hover_color=style.accent_hover, text_color=style.button_text,
+            corner_radius=style.button_radius,
         )
         self.stop_button.grid(row=1, column=8, padx=4, pady=(0, 6), sticky="ew")
 
         self.next_button = ctk.CTkButton(
             content, text="Next", command=self._on_next_clicked, width=70,
-            fg_color=tokens.get("accent_button_fg"), hover_color=tokens.get("accent_button_hover")
+            fg_color=style.accent_soft, hover_color=style.accent_hover, text_color=style.button_text,
+            corner_radius=style.button_radius,
         )
         self.next_button.grid(row=1, column=9, padx=4, pady=(0, 6), sticky="ew")
 

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 
 import customtkinter as ctk
 from modules.helpers import theme_manager
+from modules.ui.styles.compact_bar_style import build_compact_bar_style
 
 from modules.dice import dice_engine
 from modules.dice import dice_preferences
@@ -108,7 +109,14 @@ class DiceBarWindow(ctk.CTkToplevel):
         self.grid_columnconfigure(0, weight=1)
 
         tokens = theme_manager.get_tokens()
-        bar = ctk.CTkFrame(self, corner_radius=0, fg_color=tokens.get("panel_bg"))
+        style = build_compact_bar_style(tokens)
+        bar = ctk.CTkFrame(
+            self,
+            corner_radius=14,
+            fg_color=style.shell_bg,
+            border_width=style.border_width,
+            border_color=style.panel_border,
+        )
         bar.grid(row=0, column=0, sticky="nsew", padx=8, pady=4)
         bar.grid_columnconfigure(0, weight=0)
         bar.grid_columnconfigure(1, weight=1)
@@ -121,13 +129,21 @@ class DiceBarWindow(ctk.CTkToplevel):
             bar,
             text="◀",
             width=16,
-            fg_color=tokens.get("button_fg"),
+            fg_color=style.accent_soft,
+            hover_color=style.accent_hover,
+            corner_radius=style.button_radius,
             command=self._toggle_collapsed,
         )
         collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")
         self._collapse_button = collapse_button
 
-        content = ctk.CTkFrame(bar, corner_radius=0, fg_color=tokens.get("panel_alt_bg"))
+        content = ctk.CTkFrame(
+            bar,
+            corner_radius=12,
+            fg_color=style.content_bg,
+            border_width=1,
+            border_color=style.panel_border,
+        )
         self._content_grid_options = {"row": 0, "column": 1, "padx": 0, "pady": 0, "sticky": "nsew"}
         content.grid(**self._content_grid_options)
         for column in range(8):
@@ -142,9 +158,9 @@ class DiceBarWindow(ctk.CTkToplevel):
             content,
             text="ROLL BUILDER",
             font=("Segoe UI", 10, "bold"),
-            corner_radius=8,
-            fg_color=tokens.get("sidebar_active_bg"),
-            text_color=tokens.get("sidebar_active_fg"),
+            corner_radius=style.pill_radius,
+            fg_color=style.badge_fg,
+            text_color=style.badge_text,
             padx=10,
             pady=2,
         )
@@ -154,9 +170,9 @@ class DiceBarWindow(ctk.CTkToplevel):
             content,
             text="RESULT",
             font=("Segoe UI", 10, "bold"),
-            corner_radius=8,
-            fg_color=tokens.get("sidebar_hover_bg"),
-            text_color=tokens.get("text_primary"),
+            corner_radius=style.pill_radius,
+            fg_color=style.accent_soft,
+            text_color=style.badge_text,
             padx=10,
             pady=2,
         )
@@ -189,8 +205,10 @@ class DiceBarWindow(ctk.CTkToplevel):
             width=80,
             height=32,
             command=self.roll,
-            fg_color="#2fa572",
-            hover_color="#23865a",
+            fg_color=style.accent_strong,
+            hover_color=style.accent_hover,
+            text_color=style.button_text,
+            corner_radius=style.button_radius,
             font=("Segoe UI", 14, "bold"),
         )
         roll_button.grid(row=0, column=3, padx=4, pady=4, sticky="new")
@@ -201,6 +219,10 @@ class DiceBarWindow(ctk.CTkToplevel):
             width=70,
             height=32,
             command=self._clear_formula,
+            fg_color=style.accent_soft,
+            hover_color=style.accent_hover,
+            text_color=style.button_text,
+            corner_radius=style.button_radius,
         )
         clear_button.grid(row=0, column=4, padx=4, pady=4, sticky="new")
 
@@ -208,7 +230,13 @@ class DiceBarWindow(ctk.CTkToplevel):
         preset_frame.grid(row=0, column=5, padx=(6, 4), pady=4, sticky="nw")
         self._preset_frame = preset_frame
 
-        result_frame = ctk.CTkFrame(content, corner_radius=10, fg_color=tokens.get("panel_alt_bg"))
+        result_frame = ctk.CTkFrame(
+            content,
+            corner_radius=12,
+            fg_color=style.content_bg,
+            border_width=1,
+            border_color=style.panel_border,
+        )
         result_frame.grid(row=1, column=0, columnspan=7, padx=(8, 8), pady=(0, 8), sticky="new")
         result_frame.grid_columnconfigure(0, weight=1)
         result_frame.grid_columnconfigure(1, weight=0)

--- a/modules/ui/styles/compact_bar_style.py
+++ b/modules/ui/styles/compact_bar_style.py
@@ -1,0 +1,41 @@
+"""Shared visual styles for compact floating bars (dice/audio)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CompactBarStyle:
+    """Palette and sizing tokens for compact bars."""
+
+    shell_bg: str
+    content_bg: str
+    panel_border: str
+    accent_soft: str
+    accent_strong: str
+    accent_hover: str
+    badge_fg: str
+    badge_text: str
+    button_text: str
+    pill_radius: int = 12
+    button_radius: int = 10
+    border_width: int = 1
+
+
+def build_compact_bar_style(tokens: dict) -> CompactBarStyle:
+    """Build a vivid style from the current theme tokens."""
+    accent = tokens.get("button_fg") or "#11a054"
+    accent_hover = tokens.get("button_hover") or "#0d7b40"
+    badge_text = tokens.get("sidebar_active_fg") or "#ecfff5"
+    return CompactBarStyle(
+        shell_bg=tokens.get("panel_bg") or "#0f1a12",
+        content_bg=tokens.get("panel_alt_bg") or "#13261a",
+        panel_border="#2ecf8b",
+        accent_soft="#1a6f47",
+        accent_strong=accent,
+        accent_hover=accent_hover,
+        badge_fg="#0f5133",
+        badge_text=badge_text,
+        button_text="#ecfff5",
+    )


### PR DESCRIPTION
### Motivation
- Provide a single, reusable visual language for always-on-top compact bars so dice and audio UIs look consistent and easier to evolve. 
- Make the dice and audio compact bars visually cooler with rounded shells, pill badges, and stronger action affordances for a modern, premium feel. 
- Keep styling logic separate to respect the requested subdirectory/file organization and simplify future tweaks. 

### Description
- Added a new shared style dataclass and builder at `modules/ui/styles/compact_bar_style.py` providing palette and sizing tokens for compact bars. 
- Updated `modules/dice/dice_bar_window.py` to consume the shared style and apply rounded shell/content frames, bordered panels, pill labels, and styled buttons. 
- Updated `modules/audio/audio_bar_window.py` to use the same style tokens and apply matching rounded/bordered container, pill labels, and consistent transport button styling. 

### Testing
- Ran `python -m compileall modules/ui/styles/compact_bar_style.py modules/dice/dice_bar_window.py modules/audio/audio_bar_window.py` which succeeded. 
- Ran `pytest -q` which failed during test collection due to unrelated environment/test-collection issues (missing/stubbed UI libs and test import collisions) rather than errors from these UI changes. 
- Static runtime checks (module import/compile) for the modified files passed locally in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ec76b32c832bb292cbd7ebc98ffd)