### PR TITLE
Fix GM table minimized tray spacing when hidden

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -55,6 +55,9 @@ PANEL_MARGIN = 12
 PANEL_GUTTER = 12
 PANEL_SNAP_THRESHOLD = 48
 PANEL_RESIZE_HITBOX = 10
+TRAY_VISIBLE_PADY = (0, 18)
+SURFACE_PADY_WITH_TRAY = (0, 10)
+SURFACE_PADY_NO_TRAY = 0
 CAMERA_MIN_ZOOM = 0.5
 CAMERA_MAX_ZOOM = 1.75
 CAMERA_ZOOM_STEP = 0.15
@@ -1090,7 +1093,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             border_width=1,
             border_color=TABLE_PALETTE["table_line"],
         )
-        self.surface.grid(row=0, column=0, sticky="nsew", padx=18, pady=(0, 10))
+        self.surface.grid(row=0, column=0, sticky="nsew", padx=18, pady=SURFACE_PADY_WITH_TRAY)
         self.surface.bind("<Configure>", self._on_surface_configure, add="+")
 
         self._desk_texture_canvas = tk.Canvas(
@@ -1181,7 +1184,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             border_width=1,
             border_color=TABLE_PALETTE["table_line"],
         )
-        self.tray.grid(row=1, column=0, sticky="ew", padx=18, pady=(0, 18))
+        self.tray.grid(row=1, column=0, sticky="ew", padx=18)
         self.tray.grid_columnconfigure(1, weight=1)
 
         self.tray_label = ctk.CTkLabel(
@@ -1257,9 +1260,12 @@ class GMTableWorkspace(ctk.CTkFrame):
             child.destroy()
         minimized_ids = self._minimized_panel_ids()
         if not minimized_ids:
+            self.surface.grid_configure(pady=SURFACE_PADY_NO_TRAY)
             tray.grid_remove()
             return
+        self.surface.grid_configure(pady=SURFACE_PADY_WITH_TRAY)
         tray.grid()
+        tray.grid_configure(pady=TRAY_VISIBLE_PADY)
         for panel_id in minimized_ids:
             definition = self._definitions.get(panel_id)
             if definition is None:


### PR DESCRIPTION
### Motivation
- Prevent the GM Table from reserving a persistent bottom band when no panels are minimized by moving tray-related bottom spacing into state-driven logic. 
- Ensure `surface` fills the available height when `minimized_ids` is empty so no horizontal gray strip remains at the window bottom. 
- Keep all changes local to the GM Table workspace so other windows and docks are unaffected.

### Description
- Introduced GM Table-local constants `TRAY_VISIBLE_PADY`, `SURFACE_PADY_WITH_TRAY`, and `SURFACE_PADY_NO_TRAY` to control bottom padding explicitly. 
- Replaced the static `pady` on `self.surface.grid(...)` and `self.tray.grid(...)` with `SURFACE_PADY_WITH_TRAY` and moved the tray's outer `pady` into conditional configuration. 
- Updated `_refresh_minimized_tray` to call `self.surface.grid_configure(pady=...)` so the surface bottom padding is removed when `minimized_ids` is empty and applied when the tray is visible, while preserving `tray.grid_remove()` and the existing restore-button creation logic. 
- Limited edits to `modules/scenarios/gm_table/workspace.py` and only adjusted GM Table-local layout constants so other UI areas remain unchanged.

### Testing
- Verified that `python -m py_compile modules/scenarios/gm_table/workspace.py` succeeds. 
- Confirmed the new logic preserves tray visibility and restore-button behavior when minimized panels exist. 
- Inspected the module diff to ensure only GM Table workspace changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ad766d24832b92c747995085d0c1)