### PR TITLE
Stabilize visual flow progression on explicit links

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/flow_canvas/model.py
+++ b/modules/scenarios/wizard_steps/scenes/flow_canvas/model.py
@@ -48,6 +48,11 @@ class FlowCanvasModel:
         return len(self._payload["links"]) != before
 
     def reorder_nodes(self, dragged_id: str, target_id: str, *, place_after: bool = False) -> bool:
+        """Reorder visual presentation only.
+
+        `scene_index` is intentionally a UI ordering field and must not be used to infer
+        logical progression between scenes. Progression remains defined by explicit links.
+        """
         nodes = self._payload.get("nodes", [])
         drag_key = str(dragged_id or "")
         target_key = str(target_id or "")

--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -317,6 +317,14 @@ def build_visual_flow_from_scenes(scenes, existing_visual_payload=None):
                 node.setdefault("_extra_fields", {}).setdefault("visual_flow_ambiguities", []).append({"target": str(nxt or "").strip(), "reason": reason})
             links.append({"source": node["id"], "target": nodes[target_idx]["id"], "label": "", "kind": "scene_link"})
     links = normalise_flow_links(nodes, links)
+    linked_node_ids = set()
+    for link in links:
+        linked_node_ids.add(str(link.get("source") or ""))
+        linked_node_ids.add(str(link.get("target") or ""))
+    for node in nodes:
+        node_id = str(node.get("id") or "")
+        if node_id and node_id not in linked_node_ids:
+            node.setdefault("_extra_fields", {})["visual_flow_isolated"] = "no_incoming_or_outgoing_links"
     return {"version": _VISUAL_FLOW_VERSION, "nodes": nodes, "links": links}
 
 
@@ -342,7 +350,10 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
         if key and key not in existing_by_title:
             existing_by_title[key] = scene
     result = []
-    for node in sorted(nodes, key=lambda n: int(n.get("scene_index", 0))):
+    node_id_to_exported_scene = {}
+    # NOTE: scene_index is presentation order only. Logical progression is always derived
+    # from explicit links, never from index adjacency or fallback ordering.
+    for node in sorted(nodes, key=lambda n: (int(n.get("scene_index", 0)), str(n.get("id") or ""))):
         idx = int(node.get("scene_index", 0))
         title = str(node.get("title") or "").strip() or f"Scene {idx + 1}"
         scene = copy.deepcopy(existing_by_index.get(idx) or existing_by_title.get(title.casefold()) or {})
@@ -378,6 +389,7 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
             scene["Type"] = str(scene_fields.get("SceneType"))
         scene["Text"] = compose_scene_text_from_fields(scene)
         result.append(scene)
+        node_id_to_exported_scene[str(node.get("id") or "")] = scene
 
     id_to_scene = {str(node.get("id")): node for node in nodes}
     outgoing = {}
@@ -395,10 +407,10 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
         if title_counts.get(target_title, 0) > 1 and target_scene_id:
             outgoing_link["target_id"] = target_scene_id
         outgoing.setdefault(source_id, []).append(outgoing_link)
-    for index, node in enumerate(sorted(nodes, key=lambda n: int(n.get("scene_index", 0)))):
-        if index >= len(result):
+    for node in sorted(nodes, key=lambda n: (int(n.get("scene_index", 0)), str(n.get("id") or ""))):
+        scene = node_id_to_exported_scene.get(str(node.get("id") or ""))
+        if scene is None:
             continue
-        scene = result[index]
         raw_outgoing = outgoing.get(str(node.get("id")), [])
         scene["LinkData"] = raw_outgoing
         normalised_links = normalise_scene_links(scene)
@@ -419,6 +431,17 @@ def export_visual_flow_to_scenes(flow_payload, existing_scenes=None):
         for key in _SCENE_REQUIRED_EXPORT_STRING_FIELDS:
             scene.setdefault(key, "")
         scene["Text"] = compose_scene_text_from_fields(scene)
+    # Deterministic handling for disconnected nodes: keep them exported and mark them.
+    isolated_node_ids = {str(node.get("id") or "") for node in nodes}
+    for link in links:
+        isolated_node_ids.discard(str(link.get("source") or ""))
+        isolated_node_ids.discard(str(link.get("target") or ""))
+    for node_id in sorted(nid for nid in isolated_node_ids if nid):
+        scene = node_id_to_exported_scene.get(node_id)
+        if scene is None:
+            continue
+        scene.setdefault("_extra_fields", {})["visual_flow_isolated"] = "no_incoming_or_outgoing_links"
+
     return result
 
 

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -243,6 +243,46 @@ def test_model_reorder_nodes_is_deterministic_from_same_input():
     assert [node["scene_index"] for node in model_1.payload["nodes"]] == [0, 1, 2, 3]
 
 
