### PR TITLE
Refactor visual-flow interactions into reusable modules and add parity checklist tests

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -10,6 +10,18 @@ import customtkinter as ctk
 from modules.scenarios.scene_flow_rendering import apply_scene_flow_canvas_styling
 from modules.scenarios.wizard_steps.scenes.component_library.node_factory import build_default_node
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
+from modules.scenarios.wizard_steps.scenes.visual_flow.commands import (
+    make_create_link_command,
+    make_delete_node_command,
+    make_update_link_command,
+)
+from modules.scenarios.wizard_steps.scenes.visual_flow.interactions import (
+    normalise_link_selection,
+    normalise_single_selection,
+    now,
+    resolve_link_target,
+    should_open_context_menu,
+)
 def _slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-") or "scene"
 
@@ -53,6 +65,7 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self._pan_state = None
         self._space_held = False
         self._drag_link_source = None
+        self._context_press_ts = 0.0
         self._zoom = 1.0
         self._offset_x = 0
         self._offset_y = 0
@@ -62,7 +75,9 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self.canvas.bind("<Button-2>", self._start_pan)
         self.canvas.bind("<B2-Motion>", self._pan)
         self.canvas.bind("<ButtonRelease-2>", self._end_pan)
-        self.canvas.bind("<Button-3>", self._canvas_menu)
+        self.canvas.bind("<Button-3>", self._on_context_press)
+        self.canvas.bind("<ButtonRelease-3>", self._canvas_menu)
+        self.canvas.bind("<ButtonRelease-1>", self._complete_link_drag, add="+")
         self.canvas.bind("<Double-1>", self._double_click)
         self.canvas.bind("<Control-0>", lambda _e: self.reset_zoom())
         self.canvas.bind_all("<Delete>", lambda _e: self.delete_selected())
@@ -205,7 +220,12 @@ class VisualFlowCanvas(ctk.CTkFrame):
             link["label"] = text
             self._emit_change(); self.render()
 
+    def _on_context_press(self, _event):
+        self._context_press_ts = now()
+
     def _canvas_menu(self, event):
+        if not should_open_context_menu(3, self._context_press_ts, now()):
+            return
         menu = tk.Menu(self, tearoff=False)
         menu.add_command(label="Add scene", command=lambda: self._add_node_at(event.x, event.y, "scene"))
         menu.add_command(label="Add condition", command=lambda: self._add_node_at(event.x, event.y, "condition"))
@@ -214,6 +234,8 @@ class VisualFlowCanvas(ctk.CTkFrame):
         menu.tk_popup(event.x_root, event.y_root)
 
     def _link_menu(self, event, link_id):
+        if not should_open_context_menu(3, self._context_press_ts, now()):
+            return
         self.select_link(link_id)
         menu = tk.Menu(self, tearoff=False)
         menu.add_command(label="Edit link", command=lambda: self._edit_link(link_id))
@@ -245,28 +267,56 @@ class VisualFlowCanvas(ctk.CTkFrame):
         return node
 
     def _start_link_drag(self, event, node_id):
-        self._drag_link_source = node_id
+        self._drag_link_source = str(node_id or "").strip() or None
+
+    def _complete_link_drag(self, event):
+        if not self._drag_link_source:
+            return
+        source_id = self._drag_link_source
+        self._drag_link_source = None
+        item = self.canvas.find_withtag("current")
+        target_id = None
+        if item:
+            tags = self.canvas.gettags(item[0])
+            if "node" in tags and len(tags) > 1:
+                target_id = tags[-1]
+        target_id = resolve_link_target(source_id, [target_id])
+        if not target_id:
+            return
+        existing = self.model.payload.setdefault("links", [])
+        link = {"id": normalise_flow_node_id(f"{source_id}-{target_id}", [l.get("id") for l in existing]), "source": source_id, "target": target_id, "label": "", "kind": "scene_link"}
+        existing.append(link)
+        cmd = make_create_link_command(source_id=source_id, target_id=target_id, link_payload=link)
+        if cmd.changed:
+            self._emit_change(); self.render()
 
     def _emit_change(self):
         if self.on_change:
             self.on_change()
 
     def select_node(self, node_id, emit=False):
