### PR TITLE
Handle scene link migration on inline title rename

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/canvas_scene_planner.py
@@ -262,12 +262,25 @@ class CanvasScenePlanner(ctk.CTkFrame):
         if not isinstance(index, int) or index < 0 or index >= len(self.scenes):
             return
         scene = self.scenes[index]
-        scene["Title"] = data.get("Title") or scene.get("Title") or f"Scene {index + 1}"
+        old_title = str(scene.get("Title") or "").strip()
+        new_title = str(data.get("Title") or old_title or f"Scene {index + 1}").strip()
+        scene["Title"] = new_title
         scene["Summary"] = data.get("Summary", "")
         scene["SceneType"] = data.get("SceneType", "")
         for field_name in SCENE_STRUCTURED_FIELDS:
             scene[field_name] = parse_multiline_items(data.get(field_name))
         scene["_structured_prefilled"] = bool(data.get("_structured_prefilled"))
+
+        if new_title != old_title:
+            for linked_scene in self.scenes:
+                links = []
+                for link in normalise_scene_links(linked_scene):
+                    if link.get("target") == old_title:
+                        link["target"] = new_title
+                    links.append(link)
+                linked_scene["LinkData"] = links
+                linked_scene["NextScenes"] = [link["target"] for link in links]
+
         self._close_inline_scene_editor()
         self.canvas.set_scenes(self.scenes, self.selected_index)
 

--- a/tests/scenarios/wizard_steps/scenes/test_canvas_scene_planner_inline_rename.py
+++ b/tests/scenarios/wizard_steps/scenes/test_canvas_scene_planner_inline_rename.py
@@ -1,0 +1,53 @@
+from modules.scenarios.wizard_steps.scenes.canvas_scene_planner import CanvasScenePlanner
+
+
+class _FakeCanvas:
+    def __init__(self):
+        self.calls = []
+
+    def set_scenes(self, scenes, selected_index):
+        self.calls.append((scenes, selected_index))
+
+
+def test_apply_inline_scene_update_migrates_incoming_links_on_title_rename():
+    planner = CanvasScenePlanner.__new__(CanvasScenePlanner)
+    planner.scenes = [
+        {
+            "Title": "Intro",
+            "Summary": "",
+            "SceneType": "",
+            "LinkData": [{"target": "Target", "text": "Go to target"}],
+            "NextScenes": ["Target"],
+        },
+        {
+            "Title": "Target",
+            "Summary": "",
+            "SceneType": "",
+            "LinkData": [],
+            "NextScenes": [],
+        },
+    ]
+    planner.selected_index = 1
+    planner.canvas = _FakeCanvas()
+    planner._inline_editor = None
+    planner._close_inline_scene_editor = lambda: None
+
+    planner._apply_inline_scene_update(
+        1,
+        {
+            "Title": "Target Renamed",
+            "Summary": "Updated summary",
+            "SceneType": "Outcome",
+            "_structured_prefilled": False,
+        },
+    )
+
+    source_scene = planner.scenes[0]
+    renamed_scene = planner.scenes[1]
+
+    assert renamed_scene["Title"] == "Target Renamed"
+    assert source_scene["LinkData"] == [{"target": "Target Renamed", "text": "Go to target"}]
+    assert source_scene["NextScenes"] == ["Target Renamed"]
+    assert all(link["target"] != "Target" for link in source_scene["LinkData"])
+    assert "Target" not in source_scene["NextScenes"]
+    assert planner.canvas.calls, "Canvas should refresh after link migration"


### PR DESCRIPTION
### Motivation
- Prevent stale incoming links when a scene title is changed via the inline editor so links remain consistent across the canvas.
- Ensure link normalization is applied when migrating targets so `LinkData` and `NextScenes` reflect the updated title.

### Description
- Capture `old_title` and compute a normalized `new_title` in `CanvasScenePlanner._apply_inline_scene_update` and only run migration when they differ.
- For every scene call `normalise_scene_links`, update any link where `target == old_title` to `new_title`, then rebuild `LinkData` and `NextScenes` from the normalized links.
- Keep the existing canvas refresh call (`self.canvas.set_scenes(...)`) so the UI is refreshed after migration.
- Add a focused scenario test `tests/scenarios/wizard_steps/scenes/test_canvas_scene_planner_inline_rename.py` that renames a scene and asserts incoming links and `NextScenes` are updated and no stale references remain.

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_canvas_scene_planner_inline_rename.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365380e48832b84b1bd8d82cfb67b)