### PR TITLE
fix(ui): center collapse icon in audio and dice bars

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -106,14 +106,15 @@ class AudioBarWindow(ctk.CTkToplevel):
             text="◀",
             width=30,
             height=26,
-            font=("Segoe UI Symbol", 16),
+            font=("Segoe UI Symbol", 15),
+            anchor="center",
             fg_color="transparent",
             hover_color=style.accent_hover,
             corner_radius=0,
             border_width=0,
             command=self._toggle_collapsed,
         )
-        self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")
+        self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=(3, 3), sticky="nsw")
 
         content = ctk.CTkFrame(
             bar,

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -132,14 +132,15 @@ class DiceBarWindow(ctk.CTkToplevel):
             text="◀",
             width=30,
             height=26,
-            font=("Segoe UI Symbol", 16),
+            font=("Segoe UI Symbol", 15),
+            anchor="center",
             fg_color="transparent",
             hover_color=style.accent_hover,
             corner_radius=0,
             border_width=0,
             command=self._toggle_collapsed,
         )
-        collapse_button.grid(row=0, column=0, padx=(4, 6), pady=4, sticky="nsw")
+        collapse_button.grid(row=0, column=0, padx=(4, 6), pady=(3, 3), sticky="nsw")
         self._collapse_button = collapse_button
 
         content = ctk.CTkFrame(


### PR DESCRIPTION
### Motivation
- The collapse/expand chevron in the compact audio and dice bars was visually off-center vertically, so the control needed small layout/touch-ups for consistent alignment.

### Description
- Adjusted the collapse button in `modules/dice/dice_bar_window.py` and `modules/audio/audio_bar_window.py` by reducing the symbol font size, adding `anchor="center"`, and tuning the top/bottom padding to better vertically center the chevron.

### Testing
- Ran `python -m py_compile modules/dice/dice_bar_window.py modules/audio/audio_bar_window.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a294891c832b91c96310d553bc0e)