### PR TITLE
Guard AudioBarWindow UI updates after teardown to prevent TclError

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -346,6 +346,8 @@ class AudioBarWindow(ctk.CTkToplevel):
 
     def _dispatch_controller_event(self, section: str, event: str, payload: Dict[str, Any]) -> None:
         """Internal helper for dispatch controller event."""
+        if not self._ui_ready_for_updates():
+            return
         try:
             self.after(0, self._handle_controller_event, section, event, payload)
         except Exception as exc:  # pragma: no cover - defensive
@@ -356,6 +358,8 @@ class AudioBarWindow(ctk.CTkToplevel):
 
     def _handle_controller_event(self, section: str, event: str, payload: Dict[str, Any]) -> None:
         """Internal helper for handle controller event."""
+        if not self._ui_ready_for_updates():
+            return
         if section != self._active_section:
             return
 
@@ -659,6 +663,8 @@ class AudioBarWindow(ctk.CTkToplevel):
     # ------------------------------------------------------------------
     def _refresh_from_state(self, section: Optional[str] = None) -> None:
         """Refresh from state."""
+        if not self._ui_ready_for_updates():
+            return
         section = section or self._active_section
         state = self.controller.get_state(section)
         self._refresh_filter_menus(state)
@@ -712,6 +718,8 @@ class AudioBarWindow(ctk.CTkToplevel):
 
     def _refresh_filter_menus(self, state: Optional[Dict[str, Any]]) -> None:
         """Refresh filter menus."""
+        if not self._ui_ready_for_updates():
+            return
         library = getattr(self.controller, "library", None)
         if library is None:
             return
@@ -1047,6 +1055,25 @@ class AudioBarWindow(ctk.CTkToplevel):
         """Handle destroy event."""
         if event.widget is self:
             self._detach_controller_listener()
+
+    def _ui_ready_for_updates(self) -> bool:
+        """Return whether widgets still exist and can be safely updated."""
+        try:
+            if not self.winfo_exists():
+                return False
+        except tk.TclError:
+            return False
+
+        for widget_name in ("category_menu", "mood_menu", "now_playing_menu", "search_results_menu"):
+            widget = getattr(self, widget_name, None)
+            if widget is None:
+                return False
+            try:
+                if not widget.winfo_exists():
+                    return False
+            except tk.TclError:
+                return False
+        return True
 
     def _on_close(self) -> None:
         """Handle close."""


### PR DESCRIPTION
### Motivation
- Prevent crashes when controller callbacks run after the `AudioBarWindow` (or its option-menu widgets) has been destroyed, which triggered `_tkinter.TclError: invalid command name "...dropdownmenu"` during dropdown reconfiguration.

### Description
- Add a `_ui_ready_for_updates()` helper that verifies `winfo_exists()` for the toplevel and critical dropdown widgets and safely handles `tk.TclError`.
- Short-circuit controller callback scheduling and handling by returning early in ` _dispatch_controller_event` and `_handle_controller_event` when the UI is not ready.
- Short-circuit state/menu refresh paths by returning early in `_refresh_from_state` and `_refresh_filter_menus` to avoid mutating destroyed widgets.
- All changes are localized to `modules/audio/audio_bar_window.py`.

### Testing
- Ran `python -m compileall modules/audio/audio_bar_window.py`, which succeeded.
- Ran `pytest -q`, which aborted during global test collection due to unrelated environment/import issues (several modules failing to import/mocked UI backends); these failures are not caused by this localized UI lifecycle guard.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1075f9a0c832b8069af51d73efc5a)