### PR TITLE
Enhance scene-flow node shapes and style dispatch

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/node_rendering.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/node_rendering.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+DEFAULT_NODE_KIND = "scene"
+
+_NODE_BASE_STYLE = {
+    "title_color": "#f8fafc",
+    "title_accent": "#94a3b8",
+    "body_fill": "#0f172a",
+    "body_outline": "#334155",
+    "body_width": 2,
+    "handle_fill": "#38bdf8",
+    "handle_outline": "",
+    "selected_outline": "#e2e8f0",
+    "selected_width": 3,
+    "shape": "card",
+    "symbol": "●",
+}
+
+NODE_STYLES = {
+    "scene": {**_NODE_BASE_STYLE, "body_fill": "#1f2937", "body_outline": "#60a5fa", "symbol": "●", "shape": "card_scene"},
+    "objective": {**_NODE_BASE_STYLE, "body_fill": "#1f3a2e", "body_outline": "#34d399", "symbol": "◆", "shape": "card_objective"},
+    "side_objective": {**_NODE_BASE_STYLE, "body_fill": "#1b3448", "body_outline": "#38bdf8", "symbol": "◇", "shape": "card_side_objective"},
+    "interaction": {**_NODE_BASE_STYLE, "body_fill": "#31253f", "body_outline": "#a78bfa", "symbol": "◎", "shape": "card_interaction"},
+    "condition": {**_NODE_BASE_STYLE, "body_fill": "#3b2f1f", "body_outline": "#f59e0b", "symbol": "?", "shape": "diamond"},
+    "action": {**_NODE_BASE_STYLE, "body_fill": "#2f1f3b", "body_outline": "#c084fc", "symbol": "▶", "shape": "card_action"},
+    "note": {**_NODE_BASE_STYLE, "body_fill": "#2d2d2d", "body_outline": "#a3a3a3", "symbol": "■", "shape": "note"},
+}
+
+
+def resolve_node_visual(kind: str, selected: bool = False) -> dict:
+    style = dict(NODE_STYLES.get(str(kind or "").strip(), NODE_STYLES[DEFAULT_NODE_KIND]))
+    style["kind"] = kind if kind in NODE_STYLES else DEFAULT_NODE_KIND
+    if selected:
+        style["body_outline"] = style["selected_outline"]
+        style["body_width"] = style["selected_width"]
+    return style

