### PR TITLE
Add GraphScenarioPlanner and 'graph' planning mode to ScenesPlanningStep

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -36,6 +36,7 @@ from modules.scenarios.scenario_character_graph import (
 )
 from modules.scenarios.wizard_steps.scenes.canvas_scene_planner import CanvasScenePlanner
 from modules.scenarios.wizard_steps.scenes.guided_scene_planner import GuidedScenePlanner
+from modules.scenarios.wizard_steps.scenes.graph_scenario_planner import GraphScenarioPlanner
 from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
     SCENE_ENTITY_FIELDS as SCENE_CARD_ENTITY_FIELDS,
     normalise_entity_list,
@@ -286,7 +287,7 @@ class ScenesPlanningStep(WizardStep):
         mode_row = ctk.CTkFrame(root, fg_color="transparent")
         mode_row.grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 6))
         ctk.CTkLabel(mode_row, text="Planning mode", text_color="#9db4d1").pack(side="left", padx=(2, 8))
-        self.mode_switch = ctk.CTkSegmentedButton(mode_row, values=["guided", "canvas"], variable=self.mode_var, command=self._on_mode_changed)
+        self.mode_switch = ctk.CTkSegmentedButton(mode_row, values=["guided", "canvas", "graph"], variable=self.mode_var, command=self._on_mode_changed)
         self.mode_switch.pack(side="left")
 
         self._planner_holder = ctk.CTkFrame(root, fg_color="transparent")
@@ -302,6 +303,7 @@ class ScenesPlanningStep(WizardStep):
             self._planner_holder,
             entity_selector_callbacks=self._build_entity_selector_callbacks(),
         )
+        self.graph_planner = GraphScenarioPlanner(self._planner_holder)
         self._active_mode = None
         self.scenes = []
         self._set_mode("guided", remap=False)
@@ -411,22 +413,32 @@ class ScenesPlanningStep(WizardStep):
 
     def _set_mode(self, mode, *, remap):
         """Set mode."""
-        mode = "canvas" if str(mode).strip().lower() == "canvas" else "guided"
+        normalized_mode = str(mode).strip().lower()
+        mode = normalized_mode if normalized_mode in {"guided", "canvas", "graph"} else "guided"
         if self._active_mode == mode and remap:
             return
         current_scenes = self._collect_active_scenes() if remap else self.scenes
         if mode == "guided":
             self.guided_planner.grid(row=0, column=0, sticky="nsew")
             self.canvas_planner.grid_forget()
+            self.graph_planner.grid_forget()
             cards = scenes_to_guided_cards(current_scenes)
             self.guided_planner.load_cards(cards)
             self.scenes = guided_cards_to_scenes(self.guided_planner.export_cards())
-        else:
+        elif mode == "canvas":
             self.canvas_planner.grid(row=0, column=0, sticky="nsew")
             self.guided_planner.grid_forget()
+            self.graph_planner.grid_forget()
             scenes = guided_cards_to_scenes(self.guided_planner.export_cards()) if self._active_mode == "guided" and remap else current_scenes
             self.canvas_planner.load_scenes(scenes)
             self.scenes = self.canvas_planner.export_scenes()
+        else:
+            self.graph_planner.grid(row=0, column=0, sticky="nsew")
+            self.guided_planner.grid_forget()
+            self.canvas_planner.grid_forget()
+            scenes = guided_cards_to_scenes(self.guided_planner.export_cards()) if self._active_mode == "guided" and remap else current_scenes
+            self.graph_planner.load_scenes(scenes)
+            self.scenes = self.graph_planner.export_scenes()
         self._active_mode = mode
         self.mode_var.set(mode)
 
@@ -434,6 +446,8 @@ class ScenesPlanningStep(WizardStep):
         """Collect active scenes."""
         if self._active_mode == "guided":
             return guided_cards_to_scenes(self.guided_planner.export_cards())
+        if self._active_mode == "graph":
+            return self.graph_planner.export_scenes()
         return self.canvas_planner.export_scenes()
 
     def _switch_to_epic_finale_planner(self):

