### PR TITLE
Fix clipped PLAYBACK pill in audio bar header

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -148,7 +148,7 @@ class AudioBarWindow(ctk.CTkToplevel):
             padx=10,
             pady=2,
         )
-        playback_pill.grid(row=0, column=6, columnspan=3, padx=(16, 4), pady=4, sticky="w")
+        playback_pill.grid(row=0, column=6, padx=(16, 8), pady=4, sticky="w")
 
         self.section_toggle_button = ctk.CTkButton(
             content,


### PR DESCRIPTION
### Motivation
- The `PLAYBACK` pill in the audio bar header was spanning into the checkbox area and appearing cut off, so the layout needed a small adjustment to prevent overlap with the `Continue`/`Loop`/`Shuffle` controls.

### Description
- Adjusted the header pill layout in `modules/audio/audio_bar_window.py` by removing `columnspan=3` and tightening the right padding to place the `PLAYBACK` pill solely in its own column (`playback_pill.grid(row=0, column=6, padx=(16, 8), pady=4, sticky="w")`).

### Testing
- Ran `python -m compileall modules/audio/audio_bar_window.py` and the file compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10b21c998832b85fb9a35cb51c15e)