### PR TITLE
Add typed graph schema models and centralized graph mode state

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/graph_mode/schema.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/schema.py
@@ -1,9 +1,53 @@
-"""Scene schema helpers for graph mode planner."""
+"""Typed schema models and deterministic helpers for graph mode planner."""
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass, field
+from hashlib import sha1
+from typing import Any, Mapping
 
 SCENE_DEFAULT_TITLE = "Objective principal"
+GRAPH_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(slots=True, frozen=True)
+class GraphNodePosition:
+    """Canvas position for a graph node."""
+
+    x: float
+    y: float
+
+
+@dataclass(slots=True, frozen=True)
+class GraphNode:
+    """Typed graph node model."""
+
+    id: str
+    type: str
+    title: str
+    position: GraphNodePosition
+    payload: dict[str, Any] = field(default_factory=dict)
+    active: bool = True
+
+
+@dataclass(slots=True, frozen=True)
+class GraphEdge:
+    """Typed graph edge model."""
+
+    id: str
+    source: str
+    target: str
+    label: str = ""
+    condition_type: str = "always"
+
+
+@dataclass(slots=True, frozen=True)
+class GraphScenarioDocument:
+    """Top-level graph scenario document used for import/export."""
+
+    schema_version: str
+    nodes: tuple[GraphNode, ...]
+    edges: tuple[GraphEdge, ...]
+    meta: dict[str, Any] | None = None
 
 
 def normalize_scene(scene: dict[str, Any], index: int) -> dict[str, Any]:
@@ -13,3 +57,52 @@ def normalize_scene(scene: dict[str, Any], index: int) -> dict[str, Any]:
     normalized["success_condition"] = str(normalized.get("success_condition") or "").strip()
     normalized["notes"] = str(normalized.get("notes") or "").strip()
     return normalized