--- a/modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py
@@ -1,0 +1,100 @@
+"""Graph-inspired scenario planner with node list and property panel."""
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class GraphScenarioPlanner(ctk.CTkFrame):
+    """Lightweight node flow planner that maps to scenario scenes."""
+
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")
+        self.grid_columnconfigure(0, weight=3)
+        self.grid_columnconfigure(1, weight=2)
+        self.grid_rowconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            self,
+            text="Flow Graph (Wizard + Node Editor)",
+            font=ctk.CTkFont(size=15, weight="bold"),
+        ).grid(row=0, column=0, sticky="w", padx=(2, 8), pady=(0, 8))
+
+        ctk.CTkLabel(
+            self,
+            text="Select a node on the left, edit its properties on the right.",
+            text_color="#8ca2bf",
+        ).grid(row=0, column=1, sticky="e", padx=(8, 2), pady=(0, 8))
+
+        self.nodes_list = ctk.CTkTextbox(self, corner_radius=12)
+        self.nodes_list.grid(row=1, column=0, sticky="nsew", padx=(0, 8))
+
+        self.properties = ctk.CTkFrame(self, fg_color="#101827", corner_radius=12)
+        self.properties.grid(row=1, column=1, sticky="nsew")
+        self.properties.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(self.properties, text="Properties", font=ctk.CTkFont(size=14, weight="bold")).grid(
+            row=0, column=0, sticky="w", padx=12, pady=(10, 6)
+        )
+        self.title_var = ctk.StringVar()
+        self.objective_var = ctk.StringVar()
+        self.success_condition_var = ctk.StringVar()
+
+        self._entry(self.properties, "Node title", self.title_var, 1)
+        self._entry(self.properties, "Objective", self.objective_var, 2)
+        self._entry(self.properties, "Success condition", self.success_condition_var, 3)
+
+        self.notes_box = ctk.CTkTextbox(self.properties, height=180)
+        ctk.CTkLabel(self.properties, text="Notes").grid(row=4, column=0, sticky="w", padx=12, pady=(10, 2))
+        self.notes_box.grid(row=5, column=0, sticky="nsew", padx=12, pady=(0, 12))
+        self.properties.grid_rowconfigure(5, weight=1)
+
+        self._scenes = []
+
+    @staticmethod
+    def _entry(parent, label, variable, row):
+        ctk.CTkLabel(parent, text=label).grid(row=row * 2 - 1, column=0, sticky="w", padx=12, pady=(4, 2))
+        ctk.CTkEntry(parent, textvariable=variable).grid(row=row * 2, column=0, sticky="ew", padx=12)
+
+    def load_scenes(self, scenes):
+        """Load scenario scenes into graph-like planner."""
+        self._scenes = list(scenes or [])
+        self.nodes_list.delete("1.0", "end")
+        if not self._scenes:
+            self.nodes_list.insert("1.0", "• Objective principal\n  → Scène 1 (à définir)")
+            self.title_var.set("Objective principal")
+            self.objective_var.set("")
+            self.success_condition_var.set("")
+            self.notes_box.delete("1.0", "end")
+            return
+
+        lines = []
+        for index, scene in enumerate(self._scenes, start=1):
+            title = str(scene.get("title") or f"Scene {index}").strip()
+            objective = str(scene.get("objective") or "").strip()
+            marker = "🎯" if index == 1 else "💬"
+            lines.append(f"{marker} {index}. {title}")
+            if objective:
+                lines.append(f"   └─ objectif: {objective}")
+            if index < len(self._scenes):
+                lines.append(f"   └─ ensuite → {index + 1}")
+
+        self.nodes_list.insert("1.0", "\n".join(lines))
+        first = self._scenes[0]
+        self.title_var.set(str(first.get("title") or ""))
+        self.objective_var.set(str(first.get("objective") or ""))
+        self.success_condition_var.set(str(first.get("success_condition") or ""))
+        self.notes_box.delete("1.0", "end")
+        self.notes_box.insert("1.0", str(first.get("notes") or ""))
+
+    def export_scenes(self):
+        """Export edited data preserving scene list."""
+        if not self._scenes:
+            return []
+        first = dict(self._scenes[0])
+        first["title"] = self.title_var.get().strip() or first.get("title") or "Objective principal"
+        first["objective"] = self.objective_var.get().strip()
+        first["success_condition"] = self.success_condition_var.get().strip()
+        first["notes"] = self.notes_box.get("1.0", "end").strip()
+        exported = [first]
+        exported.extend(self._scenes[1:])
+        return exported


### PR DESCRIPTION
### Motivation

- Provide an additional graph-style scene planning UI to give users a node-list + property-panel alternative to the existing guided and canvas planners.
- Integrate the new planner so scenes can be edited and exported/imported consistently across planner modes.

### Description

- Add a new `GraphScenarioPlanner` component in `modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py` that renders a node list and properties panel and implements `load_scenes` and `export_scenes`.
- Import and instantiate `GraphScenarioPlanner` in `ScenesPlanningStep`, add `"graph"` to the `mode_switch` values, and create `self.graph_planner` alongside the existing planners.
- Update mode normalization in `_set_mode` to accept `"guided"`, `"canvas"`, or `"graph"`, and add logic to show/hide the `graph_planner` and route scene loading/exporting to/from it.
- Extend `_collect_active_scenes` to return scene data from `graph_planner` when the active mode is `graph`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25b9ec578832bb0353b83a45c8e76)