### PR TITLE
Add interactive minimap to VisualFlowCanvas with coordinate transforms and tests

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/minimap.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/minimap.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+def world_to_minimap(
+    world_x: float,
+    world_y: float,
+    *,
+    world_bounds: tuple[float, float, float, float],
+    minimap_bounds: tuple[float, float, float, float],
+) -> tuple[float, float]:
+    min_world_x, min_world_y, max_world_x, max_world_y = world_bounds
+    mini_left, mini_top, mini_right, mini_bottom = minimap_bounds
+    world_w = max(1.0, float(max_world_x - min_world_x))
+    world_h = max(1.0, float(max_world_y - min_world_y))
+    mini_w = max(1.0, float(mini_right - mini_left))
+    mini_h = max(1.0, float(mini_bottom - mini_top))
+    px = (float(world_x) - min_world_x) / world_w
+    py = (float(world_y) - min_world_y) / world_h
+    return mini_left + px * mini_w, mini_top + py * mini_h
+
+
+def minimap_to_world(
+    minimap_x: float,
+    minimap_y: float,
+    *,
+    world_bounds: tuple[float, float, float, float],
+    minimap_bounds: tuple[float, float, float, float],
+) -> tuple[float, float]:
+    min_world_x, min_world_y, max_world_x, max_world_y = world_bounds
+    mini_left, mini_top, mini_right, mini_bottom = minimap_bounds
+    world_w = max(1.0, float(max_world_x - min_world_x))
+    world_h = max(1.0, float(max_world_y - min_world_y))
+    mini_w = max(1.0, float(mini_right - mini_left))
+    mini_h = max(1.0, float(mini_bottom - mini_top))
+    px = (float(minimap_x) - mini_left) / mini_w
+    py = (float(minimap_y) - mini_top) / mini_h
+    return min_world_x + px * world_w, min_world_y + py * world_h
+

--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -10,6 +10,7 @@ import customtkinter as ctk
 from modules.scenarios.wizard_steps.scenes.component_library.definitions import COMPONENT_GROUPS
 from modules.scenarios.scene_flow_rendering import apply_scene_flow_canvas_styling
 from modules.scenarios.wizard_steps.scenes.component_library.node_factory import build_default_node