-        self._selected_link_id = None
-        self._selected_node_id = str(node_id or "")
+        self._selected_node_id, self._selected_link_id = normalise_single_selection(node_id)
+        self._selected_node_id = self._selected_node_id or ""
         if emit and self.on_select:
             self.on_select(self._selected_node_id, source="canvas")
 
     def select_link(self, link_id):
-        self._selected_node_id = None
-        self._selected_link_id = str(link_id or "")
+        self._selected_node_id, self._selected_link_id = normalise_link_selection(link_id)
+        self._selected_link_id = self._selected_link_id or ""
 
     def delete_selected(self):
+        changed = False
         if self._selected_node_id:
-            self.model.remove_node(self._selected_node_id)
+            node = self.model.get_node(self._selected_node_id)
+            links = [l for l in (self.model.payload.get("links") or []) if l.get("source") == self._selected_node_id or l.get("target") == self._selected_node_id]
+            cmd = make_delete_node_command(node_id=self._selected_node_id, removed_node=node, removed_links=links)
+            changed = self.model.remove_node(self._selected_node_id) and cmd.changed
         elif self._selected_link_id:
-            self.model.remove_link(self._selected_link_id)
-        self._emit_change(); self.render()
+            link = self.model.get_link(self._selected_link_id)
+            changed = self.model.remove_link(self._selected_link_id)
+            _ = make_update_link_command(link_id=self._selected_link_id, before=link or {}, after={})
+        if changed:
+            self._emit_change(); self.render()
 
     def duplicate_selected(self):
         if not self._selected_node_id:

