### PR TITLE
Fix Tkinter callback crash in flow properties text fields

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -478,7 +478,7 @@ class FlowPropertiesPanel(ctk.CTkFrame):
         box.pack(fill="x", pady=(0, 6))
         box.insert("1.0", value)
         if key is not None:
-            box.bind("<KeyRelease>", lambda _e, k=key, b=box: self._emit({k: b.get("1.0", "end-1c")}), add="+")
+            box.bind("<KeyRelease>", lambda _e=None, k=key, b=box: self._emit({k: b.get("1.0", "end-1c")}), add="+")
 
     def _make_checkbox(self, label, value, key=None):
         var = ctk.BooleanVar(value=bool(value))


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` raised when the key-release callback in `FlowPropertiesPanel._make_text` is invoked without a Tk event object.

### Description
- Make the bound key-release callback accept an optional event by changing `lambda _e, k=key, b=box: ...` to `lambda _e=None, k=key, b=box: ...` in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py`.

### Testing
- Ran `python -m pytest -q tests/test_scenario_builder_wizard.py --maxfail=1` and the suite passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f341715878832b93ef351600b0b801)