+from modules.scenarios.wizard_steps.scenes.flow_canvas.minimap import minimap_to_world, world_to_minimap
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
 from modules.scenarios.wizard_steps.scenes.flow_canvas.node_rendering import NODE_STYLES as _NODE_STYLES, resolve_node_visual
 from modules.scenarios.wizard_steps.scenes.visual_flow.commands import (
@@ -80,9 +81,12 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self._zoom = 1.0
         self._offset_x = 0
         self._offset_y = 0
+        self._minimap_drag_active = False
+        self._minimap_projection = None
         self._bind_events()
 
     def _bind_events(self):
+        self.canvas.bind("<MouseWheel>", self._zoom_view)
         self.canvas.bind("<Button-2>", self._start_pan)
         self.canvas.bind("<B2-Motion>", self._pan)
         self.canvas.bind("<ButtonRelease-2>", self._end_pan)
@@ -192,8 +196,80 @@ class VisualFlowCanvas(ctk.CTkFrame):
             self.canvas.tag_bind(line, "<Button-1>", lambda _e, link_id=lid: self.select_link(link_id))
             self.canvas.tag_bind(line, "<Button-3>", lambda e, link_id=lid: self._link_menu(e, link_id))
 
+
+    def _zoom_view(self, event):
+        factor = 1.1 if event.delta > 0 else 0.9
+        prev_zoom = self._zoom
+        self._zoom = min(3.0, max(0.3, self._zoom * factor))
+        if abs(self._zoom - prev_zoom) < 1e-9:
+            return
+        wx, wy = self._screen_to_world(event.x, event.y)
+        self._offset_x = int(event.x - wx * self._zoom)
+        self._offset_y = int(event.y - wy * self._zoom)
+        self.render()
+
+    def _compute_world_bounds(self):
+        nodes = self.model.payload.get("nodes") or []
+        if not nodes:
+            return (0.0, 0.0, 1000.0, 700.0)
+        left = min(float(n.get("x", 0)) for n in nodes)
+        top = min(float(n.get("y", 0)) for n in nodes)
+        right = max(float(n.get("x", 0)) + 190.0 for n in nodes)
+        bottom = max(float(n.get("y", 0)) + 88.0 for n in nodes)
+        return (left - 80.0, top - 80.0, right + 80.0, bottom + 80.0)
+
+    def _apply_minimap_recenter(self, sx, sy):
+        projection = self._minimap_projection
+        if not projection:
+            return
+        world_x, world_y = minimap_to_world(
+            sx,
+            sy,
+            world_bounds=projection["world_bounds"],
+            minimap_bounds=projection["minimap_bounds"],
+        )
+        self._offset_x = int(self.canvas.winfo_width() / 2 - world_x * self._zoom)
+        self._offset_y = int(self.canvas.winfo_height() / 2 - world_y * self._zoom)
+        self.render()
+
+    def _start_minimap_drag(self, event):
+        self._minimap_drag_active = True
+        self._apply_minimap_recenter(event.x, event.y)
+
+    def _drag_minimap(self, event):
+        if self._minimap_drag_active:
+            self._apply_minimap_recenter(event.x, event.y)
+
+    def _end_minimap_drag(self, _event):
+        self._minimap_drag_active = False
+
     def _draw_minimap(self):
-        self.canvas.create_rectangle(16, self.canvas.winfo_height() - 126, 176, self.canvas.winfo_height() - 16, fill="#111827", outline="#4b5563")
+        mini_left, mini_top = 16, self.canvas.winfo_height() - 126
+        mini_right, mini_bottom = 176, self.canvas.winfo_height() - 16
+        minimap_bounds = (mini_left + 8, mini_top + 8, mini_right - 8, mini_bottom - 8)
+        world_bounds = self._compute_world_bounds()
+        self._minimap_projection = {"world_bounds": world_bounds, "minimap_bounds": minimap_bounds}
+
+        shell = self.canvas.create_rectangle(mini_left, mini_top, mini_right, mini_bottom, fill="#111827", outline="#4b5563", tags=("minimap",))
+        self.canvas.tag_bind(shell, "<Button-1>", self._start_minimap_drag)
+        self.canvas.tag_bind(shell, "<B1-Motion>", self._drag_minimap)
+        self.canvas.tag_bind(shell, "<ButtonRelease-1>", self._end_minimap_drag)
+
+        for node in self.model.payload.get("nodes") or []:
+            wx = float(node.get("x", 0)) + 95.0
+            wy = float(node.get("y", 0)) + 44.0
+            mx, my = world_to_minimap(wx, wy, world_bounds=world_bounds, minimap_bounds=minimap_bounds)
+            dot = self.canvas.create_oval(mx - 2, my - 2, mx + 2, my + 2, fill="#93c5fd", outline="", tags=("minimap",))
+            self.canvas.tag_bind(dot, "<Button-1>", self._start_minimap_drag)
+            self.canvas.tag_bind(dot, "<B1-Motion>", self._drag_minimap)
+            self.canvas.tag_bind(dot, "<ButtonRelease-1>", self._end_minimap_drag)
+
+        vw, vh = max(1, self.canvas.winfo_width()), max(1, self.canvas.winfo_height())
+        top_left_world = self._screen_to_world(0, 0)
+        bottom_right_world = self._screen_to_world(vw, vh)
+        vx1, vy1 = world_to_minimap(top_left_world[0], top_left_world[1], world_bounds=world_bounds, minimap_bounds=minimap_bounds)
+        vx2, vy2 = world_to_minimap(bottom_right_world[0], bottom_right_world[1], world_bounds=world_bounds, minimap_bounds=minimap_bounds)
+        self.canvas.create_rectangle(vx1, vy1, vx2, vy2, outline="#fbbf24", width=1, tags=("minimap",))
 
     def _start_node_drag(self, event, node_id):
         if self._space_held:

--- a/tests/scenarios/wizard_steps/scenes/test_flow_canvas_minimap_transforms.py
+++ b/tests/scenarios/wizard_steps/scenes/test_flow_canvas_minimap_transforms.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from modules.scenarios.wizard_steps.scenes.flow_canvas.minimap import minimap_to_world, world_to_minimap
+from modules.scenarios.wizard_steps.scenes.flow_canvas.view import VisualFlowCanvas
+
+
+def test_world_to_minimap_and_back_round_trip():
+    world_bounds = (100.0, 50.0, 500.0, 250.0)
+    minimap_bounds = (20.0, 30.0, 180.0, 130.0)
+
+    mini_x, mini_y = world_to_minimap(300.0, 150.0, world_bounds=world_bounds, minimap_bounds=minimap_bounds)
+    world_x, world_y = minimap_to_world(mini_x, mini_y, world_bounds=world_bounds, minimap_bounds=minimap_bounds)
+
+    assert world_x == 300.0
+    assert world_y == 150.0
+
+
+def test_screen_world_transforms_round_trip_on_canvas_viewport_state():
+    stub = SimpleNamespace(_zoom=1.5, _offset_x=240, _offset_y=-70)
+
+    world_x, world_y = VisualFlowCanvas._screen_to_world(stub, 510, 305)
+    screen_x, screen_y = VisualFlowCanvas._world_to_screen(stub, world_x, world_y)
+
+    assert screen_x == 510
+    assert screen_y == 305
+
+
+def test_minimap_recenter_updates_offsets_for_viewport_center():
+    class _CanvasStub:
+        @staticmethod
+        def winfo_width():
+            return 800
+
+        @staticmethod
+        def winfo_height():
+            return 600
+
+    state = {"rendered": 0}
+    stub = SimpleNamespace(
+        _zoom=1.0,
+        _offset_x=0,
+        _offset_y=0,
+        canvas=_CanvasStub(),
+        _minimap_projection={
+            "world_bounds": (0.0, 0.0, 1000.0, 1000.0),
+            "minimap_bounds": (20.0, 20.0, 180.0, 180.0),
+        },
+    )
+    stub.render = lambda: state.__setitem__("rendered", state["rendered"] + 1)
+
+    VisualFlowCanvas._apply_minimap_recenter(stub, 100, 100)
+
+    assert stub._offset_x == -100
+    assert stub._offset_y == -200
+    assert state["rendered"] == 1


### PR DESCRIPTION
### Motivation
- Provide a reusable minimap for the scene-flow canvas so users can see an overview of nodes and the current viewport. 
- Allow quick recentering of the main canvas by clicking or dragging inside the minimap for faster navigation of large graphs. 
- Encapsulate coordinate math for minimap/world conversion in a separate module to keep the view code cleaner and testable. 

### Description
- Add `modules/scenarios/wizard_steps/scenes/flow_canvas/minimap.py` with `world_to_minimap` and `minimap_to_world` helper functions to convert between world and minimap spaces. 
- Extend `VisualFlowCanvas` to render node center dots in the minimap, draw the viewport rectangle in minimap coordinates, and maintain `_minimap_projection` metadata for interactions. 
- Add minimap interactions via `_start_minimap_drag`, `_drag_minimap`, `_end_minimap_drag`, and `_apply_minimap_recenter` to recenter the main canvas when the minimap is clicked or dragged. 
- Wire minimap redraws into the existing `render()` flow so pan/zoom/node moves remain the single source of truth for updates, and add wheel-zoom handling to ensure minimap reflects zoom changes. 
- Add tests in `tests/scenarios/wizard_steps/scenes/test_flow_canvas_minimap_transforms.py` covering `world<->minimap` round-trip, `screen<->world` round-trip using `VisualFlowCanvas` transforms, and minimap recenter offset behavior. 

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_visual_flow_canvas_link_drag.py tests/scenarios/wizard_steps/scenes/test_flow_canvas_minimap_transforms.py` and observed all tests pass. 
- Test summary: `6 passed` for the targeted test set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34e93be44832b9f178bef18be95a6)