### PR TITLE
Add FlowHierarchyPanel context menu and route actions through VisualFlowPlanner

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -294,10 +294,21 @@ class FlowHierarchyPanel(ctk.CTkFrame):
         "scene": "🎬 ",
     }
 
-    def __init__(self, master, on_select=None, on_open=None):
+    _MENU_NODE_TYPES = (
+        ("Scene", "scene"),
+        ("Objective", "objective"),
+        ("Side Objective", "side_objective"),
+        ("Interaction", "interaction"),
+        ("Condition", "condition"),
+        ("Action", "action"),
+        ("Note", "note"),
+    )
+
+    def __init__(self, master, on_select=None, on_open=None, on_context_command=None):
         super().__init__(master)
         self.on_select = on_select
         self.on_open = on_open
+        self.on_context_command = on_context_command
         self._item_to_node_id = {}
         self._node_id_to_item = {}
         self._suspend_events = False
@@ -308,6 +319,8 @@ class FlowHierarchyPanel(ctk.CTkFrame):
             self._tree.pack(fill="both", expand=True, padx=8, pady=8)
             self._tree.bind("<<TreeviewSelect>>", self._emit_select)
             self._tree.bind("<Double-1>", self._emit_open)
+            self._tree.bind("<Button-3>", self._show_context_menu, add="+")
+            self._tree.bind("<Button-2>", self._show_context_menu, add="+")
 
     def render(self, nodes, links=None, scenario_title=""):
         if not self._tree:
@@ -394,6 +407,35 @@ class FlowHierarchyPanel(ctk.CTkFrame):
         node_id = self._item_to_node_id.get(selection[0]) if selection else None
         if node_id and self.on_open:
             self.on_open(node_id)
+
+    def _show_context_menu(self, event):
+        if not self._tree:
+            return
+        item_id = self._tree.identify_row(event.y)
+        node_id = self._item_to_node_id.get(item_id)
+        is_node_target = bool(node_id)
+        if is_node_target and item_id:
+            self._tree.selection_set(item_id)
+            self._tree.focus(item_id)
+            self._emit_select()
+        menu = tk.Menu(self, tearoff=False)
+        add_menu = tk.Menu(menu, tearoff=False)
+        for label, node_type in self._MENU_NODE_TYPES:
+            add_menu.add_command(label=label, command=lambda nt=node_type: self._dispatch_command("add", node_type=nt, node_id=node_id))
+        menu.add_cascade(label="Add", menu=add_menu)
+        menu.add_separator()
+        menu.add_command(label="Delete", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("delete", node_id=node_id))
+        menu.add_command(label="Move Up", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("move_up", node_id=node_id))
+        menu.add_command(label="Move Down", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("move_down", node_id=node_id))
+        menu.add_separator()
+        menu.add_command(label="Cut", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("cut", node_id=node_id))
+        menu.add_command(label="Copy", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("copy", node_id=node_id))
+        menu.add_command(label="Paste", command=lambda: self._dispatch_command("paste", node_id=node_id))
+        menu.tk_popup(event.x_root, event.y_root)
+
+    def _dispatch_command(self, command, **kwargs):
+        if callable(self.on_context_command):
+            self.on_context_command(command, kwargs)
 
 
 class FlowPropertiesPanel(ctk.CTkFrame):
@@ -562,7 +604,8 @@ class VisualFlowPlanner(ctk.CTkFrame):
         self._flow_payload = {"version": _VISUAL_FLOW_VERSION, "nodes": [], "links": []}
         self._scenes = []
 
-        self.hierarchy = FlowHierarchyPanel(self, on_select=self._on_select, on_open=self._open_node_properties)
+        self._clipboard_node = None
+        self.hierarchy = FlowHierarchyPanel(self, on_select=self._on_select, on_open=self._open_node_properties, on_context_command=self._handle_hierarchy_command)
         self.hierarchy.grid(row=0, column=0, sticky="nsew")
         self.canvas = VisualFlowCanvas(self, on_select=self._on_select, on_change=self.mark_dirty, on_save=self._safe_save)
         self.canvas.grid(row=0, column=1, sticky="nsew")
@@ -609,6 +652,87 @@ class VisualFlowPlanner(ctk.CTkFrame):
 
     def mark_dirty(self):
         self._dirty = True
