### PR TITLE
Graph-mode: validation rules, interactive validation panel, and canvas focus

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/canvas_view.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/canvas_view.py
@@ -128,6 +128,26 @@ class GraphCanvasView(ctk.CTkFrame):
         n = self.nodes[node_id]
         return (n["x"] + (self.NODE_W if out else 0), n["y"] + self.NODE_H / 2)
 
+
+    def focus_on_node(self, node_id: str) -> None:
+        if node_id not in self.nodes:
+            return
+        self.selected_nodes = {node_id}
+        self.selected_edge_id = None
+        node = self.nodes[node_id]
+        self.pan_x = (self.canvas.winfo_width() or 900) / 2 - (node["x"] + self.NODE_W / 2) * self.zoom
+        self.pan_y = (self.canvas.winfo_height() or 600) / 2 - (node["y"] + self.NODE_H / 2) * self.zoom
+        self.redraw_full()
+        self._notify_selection()
+
+    def focus_on_edge(self, edge_id: str) -> None:
+        if not any(existing_edge_id == edge_id for existing_edge_id, _src, _dst in self.edges):
+            return
+        self.selected_edge_id = edge_id
+        self.selected_nodes.clear()
+        self._redraw_edges()
+        self._notify_selection()
+
     def _on_left_down(self, event):
         if self._space_pan:
             self._on_pan_start(event)

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/ui/validation_panel.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/ui/validation_panel.py
@@ -1,8 +1,60 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import customtkinter as ctk
+
+from ..validation import ValidationIssue
 
 
 class ValidationPanel(ctk.CTkFrame):
     def __init__(self, master):
         super().__init__(master, fg_color="transparent")
+        self._blocking_issues: list[ValidationIssue] = []
+        self._warning_issues: list[ValidationIssue] = []
+        self.on_issue_click: Callable[[ValidationIssue], None] | None = None
+
+        self.grid_columnconfigure(0, weight=1)
+
+        self._errors_label = ctk.CTkLabel(self, text="Blocking errors", anchor="w")
+        self._errors_label.grid(row=0, column=0, sticky="ew", padx=4, pady=(0, 4))
+
+        self._errors_frame = ctk.CTkScrollableFrame(self, fg_color="transparent", height=120)
+        self._errors_frame.grid(row=1, column=0, sticky="nsew", padx=4)
+
+        self._warnings_label = ctk.CTkLabel(self, text="Warnings", anchor="w")
+        self._warnings_label.grid(row=2, column=0, sticky="ew", padx=4, pady=(12, 4))
+
+        self._warnings_frame = ctk.CTkScrollableFrame(self, fg_color="transparent", height=100)
+        self._warnings_frame.grid(row=3, column=0, sticky="nsew", padx=4)
+
+    def update_issues(self, issues: list[ValidationIssue]) -> None:
+        self._blocking_issues = [issue for issue in issues if issue.blocking]
+        self._warning_issues = [issue for issue in issues if not issue.blocking]
+        self._render_frame(self._errors_frame, self._blocking_issues)
+        self._render_frame(self._warnings_frame, self._warning_issues)
+
+    def has_blocking_errors(self) -> bool:
+        return bool(self._blocking_issues)
+
+    def _render_frame(self, frame: ctk.CTkScrollableFrame, issues: list[ValidationIssue]) -> None:
+        for child in frame.winfo_children():
+            child.destroy()
+        if not issues:
+            ctk.CTkLabel(frame, text="None", text_color="#94a3b8", anchor="w").pack(fill="x", padx=4, pady=2)
+            return
+        for issue in issues:
+            button = ctk.CTkButton(
+                frame,
+                text=f"• {issue.message}",
+                anchor="w",
+                fg_color="transparent",
+                hover_color="#1e293b",
+                command=lambda current=issue: self._handle_issue_click(current),
+            )
+            button.pack(fill="x", padx=2, pady=1)
+
+    def _handle_issue_click(self, issue: ValidationIssue) -> None:
+        if self.on_issue_click is None:
+            return
+        self.on_issue_click(issue)