--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -11,6 +11,7 @@ from modules.scenarios.wizard_steps.scenes.component_library.definitions import 
 from modules.scenarios.scene_flow_rendering import apply_scene_flow_canvas_styling
 from modules.scenarios.wizard_steps.scenes.component_library.node_factory import build_default_node
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
+from modules.scenarios.wizard_steps.scenes.flow_canvas.node_rendering import NODE_STYLES as _NODE_STYLES, resolve_node_visual
 from modules.scenarios.wizard_steps.scenes.visual_flow.commands import (
     make_create_link_command,
     make_delete_node_command,
@@ -36,14 +37,6 @@ def normalise_flow_node_id(title, existing_ids):
         candidate = f"{base}-{idx}"
         idx += 1
     return candidate
-
-_NODE_STYLES = {
-    "scene": {"fill": "#1f2937", "outline": "#60a5fa", "symbol": "●"},
-    "objective": {"fill": "#1f3a2e", "outline": "#34d399", "symbol": "◆"},
-    "condition": {"fill": "#3b2f1f", "outline": "#f59e0b", "symbol": "?"},
-    "action": {"fill": "#2f1f3b", "outline": "#c084fc", "symbol": "▶"},
-    "note": {"fill": "#3a3a3a", "outline": "#a3a3a3", "symbol": "■"},
-}
 
 _CONDITION_LABELS = {"yes": "Yes", "no": "No", "success": "Success", "failure": "Failure"}
 
@@ -153,16 +146,26 @@ class VisualFlowCanvas(ctk.CTkFrame):
         for node in self.model.payload.get("nodes") or []:
             nid = str(node.get("id") or "")
             kind = str(node.get("kind") or "scene")
-            style = _NODE_STYLES.get(kind, _NODE_STYLES["scene"])
+            style = resolve_node_visual(kind, selected=nid == self._selected_node_id)
             x, y = self._world_to_screen(int(node.get("x", 0)), int(node.get("y", 0)))
             w, h = 190 * self._zoom, 88 * self._zoom
-            rect = self.canvas.create_rectangle(x, y, x + w, y + h, fill=style["fill"], outline=style["outline"], width=2, tags=("node", nid))
-            self.canvas.create_text(x + 10, y + 10, text=f"{style['symbol']} {node.get('title') or 'Untitled'}", anchor="nw", fill="#f8fafc", tags=("node", nid))
-            handle = self.canvas.create_oval(x + w - 14, y + h / 2 - 6, x + w - 2, y + h / 2 + 6, fill="#38bdf8", outline="", tags=("handle", nid))
-            self._node_items[nid] = {"rect": rect, "handle": handle}
-            self.canvas.tag_bind(rect, "<Button-1>", lambda e, node_id=nid: self._start_node_drag(e, node_id))
-            self.canvas.tag_bind(rect, "<B1-Motion>", self._drag_node)
-            self.canvas.tag_bind(rect, "<ButtonRelease-1>", self._end_node_drag)
+            if style["shape"] == "diamond":
+                body = self.canvas.create_polygon(
+                    x + w / 2, y, x + w, y + h / 2, x + w / 2, y + h, x, y + h / 2,
+                    fill=style["body_fill"], outline=style["body_outline"], width=style["body_width"], tags=("node", nid)
+                )
+            elif style["shape"] == "note":
+                body = self.canvas.create_rectangle(x, y, x + w, y + h, fill=style["body_fill"], outline=style["body_outline"], width=style["body_width"], tags=("node", nid))
+                self.canvas.create_polygon(x + w - 26, y, x + w, y, x + w, y + 26, fill="#525252", outline=style["body_outline"], width=1, tags=("node", nid))
+            else:
+                body = self.canvas.create_rectangle(x, y, x + w, y + h, fill=style["body_fill"], outline=style["body_outline"], width=style["body_width"], tags=("node", nid))
+
+            self.canvas.create_text(x + 10, y + 10, text=f"{style['symbol']} {node.get('title') or 'Untitled'}", anchor="nw", fill=style["title_color"], tags=("node", nid))
+            handle = self.canvas.create_oval(x + w - 14, y + h / 2 - 6, x + w - 2, y + h / 2 + 6, fill=style["handle_fill"], outline=style["handle_outline"], tags=("handle", nid))
+            self._node_items[nid] = {"body": body, "handle": handle}
+            self.canvas.tag_bind(body, "<Button-1>", lambda e, node_id=nid: self._start_node_drag(e, node_id))
+            self.canvas.tag_bind(body, "<B1-Motion>", self._drag_node)
+            self.canvas.tag_bind(body, "<ButtonRelease-1>", self._end_node_drag)
             self.canvas.tag_bind(handle, "<Button-1>", lambda e, node_id=nid: self._start_link_drag(e, node_id))
 
     def _draw_links(self):

--- a/tests/scenarios/flow_canvas/test_node_rendering.py
+++ b/tests/scenarios/flow_canvas/test_node_rendering.py
@@ -1,0 +1,25 @@
+from modules.scenarios.wizard_steps.scenes.flow_canvas.node_rendering import resolve_node_visual
+
+
+def test_resolve_node_visual_snapshot_by_kind():
+    snapshot = {
+        "scene": ("card_scene", "#1f2937", "#60a5fa", "●"),
+        "objective": ("card_objective", "#1f3a2e", "#34d399", "◆"),
+        "side_objective": ("card_side_objective", "#1b3448", "#38bdf8", "◇"),
+        "interaction": ("card_interaction", "#31253f", "#a78bfa", "◎"),
+        "condition": ("diamond", "#3b2f1f", "#f59e0b", "?"),
+        "action": ("card_action", "#2f1f3b", "#c084fc", "▶"),
+        "note": ("note", "#2d2d2d", "#a3a3a3", "■"),
+    }
+
+    for kind, expected in snapshot.items():
+        visual = resolve_node_visual(kind)
+        assert (visual["shape"], visual["body_fill"], visual["body_outline"], visual["symbol"]) == expected
+
+
+def test_resolve_node_visual_selection_and_fallback_snapshot():
+    selected = resolve_node_visual("condition", selected=True)
+    fallback = resolve_node_visual("unknown_kind")
+
+    assert (selected["body_outline"], selected["body_width"]) == ("#e2e8f0", 3)
+    assert (fallback["shape"], fallback["body_fill"], fallback["symbol"]) == ("card_scene", "#1f2937", "●")


### PR DESCRIPTION
### Motivation
- Provide explicit visual tokens for every scene-flow node kind so the canvas can render distinct shapes and consistent highlights. 
- Render node kinds with semantic shapes (diamond for condition, note-card for notes, differentiated cards for scene/objective/side objective/interaction/action) to improve readability of flow diagrams. 
- Make selection/highlight visuals uniform across shapes and add headless-friendly tests for dispatch logic.

### Description
- Added `modules/scenarios/wizard_steps/scenes/flow_canvas/node_rendering.py` which centralises `NODE_STYLES` and exposes `resolve_node_visual(kind, selected=False)` returning unified visual tokens and selection adjustments. 
- Updated `_draw_nodes` in `modules/scenarios/wizard_steps/scenes/flow_canvas/view.py` to call `resolve_node_visual` and branch by `shape` to draw diamond polygons, note-style cards (folded corner), or regular differentiated cards, while wiring consistent selection outline/width. 
- Added headless snapshot-like tests in `tests/scenarios/flow_canvas/test_node_rendering.py` validating per-kind shape/colour/symbol mapping and selection/fallback behaviour. 
- Kept a sober/dark theme and preserved existing scene-flow styling by reusing theme colours and fill/outlines from the new style tokens.

### Testing
- Ran `pytest -q tests/scenarios/flow_canvas/test_node_rendering.py tests/scenarios/flow_canvas/test_canvas_context_menu.py tests/scenarios/wizard_steps/scenes/test_visual_flow_canvas_link_drag.py`, which completed successfully with all tests passing. 
- Ran `pytest -q tests/scenarios/flow_canvas/test_node_rendering.py` to validate the new resolver tests in isolation, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34d8c0160832b86a53fec64906c2b)