### PR TITLE
Polish collapsed audio/dice bar toggle icon rendering

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -101,13 +101,15 @@ class AudioBarWindow(ctk.CTkToplevel):
         self._collapse_button = ctk.CTkButton(
             bar,
             text="◀",
-            width=16,
+            width=28,
+            height=28,
             fg_color=style.accent_soft,
             hover_color=style.accent_hover,
             corner_radius=style.button_radius,
+            font=("Segoe UI Symbol", 14, "bold"),
             command=self._toggle_collapsed,
         )
-        self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")
+        self._collapse_button.grid(row=0, column=0, padx=(6, 8), pady=6, sticky="nsw")
 
         content = ctk.CTkFrame(
             bar,

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -128,13 +128,15 @@ class DiceBarWindow(ctk.CTkToplevel):
         collapse_button = ctk.CTkButton(
             bar,
             text="◀",
-            width=16,
+            width=28,
+            height=28,
             fg_color=style.accent_soft,
             hover_color=style.accent_hover,
             corner_radius=style.button_radius,
+            font=("Segoe UI Symbol", 14, "bold"),
             command=self._toggle_collapsed,
         )
-        collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")
+        collapse_button.grid(row=0, column=0, padx=(6, 8), pady=6, sticky="nsw")
         self._collapse_button = collapse_button
 
         content = ctk.CTkFrame(


### PR DESCRIPTION
### Motivation
- The audio and dice compact bars showed clipped or poorly rendered arrow glyphs when collapsed, producing an untidy appearance that needed visual polish.

### Description
- Increased the collapse button size in `modules/audio/audio_bar_window.py` and `modules/dice/dice_bar_window.py` by setting `width=28` and `height=28` so the arrow glyph is not clipped.
- Applied an explicit symbol-friendly font `("Segoe UI Symbol", 14, "bold")` to the collapse buttons to improve glyph legibility and consistency across platforms.
- Adjusted the collapse button grid padding to `padx=(6, 8), pady=6` to keep the control visually balanced in compact mode.

### Testing
- Ran `python -m compileall modules/audio/audio_bar_window.py modules/dice/dice_bar_window.py` and the modules compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10c553fc8832ba758eb1415e42fb7)