### PR TITLE
Validate visual-flow link property edits against existing nodes

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -506,8 +506,10 @@ class FlowPropertiesPanel(ctk.CTkFrame):
         self._node = None
         self._link = None
         self._id_edit_enabled = False
+        self._feedback_var = ctk.StringVar(value="")
 
         ctk.CTkLabel(self, text="Properties").pack(anchor="w", padx=8, pady=(8, 4))
+        ctk.CTkLabel(self, textvariable=self._feedback_var, text_color="#fca5a5").pack(anchor="w", padx=8, pady=(0, 4))
         self._body = ctk.CTkFrame(self, fg_color="transparent")
         self._body.pack(fill="both", expand=True, padx=8, pady=(0, 8))
         self._render_empty()
@@ -516,6 +518,7 @@ class FlowPropertiesPanel(ctk.CTkFrame):
         self._node = node if isinstance(node, dict) else None
         self._link = link if isinstance(link, dict) else None
         self._id_edit_enabled = False
+        self.set_feedback("")
         for child in self._body.winfo_children():
             child.destroy()
         if self._node:
@@ -611,6 +614,9 @@ class FlowPropertiesPanel(ctk.CTkFrame):
     def _emit(self, changes):
         if callable(self.on_change):
             self.on_change(changes, node=self._node, link=self._link)
+
+    def set_feedback(self, message):
+        self._feedback_var.set(str(message or ""))
 
 
 class ComponentLibraryPanel(ctk.CTkFrame):
@@ -823,9 +829,19 @@ class VisualFlowPlanner(ctk.CTkFrame):
         target = node if isinstance(node, dict) else link
         if not isinstance(target, dict):
             return
+        self._set_property_feedback("")
         if changes.get("_delete") and link is target:
             self.canvas.model.remove_link(str(link.get("id") or ""))
         else:
+            node_ids = {str(item.get("id") or "").strip() for item in (payload.get("nodes") or []) if isinstance(item, dict)}
+            title_aliases = {}
+            for item in payload.get("nodes") or []:
+                if not isinstance(item, dict):
+                    continue
+                item_id = str(item.get("id") or "").strip()
+                title_key = str(item.get("title") or "").strip().casefold()
+                if item_id and title_key:
+                    title_aliases.setdefault(title_key, set()).add(item_id)
             scene_fields = target.setdefault("scene_fields", {}) if target is node else None
             for key, value in changes.items():
                 if isinstance(key, tuple) and key and key[0] == "scene_fields" and node is target:
@@ -847,10 +863,33 @@ class VisualFlowPlanner(ctk.CTkFrame):
                             if str(lk.get("target") or "") == old_id:
                                 lk["target"] = new_id
                 else:
+                    if link is target and key in {"source", "target"}:
+                        raw = str(value or "").strip()
+                        if not raw:
+                            self._set_property_feedback(f"Invalid {key}: value is required.")
+                            continue
+                        resolved = raw
+                        if resolved not in node_ids:
+                            alias_candidates = title_aliases.get(raw.casefold(), set())
+                            if len(alias_candidates) == 1:
+                                resolved = next(iter(alias_candidates))
+                            else:
+                                self._set_property_feedback(f"Invalid {key}: '{raw}' does not match a node id/title.")
+                                continue
+                        value = resolved
                     target[key] = value
+            if link is target:
+                existing_id = str(link.get("id") or "").strip()
+                payload["links"] = normalise_flow_links(payload.get("nodes") or [], payload.get("links") or [])
+                if existing_id and not any(str(item.get("id") or "") == existing_id for item in payload["links"]):
+                    self._set_property_feedback("Link edit was rejected because it produced an invalid connection.")
         self.mark_dirty()
         self.hierarchy.render(payload.get("nodes") or [], payload.get("links") or [], self._scenario_title)
         self.canvas.render()