+def test_export_progression_uses_explicit_links_not_scene_index_order_after_manual_reorder():
+    flow_payload = {
+        "version": 1,
+        "nodes": [
+            {"id": "a", "scene_index": 2, "title": "Start", "summary": "", "kind": "scene", "x": 0, "y": 0},
+            {"id": "b", "scene_index": 0, "title": "Middle", "summary": "", "kind": "scene", "x": 0, "y": 0},
+            {"id": "c", "scene_index": 1, "title": "End", "summary": "", "kind": "scene", "x": 0, "y": 0},
+        ],
+        "links": [
+            {"id": "a-b", "source": "a", "target": "b", "label": "to middle", "kind": "scene_link"},
+            {"id": "b-c", "source": "b", "target": "c", "label": "to end", "kind": "scene_link"},
+        ],
+    }
+
+    exported = export_visual_flow_to_scenes(flow_payload)
+    by_title = {scene["Title"]: scene for scene in exported}
+    assert by_title["Start"]["NextScenes"] == ["Middle"]
+    assert by_title["Middle"]["NextScenes"] == ["End"]
+    assert by_title["End"]["NextScenes"] == []
+
+
+def test_disconnected_nodes_get_deterministic_isolated_marker_on_export_and_import():
+    flow_payload = {
+        "version": 1,
+        "nodes": [
+            {"id": "a", "scene_index": 0, "title": "Connected A", "summary": "", "kind": "scene", "x": 0, "y": 0},
+            {"id": "b", "scene_index": 1, "title": "Connected B", "summary": "", "kind": "scene", "x": 0, "y": 0},
+            {"id": "c", "scene_index": 2, "title": "Isolated", "summary": "", "kind": "scene", "x": 0, "y": 0},
+        ],
+        "links": [{"id": "a-b", "source": "a", "target": "b", "label": "", "kind": "scene_link"}],
+    }
+    exported = export_visual_flow_to_scenes(flow_payload)
+    isolated_scene = next(scene for scene in exported if scene["Title"] == "Isolated")
+    assert isolated_scene["_extra_fields"]["visual_flow_isolated"] == "no_incoming_or_outgoing_links"
+
+    rebuilt = build_visual_flow_from_scenes(exported)
+    rebuilt_isolated = next(node for node in rebuilt["nodes"] if node["title"] == "Isolated")
+    assert rebuilt_isolated["_extra_fields"]["visual_flow_isolated"] == "no_incoming_or_outgoing_links"
+
+
 def test_invalid_reorder_target_detects_descendant():
     model = FlowCanvasModel(
         {


### PR DESCRIPTION
### Motivation

- Clarify that `scene_index` is a UI/presentation ordering field and must not be relied on to infer logical progression. 
- Ensure scene progression is always derived from explicit links and not fallbacks to index adjacency or unstable index ordering. 
- Detect and deterministically handle nodes that have no incoming or outgoing links so exports/imports remain stable after manual reorders. 

### Description

- Documented the `reorder_nodes` behavior in `FlowCanvasModel` by adding a docstring that `scene_index` is presentation-only and not a source of progression (`modules/scenarios/wizard_steps/scenes/flow_canvas/model.py`).
- Made export/import/export-building deterministic by stabilizing node sorting with `(scene_index, id)` and mapping exported scenes by node id to remove fragile index→result coupling inside `export_visual_flow_to_scenes` (`modules/scenarios/wizard_steps/scenes/visual_flow_planner.py`).
- Added deterministic isolated-node handling by marking nodes with no incoming or outgoing links with `_extra_fields["visual_flow_isolated"] = "no_incoming_or_outgoing_links"` on both build and export paths (`build_visual_flow_from_scenes` and `export_visual_flow_to_scenes`).
- Added regression tests that verify that manual reorders (changing `scene_index` without editing links) do not change logical progression and that disconnected nodes are consistently marked across export/import (`tests/scenarios/test_visual_flow_planner.py`).

### Testing

- Ran the focused pytest selection `pytest -q tests/scenarios/test_visual_flow_planner.py -k "reorder_nodes or explicit_links_not_scene_index_order or disconnected_nodes_get_deterministic_isolated_marker"` and all selected tests passed. 
- The added tests exercise manual reorder determinism and isolated-node detection and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f368feff60832baad379e74c69b4ae)