### PR TITLE
Expand VisualFlowCanvas menu taxonomy and unify node creation; add canvas menu smoke tests

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -7,6 +7,7 @@ from tkinter import simpledialog
 
 import customtkinter as ctk
 
+from modules.scenarios.wizard_steps.scenes.component_library.definitions import COMPONENT_GROUPS
 from modules.scenarios.scene_flow_rendering import apply_scene_flow_canvas_styling
 from modules.scenarios.wizard_steps.scenes.component_library.node_factory import build_default_node
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
@@ -45,6 +46,22 @@ _NODE_STYLES = {
 }
 
 _CONDITION_LABELS = {"yes": "Yes", "no": "No", "success": "Success", "failure": "Failure"}
+
+
+def _menu_node_entries():
+    by_kind = {}
+    for group in COMPONENT_GROUPS:
+        for item in group.get("items") or []:
+            kind = str(item.get("kind") or "").strip()
+            label = str(item.get("label") or "").strip()
+            icon = str(item.get("icon") or "").strip()
+            if kind and label:
+                by_kind[kind] = {"kind": kind, "label": label, "icon": icon}
+    ordered_kinds = ["scene", "objective", "side_objective", "interaction", "condition", "action", "note"]
+    return [by_kind[kind] for kind in ordered_kinds if kind in by_kind]
+
+
+_CANVAS_MENU_NODE_ENTRIES = _menu_node_entries()
 
 
 class VisualFlowCanvas(ctk.CTkFrame):
@@ -248,8 +265,11 @@ class VisualFlowCanvas(ctk.CTkFrame):
         if not should_open_context_menu(3, self._context_press_ts, now()):
             return
         menu = tk.Menu(self, tearoff=False)
-        menu.add_command(label="Add scene", command=lambda: self._add_node_at(event.x, event.y, "scene"))
-        menu.add_command(label="Add condition", command=lambda: self._add_node_at(event.x, event.y, "condition"))
+        for entry in _CANVAS_MENU_NODE_ENTRIES:
+            menu.add_command(
+                label=f"Add {entry['icon']} {entry['label']}",
+                command=lambda node_kind=entry["kind"]: self._add_node_at(event.x, event.y, node_kind),
+            )
         menu.add_command(label="Reset Zoom", command=self.reset_zoom)
         menu.add_command(label="Fit", command=self.fit_view)
         menu.tk_popup(event.x_root, event.y_root)
@@ -265,24 +285,20 @@ class VisualFlowCanvas(ctk.CTkFrame):
 
     def _add_node_at(self, sx, sy, kind):
         wx, wy = self._screen_to_world(sx, sy)
-        existing_nodes = self.model.payload.get("nodes") or []
-        node = build_default_node(kind=kind, x=int(wx), y=int(wy), existing_ids=[n.get("id") for n in existing_nodes], scene_index=len(existing_nodes))
-        self.model.payload.setdefault("nodes", []).append(node)
+        self._create_node(kind=kind, x=int(wx), y=int(wy))
         self._emit_change(); self.render()
+
+    def _create_node(self, kind, x, y):
+        existing_nodes = self.model.payload.get("nodes") or []
+        node = build_default_node(kind=kind, x=int(x), y=int(y), existing_ids=[n.get("id") for n in existing_nodes], scene_index=len(existing_nodes))
+        self.model.payload.setdefault("nodes", []).append(node)
+        return node
 
     def create_node_at_viewport_center(self, kind):
         cx = self.canvas.winfo_width() / 2
         cy = self.canvas.winfo_height() / 2
         wx, wy = self._screen_to_world(cx, cy)
-        existing_nodes = self.model.payload.get("nodes") or []
-        node = build_default_node(
-            kind=kind,
-            x=int(wx),
-            y=int(wy),
-            existing_ids=[n.get("id") for n in existing_nodes],
-            scene_index=len(existing_nodes),
-        )
-        self.model.payload.setdefault("nodes", []).append(node)
+        node = self._create_node(kind=kind, x=int(wx), y=int(wy))
         self._emit_change()
         self.render()
         return node

--- a/tests/scenarios/flow_canvas/test_canvas_context_menu.py
+++ b/tests/scenarios/flow_canvas/test_canvas_context_menu.py
@@ -1,0 +1,46 @@
+import types
+
+from modules.scenarios.wizard_steps.scenes.flow_canvas import view
+
+
+class _FakeMenu:
+    def __init__(self, *_args, **_kwargs):
+        self.commands = []
+        self.popup_args = None
+
+    def add_command(self, label, command):
+        self.commands.append({"label": label, "command": command})
+
+    def tk_popup(self, x_root, y_root):
+        self.popup_args = (x_root, y_root)
+
+
+def test_canvas_menu_actions_map_to_expected_node_kinds(monkeypatch):
+    captured_kinds = []
+    fake_menu = _FakeMenu()
+
+    monkeypatch.setattr(view.tk, "Menu", lambda *_args, **_kwargs: fake_menu)
+    monkeypatch.setattr(view, "should_open_context_menu", lambda *_args: True)
+    monkeypatch.setattr(view, "now", lambda: 10.0)
+
+    canvas = view.VisualFlowCanvas.__new__(view.VisualFlowCanvas)
+    canvas._context_press_ts = 0.0
+    canvas._add_node_at = lambda _x, _y, kind: captured_kinds.append(kind)
+    canvas.reset_zoom = lambda: None
+    canvas.fit_view = lambda: None
+
+    event = types.SimpleNamespace(x=100, y=200, x_root=10, y_root=20)
+    canvas._canvas_menu(event)
+
+    for command in fake_menu.commands[:7]:
+        command["command"]()
+
+    assert captured_kinds == [
+        "scene",
+        "objective",
+        "side_objective",
+        "interaction",
+        "condition",
+        "action",
+        "note",
+    ]


### PR DESCRIPTION
### Motivation
- Provide full right-click node creation options (Scene, Objective, Side Objective, Interaction, Condition, Action, Note) to match the component library and tree taxonomy.
- Remove duplicated node-creation logic by reusing a single helper so canvas-context and library-driven creation behave identically.
- Add a lightweight smoke test to ensure each menu action maps to the expected node `kind`.

### Description
- Import `COMPONENT_GROUPS` and add `_menu_node_entries()` with `_CANVAS_MENU_NODE_ENTRIES` to source menu labels/icons from the component library and keep them consistent with the tree taxonomy.
- Replace hard-coded menu entries in `VisualFlowCanvas._canvas_menu` with a loop that renders entries from `_CANVAS_MENU_NODE_ENTRIES` and shows label + icon.
- Introduce a single `_create_node(kind, x, y)` helper and make both `_add_node_at(...)` and `create_node_at_viewport_center(...)` reuse it.
- Add `tests/scenarios/flow_canvas/test_canvas_context_menu.py` which monkeypatches `tk.Menu` and related helpers and verifies the canvas menu add-commands map to the expected `kind` sequence.

### Testing
- Ran `pytest -q tests/scenarios/flow_canvas/test_canvas_context_menu.py tests/scenarios/test_visual_flow_planner.py::test_planner_add_and_paste_anchor_generate_valid_links` and both tests passed.
- Test run result: `2 passed` in ~0.25s.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34c6a1314832bb5c918b56a9d8e47)