### PR TITLE
Persist VisualFlowCanvas viewport in visual flow payload

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -96,6 +96,24 @@ class VisualFlowCanvas(ctk.CTkFrame):
     def export_payload(self):
         return copy.deepcopy(self.model.payload)
 
+    def get_viewport_state(self):
+        return {"x": self._offset_x, "y": self._offset_y, "zoom": self._zoom}
+
+    def set_viewport_state(self, viewport_dict):
+        if not isinstance(viewport_dict, dict):
+            return
+        x = viewport_dict.get("x", self._offset_x)
+        y = viewport_dict.get("y", self._offset_y)
+        zoom = viewport_dict.get("zoom", self._zoom)
+        if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+            return
+        if not isinstance(zoom, (int, float)) or zoom <= 0:
+            return
+        self._offset_x = int(x)
+        self._offset_y = int(y)
+        self._zoom = float(zoom)
+        self.render()
+
     def render(self):
         self.canvas.delete("all")
         self._node_items.clear()

--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -694,10 +694,13 @@ class VisualFlowPlanner(ctk.CTkFrame):
         self._flow_payload = build_visual_flow_from_scenes(self._scenes, existing_visual_payload=visual_payload)
         self.hierarchy.render(self._flow_payload.get("nodes") or [], self._flow_payload.get("links") or [], self._scenario_title)
         self.canvas.set_payload(self._flow_payload)
+        if isinstance(visual_payload, dict) and isinstance(visual_payload.get("viewport"), dict):
+            self.canvas.set_viewport_state(visual_payload["viewport"])
         self._dirty = False
 
     def export_visual_payload(self):
         self._flow_payload = self.canvas.export_payload()
+        self._flow_payload["viewport"] = self.canvas.get_viewport_state()
         return copy.deepcopy(self._flow_payload)
 
     def export_scenes(self):

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -174,9 +174,18 @@ class _FakeCanvas:
         self.render_calls = 0
         self.created = 0
         self.selected = None
+        self.viewport = {"x": 0, "y": 0, "zoom": 1.0}
+        self.viewport_set_calls = 0
 
     def render(self):
         self.render_calls += 1
+
+    def set_payload(self, payload):
+        self.model.set_payload(payload)
+        self.render()
+
+    def export_payload(self):
+        return self.model.payload
 
     def create_node_at_viewport_center(self, kind):
         self.created += 1
@@ -186,6 +195,13 @@ class _FakeCanvas:
 
     def select_node(self, node_id, emit=False):
         self.selected = (node_id, emit)
+
+    def get_viewport_state(self):
+        return dict(self.viewport)
+
+    def set_viewport_state(self, viewport_dict):
+        self.viewport_set_calls += 1
+        self.viewport = dict(viewport_dict)
 
 
 class _FakeHierarchy:
@@ -265,3 +281,33 @@ def test_planner_reorder_command_keeps_selection_and_export_order_deterministic(
     assert [node["id"] for node in planner.canvas.model.payload["nodes"]] == ["c", "a", "b"]
     exported = export_visual_flow_to_scenes(planner.canvas.model.payload)
     assert [scene["Title"] for scene in exported] == ["C", "A", "B"]
+
+
+def test_planner_visual_payload_round_trip_preserves_viewport():
+    planner = _build_headless_planner({"version": 1, "nodes": [], "links": []})
+    planner.canvas.viewport = {"x": 120, "y": -35, "zoom": 1.25}
+
+    payload = planner.export_visual_payload()
+
+    assert payload["viewport"] == {"x": 120, "y": -35, "zoom": 1.25}
+
+
+def test_planner_load_from_state_applies_viewport_when_present():
+    planner = _build_headless_planner({"version": 1, "nodes": [], "links": []})
+    scenes = [{"Title": "Start", "Summary": "", "SceneType": ""}]
+    visual_payload = {"nodes": [], "links": [], "viewport": {"x": 80, "y": 40, "zoom": 0.85}}
+
+    planner.load_from_state(scenes, visual_payload=visual_payload, scenario_title="Campaign")
+
+    assert planner.canvas.viewport_set_calls == 1
+    assert planner.canvas.viewport == {"x": 80, "y": 40, "zoom": 0.85}
+
+
+def test_planner_load_from_state_keeps_backward_compat_without_viewport():
+    planner = _build_headless_planner({"version": 1, "nodes": [], "links": []})
+    scenes = [{"Title": "Start", "Summary": "", "SceneType": ""}]
+    visual_payload = {"nodes": [], "links": []}
+
+    planner.load_from_state(scenes, visual_payload=visual_payload, scenario_title="Campaign")
+
+    assert planner.canvas.viewport_set_calls == 0


### PR DESCRIPTION
### Motivation
- Allow the visual flow editor to save and restore the canvas viewport (offset and zoom) as part of the visual payload so users resume where they left off.

### Description
- Exposed `get_viewport_state()` and `set_viewport_state(viewport_dict)` on `VisualFlowCanvas` with defensive input validation for type and numeric `x/y` and positive `zoom` and re-render on apply (`modules/scenarios/wizard_steps/scenes/flow_canvas/view.py`).
- Included `payload["viewport"] = canvas.get_viewport_state()` in `VisualFlowPlanner.export_visual_payload()` so exports contain viewport state (`modules/scenarios/wizard_steps/scenes/visual_flow_planner.py`).
- Applied `visual_payload["viewport"]` in `VisualFlowPlanner.load_from_state(...)` when present and shaped correctly, keeping behavior unchanged when `viewport` is absent (`modules/scenarios/wizard_steps/scenes/visual_flow_planner.py`).
- Added tests to verify viewport export/load round-trip and backward compatibility and extended the headless fake canvas in tests to support payload/viewport methods (`tests/scenarios/test_visual_flow_planner.py`).

### Testing
- Ran `pytest -q tests/scenarios/test_visual_flow_planner.py` and all tests passed (15 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ab99b48832b8eeebca29ce6d88f)