### PR TITLE
VisualFlowCanvas: add drag-preview, geometry target resolution, and cancel paths

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -65,6 +65,7 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self._pan_state = None
         self._space_held = False
         self._drag_link_source = None
+        self._drag_link_preview_item = None
         self._context_press_ts = 0.0
         self._zoom = 1.0
         self._offset_x = 0
@@ -78,7 +79,9 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self.canvas.bind("<Button-3>", self._on_context_press)
         self.canvas.bind("<ButtonRelease-3>", self._canvas_menu)
         self.canvas.bind("<ButtonRelease-1>", self._complete_link_drag, add="+")
+        self.canvas.bind("<B1-Motion>", self._drag_link_motion, add="+")
         self.canvas.bind("<Double-1>", self._double_click)
+        self.canvas.bind_all("<Escape>", self._cancel_link_drag)
         self.canvas.bind("<Control-0>", lambda _e: self.reset_zoom())
         self.canvas.bind_all("<Delete>", lambda _e: self.delete_selected())
         self.canvas.bind_all("<Control-d>", lambda _e: self.duplicate_selected())
@@ -286,18 +289,73 @@ class VisualFlowCanvas(ctk.CTkFrame):
 
     def _start_link_drag(self, event, node_id):
         self._drag_link_source = str(node_id or "").strip() or None
+        self._update_link_preview(event.x, event.y)
+
+    def _drag_link_motion(self, event):
+        if not self._drag_link_source:
+            return
+        self._update_link_preview(event.x, event.y)
+
+    def _update_link_preview(self, sx, sy):
+        if not self._drag_link_source:
+            self._clear_link_preview()
+            return
+        source_node = self.model.get_node(self._drag_link_source)
+        if not source_node:
+            self._clear_link_preview()
+            return
+        from_x, from_y = self._world_to_screen(int(source_node.get("x", 0)) + 190, int(source_node.get("y", 0)) + 44)
+        if self._drag_link_preview_item:
+            self.canvas.coords(self._drag_link_preview_item, from_x, from_y, sx, sy)
+        else:
+            self._drag_link_preview_item = self.canvas.create_line(
+                from_x, from_y, sx, sy, fill="#7dd3fc", width=2, dash=(6, 4), tags=("link_preview",)
+            )
+
+    def _clear_link_preview(self):
+        if self._drag_link_preview_item:
+            self.canvas.delete(self._drag_link_preview_item)
+            self._drag_link_preview_item = None
+
+    def _cancel_link_drag(self, _event=None):
+        self._drag_link_source = None
+        self._clear_link_preview()
+
+    def _resolve_link_target_from_geometry(self, source_id, sx, sy):
+        wx, wy = self._screen_to_world(sx, sy)
+        best_target = None
+        best_distance = None
+        for node in self.model.payload.get("nodes") or []:
+            node_id = str(node.get("id") or "")
+            if not node_id or node_id == source_id:
+                continue
+            nx, ny = int(node.get("x", 0)), int(node.get("y", 0))
+            left, top, right, bottom = nx, ny, nx + 190, ny + 88
+            if left <= wx <= right and top <= wy <= bottom:
+                return node_id
+            cx, cy = nx + 95, ny + 44
+            dist = ((wx - cx) ** 2 + (wy - cy) ** 2) ** 0.5
+            if best_distance is None or dist < best_distance:
+                best_target = node_id
+                best_distance = dist
+        if best_distance is not None and best_distance <= 120:
+            return best_target
+        return None
 
     def _complete_link_drag(self, event):
         if not self._drag_link_source:
             return
         source_id = self._drag_link_source
         self._drag_link_source = None
+        self._clear_link_preview()
         item = self.canvas.find_withtag("current")
         target_id = None
         if item:
             tags = self.canvas.gettags(item[0])
             if "node" in tags and len(tags) > 1:
                 target_id = tags[-1]
+        if not target_id:
+            target_id = self._resolve_link_target_from_geometry(source_id, event.x, event.y)
         target_id = resolve_link_target(source_id, [target_id])
         if not target_id:
             return
@@ -306,7 +364,10 @@ class VisualFlowCanvas(ctk.CTkFrame):
         existing.append(link)
         cmd = make_create_link_command(source_id=source_id, target_id=target_id, link_payload=link)
         if cmd.changed:
-            self._emit_change(); self.render()
+            self.select_link(link["id"])
+            self._emit_change()
+            self.render()
+            self._edit_link(link["id"])
 
     def _emit_change(self):
         if self.on_change:

