### PR TITLE
Add draggable hierarchy reordering with model-backed node ordering

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/model.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/model.py
@@ -46,3 +46,24 @@ class FlowCanvasModel:
         before = len(self._payload.get("links", []))
         self._payload["links"] = [l for l in self._payload.get("links", []) if str(l.get("id") or "") != str(link_id or "")]
         return len(self._payload["links"]) != before
+
+    def reorder_nodes(self, dragged_id: str, target_id: str, *, place_after: bool = False) -> bool:
+        nodes = self._payload.get("nodes", [])
+        drag_key = str(dragged_id or "")
+        target_key = str(target_id or "")
+        if not drag_key or not target_key or drag_key == target_key:
+            return False
+
+        drag_index = next((idx for idx, node in enumerate(nodes) if str(node.get("id") or "") == drag_key), -1)
+        target_index = next((idx for idx, node in enumerate(nodes) if str(node.get("id") or "") == target_key), -1)
+        if drag_index < 0 or target_index < 0:
+            return False
+
+        node = nodes.pop(drag_index)
+        if drag_index < target_index:
+            target_index -= 1
+        insert_at = target_index + (1 if place_after else 0)
+        nodes.insert(max(0, min(insert_at, len(nodes))), node)
+        for position, item in enumerate(nodes):
+            item["scene_index"] = position
+        return True

--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -313,6 +313,9 @@ class FlowHierarchyPanel(ctk.CTkFrame):
         self._node_id_to_item = {}
         self._suspend_events = False
         self._tree = None
+        self._dragged_item_id = None
+        self._drop_target_item_id = None
+        self._drop_place_after = False
 
         if ttk and hasattr(ttk, "Treeview"):
             self._tree = ttk.Treeview(self, show="tree", selectmode="browse")
@@ -321,6 +324,11 @@ class FlowHierarchyPanel(ctk.CTkFrame):
             self._tree.bind("<Double-1>", self._emit_open)
             self._tree.bind("<Button-3>", self._show_context_menu, add="+")
             self._tree.bind("<Button-2>", self._show_context_menu, add="+")
+            self._tree.bind("<ButtonPress-1>", self._on_drag_start, add="+")
+            self._tree.bind("<B1-Motion>", self._on_drag_motion, add="+")
+            self._tree.bind("<ButtonRelease-1>", self._on_drag_release, add="+")
+            self._tree.bind("<Alt-Up>", self._on_move_up_shortcut, add="+")
+            self._tree.bind("<Alt-Down>", self._on_move_down_shortcut, add="+")
 
     def render(self, nodes, links=None, scenario_title=""):
         if not self._tree:
@@ -342,6 +350,8 @@ class FlowHierarchyPanel(ctk.CTkFrame):
             self._item_to_node_id[item_id] = node_id
             if node_id:
                 self._node_id_to_item[node_id] = item_id
+        self._dragged_item_id = None
+        self._drop_target_item_id = None
 
     def select_node(self, node_id):
         if not self._tree:
@@ -436,6 +446,56 @@ class FlowHierarchyPanel(ctk.CTkFrame):
     def _dispatch_command(self, command, **kwargs):
         if callable(self.on_context_command):
             self.on_context_command(command, kwargs)
