### PR TITLE
Adjust collapsed geometry sizing for dice and audio bars

### DIFF
--- a/modules/audio/audio_bar_window.py
+++ b/modules/audio/audio_bar_window.py
@@ -998,16 +998,42 @@ class AudioBarWindow(ctk.CTkToplevel):
             self.update_idletasks()
             if self._is_collapsed:
                 target = self._collapse_button or self
+                bar_frame = self._bar_frame or self
                 button_width = int(target.winfo_reqwidth() or 0)
                 bar_border = int((self._bar_frame.cget("border_width") if self._bar_frame is not None else 0) or 0)
                 horizontal_padding = 8
                 width = max(COLLAPSED_WIDTH_FLOOR, button_width + horizontal_padding + (bar_border * 2))
-                height_source = target
+
+                grid_info = target.grid_info() if self._collapse_button is not None else {}
+                raw_pady = grid_info.get("pady", 0)
+                vertical_padding = 0
+                if isinstance(raw_pady, tuple):
+                    vertical_padding = sum(int(value) for value in raw_pady)
+                elif isinstance(raw_pady, str):
+                    pieces = [piece.strip() for piece in raw_pady.split()] if raw_pady else []
+                    if len(pieces) == 1:
+                        vertical_padding = int(pieces[0]) * 2
+                    elif len(pieces) >= 2:
+                        vertical_padding = int(pieces[0]) + int(pieces[1])
+                else:
+                    vertical_padding = int(raw_pady) * 2
+
+                button_height = int(target.winfo_reqheight() or 0)
+                collapsed_core_height = max(
+                    int(bar_frame.winfo_reqheight() or 0),
+                    button_height + vertical_padding + (bar_border * 2),
+                )
+                collapsed_core_height += 3
+                height_source = bar_frame
             else:
                 width = self.winfo_screenwidth()
                 height_source = self._bar_frame or self
             collapsed_floor = COLLAPSED_HEIGHT_FLOOR if self._is_collapsed else 36
-            height = max(collapsed_floor, int((height_source.winfo_reqheight() if height_source else 36) + 16))
+            if self._is_collapsed:
+                base_height = collapsed_core_height
+            else:
+                base_height = int(height_source.winfo_reqheight() if height_source else 36)
+            height = max(collapsed_floor, int(base_height + 16))
             y = self.winfo_screenheight() - height
             if self._is_collapsed:
                 y -= COLLAPSED_Y_OFFSET

--- a/modules/dice/dice_bar_window.py
+++ b/modules/dice/dice_bar_window.py
@@ -523,19 +523,35 @@ class DiceBarWindow(ctk.CTkToplevel):
             if self._is_collapsed:
                 # Continue with this path when is collapsed is set.
                 target = self._collapse_button or self
+                bar_frame = self._bar_frame or self
                 button_width = int(target.winfo_reqwidth() or 0)
                 bar_border = int((self._bar_frame.cget("border_width") if self._bar_frame is not None else 0) or 0)
                 horizontal_padding = 8
                 width = max(COLLAPSED_WIDTH_FLOOR, button_width + horizontal_padding + (bar_border * 2))
-                height_source = target
-                if self._collapsed_height_hint is None and height_source is not None:
-                    # Handle the branch where collapsed height hint is missing and height source is available.
-                    try:
-                        measured = int(height_source.winfo_reqheight() or 0)
-                    except Exception:
-                        measured = 0
-                    if measured:
-                        self._collapsed_height_hint = measured
+
+                grid_info = target.grid_info() if self._collapse_button is not None else {}
+                raw_pady = grid_info.get("pady", 0)
+                vertical_padding = 0
+                if isinstance(raw_pady, tuple):
+                    vertical_padding = sum(int(value) for value in raw_pady)
+                elif isinstance(raw_pady, str):
+                    pieces = [piece.strip() for piece in raw_pady.split()] if raw_pady else []
+                    if len(pieces) == 1:
+                        vertical_padding = int(pieces[0]) * 2
+                    elif len(pieces) >= 2:
+                        vertical_padding = int(pieces[0]) + int(pieces[1])
+                else:
+                    vertical_padding = int(raw_pady) * 2
+
+                button_height = int(target.winfo_reqheight() or 0)
+                collapsed_core_height = max(
+                    int(bar_frame.winfo_reqheight() or 0),
+                    button_height + vertical_padding + (bar_border * 2),
+                )
+                collapsed_core_height += 3
+                if self._collapsed_height_hint is None or collapsed_core_height > self._collapsed_height_hint:
+                    self._collapsed_height_hint = collapsed_core_height
+                height_source = bar_frame
             else:
                 width = self.winfo_screenwidth()
                 height_source = self._bar_frame or self


### PR DESCRIPTION
### Motivation
- Collapsed bar height was being derived only from the collapse button requested height which produced inconsistent sizes across DPI/font settings and between dice/audio bars.
- The goal is to compute collapsed height from the bar container after layout, add a small safety margin, and ensure the computed height respects button size, grid padding, and bar border while still honoring `COLLAPSED_HEIGHT_FLOOR`.

### Description
- In `DiceBarWindow._apply_geometry` updated the collapsed branch to measure the bar container (`self._bar_frame`) after `update_idletasks()` and use that as the `height_source` instead of relying solely on the collapse button.
- Extracted collapse button vertical grid padding from `grid_info()["pady"]` and included it, the button requested height, and bar border contribution when computing a `collapsed_core_height` minimum, then added a small safety margin (`+3` px) before assigning the collapsed hint.
- Ensured `COLLAPSED_HEIGHT_FLOOR` remains the absolute minimum and the final height uses the stronger of floor and computed base plus padding via `HEIGHT_PADDING`.
- Applied the same parity logic to `AudioBarWindow._apply_geometry` so dice and audio compact bars behave consistently when collapsed.

### Testing
- Ran `python -m py_compile modules/dice/dice_bar_window.py modules/audio/audio_bar_window.py` which completed successfully with no syntax errors.
- No automated UI tests were present; changes were limited to geometry calculations and validated via static compilation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b0d38090832b84d9c31071934048)