### PR TITLE
Add cursor-centered zoom, toolbar and fit-to-content for flow canvas

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/view.py
@@ -13,6 +13,12 @@ from modules.scenarios.wizard_steps.scenes.component_library.node_factory import
 from modules.scenarios.wizard_steps.scenes.flow_canvas.minimap import minimap_to_world, world_to_minimap
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
 from modules.scenarios.wizard_steps.scenes.flow_canvas.node_rendering import NODE_STYLES as _NODE_STYLES, resolve_node_visual
+from modules.scenarios.wizard_steps.scenes.flow_canvas.viewport import (
+    ZOOM_MAX,
+    ZOOM_MIN,
+    clamp_zoom,
+    compute_fit_viewport,
+)
 from modules.scenarios.wizard_steps.scenes.visual_flow.commands import (
     make_create_link_command,
     make_delete_node_command,
@@ -68,6 +74,11 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self._tile_cache = {}
         self.canvas = tk.Canvas(self, bg="#0f172a", highlightthickness=0)
         self.canvas.pack(fill="both", expand=True)
+        self._toolbar = ctk.CTkFrame(self, fg_color="#111827")
+        self._toolbar.place(relx=1.0, x=-12, y=12, anchor="ne")
+        ctk.CTkButton(self._toolbar, text="−", width=28, command=self.zoom_out).pack(side="left", padx=(6, 4), pady=6)
+        ctk.CTkButton(self._toolbar, text="+", width=28, command=self.zoom_in).pack(side="left", padx=4, pady=6)
+        ctk.CTkButton(self._toolbar, text="Fit", width=42, command=self.fit_view).pack(side="left", padx=(4, 6), pady=6)
         self._node_items = {}
         self._link_items = {}
         self._selected_node_id = None
@@ -87,6 +98,8 @@ class VisualFlowCanvas(ctk.CTkFrame):
 
     def _bind_events(self):
         self.canvas.bind("<MouseWheel>", self._zoom_view)
+        self.canvas.bind("<Button-4>", self._zoom_view)
+        self.canvas.bind("<Button-5>", self._zoom_view)
         self.canvas.bind("<Button-2>", self._start_pan)
         self.canvas.bind("<B2-Motion>", self._pan)
         self.canvas.bind("<ButtonRelease-2>", self._end_pan)
@@ -97,6 +110,9 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self.canvas.bind("<Double-1>", self._double_click)
         self.canvas.bind_all("<Escape>", self._cancel_link_drag)
         self.canvas.bind("<Control-0>", lambda _e: self.reset_zoom())
+        self.canvas.bind("<Control-plus>", lambda _e: self.zoom_in())
+        self.canvas.bind("<Control-equal>", lambda _e: self.zoom_in())
+        self.canvas.bind("<Control-minus>", lambda _e: self.zoom_out())
         self.canvas.bind_all("<Delete>", lambda _e: self.delete_selected())
         self.canvas.bind_all("<Control-d>", lambda _e: self.duplicate_selected())
         self.canvas.bind_all("<Control-s>", lambda _e: self.save_state())
@@ -198,15 +214,41 @@ class VisualFlowCanvas(ctk.CTkFrame):
 
 
     def _zoom_view(self, event):
-        factor = 1.1 if event.delta > 0 else 0.9
-        prev_zoom = self._zoom
-        self._zoom = min(3.0, max(0.3, self._zoom * factor))
-        if abs(self._zoom - prev_zoom) < 1e-9:
+        direction = self._event_zoom_direction(event)
+        if direction == 0:
             return
-        wx, wy = self._screen_to_world(event.x, event.y)
-        self._offset_x = int(event.x - wx * self._zoom)
-        self._offset_y = int(event.y - wy * self._zoom)
+        self._zoom_around_screen_point(event.x, event.y, factor=1.1 if direction > 0 else (1.0 / 1.1))
+
+    @staticmethod
+    def _event_zoom_direction(event):
+        delta = getattr(event, "delta", 0)
+        if delta > 0:
+            return 1
+        if delta < 0:
+            return -1
+        num = getattr(event, "num", None)
+        if num == 4:
+            return 1
+        if num == 5:
+            return -1
+        return 0
+
+    def _zoom_around_screen_point(self, sx, sy, *, factor):
+        prev_zoom = self._zoom
+        next_zoom = clamp_zoom(prev_zoom * float(factor), minimum=ZOOM_MIN, maximum=ZOOM_MAX)
+        if abs(next_zoom - prev_zoom) < 1e-9:
+            return
+        wx, wy = self._screen_to_world(sx, sy)
+        self._zoom = next_zoom
+        self._offset_x = int(round(sx - wx * self._zoom))
+        self._offset_y = int(round(sy - wy * self._zoom))
         self.render()
+
+    def zoom_in(self):
+        self._zoom_around_screen_point(self.canvas.winfo_width() / 2, self.canvas.winfo_height() / 2, factor=1.1)
+
+    def zoom_out(self):
+        self._zoom_around_screen_point(self.canvas.winfo_width() / 2, self.canvas.winfo_height() / 2, factor=1.0 / 1.1)
 
     def _compute_world_bounds(self):
         nodes = self.model.payload.get("nodes") or []
@@ -516,4 +558,12 @@ class VisualFlowCanvas(ctk.CTkFrame):
         self.render()
 
     def fit_view(self):
-        self.reset_zoom()
+        viewport = compute_fit_viewport(
+            self.model.payload.get("nodes") or [],
+            canvas_width=self.canvas.winfo_width(),
+            canvas_height=self.canvas.winfo_height(),
+        )
+        self._zoom = viewport["zoom"]
+        self._offset_x = int(round(viewport["offset_x"]))
+        self._offset_y = int(round(viewport["offset_y"]))
+        self.render()

--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/viewport.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/viewport.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+ZOOM_MIN = 0.25
+ZOOM_MAX = 2.5
+NODE_WIDTH = 190.0
+NODE_HEIGHT = 88.0
+FIT_PADDING = 80.0
+
+
+def clamp_zoom(value: float, *, minimum: float = ZOOM_MIN, maximum: float = ZOOM_MAX) -> float:
+    return max(minimum, min(maximum, float(value)))
+
+
+def compute_fit_viewport(nodes: Iterable[dict], canvas_width: float, canvas_height: float) -> dict[str, float]:
+    width = max(1.0, float(canvas_width))
+    height = max(1.0, float(canvas_height))
+    node_list = list(nodes or [])
+    if not node_list:
+        return {"zoom": 1.0, "offset_x": 0.0, "offset_y": 0.0}
+
+    left = min(float(n.get("x", 0.0)) for n in node_list) - FIT_PADDING
+    top = min(float(n.get("y", 0.0)) for n in node_list) - FIT_PADDING
+    right = max(float(n.get("x", 0.0)) + NODE_WIDTH for n in node_list) + FIT_PADDING
+    bottom = max(float(n.get("y", 0.0)) + NODE_HEIGHT for n in node_list) + FIT_PADDING
+
+    world_w = max(1.0, right - left)
+    world_h = max(1.0, bottom - top)
+    zoom = clamp_zoom(min(width / world_w, height / world_h))
+    world_cx = (left + right) / 2.0
+    world_cy = (top + bottom) / 2.0
+    return {
+        "zoom": zoom,
+        "offset_x": (width / 2.0) - (world_cx * zoom),
+        "offset_y": (height / 2.0) - (world_cy * zoom),
+    }

--- a/tests/scenarios/wizard_steps/scenes/test_flow_canvas_viewport.py
+++ b/tests/scenarios/wizard_steps/scenes/test_flow_canvas_viewport.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from modules.scenarios.wizard_steps.scenes.flow_canvas.view import VisualFlowCanvas
+from modules.scenarios.wizard_steps.scenes.flow_canvas.viewport import ZOOM_MAX, ZOOM_MIN, clamp_zoom, compute_fit_viewport
+
+
+def test_clamp_zoom_limits_range():
+    assert clamp_zoom(0.01) == ZOOM_MIN
+    assert clamp_zoom(99.0) == ZOOM_MAX
+    assert clamp_zoom(1.25) == 1.25
+
+
+def test_compute_fit_viewport_centers_and_scales_nodes():
+    nodes = [
+        {"x": 100, "y": 100},
+        {"x": 620, "y": 320},
+    ]
+    viewport = compute_fit_viewport(nodes, canvas_width=1000, canvas_height=700)
+    assert ZOOM_MIN <= viewport["zoom"] <= ZOOM_MAX
+    assert round(viewport["zoom"], 2) == 1.15
+    assert round(viewport["offset_x"], 1) == -23.0
+    assert round(viewport["offset_y"], 1) == 58.0
+
+
+def test_zoom_around_cursor_keeps_world_anchor_and_clamps():
+    rendered = {"count": 0}
+    stub = SimpleNamespace(
+        _zoom=2.45,
+        _offset_x=50,
+        _offset_y=25,
+        render=lambda: rendered.__setitem__("count", rendered["count"] + 1),
+    )
+    stub._screen_to_world = lambda x, y: VisualFlowCanvas._screen_to_world(stub, x, y)
+
+    before_world = VisualFlowCanvas._screen_to_world(stub, 400, 300)
+    VisualFlowCanvas._zoom_around_screen_point(stub, 400, 300, factor=1.1)
+    after_world = VisualFlowCanvas._screen_to_world(stub, 400, 300)
+
+    assert stub._zoom == ZOOM_MAX
+    assert abs(before_world[0] - after_world[0]) <= 0.1
+    assert abs(before_world[1] - after_world[1]) <= 0.2
+    assert rendered["count"] == 1


### PR DESCRIPTION
### Motivation
- Improve navigation of the Visual Flow canvas by supporting mouse-wheel zoom centered at the cursor and platform-safe bindings. 
- Provide explicit zoom controls and a visible mini-toolbar for quick actions and better UX. 
- Replace a placeholder `fit_view()` with a real fit-to-content implementation and ensure zoom stays clamped and pan-coherent.

### Description
- Added a new helper module `modules/scenarios/wizard_steps/scenes/flow_canvas/viewport.py` that defines `ZOOM_MIN`/`ZOOM_MAX`, `clamp_zoom()` and `compute_fit_viewport()` to compute zoom + offsets from node bounds plus padding. 
- Updated `modules/scenarios/wizard_steps/scenes/flow_canvas/view.py` to bind platform-safe wheel events (`<MouseWheel>`, `<Button-4>`, `<Button-5>`), added `_event_zoom_direction()`, `_zoom_around_screen_point()`, `zoom_in()` and `zoom_out()` methods, wired `Ctrl++`/`Ctrl+-` and added a compact toolbar with `− / + / Fit` buttons, and replaced the previous `fit_view()` with a call to `compute_fit_viewport()`. 
- Added unit tests in `tests/scenarios/wizard_steps/scenes/test_flow_canvas_viewport.py` covering `clamp_zoom()`, `compute_fit_viewport()` and cursor-anchored zoom coherence, and reused the existing minimap/context-menu tests for integration checks. 

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_flow_canvas_viewport.py tests/scenarios/wizard_steps/scenes/test_flow_canvas_minimap_transforms.py tests/scenarios/flow_canvas/test_canvas_context_menu.py`. 
- All targeted tests passed: `7 passed`. 
- The new unit tests validate zoom clamping, fit math, and that zooming around a screen point preserves the anchored world coordinate within tolerances.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f352bf3f1c832ba102943f7ef587d6)