+
+    def _on_drag_start(self, event):
+        if not self._tree:
+            return
+        item_id = self._tree.identify_row(event.y)
+        if item_id and self._item_to_node_id.get(item_id):
+            self._dragged_item_id = item_id
+            self._drop_target_item_id = None
+            self._tree.selection_set(item_id)
+            self._tree.focus(item_id)
+
+    def _on_drag_motion(self, event):
+        if not self._tree or not self._dragged_item_id:
+            return
+        item_id = self._tree.identify_row(event.y)
+        if not item_id or item_id == self._dragged_item_id or not self._item_to_node_id.get(item_id):
+            return
+        bbox = self._tree.bbox(item_id)
+        self._drop_place_after = bool(bbox and event.y > (bbox[1] + (bbox[3] // 2)))
+        self._drop_target_item_id = item_id
+        self._tree.selection_set(item_id)
+
+    def _on_drag_release(self, _event):
+        if not self._tree:
+            return
+        if self._dragged_item_id and self._drop_target_item_id:
+            dragged_id = self._item_to_node_id.get(self._dragged_item_id)
+            target_id = self._item_to_node_id.get(self._drop_target_item_id)
+            if dragged_id and target_id and dragged_id != target_id:
+                self._dispatch_command("reorder", node_id=dragged_id, target_node_id=target_id, place_after=self._drop_place_after)
+        self._dragged_item_id = None
+        self._drop_target_item_id = None
+
+    def _on_move_up_shortcut(self, *_):
+        if not self._tree:
+            return
+        selection = self._tree.selection()
+        node_id = self._item_to_node_id.get(selection[0]) if selection else None
+        if node_id:
+            self._dispatch_command("move_up", node_id=node_id)
+        return "break"
+
+    def _on_move_down_shortcut(self, *_):
+        if not self._tree:
+            return
+        selection = self._tree.selection()
+        node_id = self._item_to_node_id.get(selection[0]) if selection else None
+        if node_id:
+            self._dispatch_command("move_down", node_id=node_id)
+        return "break"
 
 
 class FlowPropertiesPanel(ctk.CTkFrame):
@@ -679,15 +739,19 @@ class VisualFlowPlanner(ctk.CTkFrame):
     def reorder_node(self, node_id, direction):
         nodes = self.canvas.model.payload.get("nodes") or []
         idx = next((i for i, node in enumerate(nodes) if str(node.get("id") or "") == str(node_id or "")), -1)
-        if idx < 0:
-            return
         target = idx - 1 if direction == "up" else idx + 1
-        if target < 0 or target >= len(nodes):
+        if idx < 0 or target < 0 or target >= len(nodes):
             return
-        nodes[idx], nodes[target] = nodes[target], nodes[idx]
-        for pos, node in enumerate(nodes):
-            node["scene_index"] = pos
-        self._refresh_views()
+        target_id = str(nodes[target].get("id") or "")
+        place_after = direction == "down"
+        if self.canvas.model.reorder_nodes(str(node_id or ""), target_id, place_after=place_after):
+            self._refresh_views()
+            self._on_select(node_id, source="canvas")
+
+    def reorder_node_relative(self, node_id, target_node_id, place_after=False):
+        if self.canvas.model.reorder_nodes(str(node_id or ""), str(target_node_id or ""), place_after=bool(place_after)):
+            self._refresh_views()
+            self._on_select(node_id, source="canvas")
 
     def cut_node(self, node_id):
         self.copy_node(node_id)
@@ -727,6 +791,8 @@ class VisualFlowPlanner(ctk.CTkFrame):
             self.reorder_node(node_id, "up")
         elif command == "move_down" and node_id:
             self.reorder_node(node_id, "down")
+        elif command == "reorder" and node_id:
+            self.reorder_node_relative(node_id, (context or {}).get("target_node_id"), place_after=bool((context or {}).get("place_after")))
         elif command == "cut" and node_id:
             self.cut_node(node_id)
         elif command == "copy" and node_id:

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -153,6 +153,21 @@ def test_visual_flow_unique_ids():
     assert normalise_flow_node_id("Scene", used) == "scene-3"
 
 
+def test_model_reorder_nodes_updates_order_without_link_mutation():
+    model = FlowCanvasModel(
+        {
+            "version": 1,
+            "nodes": [{"id": "a", "scene_index": 0}, {"id": "b", "scene_index": 1}, {"id": "c", "scene_index": 2}],
+            "links": [{"id": "a-b", "source": "a", "target": "b"}, {"id": "b-c", "source": "b", "target": "c"}],
+        }
+    )
+    original_links = list(model.payload["links"])
+    assert model.reorder_nodes("c", "a", place_after=False) is True
+    assert [node["id"] for node in model.payload["nodes"]] == ["c", "a", "b"]
+    assert [node["scene_index"] for node in model.payload["nodes"]] == [0, 1, 2]
+    assert model.payload["links"] == original_links
+
+
 class _FakeCanvas:
     def __init__(self, payload):
         self.model = FlowCanvasModel(payload)
@@ -232,3 +247,21 @@ def test_planner_add_and_paste_anchor_generate_valid_links():
     planner._handle_hierarchy_command("paste", {"node_id": "root"})
     latest_id = planner.canvas.model.payload["nodes"][-1]["id"]
     assert any(link["source"] == "root" and link["target"] == latest_id for link in planner.canvas.model.payload["links"])
+
+
+def test_planner_reorder_command_keeps_selection_and_export_order_deterministic():
+    planner = _build_headless_planner(
+        {
+            "version": 1,
+            "nodes": [
+                {"id": "a", "title": "A", "kind": "scene", "scene_index": 0, "x": 0, "y": 0},
+                {"id": "b", "title": "B", "kind": "scene", "scene_index": 1, "x": 0, "y": 0},
+                {"id": "c", "title": "C", "kind": "scene", "scene_index": 2, "x": 0, "y": 0},
+            ],
+            "links": [{"id": "a-c", "source": "a", "target": "c", "label": "", "kind": "scene_link"}],
+        }
+    )
+    planner._handle_hierarchy_command("reorder", {"node_id": "c", "target_node_id": "a", "place_after": False})
+    assert [node["id"] for node in planner.canvas.model.payload["nodes"]] == ["c", "a", "b"]
+    exported = export_visual_flow_to_scenes(planner.canvas.model.payload)
+    assert [scene["Title"] for scene in exported] == ["C", "A", "B"]


### PR DESCRIPTION
### Motivation
- Provide intuitive drag-and-drop reordering in the flow hierarchy and keyboard fallbacks to improve accessibility and parity with the context menu.
- Ensure reorder operations update the planner model (single source of truth) so rendering, exports and traversal/grouping remain deterministic and consistent.
- Preserve link topology and selection state across reorder operations so visual semantics and canvas emphasis remain stable.

### Description
- Added `FlowCanvasModel.reorder_nodes(dragged_id, target_id, place_after=False)` to perform deterministic reordering and renumber `scene_index` while leaving `links` untouched.
- Implemented tree drag lifecycle in `FlowHierarchyPanel` via `_on_drag_start`, `_on_drag_motion`, and `_on_drag_release` that dispatch a `reorder` command containing `node_id`, `target_node_id`, and `place_after`.
- Added keyboard fallbacks bound to `Alt+Up` and `Alt+Down` in the hierarchy tree that dispatch `move_up` / `move_down` commands for accessibility.
- Wired planner handlers (`VisualFlowPlanner`) to use the model reorder API via `reorder_node` / `reorder_node_relative`, refresh derived rendering (`_refresh_views`) and re-focus the selected node after reorder.
- Added tests in `tests/scenarios/test_visual_flow_planner.py` covering model-level reorder stability, no link mutation on reorder, and deterministic exported node ordering after a reorder.

### Testing
- Ran the full file with `pytest -q tests/scenarios/test_visual_flow_planner.py`, which showed a pre-existing unrelated failure in `test_reuses_existing_visual_nodes_and_preserves_unknown_keys` (unrelated to these changes).
- Ran focused tests with `pytest -q tests/scenarios/test_visual_flow_planner.py -k 'reorder_nodes_updates_order_without_link_mutation or planner_reorder_command_keeps_selection_and_export_order_deterministic or planner_context_commands_delete_reorder_and_copy_paste'`, and the selected tests passed (3 passed, 9 deselected).
- New tests added: `test_model_reorder_nodes_updates_order_without_link_mutation` and `test_planner_reorder_command_keeps_selection_and_export_order_deterministic`, both of which passed in the targeted runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f344d1af18832bbbc9748318521991)