### PR TITLE
Harden visual flow planner context command behavior

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -751,10 +751,19 @@ class VisualFlowPlanner(ctk.CTkFrame):
         return export_visual_flow_to_scenes(self._flow_payload, existing_scenes=self._scenes)
 
     def delete_selected(self):
+        before = self.canvas.export_payload()
         self.canvas.delete_selected()
+        after = self.canvas.export_payload()
+        if before != after:
+            self._refresh_views()
+            self._on_select(None, source="canvas")
 
     def duplicate_selected(self):
+        before = self.canvas.export_payload()
         self.canvas.duplicate_selected()
+        after = self.canvas.export_payload()
+        if before != after:
+            self._refresh_views()
 
     def mark_dirty(self):
         self._dirty = True

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -1,3 +1,5 @@
+import copy
+
 from modules.scenarios.wizard_steps.scenes.flow_canvas.model import FlowCanvasModel
 from modules.scenarios.wizard_steps.scenes.visual_flow_planner import (
     VisualFlowPlanner,
@@ -217,7 +219,7 @@ class _FakeCanvas:
         self.render()
 
     def export_payload(self):
-        return self.model.payload
+        return copy.deepcopy(self.model.payload)
 
     def create_node_at_viewport_center(self, kind):
         self.created += 1
@@ -400,3 +402,81 @@ def test_planner_reorder_rejects_drop_on_descendant():
     planner.reorder_node_relative("a", "c", place_after=False)
     assert [node["id"] for node in planner.canvas.model.payload["nodes"]] == before
     assert planner.canvas.render_calls == 0
+
+
+def test_context_commands_mutating_actions_refresh_and_mark_dirty():
+    commands = [
+        ("add", {"node_id": "a", "node_type": "scene"}),
+        ("delete", {"node_id": "b"}),
+        ("move_up", {"node_id": "b"}),
+        ("move_down", {"node_id": "a"}),
+        ("reorder", {"node_id": "b", "target_node_id": "a", "place_after": False}),
+        ("cut", {"node_id": "b"}),
+        ("paste", {"node_id": "a"}),
+    ]
+
+    for command, context in commands:
+        planner = _build_headless_planner(
+            {
+                "version": 1,
+                "nodes": [
+                    {"id": "a", "title": "A", "kind": "scene", "scene_index": 0, "x": 0, "y": 0},
+                    {"id": "b", "title": "B", "kind": "scene", "scene_index": 1, "x": 10, "y": 20},
+                ],
+                "links": [{"id": "a-b", "source": "a", "target": "b", "label": "", "kind": "scene_link"}],
+            }
+        )
+        if command == "paste":
+            planner._handle_hierarchy_command("copy", {"node_id": "b"})
+        start_hierarchy = planner.hierarchy.calls
+        start_render = planner.canvas.render_calls
+        assert planner._dirty is False
+
+        planner._handle_hierarchy_command(command, context)
+
+        assert planner._dirty is True
+        assert planner.hierarchy.calls > start_hierarchy
+        assert planner.canvas.render_calls > start_render
+
+
+def test_copy_command_is_non_mutating_for_context_menu():
+    planner = _build_headless_planner(
+        {
+            "version": 1,
+            "nodes": [{"id": "a", "title": "A", "kind": "scene", "scene_index": 0, "x": 0, "y": 0}],
+            "links": [],
+        }
+    )
+    payload_before = planner.canvas.export_payload()
+    planner._handle_hierarchy_command("copy", {"node_id": "a"})
+    assert planner.canvas.export_payload() == payload_before
+    assert planner._dirty is False
+
+
+def test_paste_generates_unique_id_skips_link_cloning_and_applies_position_offset():
+    planner = _build_headless_planner(
+        {
+            "version": 1,
+            "nodes": [
+                {"id": "a", "title": "A", "kind": "scene", "scene_index": 0, "x": 0, "y": 0},
+                {"id": "b", "title": "B", "kind": "scene", "scene_index": 1, "x": 10, "y": 20},
+                {"id": "b-2", "title": "B", "kind": "scene", "scene_index": 2, "x": 20, "y": 30},
+                {"id": "c", "title": "C", "kind": "scene", "scene_index": 3, "x": 50, "y": 60},
+            ],
+            "links": [
+                {"id": "a-b", "source": "a", "target": "b", "label": "", "kind": "scene_link"},
+                {"id": "b-c", "source": "b", "target": "c", "label": "", "kind": "scene_link"},
+            ],
+        }
+    )
+    planner._handle_hierarchy_command("copy", {"node_id": "b"})
+    planner._handle_hierarchy_command("paste", {"node_id": "a"})
+
+    pasted = planner.canvas.model.payload["nodes"][-1]
+    assert pasted["id"] not in {"b", "b-2"}
+    assert pasted["x"] == 50
+    assert pasted["y"] == 60
+
+    links = planner.canvas.model.payload["links"]
+    assert any(link["source"] == "a" and link["target"] == pasted["id"] for link in links)
+    assert not any(link["source"] == pasted["id"] or link["target"] == pasted["id"] and link["source"] != "a" for link in links)


### PR DESCRIPTION
### Motivation
- Audit and tighten the planner-level command handlers so all menu/context actions reliably mutate the model and drive UI refreshes when appropriate.
- Ensure paste semantics produce fresh unique IDs, obey a simple link-cloning policy, and apply a deterministic positional offset.
- Add command-level tests to prevent regressions and verify that mutating vs non-mutating actions behave correctly with respect to model updates, view refresh and dirty marking.

### Description
- Updated `delete_selected` and `duplicate_selected` in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` to compare `before`/`after` payloads and call `_refresh_views()` (and clear selection on delete) only when a real mutation occurred.
- Ensured clipboard/paste semantics produce regenerated unique node IDs, apply a positional offset (`+40,+40`) and only create an optional anchor->clone link without cloning the source node's full link graph (implemented in `paste_node`).
- Kept `copy_node` non-mutating (only updates the planner clipboard) and wired all hierarchy/context commands (`add`, `delete`, `move_up`, `move_down`, `reorder`, `cut`, `copy`, `paste`) to the same planner-level flows that refresh hierarchy/canvas and mark dirty when needed.
- Hardened tests and test helpers by making the headless fake canvas `export_payload` return a deep copy and added command-level tests in `tests/scenarios/test_visual_flow_planner.py` covering mutating actions refresh/dirty behavior, non-mutating `copy`, and paste-specific id/links/position behavior.

### Testing
- Ran `pytest -q tests/scenarios/test_visual_flow_planner.py` and all tests passed (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f358b6de8c832bba5eb4f5308af688)