### PR TITLE
Preserve visual node types across mode switches and save/load

### DIFF
--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -409,6 +409,8 @@ class ScenesPlanningStep(WizardStep):
         if self._active_mode == mode and remap:
             return
         current_scenes = self._collect_active_scenes() if remap else self.scenes
+        if remap and self._active_mode == "visual" and isinstance(self._state_ref, dict):
+            self._state_ref["_ScenarioVisualFlow"] = self.visual_planner.export_visual_payload()
         if mode == "guided":
             self.guided_planner.grid(row=0, column=0, sticky="nsew")
             self.canvas_planner.grid_forget()
@@ -631,6 +633,7 @@ class ScenesPlanningStep(WizardStep):
                 layout.append(copy.deepcopy(scene.get("_canvas") or {}))
             state["Scenes"] = payload
             state["_SceneLayout"] = layout
+            state["_ScenarioVisualFlow"] = self.visual_planner.export_visual_payload()
 
         if isinstance(self._root_extra_fields, dict):
             for key, value in self._root_extra_fields.items():

--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -50,6 +50,8 @@ _PLAYABLE_NODE_KIND_TO_SCENE_TYPE = {
     "action": "Action",
     "note": "Note",
 }
+_VISUAL_NODE_TYPE_FIELD = "_visual_node_type"
+_SCENE_TYPE_TO_NODE_KIND = {value: key for key, value in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE.items()}
 
 
 def _slugify(text: str) -> str:
@@ -185,7 +187,7 @@ def build_visual_flow_from_scenes(scenes, existing_visual_payload=None):
                 "scene_index": idx,
                 "x": int(canvas.get("x", matched.get("x", 0) or 0)),
                 "y": int(canvas.get("y", matched.get("y", 0) or 0)),
