### PR TITLE
Remove oval styling from audio and dice bar expand buttons

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -102,9 +102,10 @@ class AudioBarWindow(ctk.CTkToplevel):
             bar,
             text="◀",
             width=16,
-            fg_color=style.accent_soft,
+            fg_color="transparent",
             hover_color=style.accent_hover,
-            corner_radius=style.button_radius,
+            corner_radius=0,
+            border_width=0,
             command=self._toggle_collapsed,
         )
         self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -129,9 +129,10 @@ class DiceBarWindow(ctk.CTkToplevel):
             bar,
             text="◀",
             width=16,
-            fg_color=style.accent_soft,
+            fg_color="transparent",
             hover_color=style.accent_hover,
-            corner_radius=style.button_radius,
+            corner_radius=0,
+            border_width=0,
             command=self._toggle_collapsed,
         )
         collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")


### PR DESCRIPTION
### Motivation
- Remove the visible oval/shaped background around the expand/collapse buttons in the audio and dice bars so the arrow icon appears on a flat, transparent control as requested.

### Description
- Updated the expand/collapse button styling in `modules/audio/audio_bar_window.py` and `modules/dice/dice_bar_window.py` by setting `fg_color="transparent"`, `corner_radius=0`, and `border_width=0` while preserving `hover_color` and the existing `command` behavior.

### Testing
- Compiled the modified files with `python -m py_compile modules/audio/audio_bar_window.py modules/dice/dice_bar_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11d0b6a90832b88af8ba884e06ba3)