### PR TITLE
Set explicit sizing and font for collapse glyph in audio and dice bar windows

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -104,7 +104,9 @@ class AudioBarWindow(ctk.CTkToplevel):
         self._collapse_button = ctk.CTkButton(
             bar,
             text="◀",
-            width=16,
+            width=30,
+            height=26,
+            font=("Segoe UI Symbol", 16),
             fg_color="transparent",
             hover_color=style.accent_hover,
             corner_radius=0,

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -130,7 +130,9 @@ class DiceBarWindow(ctk.CTkToplevel):
         collapse_button = ctk.CTkButton(
             bar,
             text="◀",
-            width=16,
+            width=30,
+            height=26,
+            font=("Segoe UI Symbol", 16),
             fg_color="transparent",
             hover_color=style.accent_hover,
             corner_radius=0,


### PR DESCRIPTION
### Motivation
- Ensure the collapse glyphs (`◀` / `▶`) render predictably and without clipping at 100% and high‑DPI scaling by using explicit icon-friendly dimensions and a predictable symbol font.

### Description
- Updated the collapse button in `modules/audio/audio_bar_window.py` and `modules/dice/dice_bar_window.py` to use `width=30`, `height=26`, and `font=("Segoe UI Symbol", 16)` while preserving `fg_color="transparent"` and the existing `hover_color` and toggle behavior.

### Testing
- Ran an automated search to verify the edits with `rg -n 'text="◀"|width=30|height=26|Segoe UI Symbol'` which found the updated declarations; runtime visual verification on a display (100% and high‑DPI) is required locally to confirm no clipping of `◀` / `▶`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a085e3dc832b9ef2bc10d4ec0f96)