-                "kind": str(matched.get("kind") or _SCENE_TYPE_OVERRIDES.get(str(scene.get("SceneType") or "").strip(), "scene")).strip() or "scene",
+                "kind": _normalise_node_kind(_scene_to_node_kind(scene, matched.get("kind"))),
                 "summary": str(scene.get("Summary") or ""),
                 "scene_fields": {
                     "SceneType": str(scene.get("SceneType") or ""),
@@ -238,9 +240,11 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
         scene.setdefault("_extra_fields", {})
         scene["Title"] = title
         scene["Summary"] = str(node.get("summary") or scene.get("Summary") or "")
-        scene_type = _PLAYABLE_NODE_KIND_TO_SCENE_TYPE.get(str(node.get("kind") or "").strip(), "")
+        node_kind = _normalise_node_kind(node.get("kind"))
+        scene_type = _PLAYABLE_NODE_KIND_TO_SCENE_TYPE.get(node_kind, "")
         scene["SceneType"] = scene_type or str(scene.get("SceneType") or "")
         scene["Type"] = scene_type or str(scene.get("Type") or scene.get("SceneType") or "")
+        scene["_extra_fields"][_VISUAL_NODE_TYPE_FIELD] = node_kind
         scene.setdefault("LinkData", [])
         scene.setdefault("NextScenes", [])
         scene["_canvas"] = {"x": int(node.get("x", 0)), "y": int(node.get("y", 0))}
@@ -659,3 +663,17 @@ class VisualFlowPlanner(ctk.CTkFrame):
         callback = getattr(self, "save_state", None)
         if callable(callback):
             callback()
+def _normalise_node_kind(kind: Any) -> str:
+    value = str(kind or "").strip()
+    return value if value in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE else "scene"
+
+
+def _scene_to_node_kind(scene: dict[str, Any], existing_kind: Any = None) -> str:
+    if str(existing_kind or "").strip() in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE:
+        return str(existing_kind).strip()
+    extras = scene.get("_extra_fields") if isinstance(scene.get("_extra_fields"), dict) else {}
+    stored = str(extras.get(_VISUAL_NODE_TYPE_FIELD) or "").strip()
+    if stored in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE:
+        return stored
+    scene_type = str(scene.get("SceneType") or "").strip()
+    return _SCENE_TYPE_TO_NODE_KIND.get(scene_type, "scene")

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -98,6 +98,25 @@ def test_visual_flow_round_trip_preserves_scene_fields():
     assert by_title["Dockside"]["NextScenes"] == ["Ambush"]
 
 
+def test_visual_flow_round_trip_preserves_node_kinds_via_extra_metadata():
+    flow_payload = {
+        "version": 1,
+        "nodes": [
+            {"id": "n1", "scene_index": 0, "title": "Objective", "summary": "", "kind": "objective", "x": 0, "y": 0},
+            {"id": "n2", "scene_index": 1, "title": "Condition", "summary": "", "kind": "condition", "x": 0, "y": 0},
+            {"id": "n3", "scene_index": 2, "title": "Fallback", "summary": "", "kind": "scene", "x": 0, "y": 0},
+        ],
+        "links": [],
+    }
+
+    scenes = export_visual_flow_to_scenes(flow_payload)
+    rebuilt = build_visual_flow_from_scenes(scenes)
+    by_title = {node["title"]: node for node in rebuilt["nodes"]}
+    assert by_title["Objective"]["kind"] == "objective"
+    assert by_title["Condition"]["kind"] == "condition"
+    assert by_title["Fallback"]["kind"] == "scene"
+
+
 def test_visual_flow_exports_linkdata_and_nextscenes():
     flow_payload = {
         "version": 1,

--- a/tests/test_scenario_builder_wizard.py
+++ b/tests/test_scenario_builder_wizard.py
@@ -533,6 +533,22 @@ def test_scenes_planning_mode_switch_guided_visual_canvas_preserves_data():
     assert by_title["Market"]["Places"] == ["Grand Bazaar"]
 
 
+def test_visual_types_survive_mode_switch_and_save_reload():
+    scenes = [
+        {"Title": "A", "Summary": "", "SceneType": "Scene", "NextScenes": []},
+        {"Title": "B", "Summary": "", "SceneType": "Scene", "NextScenes": []},
+    ]
+    visual = build_visual_flow_from_scenes(scenes)
+    visual["nodes"][0]["kind"] = "objective"
+    visual["nodes"][1]["kind"] = "interaction"
+
+    exported = export_visual_flow_to_scenes(visual, existing_scenes=scenes)
+    rebuilt = build_visual_flow_from_scenes(exported, existing_visual_payload=visual)
+    by_title = {node["title"]: node["kind"] for node in rebuilt["nodes"]}
+    assert by_title["A"] == "objective"
+    assert by_title["B"] == "interaction"
+
+
 def test_finish_embedded_can_persist_before_callback(monkeypatch):
     """Verify that finish embedded can persist before callback."""
     wizard = scenario_builder_wizard.ScenarioBuilderWizard.__new__(


### PR DESCRIPTION
### Motivation
- Prevent loss of visual node semantics when switching between visual/canvas/guided modes or when saving/loading scenarios so node kinds like `objective`, `interaction`, `condition`, etc. remain stable.
- Ensure the visual flow payload is preferred and kept current so returning to visual mode does not re-derive generic `scene` kinds and overwrite user intent.

### Description
- Added explicit bidirectional mapping and helpers in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` (`_VISUAL_NODE_TYPE_FIELD`, `_SCENE_TYPE_TO_NODE_KIND`, `_normalise_node_kind`, `_scene_to_node_kind`) to map between scene `SceneType` and visual node `kind` and to restore kinds deterministically.
- Persisted the original visual node kind into scene metadata during export by writing `_extra_fields['_visual_node_type']` in `export_visual_flow_to_scenes` so saved scenarios retain the visual type without breaking older data.
- Restored node kind when rebuilding visual flow in `build_visual_flow_from_scenes` using the priority: existing visual kind → `_extra_fields['_visual_node_type']` → `SceneType` mapping → default `scene`, and preserved existing visual node keys when reconciling with scenes.
- Synchronized `_ScenarioVisualFlow` in `modules/scenarios/scenario_builder_wizard.py` by updating `ScenesPlanningStep._set_mode()` to export the current visual payload when leaving visual mode and by ensuring `save_state()` writes `_ScenarioVisualFlow` even when saving from non-visual modes.
- Added regression tests to `tests/scenarios/test_visual_flow_planner.py` and `tests/test_scenario_builder_wizard.py` that verify mixed node kinds survive export/rebuild and mode switch + save/reload cycles.

### Testing
- Added and ran the focused test set including the new `test_visual_flow_round_trip_preserves_node_kinds_via_extra_metadata` and `test_visual_types_survive_mode_switch_and_save_reload` in `tests/scenarios/test_visual_flow_planner.py` and `tests/test_scenario_builder_wizard.py`, respectively, and they passed.
- Executed `pytest` against the modified test files and observed all targeted tests passing (4 passed, others deselected in the focused run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f342fbe1dc832baa9bc49627bfeb74)