### PR TITLE
Add Scenario Builder scenes-step QA report (2026-04-30)

### DIFF
--- a/QA_REPORT_2026-04-30.md
+++ b/QA_REPORT_2026-04-30.md
@@ -1,0 +1,58 @@
+# Scenario Builder Scenes Step Check Report (2026-04-30)
+
+## Scope requested
+Manual checks for Scenario Builder scenes step:
+1. Segmented button options (`guided | canvas | visual`)
+2. Visual mode node/link editing workflow
+3. Selection sync + edit interactions
+4. Save/reopen persistence and compatibility
+5. Cross-mode round trip without data loss
+6. ReviewStep flow preview render integrity
+
+## Execution context
+- Environment is headless CLI; no interactive desktop session available for true manual UI driving.
+- Therefore, manual pointer/drag interactions were validated through existing automated tests that cover the same logic paths.
+
+## Evidence and outcomes
+
+### 1) Segmented button supports `guided | canvas | visual`
+**PASS (code-level + test coverage support)**
+- Scenes step mode segmented button is initialized with exact values `['guided', 'canvas', 'visual']`.
+- Mode guard also explicitly accepts only this set and falls back to `guided`.
+
+### 2) Visual mode node/link creation (including labeled branches)
+**PASS (automated)**
+- Visual flow tests verify round-trip export of `LinkData` and `NextScenes`.
+- Links preserve label text (`text`) and target scene mapping.
+
+### 3) Interaction validations
+- selection sync (tree/canvas/properties): **PARTIAL (logic covered; not pointer-driven manually)**
+- drag / duplicate / delete: **PARTIAL (delete/link mutation covered in tests; drag/duplicate need live UI session)**
+- link create/edit/delete: **PASS (automated link export/delete coverage)**
+- pan/zoom/minimap: **NOT EXECUTED (requires interactive UI rendering/input)**
+- component click-to-add: **NOT EXECUTED (requires interactive UI events)**
+
+### 4) Save + reopen checks
+**PASS (automated/state-level)**
+- `_ScenarioVisualFlow` persistence path is exercised by visual flow round-trip tests.
+- Scene export compatibility for `Scenes`/`LinkData`/`NextScenes` and `_SceneLayout` is covered by mode-switch + export assertions.
+- Structured/entity fields retention is covered by guided/canvas/visual adapter and round-trip tests.
+
+### 5) guided → visual → canvas → guided data integrity
+**PASS (automated)**
+- Dedicated test verifies planning mode switch preserves data across all three modes.
+
+### 6) ReviewStep flow preview
+**PASS (automated)**
+- Tests confirm `ReviewStep.load_state(...)` still triggers flow preview render and normalizes scene links correctly.
+
+## Commands executed
+```bash
+pytest -q tests/test_scenario_builder_wizard.py::test_scenes_planning_mode_switch_guided_visual_canvas_preserves_data \
+  tests/test_scenario_builder_wizard.py::test_review_step_load_state_normalises_scene_links_for_preview_render \
+  tests/test_scenario_builder_wizard.py::test_review_step_still_renders_visual_exported_links \
+  tests/scenarios/test_visual_flow_planner.py -q
+```
+
+## Recommendation
+To fully complete the remaining manual-only checks (drag, pan/zoom/minimap, click-to-add, full selection sync by UI focus), rerun this checklist in a desktop session (X11/Wayland) with the app window visible and record a screen capture.


### PR DESCRIPTION
### Motivation
- Add a concise QA report that captures the requested Scenario Builder scenes-step checklist and records automated validation where pointer-driven UI interaction could not be executed in a headless environment.

### Description
- Create `QA_REPORT_2026-04-30.md` documenting each checklist item, pass/partial/not-executed outcomes, and the exact `pytest` command used to validate non-interactive logic paths.

### Testing
- Ran `pytest -q tests/test_scenario_builder_wizard.py::test_scenes_planning_mode_switch_guided_visual_canvas_preserves_data tests/test_scenario_builder_wizard.py::test_review_step_load_state_normalises_scene_links_for_preview_render tests/test_scenario_builder_wizard.py::test_review_step_still_renders_visual_exported_links tests/scenarios/test_visual_flow_planner.py -q` and the targeted tests completed successfully (all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33caf3738832ba5f5267fc4c3a575)