### PR TITLE
Adjust audio bar expand button vertical position

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -114,7 +114,7 @@ class AudioBarWindow(ctk.CTkToplevel):
             border_width=0,
             command=self._toggle_collapsed,
         )
-        self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=(3, 3), sticky="nsw")
+        self._collapse_button.grid(row=0, column=0, padx=(4, 6), pady=(1, 3), sticky="nsw")
 
         content = ctk.CTkFrame(
             bar,


### PR DESCRIPTION
### Motivation
- Improve the visual alignment of the audio bar's collapse/expand control by nudging the button upward for better centering within the compact bar.

### Description
- Reduced the top grid padding for the collapse/expand button in `modules/audio/audio_bar_window.py` by changing `pady=(3, 3)` to `pady=(1, 3)`, moving the button up a small amount without altering behavior.

### Testing
- Compiled the module with `python -m py_compile modules/audio/audio_bar_window.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae5f5440832b9a51a4fb811bd8be)