--- a/modules/scenarios/wizard_steps/scenes/graph_mode/validation.py
+++ b/modules/scenarios/wizard_steps/scenes/graph_mode/validation.py
@@ -1,10 +1,141 @@
 """Validation helpers for graph mode scenes."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Literal
 
-def validate_scenes(scenes: list[dict]) -> list[str]:
-    issues: list[str] = []
+
+Severity = Literal["error", "warning"]
+IssueCode = Literal[
+    "invalid_title",
+    "start_count",
+    "missing_reachable_end",
+    "orphan_node",
+    "choice_outgoing",
+    "condition_exits",
+]
+
+
+@dataclass(slots=True, frozen=True)
+class ValidationIssue:
+    code: IssueCode
+    severity: Severity
+    message: str
+    node_id: str | None = None
+    edge_id: str | None = None
+
+    @property
+    def blocking(self) -> bool:
+        return self.severity == "error"
+
+
+def validate_scenes(scenes: list[dict], edges: list[dict] | None = None) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    edge_rows = list(edges or [])
+    node_ids = {str(scene.get("id")) for scene in scenes if scene.get("id")}
+
     for index, scene in enumerate(scenes, start=1):
         if not str(scene.get("title") or "").strip():
-            issues.append(f"Scene {index} has an empty title")
+            issues.append(
+                ValidationIssue(
+                    code="invalid_title",
+                    severity="warning",
+                    message=f"Scene {index} has an empty title",
+                    node_id=str(scene.get("id") or "") or None,
+                )
+            )
+
+    start_nodes = [scene for scene in scenes if str(scene.get("type") or "").upper() == "START"]
+    if len(start_nodes) != 1:
+        issues.append(
+            ValidationIssue(
+                code="start_count",
+                severity="error",
+                message=f"Graph must contain exactly one START node (found {len(start_nodes)})",
+                node_id=str(start_nodes[0].get("id")) if start_nodes else None,
+            )
+        )
+
+    adjacency: dict[str, list[dict]] = {node_id: [] for node_id in node_ids}
+    incoming_count: dict[str, int] = {node_id: 0 for node_id in node_ids}
+    for edge in edge_rows:
+        source = str(edge.get("source") or "")
+        target = str(edge.get("target") or "")
+        if source in adjacency:
+            adjacency[source].append(edge)
+        if target in incoming_count:
+            incoming_count[target] += 1
+
+    reachable: set[str] = set()
+    if len(start_nodes) == 1:
+        stack = [str(start_nodes[0].get("id") or "")]
+        while stack:
+            node_id = stack.pop()
+            if not node_id or node_id in reachable:
+                continue
+            reachable.add(node_id)
+            for edge in adjacency.get(node_id, []):
+                nxt = str(edge.get("target") or "")
+                if nxt and nxt not in reachable:
+                    stack.append(nxt)
+
+    has_reachable_end = any(
+        str(scene.get("type") or "").upper() in {"END_SUCCESS", "END_FAIL"}
+        and str(scene.get("id") or "") in reachable
+        for scene in scenes
+    )
+    if not has_reachable_end:
+        issues.append(
+            ValidationIssue(
+                code="missing_reachable_end",
+                severity="error",
+                message="Graph must have at least one reachable END_SUCCESS or END_FAIL node",
+            )
+        )
+
+    for scene in scenes:
+        node_id = str(scene.get("id") or "")
+        if not node_id:
+            continue
+        if incoming_count.get(node_id, 0) == 0 and node_id not in {str(n.get("id") or "") for n in start_nodes}:
+            issues.append(
+                ValidationIssue(
+                    code="orphan_node",
+                    severity="error",
+                    message="Node is orphaned (no incoming edges)",
+                    node_id=node_id,
+                )
+            )
+
+    for scene in scenes:
+        node_id = str(scene.get("id") or "")
+        node_type = str(scene.get("type") or "").upper()
+        outgoing = adjacency.get(node_id, [])
+
+        if node_type == "CHOICE" and len(outgoing) < 2:
+            issues.append(
+                ValidationIssue(
+                    code="choice_outgoing",
+                    severity="error",
+                    message="CHOICE node must have at least 2 outgoing edges",
+                    node_id=node_id,
+                )
+            )
+
+        if node_type == "CONDITION":
+            exits = {
+                str(edge.get("condition_value") or edge.get("label") or edge.get("condition_type") or "").strip().lower()
+                for edge in outgoing
+                if str(edge.get("condition_value") or edge.get("label") or edge.get("condition_type") or "").strip()
+            }
+            if len(exits) < 2:
+                issues.append(
+                    ValidationIssue(
+                        code="condition_exits",
+                        severity="error",
+                        message="CONDITION node must expose at least 2 logical exits",
+                        node_id=node_id,
+                    )
+                )
+
     return issues

--- a/tests/scenarios/test_graph_mode_validation.py
+++ b/tests/scenarios/test_graph_mode_validation.py
@@ -1,0 +1,31 @@
+from modules.scenarios.wizard_steps.scenes.graph_mode.validation import validate_scenes
+
+
+def _scene(node_id: str, node_type: str):
+    return {"id": node_id, "type": node_type, "title": node_id}
+
+
+def test_requires_exactly_one_start():
+    scenes = [_scene("a", "START"), _scene("b", "START"), _scene("end", "END_SUCCESS")]
+    issues = validate_scenes(scenes, [])
+    assert any(i.code == "start_count" and i.blocking for i in issues)
+
+
+def test_reachable_end_is_required_and_orphan_detected():
+    scenes = [_scene("start", "START"), _scene("mid", "SCENE"), _scene("end", "END_SUCCESS")]
+    edges = [{"id": "e1", "source": "start", "target": "mid"}]
+    issues = validate_scenes(scenes, edges)
+    assert any(i.code == "missing_reachable_end" for i in issues)
+    assert any(i.code == "orphan_node" and i.node_id == "end" for i in issues)
+
+
+def test_choice_and_condition_rules():
+    scenes = [_scene("start", "START"), _scene("choice", "CHOICE"), _scene("cond", "CONDITION"), _scene("end", "END_FAIL")]
+    edges = [
+        {"id": "e1", "source": "start", "target": "choice"},
+        {"id": "e2", "source": "choice", "target": "cond"},
+        {"id": "e3", "source": "cond", "target": "end", "condition_value": "yes"},
+    ]
+    issues = validate_scenes(scenes, edges)
+    assert any(i.code == "choice_outgoing" for i in issues)
+    assert any(i.code == "condition_exits" for i in issues)


### PR DESCRIPTION
### Motivation
- Ensure graph scenarios are well-formed by enforcing common structural rules and surfacing issues with proper severities so the wizard can block progress when necessary.
- Make validation actionable in the UI by separating blocking errors from warnings and allowing users to focus the canvas on offending nodes/edges when an issue is clicked.

### Description
- Implemented a typed validation engine in `modules/scenarios/wizard_steps/scenes/graph_mode/validation.py` which returns `ValidationIssue` instances and enforces: exactly one `START`, at least one reachable `END_SUCCESS`/`END_FAIL`, no orphan nodes (excluding `START`), `CHOICE` nodes with >= 2 outgoing edges, and `CONDITION` nodes with >= 2 logical exits, via `validate_scenes(scenes, edges)`.
- Added `modules/scenarios/wizard_steps/scenes/graph_mode/ui/validation_panel.py` that renders blocking errors and warnings in separate sections, exposes `has_blocking_errors()` for wizard gating, and emits an `on_issue_click` callback when an item is clicked.
- Extended `modules/scenarios/wizard_steps/scenes/graph_mode/ui/canvas_view.py` with `focus_on_node(node_id)` and `focus_on_edge(edge_id)` helpers to select/center the offending element and notify selection changes.
- Added unit tests `tests/scenarios/test_graph_mode_validation.py` covering the new rules and behaviors.

### Testing
- Ran `pytest -q tests/scenarios/test_graph_mode_validation.py` and all tests passed (`3 passed`).
- No automated UI tests were added; the panel and canvas focus behavior are exercised via the new unit tests for validation logic only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f270d1aa80832b94457ec349a8dd5b)