### PR TITLE
Remove border around compact bar expand/collapse buttons

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -104,6 +104,7 @@ class AudioBarWindow(ctk.CTkToplevel):
             width=16,
             fg_color=style.accent_soft,
             hover_color=style.accent_hover,
+            border_width=0,
             corner_radius=style.button_radius,
             command=self._toggle_collapsed,
         )

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -131,6 +131,7 @@ class DiceBarWindow(ctk.CTkToplevel):
             width=16,
             fg_color=style.accent_soft,
             hover_color=style.accent_hover,
+            border_width=0,
             corner_radius=style.button_radius,
             command=self._toggle_collapsed,
         )


### PR DESCRIPTION
### Motivation
- Remove the visible square border around the expand/collapse control in the compact audio and dice bars so the buttons match the rounded, borderless appearance shown in the screenshot.

### Description
- Set `border_width=0` on the collapse/expand `CTkButton` in `modules/audio/audio_bar_window.py` and `modules/dice/dice_bar_window.py` to remove the button border.

### Testing
- Ran `python -m py_compile modules/audio/audio_bar_window.py modules/dice/dice_bar_window.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11c5372bc832bbd120cc6c66728ea)