### PR TITLE
Introduce graph_mode package and deprecate GraphScenarioPlanner

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -36,7 +36,7 @@ from modules.scenarios.scenario_character_graph import (
 )
 from modules.scenarios.wizard_steps.scenes.canvas_scene_planner import CanvasScenePlanner
 from modules.scenarios.wizard_steps.scenes.guided_scene_planner import GuidedScenePlanner
-from modules.scenarios.wizard_steps.scenes.graph_scenario_planner import GraphScenarioPlanner
+from modules.scenarios.wizard_steps.scenes.graph_mode import GraphModePlanner
 from modules.scenarios.wizard_steps.scenes.scene_entity_fields import (
     SCENE_ENTITY_FIELDS as SCENE_CARD_ENTITY_FIELDS,
     normalise_entity_list,
@@ -303,7 +303,7 @@ class ScenesPlanningStep(WizardStep):
             self._planner_holder,
             entity_selector_callbacks=self._build_entity_selector_callbacks(),
         )
-        self.graph_planner = GraphScenarioPlanner(self._planner_holder)
+        self.graph_planner = GraphModePlanner(self._planner_holder)
         self._active_mode = None
         self.scenes = []
         self._set_mode("guided", remap=False)

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/__init__.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/__init__.py
@@ -1,0 +1,5 @@
+"""Graph mode scene planner package."""
+
+from .controller import GraphModePlanner
+
+__all__ = ["GraphModePlanner"]

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/controller.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/controller.py
@@ -1,0 +1,61 @@
+"""Graph mode planner root widget."""
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from .mapper import scenes_to_node_lines
+from .schema import SCENE_DEFAULT_TITLE, normalize_scene
+from .state import GraphModeState
+from .ui.canvas_view import GraphCanvasView
+from .ui.properties_panel import PropertiesPanel
+from .ui.toolbar import GraphToolbar
+
+
+class GraphModePlanner(ctk.CTkFrame):
+    """Root graph-mode planner widget, compatible with planner contracts."""
+
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")
+        self.state = GraphModeState()
+
+        self.grid_columnconfigure(0, weight=3)
+        self.grid_columnconfigure(1, weight=2)
+        self.grid_rowconfigure(1, weight=1)
+
+        self.toolbar = GraphToolbar(self)
+        self.toolbar.grid(row=0, column=0, sticky="w", padx=(2, 8), pady=(0, 8))
+
+        self.canvas_view = GraphCanvasView(self)
+        self.canvas_view.grid(row=1, column=0, sticky="nsew", padx=(0, 8))
+
+        self.properties_panel = PropertiesPanel(self)
+        self.properties_panel.grid(row=1, column=1, sticky="nsew")
+
+    def load_scenes(self, scenes):
+        self.state.scenes = [normalize_scene(scene, i) for i, scene in enumerate(scenes or [], start=1)]
+        self.canvas_view.delete("1.0", "end")
+        if not self.state.scenes:
+            self.canvas_view.insert("1.0", "• Objective principal\n  → Scène 1 (à définir)")
+            self.properties_panel.fields.title_var.set(SCENE_DEFAULT_TITLE)
+            self.properties_panel.fields.objective_var.set("")
+            self.properties_panel.fields.success_condition_var.set("")
+            self.properties_panel.notes_box.delete("1.0", "end")
+            return
+
+        self.canvas_view.insert("1.0", "\n".join(scenes_to_node_lines(self.state.scenes)))
+        first = self.state.scenes[0]
+        self.properties_panel.fields.title_var.set(first.get("title") or "")
+        self.properties_panel.fields.objective_var.set(first.get("objective") or "")
+        self.properties_panel.fields.success_condition_var.set(first.get("success_condition") or "")
+        self.properties_panel.notes_box.delete("1.0", "end")
+        self.properties_panel.notes_box.insert("1.0", first.get("notes") or "")
+
+    def export_scenes(self):
+        if not self.state.scenes:
+            return []
+        first = dict(self.state.scenes[0])
+        first["title"] = self.properties_panel.fields.title_var.get().strip() or first.get("title") or SCENE_DEFAULT_TITLE
+        first["objective"] = self.properties_panel.fields.objective_var.get().strip()
+        first["success_condition"] = self.properties_panel.fields.success_condition_var.get().strip()
+        first["notes"] = self.properties_panel.notes_box.get("1.0", "end").strip()
+        return [first, *self.state.scenes[1:]]

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/mapper.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/mapper.py
@@ -1,0 +1,14 @@
+"""Mapping helpers between scene payloads and UI text."""
+from __future__ import annotations
+
+
+def scenes_to_node_lines(scenes: list[dict]) -> list[str]:
+    lines: list[str] = []
+    for index, scene in enumerate(scenes, start=1):
+        marker = "🎯" if index == 1 else "💬"
+        lines.append(f"{marker} {index}. {scene.get('title')}")
+        if scene.get("objective"):
+            lines.append(f"   └─ objectif: {scene['objective']}")
+        if index < len(scenes):
+            lines.append(f"   └─ ensuite → {index + 1}")
+    return lines

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/schema.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/schema.py
@@ -1,0 +1,15 @@
+"""Scene schema helpers for graph mode planner."""
+from __future__ import annotations
+
+from typing import Any
+
+SCENE_DEFAULT_TITLE = "Objective principal"
+
+
+def normalize_scene(scene: dict[str, Any], index: int) -> dict[str, Any]:
+    normalized = dict(scene or {})
+    normalized["title"] = str(normalized.get("title") or f"Scene {index}").strip()
+    normalized["objective"] = str(normalized.get("objective") or "").strip()
+    normalized["success_condition"] = str(normalized.get("success_condition") or "").strip()
+    normalized["notes"] = str(normalized.get("notes") or "").strip()
+    return normalized

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/state.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/state.py
@@ -1,0 +1,15 @@
+"""State container for graph mode planner."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class GraphModeState:
+    """Mutable planner state used by GraphModePlanner."""
+
+    scenes: list[dict[str, Any]] = field(default_factory=list)
+
+    def reset(self) -> None:
+        self.scenes.clear()

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/__init__.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI components for graph mode."""

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/canvas_view.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/canvas_view.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class GraphCanvasView(ctk.CTkTextbox):
+    """Read-only textual graph canvas placeholder."""
+
+    def __init__(self, master):
+        super().__init__(master, corner_radius=12)

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/edge_renderer.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/edge_renderer.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class EdgeRenderer(ctk.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/minimap.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/minimap.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class Minimap(ctk.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/node_widgets.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/node_widgets.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class NodeFields(ctk.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")
+        self.grid_columnconfigure(0, weight=1)
+        self.title_var = ctk.StringVar()
+        self.objective_var = ctk.StringVar()
+        self.success_condition_var = ctk.StringVar()
+
+        self._entry("Node title", self.title_var, 0)
+        self._entry("Objective", self.objective_var, 2)
+        self._entry("Success condition", self.success_condition_var, 4)
+
+    def _entry(self, label: str, variable: ctk.StringVar, row: int) -> None:
+        ctk.CTkLabel(self, text=label).grid(row=row, column=0, sticky="w", padx=12, pady=(4, 2))
+        ctk.CTkEntry(self, textvariable=variable).grid(row=row + 1, column=0, sticky="ew", padx=12)

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/properties_panel.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/properties_panel.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from .node_widgets import NodeFields
+
+
+class PropertiesPanel(ctk.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master, fg_color="#101827", corner_radius=12)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(3, weight=1)
+
+        ctk.CTkLabel(self, text="Properties", font=ctk.CTkFont(size=14, weight="bold")).grid(
+            row=0, column=0, sticky="w", padx=12, pady=(10, 6)
+        )
+        self.fields = NodeFields(self)
+        self.fields.grid(row=1, column=0, sticky="ew")
+
+        ctk.CTkLabel(self, text="Notes").grid(row=2, column=0, sticky="w", padx=12, pady=(10, 2))
+        self.notes_box = ctk.CTkTextbox(self, height=180)
+        self.notes_box.grid(row=3, column=0, sticky="nsew", padx=12, pady=(0, 12))

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/toolbar.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/toolbar.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class GraphToolbar(ctk.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")
+        ctk.CTkLabel(self, text="Flow Graph (Wizard + Node Editor)", font=ctk.CTkFont(size=15, weight="bold")).pack(anchor="w")

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/validation_panel.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/validation_panel.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class ValidationPanel(ctk.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master, fg_color="transparent")

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/validation.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/validation.py
@@ -1,0 +1,10 @@
+"""Validation helpers for graph mode scenes."""
+from __future__ import annotations
+
+
+def validate_scenes(scenes: list[dict]) -> list[str]:
+    issues: list[str] = []
+    for index, scene in enumerate(scenes, start=1):
+        if not str(scene.get("title") or "").strip():
+            issues.append(f"Scene {index} has an empty title")
+    return issues

--- a/modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py
@@ -1,100 +1,19 @@
-"""Graph-inspired scenario planner with node list and property panel."""
+"""Deprecated compatibility layer for graph scenario planner."""
 from __future__ import annotations
 
-import customtkinter as ctk
+from warnings import warn
+
+from modules.scenarios.wizard_steps.scenes.graph_mode import GraphModePlanner
 
 
-class GraphScenarioPlanner(ctk.CTkFrame):
-    """Lightweight node flow planner that maps to scenario scenes."""
+class GraphScenarioPlanner(GraphModePlanner):
+    """Deprecated alias for :class:`GraphModePlanner`."""
 
     def __init__(self, master):
-        super().__init__(master, fg_color="transparent")
-        self.grid_columnconfigure(0, weight=3)
-        self.grid_columnconfigure(1, weight=2)
-        self.grid_rowconfigure(1, weight=1)
-
-        ctk.CTkLabel(
-            self,
-            text="Flow Graph (Wizard + Node Editor)",
-            font=ctk.CTkFont(size=15, weight="bold"),
-        ).grid(row=0, column=0, sticky="w", padx=(2, 8), pady=(0, 8))
-
-        ctk.CTkLabel(
-            self,
-            text="Select a node on the left, edit its properties on the right.",
-            text_color="#8ca2bf",
-        ).grid(row=0, column=1, sticky="e", padx=(8, 2), pady=(0, 8))
-
-        self.nodes_list = ctk.CTkTextbox(self, corner_radius=12)
-        self.nodes_list.grid(row=1, column=0, sticky="nsew", padx=(0, 8))
-
-        self.properties = ctk.CTkFrame(self, fg_color="#101827", corner_radius=12)
-        self.properties.grid(row=1, column=1, sticky="nsew")
-        self.properties.grid_columnconfigure(0, weight=1)
-
-        ctk.CTkLabel(self.properties, text="Properties", font=ctk.CTkFont(size=14, weight="bold")).grid(
-            row=0, column=0, sticky="w", padx=12, pady=(10, 6)
+        warn(
+            "GraphScenarioPlanner is deprecated and will be removed in a future release; "
+            "use GraphModePlanner from modules.scenarios.wizard_steps.scenes.graph_mode instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        self.title_var = ctk.StringVar()
-        self.objective_var = ctk.StringVar()
-        self.success_condition_var = ctk.StringVar()
-
-        self._entry(self.properties, "Node title", self.title_var, 1)
-        self._entry(self.properties, "Objective", self.objective_var, 2)
-        self._entry(self.properties, "Success condition", self.success_condition_var, 3)
-
-        self.notes_box = ctk.CTkTextbox(self.properties, height=180)
-        ctk.CTkLabel(self.properties, text="Notes").grid(row=4, column=0, sticky="w", padx=12, pady=(10, 2))
-        self.notes_box.grid(row=5, column=0, sticky="nsew", padx=12, pady=(0, 12))
-        self.properties.grid_rowconfigure(5, weight=1)
-
-        self._scenes = []
-
-    @staticmethod
-    def _entry(parent, label, variable, row):
-        ctk.CTkLabel(parent, text=label).grid(row=row * 2 - 1, column=0, sticky="w", padx=12, pady=(4, 2))
-        ctk.CTkEntry(parent, textvariable=variable).grid(row=row * 2, column=0, sticky="ew", padx=12)
-
-    def load_scenes(self, scenes):
-        """Load scenario scenes into graph-like planner."""
-        self._scenes = list(scenes or [])
-        self.nodes_list.delete("1.0", "end")
-        if not self._scenes:
-            self.nodes_list.insert("1.0", "• Objective principal\n  → Scène 1 (à définir)")
-            self.title_var.set("Objective principal")
-            self.objective_var.set("")
-            self.success_condition_var.set("")
-            self.notes_box.delete("1.0", "end")
-            return
-
-        lines = []
-        for index, scene in enumerate(self._scenes, start=1):
-            title = str(scene.get("title") or f"Scene {index}").strip()
-            objective = str(scene.get("objective") or "").strip()
-            marker = "🎯" if index == 1 else "💬"
-            lines.append(f"{marker} {index}. {title}")
-            if objective:
-                lines.append(f"   └─ objectif: {objective}")
-            if index < len(self._scenes):
-                lines.append(f"   └─ ensuite → {index + 1}")
-
-        self.nodes_list.insert("1.0", "\n".join(lines))
-        first = self._scenes[0]
-        self.title_var.set(str(first.get("title") or ""))
-        self.objective_var.set(str(first.get("objective") or ""))
-        self.success_condition_var.set(str(first.get("success_condition") or ""))
-        self.notes_box.delete("1.0", "end")
-        self.notes_box.insert("1.0", str(first.get("notes") or ""))
-
-    def export_scenes(self):
-        """Export edited data preserving scene list."""
-        if not self._scenes:
-            return []
-        first = dict(self._scenes[0])
-        first["title"] = self.title_var.get().strip() or first.get("title") or "Objective principal"
-        first["objective"] = self.objective_var.get().strip()
-        first["success_condition"] = self.success_condition_var.get().strip()
-        first["notes"] = self.notes_box.get("1.0", "end").strip()
-        exported = [first]
-        exported.extend(self._scenes[1:])
-        return exported
+        super().__init__(master)


### PR DESCRIPTION
### Motivation
- Modularize and clarify the graph-based scene planner by splitting responsibilities into a dedicated package and smaller UI components.
- Provide a single root widget that matches the existing planner contract so other code can migrate smoothly to the new structure.
- Maintain backwards compatibility while signaling a planned removal of the legacy implementation.

### Description
- Added new package `modules/scenarios/wizard_steps/scenes/graph_mode` containing `__init__.py`, `controller.py`, `state.py`, `schema.py`, `mapper.py`, and `validation.py` to hold core planner logic and helpers.
- Implemented `GraphModePlanner` in `controller.py` which composes the UI subcomponents and exposes `load_scenes()` and `export_scenes()` to match existing planner contracts.
- Introduced UI subcomponents under `modules/scenarios/wizard_steps/scenes/graph_mode/ui/` including `canvas_view.py`, `node_widgets.py`, `edge_renderer.py`, `toolbar.py`, `properties_panel.py`, `minimap.py`, and `validation_panel.py` to keep the interface modular and readable.
- Converted `modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py` into a small compatibility alias subclass of `GraphModePlanner` that emits a `DeprecationWarning`, and updated `modules/scenarios/scenario_builder_wizard.py` to import and use `GraphModePlanner`.

### Testing
- Ran `python -m py_compile modules/scenarios/wizard_steps/scenes/graph_mode/controller.py modules/scenarios/wizard_steps/scenes/graph_scenario_planner.py modules/scenarios/scenario_builder_wizard.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f260d153a8832b81fa070dc2f74b2a)