### PR TITLE
Add shared scenario root key constants and save-path validation

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -29,6 +29,10 @@ from modules.scenarios.scene_structured_fields import (
     compose_scene_text_from_fields,
     normalise_structured_scene_items,
 )
+from modules.scenarios.schema.scenario_root_schema import (
+    SCENARIO_ROOT_KNOWN_FIELDS,
+    ensure_required_scenario_root_keys,
+)
 from modules.scenarios.scenario_character_graph import (
     ScenarioCharacterGraphEditor,
     build_scenario_graph_with_links,
@@ -230,24 +234,7 @@ class BasicInfoStep(WizardStep):
 
 
 class ScenesPlanningStep(WizardStep):
-    ROOT_KNOWN_FIELDS = {
-        "Title",
-        "Summary",
-        "Text",
-        "Secrets",
-        "Secret",
-        "Scenes",
-        "_SceneLayout",
-        "_ScenarioVisualFlow",
-        "NPCs",
-        "Creatures",
-        "Clues",
-        "Bases",
-        "Places",
-        "Maps",
-        "Factions",
-        "Objects",
-    }
+    ROOT_KNOWN_FIELDS = SCENARIO_ROOT_KNOWN_FIELDS
 
     def __init__(self, master, entity_wrappers, *, scenario_wrapper=None, finale_planner_callback=None):
         """Initialize the ScenesPlanningStep instance."""
@@ -584,6 +571,7 @@ class ScenesPlanningStep(WizardStep):
             scenario_title=self.scenario_title_var.get().strip(),
         )
         self.scenes = scenes
+        ensure_required_scenario_root_keys(state)
         self._root_extra_fields = {key: copy.deepcopy(value) for key, value in (state or {}).items() if key not in self.ROOT_KNOWN_FIELDS}
         initial_mode = "visual" if state.get("_ScenarioVisualMode") else "guided"
         self._set_mode(initial_mode, remap=False)
@@ -591,6 +579,7 @@ class ScenesPlanningStep(WizardStep):
 
     def save_state(self, state):
         """Save state."""
+        ensure_required_scenario_root_keys(state)
         self.scenes = self._collect_active_scenes()
         db_indexes = build_campaign_entity_indexes(getattr(self, "entity_wrappers", {}) or {})
         state["Title"] = self.scenario_title_var.get().strip()
@@ -2151,6 +2140,7 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
         if isinstance(scenes, str):
             scenes = [scenes]
 
+        ensure_required_scenario_root_keys(self.wizard_state)
         payload = {
             "Title": title,
             "Summary": self.wizard_state.get("Summary", ""),
@@ -2161,6 +2151,7 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
         }
         for field in SCENARIO_ENTITY_FIELD_NAMES:
             payload[field] = list(dict.fromkeys(self.wizard_state.get(field, [])))
+        ensure_required_scenario_root_keys(payload)
         sync_graph = bool(self.wizard_state.get("ScenarioCharacterGraphSync"))
 
         buttons = {

--- a/modules/scenarios/schema/scenario_root_schema.py
+++ b/modules/scenarios/schema/scenario_root_schema.py
@@ -1,0 +1,95 @@
+"""Shared constants and root-shape validation helpers for scenario payloads."""
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+PRESERVED_SCENARIO_ROOT_KEYS: tuple[str, ...] = (
+    "Title",
+    "Summary",
+    "Secrets",
+    "Secret",
+    "Scenes",
+    "_SceneLayout",
+    "NPCs",
+    "Creatures",
+    "Places",
+    "Clues",
+    "Bases",
+    "Maps",
+    "Factions",
+    "Objects",
+    "Books",
+    "Villains",
+    "Events",
+    "SceneBeats",
+    "SceneClues",
+    "SceneChallenges",
+    "SceneTwists",
+    "SceneRewards",
+    "LinkData",
+    "NextScenes",
+    "_canvas",
+    "_extra_fields",
+)
+
+ADDITIVE_SCENARIO_METADATA_KEYS: tuple[str, ...] = ("_ScenarioVisualFlow",)
+
+SCENARIO_ROOT_KNOWN_FIELDS: frozenset[str] = frozenset(
+    PRESERVED_SCENARIO_ROOT_KEYS
+    + ADDITIVE_SCENARIO_METADATA_KEYS
+    + (
+        "Text",
+        "NPCs",
+        "Creatures",
+        "Clues",
+        "Bases",
+        "Places",
+        "Maps",
+        "Factions",
+        "Objects",
+        "Books",
+        "Villains",
+        "Events",
+    )
+)
+
+
+def ensure_required_scenario_root_keys(state: dict[str, Any]) -> dict[str, Any]:
+    """Ensure required scenario root keys exist without renaming/removing existing keys."""
+    if not isinstance(state, dict):
+        return state
+
+    defaults = {
+        "Title": "",
+        "Summary": "",
+        "Secrets": "",
+        "Secret": "",
+        "Scenes": [],
+        "_SceneLayout": [],
+        "NPCs": [],
+        "Creatures": [],
+        "Places": [],
+        "Clues": [],
+        "Bases": [],
+        "Maps": [],
+        "Factions": [],
+        "Objects": [],
+        "Books": [],
+        "Villains": [],
+        "Events": [],
+        "SceneBeats": [],
+        "SceneClues": [],
+        "SceneChallenges": [],
+        "SceneTwists": [],
+        "SceneRewards": [],
+        "LinkData": [],
+        "NextScenes": [],
+        "_canvas": {},
+        "_extra_fields": {},
+    }
+    for key, default_value in defaults.items():
+        state.setdefault(key, copy.deepcopy(default_value))
+
+    state.setdefault("_ScenarioVisualFlow", {})
+    return state


### PR DESCRIPTION
### Motivation
- Centralize the set of root-level scenario keys and provide a shared, non-destructive validation helper so save/export code can rely on a canonical root shape.
- Preserve backwards compatibility by ensuring existing root keys are never renamed or removed while allowing additive metadata for visual flows.

### Description
- Added `modules/scenarios/schema/scenario_root_schema.py` which defines `PRESERVED_SCENARIO_ROOT_KEYS`, `ADDITIVE_SCENARIO_METADATA_KEYS`, `SCENARIO_ROOT_KNOWN_FIELDS`, and `ensure_required_scenario_root_keys()` to fill missing root keys without mutating existing keys.
- Updated `modules/scenarios/scenario_builder_wizard.py` to import `SCENARIO_ROOT_KNOWN_FIELDS` and `ensure_required_scenario_root_keys()` and replaced the local `ROOT_KNOWN_FIELDS` definition with the shared constant.
- Integrated `ensure_required_scenario_root_keys()` into scenario load/save flows inside `ScenesPlanningStep.load_state`, `ScenesPlanningStep.save_state`, and the wizard `finish` flow so both the in-memory `wizard_state` and the final `payload` always include required root keys while leaving guided/canvas serialization branches unchanged.
- Explicitly treats `_ScenarioVisualFlow` as additive root-level metadata only, and keeps `_SceneLayout`, `_canvas`, and `_extra_fields` behavior intact.

### Testing
- Compiled the modified modules with `python -m compileall modules/scenarios/schema/scenario_root_schema.py modules/scenarios/scenario_builder_wizard.py` which completed successfully.
- Verified through local code search that `SCENARIO_ROOT_KNOWN_FIELDS` and `ensure_required_scenario_root_keys` are referenced where intended and that no references to the removed local constant remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32fd4a3a8832ba8a5c9a6467d378d)