--- a/tests/scenarios/wizard_steps/scenes/test_visual_flow_canvas_link_drag.py
+++ b/tests/scenarios/wizard_steps/scenes/test_visual_flow_canvas_link_drag.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+
+from modules.scenarios.wizard_steps.scenes.flow_canvas.view import VisualFlowCanvas
+
+
+class _CanvasStub:
+    def __init__(self, tags=()):
+        self._tags = tags
+
+    def find_withtag(self, tag):
+        return (1,) if tag == "current" and self._tags else ()
+
+    def gettags(self, _item):
+        return self._tags
+
+    def delete(self, _item):
+        return None
+
+
+class _ModelStub:
+    def __init__(self):
+        self.payload = {
+            "nodes": [
+                {"id": "a", "x": 0, "y": 0},
+                {"id": "b", "x": 220, "y": 0},
+            ],
+            "links": [],
+        }
+
+
+def _make_canvas_stub(current_tags=()):
+    state = {"changed": 0, "rendered": 0, "selected": None, "edited": None}
+    obj = SimpleNamespace(
+        _drag_link_source="a",
+        _drag_link_preview_item=None,
+        model=_ModelStub(),
+        canvas=_CanvasStub(current_tags),
+    )
+    obj._clear_link_preview = lambda: None
+    obj._screen_to_world = lambda x, y: (x, y)
+    obj._resolve_link_target_from_geometry = lambda source_id, sx, sy: VisualFlowCanvas._resolve_link_target_from_geometry(obj, source_id, sx, sy)
+    obj.select_link = lambda link_id: state.__setitem__("selected", link_id)
+    obj._emit_change = lambda: state.__setitem__("changed", state["changed"] + 1)
+    obj.render = lambda: state.__setitem__("rendered", state["rendered"] + 1)
+    obj._edit_link = lambda link_id: state.__setitem__("edited", link_id)
+    return obj, state
+
+
+def test_complete_link_drag_creates_link_for_valid_geometry_target():
+    obj, state = _make_canvas_stub()
+
+    VisualFlowCanvas._complete_link_drag(obj, SimpleNamespace(x=230, y=10))
+
+    assert len(obj.model.payload["links"]) == 1
+    created = obj.model.payload["links"][0]
+    assert created["source"] == "a"
+    assert created["target"] == "b"
+    assert state["selected"] == created["id"]
+    assert state["edited"] == created["id"]
+    assert state["changed"] == 1
+
+
+def test_complete_link_drag_rejects_invalid_target_and_cancels():
+    obj, state = _make_canvas_stub()
+
+    VisualFlowCanvas._complete_link_drag(obj, SimpleNamespace(x=1000, y=1000))
+
+    assert obj.model.payload["links"] == []
+    assert state["selected"] is None
+    assert state["edited"] is None
+    assert state["changed"] == 0
+
+
+def test_complete_link_drag_rejects_self_link():
+    obj, state = _make_canvas_stub(current_tags=("node", "a"))
+
+    VisualFlowCanvas._complete_link_drag(obj, SimpleNamespace(x=10, y=10))
+
+    assert obj.model.payload["links"] == []
+    assert state["selected"] is None
+    assert state["edited"] is None
+    assert state["changed"] == 0


### PR DESCRIPTION
### Motivation
- Improve the UX when creating links by showing a temporary preview line while dragging from a node handle.  
- Make link target resolution robust by falling back to geometry (node bbox / proximity) when `current` canvas tags are not available.  
- Add explicit cancel paths and ensure newly-created links are focused and their properties opened for faster iteration.

### Description
- Added preview state and handlers in `VisualFlowCanvas`: `_drag_link_preview_item`, `_drag_link_motion`, `_update_link_preview`, `_clear_link_preview`, and `_cancel_link_drag`, and bound `<B1-Motion>` and `<Escape>` to manage preview and cancellation.  
- Implemented `_resolve_link_target_from_geometry` which inspects node bounding boxes and proximity and used it as a fallback inside `_complete_link_drag`.  
- Cleared preview on completion/cancel, rejected self-links/invalid releases, and when a link is created the code now `select_link(...)` and opens properties via `_edit_link(...)`, while preserving the right-click `Connect to...` fallback flow.  
- Changes made in `modules/scenarios/wizard_steps/scenes/flow_canvas/view.py` and new unit tests added in `tests/scenarios/wizard_steps/scenes/test_visual_flow_canvas_link_drag.py` to keep the architecture readable with separate files.

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_visual_flow_canvas_link_drag.py tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py` and received `7 passed` in ~0.26s.  
- New tests cover a valid geometry-based drag that creates a link, an invalid-drag that cancels without creating a link, and a self-link drag which is rejected.  
- Existing parity tests from `test_visual_flow_parity_checklist.py` also passed, ensuring selection and command contracts remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34b786104832b97ab2083d355c9f8)