### PR TITLE
Deep copy visual flow command payload snapshots

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow/commands.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,8 +25,8 @@ def make_delete_node_command(*, node_id: str, removed_node: dict[str, Any] | Non
 def make_update_link_command(*, link_id: str, before: dict[str, Any], after: dict[str, Any]) -> CommandResult:
     return CommandResult(
         changed=before != after,
-        before={"link_id": str(link_id or ""), "payload": dict(before or {})},
-        after={"link_id": str(link_id or ""), "payload": dict(after or {})},
+        before={"link_id": str(link_id or ""), "payload": copy.deepcopy(before or {})},
+        after={"link_id": str(link_id or ""), "payload": copy.deepcopy(after or {})},
     )
 
 
@@ -33,5 +34,5 @@ def make_create_link_command(*, source_id: str, target_id: str, link_payload: di
     return CommandResult(
         changed=bool(source_id and target_id),
         before={},
-        after={"source": str(source_id or ""), "target": str(target_id or ""), "link": dict(link_payload or {})},
+        after={"source": str(source_id or ""), "target": str(target_id or ""), "link": copy.deepcopy(link_payload or {})},
     )

--- a/tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py
+++ b/tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py
@@ -44,3 +44,26 @@ def test_parity_delete_update_command_contracts_undo_ready():
     create_cmd = make_create_link_command(source_id="a", target_id="b", link_payload={"id": "a-b"})
     assert create_cmd.changed is True
     assert create_cmd.after["target"] == "b"
+
+
+def test_update_link_command_snapshots_are_deep_copied():
+    before = {"style": {"width": 1}}
+    after = {"style": {"width": 2}}
+
+    command = make_update_link_command(link_id="a-b", before=before, after=after)
+
+    before["style"]["width"] = 99
+    after["style"]["width"] = 88
+
+    assert command.before["payload"]["style"]["width"] == 1
+    assert command.after["payload"]["style"]["width"] == 2
+
+
+def test_create_link_command_snapshots_are_deep_copied():
+    link_payload = {"meta": {"label": "A->B"}}
+
+    command = make_create_link_command(source_id="a", target_id="b", link_payload=link_payload)
+
+    link_payload["meta"]["label"] = "MUTATED"
+
+    assert command.after["link"]["meta"]["label"] == "A->B"


### PR DESCRIPTION
### Motivation

- Prevent later mutations of source dictionaries from mutating persisted command snapshots when building visual-flow commands.

### Description

- Import `copy` and switch shallow `dict(...)` copies to `copy.deepcopy(...)` in `make_update_link_command` and `make_create_link_command` inside `modules/scenarios/wizard_steps/scenes/visual_flow/commands.py` so nested payloads are stored as immutable snapshots.
- Preserve existing behavior of `make_delete_node_command` while ensuring link-related builders keep deep-copied payloads.
- Add unit tests in `tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py` that mutate source nested dictionaries after creating commands and assert stored snapshots are unchanged.

### Testing

- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_visual_flow_parity_checklist.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36a1e4ad8832b8fcb5ef95c8a2aed)