+
+
+def deterministic_graph_id(prefix: str, *parts: str) -> str:
+    """Create deterministic IDs for import/export stable round-trips."""
+
+    canonical = "|".join(str(part).strip() for part in parts)
+    digest = sha1(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}_{digest}"
+
+
+def stable_sort_nodes(nodes: list[GraphNode]) -> tuple[GraphNode, ...]:
+    """Stable canonical ordering for graph nodes."""
+
+    return tuple(sorted(nodes, key=lambda node: (node.type.casefold(), node.title.casefold(), node.id)))
+
+
+def stable_sort_edges(edges: list[GraphEdge]) -> tuple[GraphEdge, ...]:
+    """Stable canonical ordering for graph edges."""
+
+    return tuple(
+        sorted(
+            edges,
+            key=lambda edge: (
+                edge.source,
+                edge.target,
+                edge.condition_type.casefold(),
+                edge.label.casefold(),
+                edge.id,
+            ),
+        )
+    )
+
+
+def build_graph_document(
+    *,
+    nodes: list[GraphNode],
+    edges: list[GraphEdge],
+    meta: Mapping[str, Any] | None = None,
+    schema_version: str = GRAPH_SCHEMA_VERSION,
+) -> GraphScenarioDocument:
+    """Build a canonical graph scenario document with deterministic ordering."""
+
+    canonical_meta = dict(meta) if meta else None
+    return GraphScenarioDocument(
+        schema_version=schema_version,
+        nodes=stable_sort_nodes(nodes),
+        edges=stable_sort_edges(edges),
+        meta=canonical_meta,
+    )

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/state.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/state.py
@@ -1,15 +1,103 @@
-"""State container for graph mode planner."""
+"""Centralized state container for graph mode planner."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 
-@dataclass
+@dataclass(slots=True)
+class GraphViewportState:
+    """Viewport transform state."""
+
+    zoom: float = 1.0
+    pan_x: float = 0.0
+    pan_y: float = 0.0
+
+
+@dataclass(slots=True)
 class GraphModeState:
     """Mutable planner state used by GraphModePlanner."""
 
     scenes: list[dict[str, Any]] = field(default_factory=list)
+    selected_node_id: str | None = None
+    selected_edge_id: str | None = None
+    viewport: GraphViewportState = field(default_factory=GraphViewportState)
+    dirty: bool = False
+    _undo_stack: list[tuple[list[dict[str, Any]], str | None, str | None, GraphViewportState, bool]] = field(
+        default_factory=list,
+        init=False,
+        repr=False,
+    )
+    _redo_stack: list[tuple[list[dict[str, Any]], str | None, str | None, GraphViewportState, bool]] = field(
+        default_factory=list,
+        init=False,
+        repr=False,
+    )
 
     def reset(self) -> None:
         self.scenes.clear()
+        self.selected_node_id = None
+        self.selected_edge_id = None
+        self.viewport = GraphViewportState()
+        self.dirty = False
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+
+    def set_selected_node(self, node_id: str | None) -> None:
+        self.selected_node_id = node_id
+        if node_id is not None:
+            self.selected_edge_id = None
+
+    def set_selected_edge(self, edge_id: str | None) -> None:
+        self.selected_edge_id = edge_id
+        if edge_id is not None:
+            self.selected_node_id = None
+
+    def set_viewport(self, *, zoom: float | None = None, pan_x: float | None = None, pan_y: float | None = None) -> None:
+        self.viewport = GraphViewportState(
+            zoom=self.viewport.zoom if zoom is None else float(zoom),
+            pan_x=self.viewport.pan_x if pan_x is None else float(pan_x),
+            pan_y=self.viewport.pan_y if pan_y is None else float(pan_y),
+        )
+
+    def mark_clean(self) -> None:
+        self.dirty = False
+
+    def mutate(self, operation: Callable[["GraphModeState"], None]) -> None:
+        """Undo/redo-ready centralized mutation entry point."""
+
+        self._undo_stack.append(self._snapshot())
+        self._redo_stack.clear()
+        operation(self)
+        self.dirty = True
+
+    def undo(self) -> bool:
+        if not self._undo_stack:
+            return False
+        self._redo_stack.append(self._snapshot())
+        self._restore(self._undo_stack.pop())
+        return True
+
+    def redo(self) -> bool:
+        if not self._redo_stack:
+            return False
+        self._undo_stack.append(self._snapshot())
+        self._restore(self._redo_stack.pop())
+        return True
+
+    def _snapshot(self) -> tuple[list[dict[str, Any]], str | None, str | None, GraphViewportState, bool]:
+        return (
+            [dict(scene) for scene in self.scenes],
+            self.selected_node_id,
+            self.selected_edge_id,
+            GraphViewportState(self.viewport.zoom, self.viewport.pan_x, self.viewport.pan_y),
+            self.dirty,
+        )
+
+    def _restore(self, snapshot: tuple[list[dict[str, Any]], str | None, str | None, GraphViewportState, bool]) -> None:
+        scenes, selected_node_id, selected_edge_id, viewport, dirty = snapshot
+        self.scenes = [dict(scene) for scene in scenes]
+        self.selected_node_id = selected_node_id
+        self.selected_edge_id = selected_edge_id
+        self.viewport = GraphViewportState(viewport.zoom, viewport.pan_x, viewport.pan_y)
+        self.dirty = dirty


### PR DESCRIPTION
### Motivation
- Provide explicit, typed models for graph mode to make import/export and in-memory usage safer and clearer.
- Ensure import/export round-trips are deterministic so documents remain stable across saves and loads.
- Centralize UI/planner state (selection, viewport, dirty flag) and provide undo/redo-ready mutation entry points for predictable interactions.

### Description
- Add typed dataclasses in `modules/scenarios/wizard_steps/scenes/graph_mode/schema.py`: `GraphNodePosition`, `GraphNode`, `GraphEdge`, and `GraphScenarioDocument`, and a `GRAPH_SCHEMA_VERSION` constant.
- Add deterministic helpers in the schema module: `deterministic_graph_id(...)` for stable id generation, `stable_sort_nodes(...)` and `stable_sort_edges(...)` for canonical ordering, and `build_graph_document(...)` to emit a sorted document.
- Implement centralized state in `modules/scenarios/wizard_steps/scenes/graph_mode/state.py` with `GraphViewportState` and `GraphModeState` containing selection (`selected_node_id`, `selected_edge_id`), viewport (`zoom`, `pan_x`, `pan_y`), `dirty` flag, and internal undo/redo stacks.
- Provide mutation and history APIs on `GraphModeState`: `mutate(operation)`, `undo()`, `redo()`, plus `_snapshot()`/`_restore()` helpers and convenience setters `set_selected_node`, `set_selected_edge`, `set_viewport`, and `mark_clean`.

### Testing
- Compiled the modified modules with `python -m compileall modules/scenarios/wizard_steps/scenes/graph_mode/schema.py modules/scenarios/wizard_steps/scenes/graph_mode/state.py`, which succeeded without syntax errors.
- No additional automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f261b98c64832bb985a6705f568781)