### PR TITLE
Fix collapsed audio/dice bar toggle glyph rendering

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -100,13 +100,13 @@ class AudioBarWindow(ctk.CTkToplevel):
 
         self._collapse_button = ctk.CTkButton(
             bar,
-            text="◀",
+            text="<",
             width=28,
             height=28,
             fg_color=style.accent_soft,
             hover_color=style.accent_hover,
             corner_radius=style.button_radius,
-            font=("Segoe UI Symbol", 14, "bold"),
+            font=("Segoe UI", 14, "bold"),
             command=self._toggle_collapsed,
         )
         self._collapse_button.grid(row=0, column=0, padx=(6, 8), pady=6, sticky="nsw")
@@ -1034,9 +1034,9 @@ class AudioBarWindow(ctk.CTkToplevel):
         if not self._collapse_button:
             return
         if self._is_collapsed:
-            self._collapse_button.configure(text="▶")
+            self._collapse_button.configure(text=">")
         else:
-            self._collapse_button.configure(text="◀")
+            self._collapse_button.configure(text="<")
 
     # ------------------------------------------------------------------
     # Window helpers

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -127,13 +127,13 @@ class DiceBarWindow(ctk.CTkToplevel):
 
         collapse_button = ctk.CTkButton(
             bar,
-            text="◀",
+            text="<",
             width=28,
             height=28,
             fg_color=style.accent_soft,
             hover_color=style.accent_hover,
             corner_radius=style.button_radius,
-            font=("Segoe UI Symbol", 14, "bold"),
+            font=("Segoe UI", 14, "bold"),
             command=self._toggle_collapsed,
         )
         collapse_button.grid(row=0, column=0, padx=(6, 8), pady=6, sticky="nsw")
@@ -609,7 +609,7 @@ class DiceBarWindow(ctk.CTkToplevel):
         """Update collapse button."""
         if self._collapse_button is None:
             return
-        self._collapse_button.configure(text="▶" if self._is_collapsed else "◀")
+        self._collapse_button.configure(text=">" if self._is_collapsed else "<")
 
     def _on_drag_start(self, event: tk.Event) -> None:
         """Handle drag start."""


### PR DESCRIPTION
### Motivation
- The previous change introduced Unicode triangle glyphs and `Segoe UI Symbol` which caused symbol fallback rendering (boxed/missing glyphs) on some systems. 
- The collapse toggle must render consistently across platforms and fonts to avoid the broken icon shown in the screenshot. 
- Use a simple, widely-supported character and a stable font to eliminate visual fallback issues.

### Description
- Replace the Unicode triangle glyphs (`◀` / `▶`) with ASCII chevrons (`<` / `>`) for the collapse toggle in `modules/audio/audio_bar_window.py` and `modules/dice/dice_bar_window.py`.
- Change the collapse button font from `("Segoe UI Symbol", 14, "bold")` to `("Segoe UI", 14, "bold")` to avoid symbol fallback rendering.
- Update all related `configure(... text=...)` calls and conditional logic to use the new ASCII glyphs so the toggle updates correctly when collapsed/expanded.

### Testing
- Compiled the modified modules with `python -m compileall modules/audio/audio_bar_window.py modules/dice/dice_bar_window.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10d22e7c0832baeb13e97b6547f85)