### PR TITLE
Clamp collapsed dice/audio bar geometry minimums

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -18,6 +18,9 @@ from modules.helpers.logging_helper import log_exception, log_module_import
 
 log_module_import(__name__)
 
+COLLAPSED_WIDTH_FLOOR = 56
+COLLAPSED_HEIGHT_FLOOR = 40
+
 
 class AudioBarWindow(ctk.CTkToplevel):
     """Light-weight controller that mirrors the shared audio state."""
@@ -991,12 +994,16 @@ class AudioBarWindow(ctk.CTkToplevel):
             self.update_idletasks()
             if self._is_collapsed:
                 target = self._collapse_button or self
-                width = max(40, int(target.winfo_reqwidth() + 8))
+                button_width = int(target.winfo_reqwidth() or 0)
+                bar_border = int((self._bar_frame.cget("border_width") if self._bar_frame is not None else 0) or 0)
+                horizontal_padding = 8
+                width = max(COLLAPSED_WIDTH_FLOOR, button_width + horizontal_padding + (bar_border * 2))
                 height_source = target
             else:
                 width = self.winfo_screenwidth()
                 height_source = self._bar_frame or self
-            height = max(36, int((height_source.winfo_reqheight() if height_source else 36) + 16))
+            collapsed_floor = COLLAPSED_HEIGHT_FLOOR if self._is_collapsed else 36
+            height = max(collapsed_floor, int((height_source.winfo_reqheight() if height_source else 36) + 16))
             y = self.winfo_screenheight() - height
             self.geometry(f"{width}x{height}+0+{max(0, y)}")
             dice_window = getattr(self.master, "dice_bar_window", None)

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -18,6 +18,8 @@ log_module_import(__name__)
 
 INTER_BAR_GAP = 0
 HEIGHT_PADDING = 10
+COLLAPSED_WIDTH_FLOOR = 56
+COLLAPSED_HEIGHT_FLOOR = 40
 
 
 @dataclass(frozen=True)
@@ -518,7 +520,10 @@ class DiceBarWindow(ctk.CTkToplevel):
             if self._is_collapsed:
                 # Continue with this path when is collapsed is set.
                 target = self._collapse_button or self
-                width = max(40, int(target.winfo_reqwidth() + 8))
+                button_width = int(target.winfo_reqwidth() or 0)
+                bar_border = int((self._bar_frame.cget("border_width") if self._bar_frame is not None else 0) or 0)
+                horizontal_padding = 8
+                width = max(COLLAPSED_WIDTH_FLOOR, button_width + horizontal_padding + (bar_border * 2))
                 height_source = target
                 if self._collapsed_height_hint is None and height_source is not None:
                     # Handle the branch where collapsed height hint is missing and height source is available.
@@ -545,7 +550,8 @@ class DiceBarWindow(ctk.CTkToplevel):
                 base_height = self._expanded_height_hint
             if not base_height:
                 base_height = height_source.winfo_reqheight() if height_source else 36
-            height = max(36, int(base_height + HEIGHT_PADDING))
+            collapsed_floor = COLLAPSED_HEIGHT_FLOOR if self._is_collapsed else 36
+            height = max(collapsed_floor, int(base_height + HEIGHT_PADDING))
             screen_height = self.winfo_screenheight()
             y = screen_height - height
 


### PR DESCRIPTION
### Motivation
- Prevent the compact (collapsed) dice and audio bars from becoming too small such that the collapse glyph baseline or paddings are clipped. 
- Preserve the existing dynamic sizing behavior (derive size from the collapse button) while enforcing a safer minimum. 
- Keep current bottom-anchoring and inter-bar stacking behavior so companion bar geometry still updates.

### Description
- Added `COLLAPSED_WIDTH_FLOOR` and `COLLAPSED_HEIGHT_FLOOR` constants and applied them in `DiceBarWindow._apply_geometry` and `AudioBarWindow._apply_geometry`.
- For collapsed width, continue to derive size from the collapse button (`winfo_reqwidth()`), add known horizontal padding and frame border, then `max()` with the hard floor to clamp the result.
- For collapsed height, clamp computed height with a larger minimum when `_is_collapsed` is true so the glyph baseline and top/bottom paddings remain visible.
- Changes applied to `modules/dice/dice_bar_window.py` and `modules/audio/audio_bar_window.py` while preserving bottom positioning and the companion bar geometry update calls.

### Testing
- Compiled the modified modules with `python -m compileall modules/dice/dice_bar_window.py modules/audio/audio_bar_window.py` and compilation completed successfully with no syntax errors. 
- No automated UI/unit tests were run in this rollout; manual verification is recommended on multiple themes/screen-DPI settings to confirm visual spacing and stacking behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19fb7a780832bbe7c143755b8df28)