+
+    def _set_property_feedback(self, message):
+        if hasattr(self, "properties") and hasattr(self.properties, "set_feedback"):
+            self.properties.set_feedback(message)
 
     def _safe_save(self):
         callback = getattr(self, "save_state", None)

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -219,11 +219,50 @@ def _build_headless_planner(payload):
     planner = VisualFlowPlanner.__new__(VisualFlowPlanner)
     planner.canvas = _FakeCanvas(payload)
     planner.hierarchy = _FakeHierarchy()
-    planner.properties = type("P", (), {"bind_item": lambda *args, **kwargs: None})()
+    planner.properties = type(
+        "P",
+        (),
+        {
+            "bind_item": lambda *args, **kwargs: None,
+            "set_feedback": lambda self, message: setattr(self, "feedback", message),
+            "feedback": "",
+        },
+    )()
     planner._scenario_title = "Test"
     planner._dirty = False
     planner._clipboard_node = None
     return planner
+
+
+def test_link_property_edit_rejects_unknown_source_and_keeps_link_stable():
+    planner = _build_headless_planner(
+        {
+            "version": 1,
+            "nodes": [{"id": "a", "title": "Alpha"}, {"id": "b", "title": "Beta"}],
+            "links": [{"id": "a-b", "source": "a", "target": "b", "label": "", "kind": "scene_link"}],
+        }
+    )
+    link = planner.canvas.model.payload["links"][0]
+    planner._on_properties_change({"source": "missing-node"}, link=link)
+    updated = planner.canvas.model.payload["links"][0]
+    assert updated["id"] == "a-b"
+    assert updated["source"] == "a"
+    assert "Invalid source" in planner.properties.feedback
+
+
+def test_link_property_edit_maps_unique_title_alias_and_keeps_link_id():
+    planner = _build_headless_planner(
+        {
+            "version": 1,
+            "nodes": [{"id": "a", "title": "Alpha"}, {"id": "b", "title": "Beta"}, {"id": "c", "title": "Gamma"}],
+            "links": [{"id": "a-b", "source": "a", "target": "b", "label": "", "kind": "scene_link"}],
+        }
+    )
+    link = planner.canvas.model.payload["links"][0]
+    planner._on_properties_change({"target": "Gamma"}, link=link)
+    updated = planner.canvas.model.payload["links"][0]
+    assert updated["id"] == "a-b"
+    assert updated["target"] == "c"
 
 
 def test_planner_context_commands_delete_reorder_and_copy_paste():


### PR DESCRIPTION
### Motivation
- Prevent property edits from creating dangling or invalid links by enforcing that `source`/`target` reference existing node ids.
- Allow safe convenience mapping from a unique node title (case-insensitive) to its id when users edit link endpoints.
- Preserve link id stability and canonical link structure by re-running link normalization after edits.

### Description
- Added an inline feedback label and `set_feedback` hook to the properties panel so invalid edits surface to the user. (modules/scenarios/wizard_steps/scenes/visual_flow_planner.py)
- In `_on_properties_change` validate `source`/`target` for link edits against current node ids and build a `title_aliases` map for unique-title -> id resolution. (modules/scenarios/wizard_steps/scenes/visual_flow_planner.py)
- If a `source`/`target` value cannot be resolved, reject the change and show feedback instead of creating a dangling link, and if a unique title matches map it to the id. (modules/scenarios/wizard_steps/scenes/visual_flow_planner.py)
- After applying link edits the handler re-runs `normalise_flow_links(...)` to canonicalize links while checking that the edited link id remains present, and surfaces a rejection message if normalization would remove the link. (modules/scenarios/wizard_steps/scenes/visual_flow_planner.py)
- Added regression tests that assert unknown endpoint edits are rejected and that unique-title aliasing maps to the correct node id while keeping the link id stable. (tests/scenarios/test_visual_flow_planner.py)

### Testing
- Ran `pytest -q tests/scenarios/test_visual_flow_planner.py` and the test file passed with `17 passed`.
- No other test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3542f8d18832ba16a5147813bafa3)