--- a/modules/scenarios/wizard_steps/scenes/visual_flow/commands.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow/commands.py
@@ -1,0 +1,37 @@
+"""Undo-friendly command primitives for visual flow changes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    changed: bool
+    before: dict[str, Any] = field(default_factory=dict)
+    after: dict[str, Any] = field(default_factory=dict)
+
+
+def make_delete_node_command(*, node_id: str, removed_node: dict[str, Any] | None, removed_links: list[dict[str, Any]]) -> CommandResult:
+    return CommandResult(
+        changed=bool(removed_node),
+        before={"node": removed_node, "links": list(removed_links)},
+        after={"node_id": str(node_id or "")},
+    )
+
+
+def make_update_link_command(*, link_id: str, before: dict[str, Any], after: dict[str, Any]) -> CommandResult:
+    return CommandResult(
+        changed=before != after,
+        before={"link_id": str(link_id or ""), "payload": dict(before or {})},
+        after={"link_id": str(link_id or ""), "payload": dict(after or {})},
+    )
+
+
+def make_create_link_command(*, source_id: str, target_id: str, link_payload: dict[str, Any]) -> CommandResult:
+    return CommandResult(
+        changed=bool(source_id and target_id),
+        before={},
+        after={"source": str(source_id or ""), "target": str(target_id or ""), "link": dict(link_payload or {})},
+    )

--- a/modules/scenarios/wizard_steps/scenes/visual_flow/interactions.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow/interactions.py
@@ -1,0 +1,43 @@
+"""Shared interaction helpers for scene and visual flow canvases."""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable
+
+
+def should_open_context_menu(button: int, press_ts: float, release_ts: float, *, threshold_ms: int = 220) -> bool:
+    """Return True when a right/middle click should open context menu.
+
+    Mirrors scene editor semantics: open only on quick click, not on press-drag-release.
+    """
+    if button not in (2, 3):
+        return False
+    elapsed = max(0.0, release_ts - press_ts) * 1000.0
+    return elapsed <= float(threshold_ms)
+
+
+def now() -> float:
+    return time.monotonic()
+
+
+def normalise_single_selection(selected_id: str | None) -> tuple[str | None, str | None]:
+    """Exclusive selection contract: either node or link can be selected."""
+    value = str(selected_id or "").strip() or None
+    return value, None
+
+
+def normalise_link_selection(selected_id: str | None) -> tuple[str | None, str | None]:
+    """Exclusive selection contract: either link or node can be selected."""
+    value = str(selected_id or "").strip() or None
+    return None, value
+
+
+def resolve_link_target(source_id: str, target_candidates: Iterable[str]) -> str | None:
+    """Pick the first non-self candidate as link drop target."""
+    source = str(source_id or "").strip()
+    for candidate in target_candidates:
+        target = str(candidate or "").strip()
+        if target and target != source:
+            return target
+    return None

--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -855,12 +855,15 @@ class VisualFlowPlanner(ctk.CTkFrame):
             callback()
 def _normalise_node_kind(kind: Any) -> str:
     value = str(kind or "").strip()
-    return value if value in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE else "scene"
+    if not value:
+        return "scene"
+    return value
 
 
 def _scene_to_node_kind(scene: dict[str, Any], existing_kind: Any = None) -> str:
-    if str(existing_kind or "").strip() in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE:
-        return str(existing_kind).strip()
+    existing = str(existing_kind or "").strip()
+    if existing:
+        return existing
     extras = scene.get("_extra_fields") if isinstance(scene.get("_extra_fields"), dict) else {}
     stored = str(extras.get(_VISUAL_NODE_TYPE_FIELD) or "").strip()
     if stored in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE:

--- a/tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py
+++ b/tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py
@@ -1,0 +1,46 @@
+from modules.scenarios.wizard_steps.scenes.visual_flow.commands import (
+    make_create_link_command,
+    make_delete_node_command,
+    make_update_link_command,
+)
+from modules.scenarios.wizard_steps.scenes.visual_flow.interactions import (
+    normalise_link_selection,
+    normalise_single_selection,
+    resolve_link_target,
+    should_open_context_menu,
+)
+
+
+def test_parity_selection_semantics_are_exclusive():
+    node_id, link_id = normalise_single_selection("n1")
+    assert node_id == "n1"
+    assert link_id is None
+
+    node_id, link_id = normalise_link_selection("l1")
+    assert node_id is None
+    assert link_id == "l1"
+
+
+def test_parity_context_menu_click_timing():
+    assert should_open_context_menu(3, 0.0, 0.1)
+    assert not should_open_context_menu(3, 0.0, 0.5)
+    assert not should_open_context_menu(1, 0.0, 0.1)
+
+
+def test_parity_link_drag_target_resolution():
+    assert resolve_link_target("a", ["", "a", "b"]) == "b"
+    assert resolve_link_target("a", ["a", ""]) is None
+
+
+def test_parity_delete_update_command_contracts_undo_ready():
+    delete_cmd = make_delete_node_command(node_id="a", removed_node={"id": "a"}, removed_links=[{"id": "a-b"}])
+    assert delete_cmd.changed is True
+    assert delete_cmd.before["node"]["id"] == "a"
+
+    update_cmd = make_update_link_command(link_id="a-b", before={"label": "A"}, after={"label": "B"})
+    assert update_cmd.changed is True
+    assert update_cmd.before["link_id"] == "a-b"
+
+    create_cmd = make_create_link_command(source_id="a", target_id="b", link_payload={"id": "a-b"})
+    assert create_cmd.changed is True
+    assert create_cmd.after["target"] == "b"


### PR DESCRIPTION
### Motivation
- Reduce divergence between the scene canvas and visual flow canvas by centralizing shared interaction logic and command interfaces. 
- Make link drag/select/context-menu semantics explicit and reusable so both canvases can mirror proven editor patterns. 
- Prepare for undo support by defining undo-friendly command result contracts even if undo is implemented later.

### Description
- Extracted shared interaction helpers into `modules/scenarios/wizard_steps/scenes/visual_flow/interactions.py` implementing context-menu timing, exclusive selection semantics, link-target resolution, and time helpers. 
- Added undo-friendly command primitives in `modules/scenarios/wizard_steps/scenes/visual_flow/commands.py` exposing `CommandResult` and factory functions `make_delete_node_command`, `make_update_link_command`, and `make_create_link_command`. 
- Updated `modules/scenarios/wizard_steps/scenes/flow_canvas/view.py` to consume the shared helpers and command contracts for: context-menu press/release timing, exclusive node/link selection normalization, link-drag completion that creates normalized link payloads, and delete operations that emit command-shaped metadata before applying model changes. 
- Adjusted visual flow node-kind normalization in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` to preserve existing/custom node kinds to avoid regressing planner behavior. 
- Added a small parity checklist test at `tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py` validating selection semantics, context-menu timing, link-target resolution, and command signatures.

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py tests/scenarios/test_visual_flow_planner.py` and all tests passed. 
- Final test run result: `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3461f623c832ba9ac97e67a476e3a)