+
+    def _refresh_views(self):
+        payload = self.canvas.model.payload
+        self.hierarchy.render(payload.get("nodes") or [], payload.get("links") or [], self._scenario_title)
+        self.canvas.render()
+        self.mark_dirty()
+
+    def _node_anchor_context(self, node_id=None):
+        return {"node_id": str(node_id or "").strip() or None}
+
+    def add_node(self, node_type, anchor_context):
+        node = self.canvas.create_node_at_viewport_center(node_type)
+        anchor_id = str((anchor_context or {}).get("node_id") or "").strip()
+        if node and anchor_id:
+            self.canvas.model.payload.setdefault("links", []).append({"source": anchor_id, "target": node["id"], "kind": "scene_link", "label": ""})
+            self.canvas.model.payload["links"] = normalise_flow_links(self.canvas.model.payload.get("nodes") or [], self.canvas.model.payload.get("links") or [])
+        if node:
+            self._refresh_views()
+            self._on_select(node.get("id"), source="canvas")
+
+    def delete_node(self, node_id):
+        if self.canvas.model.remove_node(str(node_id or "")):
+            self._refresh_views()
+
+    def reorder_node(self, node_id, direction):
+        nodes = self.canvas.model.payload.get("nodes") or []
+        idx = next((i for i, node in enumerate(nodes) if str(node.get("id") or "") == str(node_id or "")), -1)
+        if idx < 0:
+            return
+        target = idx - 1 if direction == "up" else idx + 1
+        if target < 0 or target >= len(nodes):
+            return
+        nodes[idx], nodes[target] = nodes[target], nodes[idx]
+        for pos, node in enumerate(nodes):
+            node["scene_index"] = pos
+        self._refresh_views()
+
+    def cut_node(self, node_id):
+        self.copy_node(node_id)
+        self.delete_node(node_id)
+
+    def copy_node(self, node_id):
+        node = self.canvas.model.get_node(str(node_id or ""))
+        if node:
+            self._clipboard_node = copy.deepcopy(node)
+
+    def paste_node(self, anchor_context):
+        if not isinstance(self._clipboard_node, dict):
+            return
+        nodes = self.canvas.model.payload.get("nodes") or []
+        links = self.canvas.model.payload.get("links") or []
+        clone = copy.deepcopy(self._clipboard_node)
+        clone["id"] = normalise_flow_node_id(clone.get("title") or "scene", [n.get("id") for n in nodes])
+        clone["scene_index"] = len(nodes)
+        clone["x"] = int(clone.get("x", 0)) + 40
+        clone["y"] = int(clone.get("y", 0)) + 40
+        nodes.append(clone)
+        source_id = str((anchor_context or {}).get("node_id") or "").strip()
+        if source_id and any(str(n.get("id") or "") == source_id for n in nodes):
+            links.append({"source": source_id, "target": clone["id"], "label": "", "kind": "scene_link"})
+        self.canvas.model.payload["links"] = normalise_flow_links(nodes, links)
+        self._refresh_views()
+        self._on_select(clone.get("id"), source="canvas")
+
+    def _handle_hierarchy_command(self, command, context):
+        node_id = str((context or {}).get("node_id") or "").strip() or None
+        anchor_context = self._node_anchor_context(node_id)
+        if command == "add":
+            self.add_node((context or {}).get("node_type") or "scene", anchor_context)
+        elif command == "delete" and node_id:
+            self.delete_node(node_id)
+        elif command == "move_up" and node_id:
+            self.reorder_node(node_id, "up")
+        elif command == "move_down" and node_id:
+            self.reorder_node(node_id, "down")
+        elif command == "cut" and node_id:
+            self.cut_node(node_id)
+        elif command == "copy" and node_id:
+            self.copy_node(node_id)
+        elif command == "paste":
+            self.paste_node(anchor_context)
 
     def _on_select(self, item_id, source=""):
         payload = self.canvas.model.payload

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -1,5 +1,6 @@
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
 from modules.scenarios.wizard_steps.scenes.visual_flow_planner import (
+    VisualFlowPlanner,
     build_visual_flow_from_scenes,
     export_visual_flow_to_scenes,
     normalise_flow_node_id,
@@ -150,3 +151,84 @@ def test_visual_flow_delete_node_removes_links():
 def test_visual_flow_unique_ids():
     used = {"scene", "scene-2"}
     assert normalise_flow_node_id("Scene", used) == "scene-3"
+
+
+class _FakeCanvas:
+    def __init__(self, payload):
+        self.model = FlowCanvasModel(payload)
+        self.render_calls = 0
+        self.created = 0
+        self.selected = None
+
+    def render(self):
+        self.render_calls += 1
+
+    def create_node_at_viewport_center(self, kind):
+        self.created += 1
+        node = {"id": f"new-{self.created}", "title": f"{kind} node", "kind": kind, "scene_index": len(self.model.payload.get("nodes") or []), "x": 10, "y": 20}
+        self.model.payload.setdefault("nodes", []).append(node)
+        return node
+
+    def select_node(self, node_id, emit=False):
+        self.selected = (node_id, emit)
+
+
+class _FakeHierarchy:
+    def __init__(self):
+        self.calls = 0
+
+    def render(self, *_args, **_kwargs):
+        self.calls += 1
+
+    def select_node(self, *_args, **_kwargs):
+        return None
+
+
+def _build_headless_planner(payload):
+    planner = VisualFlowPlanner.__new__(VisualFlowPlanner)
+    planner.canvas = _FakeCanvas(payload)
+    planner.hierarchy = _FakeHierarchy()
+    planner.properties = type("P", (), {"bind_item": lambda *args, **kwargs: None})()
+    planner._scenario_title = "Test"
+    planner._dirty = False
+    planner._clipboard_node = None
+    return planner
+
+
+def test_planner_context_commands_delete_reorder_and_copy_paste():
+    planner = _build_headless_planner(
+        {
+            "version": 1,
+            "nodes": [
+                {"id": "a", "title": "A", "kind": "scene", "scene_index": 0, "x": 0, "y": 0},
+                {"id": "b", "title": "B", "kind": "scene", "scene_index": 1, "x": 0, "y": 0},
+            ],
+            "links": [{"id": "a-b", "source": "a", "target": "b", "label": "", "kind": "scene_link"}],
+        }
+    )
+    planner._handle_hierarchy_command("move_down", {"node_id": "a"})
+    nodes = planner.canvas.model.payload["nodes"]
+    assert [node["id"] for node in nodes] == ["b", "a"]
+    assert [node["scene_index"] for node in nodes] == [0, 1]
+
+    planner._handle_hierarchy_command("copy", {"node_id": "a"})
+    planner._handle_hierarchy_command("paste", {"node_id": None})
+    ids = [node["id"] for node in planner.canvas.model.payload["nodes"]]
+    assert len(ids) == 3
+    assert len(set(ids)) == 3
+
+    planner._handle_hierarchy_command("cut", {"node_id": "b"})
+    assert planner.canvas.model.get_node("b") is None
+
+
+def test_planner_add_and_paste_anchor_generate_valid_links():
+    planner = _build_headless_planner({"version": 1, "nodes": [{"id": "root", "title": "Root", "kind": "scene", "scene_index": 0, "x": 0, "y": 0}], "links": []})
+    planner._handle_hierarchy_command("add", {"node_id": "root", "node_type": "objective"})
+    added = [node for node in planner.canvas.model.payload["nodes"] if node["id"] != "root"][0]
+    assert added["kind"] == "objective"
+    assert any(link["source"] == "root" and link["target"] == added["id"] for link in planner.canvas.model.payload["links"])
+
+    planner._handle_hierarchy_command("copy", {"node_id": added["id"]})
+    planner._handle_hierarchy_command("paste", {"node_id": "root"})
+    latest_id = planner.canvas.model.payload["nodes"][-1]["id"]
+    assert any(link["source"] == "root" and link["target"] == latest_id for link in planner.canvas.model.payload["links"])


### PR DESCRIPTION
### Motivation
- Provide a right-click context menu on the visual planner hierarchy to let users add, remove, reorder and clipboard nodes directly from the tree.
- Centralize all node operations at the planner level so the tree/canvas/properties views remain synchronized and changes correctly mark the planner dirty.
- Support headless testing of command handlers (data-model level) so menu logic can be validated without real Tk windows.

### Description
- Added a context menu to `FlowHierarchyPanel` with an `Add` submenu (Scene, Objective, Side Objective, Interaction, Condition, Action, Note) and actions `Delete`, `Move Up`, `Move Down`, `Cut`, `Copy`, and `Paste`, bound to tree row and empty-area clicks (`<Button-3>` / `<Button-2>`).
- Introduced `on_context_command` wiring and a dispatcher so hierarchy menu selections call a planner handler `_handle_hierarchy_command(...)` rather than manipulating the model directly.
- Implemented planner-level command methods: `add_node(node_type, anchor_context)`, `delete_node(node_id)`, `reorder_node(node_id, direction)`, `cut_node(node_id)`, `copy_node(node_id)`, and `paste_node(anchor_context)`, plus `_refresh_views()` to re-render hierarchy/canvas and mark dirty.
- Paste logic duplicates IDs safely using `normalise_flow_node_id(...)`, offsets the pasted node position, and only creates a linking edge when an anchor node is valid; links are normalized with `normalise_flow_links(...)`.
- Added headless tests (no real Tk) for the new command handlers in `tests/scenarios/test_visual_flow_planner.py` using lightweight fake canvas/hierarchy helpers.

### Testing
- Ran `pytest -q tests/scenarios/test_visual_flow_planner.py -k 'planner_context_commands or planner_add_and_paste_anchor'` and the new headless command-handler tests passed (2 passed, 8 deselected).
- Ran the full `pytest -q tests/scenarios/test_visual_flow_planner.py` and observed 9 tests passing and 1 failing; the failing assertion is `test_reuses_existing_visual_nodes_and_preserves_unknown_keys` which expected `kind == "custom"` but currently sees `"scene"` (this appears unrelated to the new menu command handlers and should be investigated separately).
- The new tests exercise add/delete/reorder/cut/copy/paste and anchor-link behavior and validated safe id duplication and view refresh orchestration (headless tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f343c55938832b955e67e0518c65ce)