### PR TITLE
Adjust collapsed audio bar button vertical offset

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -20,6 +20,7 @@ log_module_import(__name__)
 
 COLLAPSED_WIDTH_FLOOR = 56
 COLLAPSED_HEIGHT_FLOOR = 40
+COLLAPSED_Y_OFFSET = 8
 
 
 class AudioBarWindow(ctk.CTkToplevel):
@@ -1008,6 +1009,8 @@ class AudioBarWindow(ctk.CTkToplevel):
             collapsed_floor = COLLAPSED_HEIGHT_FLOOR if self._is_collapsed else 36
             height = max(collapsed_floor, int((height_source.winfo_reqheight() if height_source else 36) + 16))
             y = self.winfo_screenheight() - height
+            if self._is_collapsed:
+                y -= COLLAPSED_Y_OFFSET
             self.geometry(f"{width}x{height}+0+{max(0, y)}")
             dice_window = getattr(self.master, "dice_bar_window", None)
             if dice_window is not None and dice_window.winfo_exists():


### PR DESCRIPTION
### Motivation

- Move the audio bar's collapsed expand button (and its outer oval shell) slightly upward so the control sits better on screen when collapsed.

### Description

- Added a `COLLAPSED_Y_OFFSET` constant and apply it in `AudioBarWindow._apply_geometry` so the vertical offset is applied only when `self._is_collapsed` is true.

### Testing

- Ran `python -m py_compile modules/audio/audio_bar_window.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1af2ff404832b956b1751e1911175)