### PR TITLE
Fix sidebar icon button sizing regression

### DIFF
--- a/modules/ui/icon_button.py
+++ b/modules/ui/icon_button.py
@@ -10,19 +10,18 @@ log_module_import(__name__)
 
 def create_icon_button(parent, icon, tooltip_text, command):
     """Create icon button."""
-    container = tk.Frame(parent, bg="#2B2B2B")
+    tokens = theme_manager.get_tokens()
+    container = tk.Frame(parent, bg=tokens.get("sidebar_header_bg", "#2B2B2B"))
 
     has_icon = icon is not None
     if has_icon:
         display_text = ""
-        width = 10
-        height = 10
+        width = 64
+        height = 64
     else:
         display_text = tooltip_text if len(tooltip_text) <= 18 else tooltip_text[:17] + "..."
         width = 160
         height = 48
-
-    tokens = theme_manager.get_tokens()
 
     btn = ctk.CTkButton(
         container,
@@ -50,4 +49,3 @@ def create_icon_button(parent, icon, tooltip_text, command):
     container.button = btn
     ToolTip(btn, tooltip_text)
     return container
-


### PR DESCRIPTION
### Motivation
- Restore readable icon-only buttons in the sidebar and make the button container respect theme tokens after a recent UI regression.

### Description
- Modify `modules/ui/icon_button.py` in `create_icon_button` to fetch `tokens = theme_manager.get_tokens()`, use `tokens.get("sidebar_header_bg", "#2B2B2B")` for the container background, restore icon-only button dimensions to `width=64` and `height=64`, and remove the redundant token lookup.

### Testing
- Ran `python -m pytest tests/test_campaign_presets.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f119119ffc832ba07963729f7e294e)