### PR TITLE
Refine visual flow scene field schema and round-trip safety

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -41,6 +41,32 @@ _NODE_KNOWN_KEYS = {
 }
 _LINK_KNOWN_KEYS = {"id", "source", "target", "label", "kind", "_extra_fields"}
 _SCENE_RECOGNISED_KEYS = {"Title", "Summary", "SceneType", "NextScenes", "LinkData", "_extra_fields"}
+_SCENE_REQUIRED_EXPORT_LIST_FIELDS = {
+    "SceneBeats",
+    "SceneClues",
+    "SceneChallenges",
+    "SceneTwists",
+    "SceneRewards",
+    "NPCs",
+    "Creatures",
+    "Places",
+    "Clues",
+    "Bases",
+    "Maps",
+    "LinkData",
+    "NextScenes",
+}
+_SCENE_REQUIRED_EXPORT_STRING_FIELDS = {"Text"}
+_SCENE_ALLOWED_ROOT_KEYS = {
+    "Title",
+    "Summary",
+    "SceneType",
+    "Type",
+    "_extra_fields",
+    "_canvas",
+    *_SCENE_REQUIRED_EXPORT_LIST_FIELDS,
+    *_SCENE_REQUIRED_EXPORT_STRING_FIELDS,
+}
 _SCENE_TYPE_OVERRIDES = {}
 _PLAYABLE_NODE_KIND_TO_SCENE_TYPE = {
     "scene": "Scene",
@@ -181,6 +207,14 @@ def build_visual_flow_from_scenes(scenes, existing_visual_payload=None):
             node_id = normalise_flow_node_id(node_id, used_ids)
         used_ids.add(node_id)
         canvas = scene.get("_canvas") if isinstance(scene.get("_canvas"), dict) else {}
+        structured_fields = {}
+        for key in SCENE_STRUCTURED_FIELDS:
+            if key in scene:
+                structured_fields[key] = copy.deepcopy(scene.get(key))
+        entity_fields = {}
+        for key in SCENE_ENTITY_FIELDS:
+            if key in scene:
+                entity_fields[key] = copy.deepcopy(scene.get(key))
         nodes.append(
             {
                 "id": node_id,
@@ -192,8 +226,8 @@ def build_visual_flow_from_scenes(scenes, existing_visual_payload=None):
                 "summary": str(scene.get("Summary") or ""),
                 "scene_fields": {
                     "SceneType": str(scene.get("SceneType") or ""),
-                    "structured": {k: copy.deepcopy(v) for k, v in scene.items() if k not in _SCENE_RECOGNISED_KEYS and k != "_extra_fields"},
-                    "entities": copy.deepcopy(scene.get("_extra_fields") or {}),
+                    "structured": structured_fields,
+                    "entities": entity_fields,
                 },
                 "_extra_fields": {k: copy.deepcopy(v) for k, v in matched.items() if k not in _NODE_KNOWN_KEYS},
             }
@@ -251,7 +285,15 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
         scene["_canvas"] = {"x": int(node.get("x", 0)), "y": int(node.get("y", 0))}
         scene_fields = node.get("scene_fields") if isinstance(node.get("scene_fields"), dict) else {}
         for key, value in (scene_fields.get("structured") or {}).items():
-            scene[key] = copy.deepcopy(value)
+            if key in SCENE_STRUCTURED_FIELDS:
+                scene[key] = copy.deepcopy(value)
+            else:
+                scene.setdefault("_extra_fields", {})[key] = copy.deepcopy(value)
+        for key, value in (scene_fields.get("entities") or {}).items():
+            if key in SCENE_ENTITY_FIELDS:
+                scene[key] = copy.deepcopy(value)
+            else:
+                scene.setdefault("_extra_fields", {})[key] = copy.deepcopy(value)
         for key in SCENE_ENTITY_FIELDS:
             scene[key] = normalise_entity_list(scene.get(key))
         for key in SCENE_STRUCTURED_FIELDS:
@@ -280,6 +322,13 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
         scene["NextScenes"] = [link["target"] for link in normalised_links]
         for key in _SCENE_RECOGNISED_KEYS:
             scene.setdefault(key, [] if key in {"NextScenes", "LinkData"} else "")
+        unknown_root_keys = [key for key in list(scene.keys()) if key not in _SCENE_ALLOWED_ROOT_KEYS]
+        for key in unknown_root_keys:
+            scene.setdefault("_extra_fields", {})[key] = copy.deepcopy(scene.pop(key))
+        for key in _SCENE_REQUIRED_EXPORT_LIST_FIELDS:
+            scene.setdefault(key, [])
+        for key in _SCENE_REQUIRED_EXPORT_STRING_FIELDS:
+            scene.setdefault(key, "")
         scene["Text"] = compose_scene_text_from_fields(scene)
     return result
 

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -101,6 +101,59 @@ def test_visual_flow_round_trip_preserves_scene_fields():
     assert by_title["Dockside"]["NextScenes"] == ["Ambush"]
 
 
+def test_visual_flow_round_trip_mixed_known_unknown_scene_fields():
+    scenes = [
+        {
+            "Title": "Dockside",
+            "Summary": "Meet contact",
+            "SceneType": "Interaction",
+            "SceneClues": ["Blue wax seal"],
+            "NPCs": ["Vera"],
+            "CustomIntel": ["shadow ledger"],
+            "_extra_fields": {"legacyHint": "retain me"},
+            "NextScenes": ["Ambush"],
+        },
+        {"Title": "Ambush", "Summary": "Fight breaks out", "SceneType": "Action", "NextScenes": []},
+    ]
+
+    payload = build_visual_flow_from_scenes(scenes)
+    node = payload["nodes"][0]
+    assert node["scene_fields"]["structured"]["SceneClues"] == ["Blue wax seal"]
+    assert node["scene_fields"]["entities"]["NPCs"] == ["Vera"]
+    assert "CustomIntel" not in node["scene_fields"]["structured"]
+
+    node["scene_fields"]["structured"]["UnknownStructured"] = ["should persist"]
+    node["scene_fields"]["entities"]["UnknownEntityBucket"] = ["should persist too"]
+
+    exported = export_visual_flow_to_scenes(payload, existing_scenes=scenes)
+    by_title = {scene["Title"]: scene for scene in exported}
+    dockside = by_title["Dockside"]
+    assert dockside["SceneClues"] == ["Blue wax seal"]
+    assert dockside["NPCs"] == ["Vera"]
+    assert dockside["_extra_fields"]["UnknownStructured"] == ["should persist"]
+    assert dockside["_extra_fields"]["UnknownEntityBucket"] == ["should persist too"]
+    assert dockside["_extra_fields"]["legacyHint"] == "retain me"
+    assert "CustomIntel" not in dockside
+    for key in (
+        "SceneBeats",
+        "SceneClues",
+        "SceneChallenges",
+        "SceneTwists",
+        "SceneRewards",
+        "NPCs",
+        "Creatures",
+        "Places",
+        "Clues",
+        "Bases",
+        "Maps",
+        "LinkData",
+        "NextScenes",
+        "_canvas",
+        "Text",
+    ):
+        assert key in dockside
+
+
 def test_visual_flow_round_trip_preserves_node_kinds_via_extra_metadata():
     flow_payload = {
         "version": 1,


### PR DESCRIPTION
### Motivation

- Make visual node scene data explicit so `SceneType`, structured fields, and entity fields are first-class and not mixed with arbitrary keys.
- Prevent silent loss of unknown scene data by preserving unexpected fields and routing them into `_extra_fields`.
- Ensure exported scenes always include the exact required keys and shape for downstream consumers.
- Add round-trip coverage to validate behavior with mixed known and unknown fields.

### Description

- Added export/schema constants `_SCENE_REQUIRED_EXPORT_LIST_FIELDS`, `_SCENE_REQUIRED_EXPORT_STRING_FIELDS`, and `_SCENE_ALLOWED_ROOT_KEYS` to codify required scene export keys and allowed root keys in visual nodes (file: `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py`).
- Changed `build_visual_flow_from_scenes` to populate `scene_fields` with explicit `SceneType`, `structured` (only known structured fields), and `entities` (only known entity fields) instead of dumping unknown keys into structured buckets.
- Updated `export_visual_flow_to_scenes` to move unknown `scene_fields` entries and unexpected root-level keys into `_extra_fields`, and to enforce defaults for required list/string export keys including `SceneBeats`, `SceneClues`, `SceneChallenges`, `SceneTwists`, `SceneRewards`, `NPCs`, `Creatures`, `Places`, `Clues`, `Bases`, `Maps`, `LinkData`, `NextScenes`, `_canvas`, and `Text`.
- Added a round-trip test `test_visual_flow_round_trip_mixed_known_unknown_scene_fields` that verifies known structured/entity fields round-trip, unknown fields are preserved under `_extra_fields`, and required export keys are present (file: `tests/scenarios/test_visual_flow_planner.py`).

### Testing

- Ran `pytest -q tests/scenarios/test_visual_flow_planner.py` which executed the visual flow planner test suite including the new round-trip test and all tests passed (`24 passed`).
- The test suite confirms preservation of unknown fields and presence of the required export keys after build/export round-trips.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f359d064e8832b8bf4e3b770152ab2)