### PR TITLE
Add root context actions and sentinel node export opt-in

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_properties_panel_helpers.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_properties_panel_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 SCENE_ENTITY_FIELDS = ("NPCs", "Creatures", "Places", "Clues", "Bases", "Maps")
 SCENE_STRUCTURED_FIELDS = ("SceneBeats", "SceneClues", "SceneChallenges", "SceneTwists", "SceneRewards")
-NODE_KIND_VALUES = ["scene", "objective", "side_objective", "interaction", "condition", "action", "note"]
+NODE_KIND_VALUES = ["scene", "objective", "side_objective", "interaction", "condition", "action", "note", "start", "end"]
 LINK_KIND_VALUES = ["scene_link", "yes", "no", "success", "failure"]
 
 

--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -77,6 +77,7 @@ _PLAYABLE_NODE_KIND_TO_SCENE_TYPE = {
     "action": "Action",
     "note": "Note",
 }
+_NON_PLAYABLE_SENTINEL_KINDS = {"start", "end"}
 _VISUAL_NODE_TYPE_FIELD = "_visual_node_type"
 _SCENE_TYPE_TO_NODE_KIND = {value: key for key, value in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE.items()}
 
@@ -256,10 +257,16 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
     """Project flow payload back to scenes while preserving unknown fields."""
     existing = [copy.deepcopy(s) if isinstance(s, dict) else {"Title": str(s)} for s in (existing_scenes or [])]
     payload = flow_payload if isinstance(flow_payload, dict) else {}
-    nodes = [
-        node for node in (payload.get("nodes") or [])
-        if isinstance(node, dict) and str(node.get("kind") or "scene").strip() in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE
-    ]
+    nodes = []
+    for node in (payload.get("nodes") or []):
+        if not isinstance(node, dict):
+            continue
+        node_kind = str(node.get("kind") or "scene").strip()
+        if node_kind in _PLAYABLE_NODE_KIND_TO_SCENE_TYPE:
+            nodes.append(node)
+            continue
+        if node_kind in _NON_PLAYABLE_SENTINEL_KINDS and bool((node.get("_extra_fields") or {}).get("export_as_scene")):
+            nodes.append(node)
     links = normalise_flow_links(nodes, payload.get("links") or [])
     existing_by_index = {idx: scene for idx, scene in enumerate(existing)}
     existing_by_title = {
@@ -492,7 +499,14 @@ class FlowHierarchyPanel(ctk.CTkFrame):
         menu.add_separator()
         menu.add_command(label="Cut", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("cut", node_id=node_id))
         menu.add_command(label="Copy", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("copy", node_id=node_id))
-        menu.add_command(label="Paste", command=lambda: self._dispatch_command("paste", node_id=node_id))
+        menu.add_command(label="Paste", state="normal" if is_node_target else "disabled", command=lambda: self._dispatch_command("paste", node_id=node_id))
+        if not is_node_target:
+            menu.add_separator()
+            root_add_menu = tk.Menu(menu, tearoff=False)
+            for label, node_type in self._MENU_NODE_TYPES:
+                root_add_menu.add_command(label=label, command=lambda nt=node_type: self._dispatch_command("add", node_type=nt, node_id=None))
+            menu.add_cascade(label="Add at Root", menu=root_add_menu)
+            menu.add_command(label="Paste at Root", command=lambda: self._dispatch_command("paste", node_id=None))
         menu.tk_popup(event.x_root, event.y_root)
 
     def _dispatch_command(self, command, **kwargs):

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -533,3 +533,34 @@ def test_paste_generates_unique_id_skips_link_cloning_and_applies_position_offse
     links = planner.canvas.model.payload["links"]
     assert any(link["source"] == "a" and link["target"] == pasted["id"] for link in links)
     assert not any(link["source"] == pasted["id"] or link["target"] == pasted["id"] and link["source"] != "a" for link in links)
+
+def test_export_visual_flow_excludes_sentinel_nodes_by_default():
+    scenes = export_visual_flow_to_scenes(
+        {
+            "version": 1,
+            "nodes": [
+                {"id": "start", "title": "Start", "kind": "start", "scene_index": 0, "x": 0, "y": 0},
+                {"id": "s1", "title": "Scene 1", "kind": "scene", "scene_index": 1, "x": 10, "y": 10},
+                {"id": "end", "title": "End", "kind": "end", "scene_index": 2, "x": 20, "y": 20},
+            ],
+            "links": [
+                {"source": "start", "target": "s1", "kind": "scene_link"},
+                {"source": "s1", "target": "end", "kind": "scene_link"},
+            ],
+        }
+    )
+    assert [scene["Title"] for scene in scenes] == ["Scene 1"]
+
+
+def test_export_visual_flow_allows_opt_in_sentinel_export():
+    scenes = export_visual_flow_to_scenes(
+        {
+            "version": 1,
+            "nodes": [
+                {"id": "start", "title": "Start", "kind": "start", "scene_index": 0, "x": 0, "y": 0, "_extra_fields": {"export_as_scene": True}},
+                {"id": "s1", "title": "Scene 1", "kind": "scene", "scene_index": 1, "x": 10, "y": 10},
+            ],
+            "links": [{"source": "start", "target": "s1", "kind": "scene_link"}],
+        }
+    )
+    assert [scene["Title"] for scene in scenes] == ["Start", "Scene 1"]


### PR DESCRIPTION
### Motivation
- Allow adding or pasting nodes at the root of the hierarchy explicitly from the context menu rather than only via node-targeted menus to match editor UX expectations.
- Support non-playable visual-only sentinel nodes (e.g. `start`, `end`) for canvas metadata without forcing them into exported scenes.
- Ensure export is deterministic and does not accidentally include sentinel nodes unless users explicitly opt in.

### Description
- Added sentinel kinds `start` and `end` to the node kind list in `modules/scenarios/wizard_steps/scenes/flow_properties_panel_helpers.py` via `NODE_KIND_VALUES` so they are selectable in the UI.
- Introduced `_NON_PLAYABLE_SENTINEL_KINDS` and updated `export_visual_flow_to_scenes` in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` to exclude sentinel nodes by default and only include them when `node["_extra_fields"]["export_as_scene"]` is truthy.
- Updated `FlowHierarchyPanel._show_context_menu` in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` to disable node-targeted `Paste` when not over a node and to add `Add at Root` and `Paste at Root` submenu/command when the click targets empty/root space.
- Added regression tests in `tests/scenarios/test_visual_flow_planner.py` that assert sentinel nodes are excluded by default and included when `_extra_fields.export_as_scene` is set.

### Testing
- Ran `pytest -q tests/scenarios/test_visual_flow_planner.py tests/scenarios/flow_canvas/test_canvas_context_menu.py` and the suite completed successfully.
- Result: `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35cd25b2c832ba7b837fb068e0682)