### PR TITLE
Stabilize visual flow link IDs during normalization and round-trips

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -107,26 +107,55 @@ def normalise_flow_links(nodes, links):
     node_ids = {str(node.get("id") or "").strip() for node in (nodes or []) if isinstance(node, dict)}
     out = []
     used_ids = set()
-    for link in links or []:
+    identity_to_existing_ids = {}
+
+    candidates = []
+    for index, link in enumerate(links or []):
         if not isinstance(link, dict):
             continue
         source = str(link.get("source") or "").strip()
         target = str(link.get("target") or "").strip()
         if source not in node_ids or target not in node_ids:
             continue
+        extra_fields = {k: copy.deepcopy(v) for k, v in link.items() if k not in _LINK_KNOWN_KEYS}
+        order_token = extra_fields.get("_order_token", index)
+        existing_id = str(link.get("id") or "").strip()
+        identity = (source, target)
+        if existing_id:
+            identity_to_existing_ids.setdefault(identity, []).append((order_token, index, existing_id))
+        label = str(link.get("label") or "").strip()
+        kind = str(link.get("kind") or "scene_link").strip() or "scene_link"
+        candidates.append((index, source, target, existing_id, extra_fields, order_token, label, kind))
+
+    for identity in identity_to_existing_ids:
+        identity_to_existing_ids[identity].sort(key=lambda item: (str(item[0]), item[1], item[2]))
+
+    for index, source, target, existing_id, extra_fields, order_token, label, kind in candidates:
+        identity = (source, target)
+        preserved_id = ""
+        if existing_id and existing_id not in used_ids:
+            preserved_id = existing_id
+        elif identity_to_existing_ids.get(identity):
+            for _, _, candidate_id in identity_to_existing_ids[identity]:
+                if candidate_id not in used_ids:
+                    preserved_id = candidate_id
+                    break
+
         record = {
-            "id": str(link.get("id") or "").strip(),
+            "id": preserved_id,
             "source": source,
             "target": target,
-            "label": str(link.get("label") or "").strip(),
-            "kind": str(link.get("kind") or "scene_link").strip() or "scene_link",
+            "label": label,
+            "kind": kind,
+            "_extra_fields": extra_fields,
         }
+
         if not record["id"]:
             record["id"] = normalise_flow_node_id(f"{source}-{target}", used_ids)
         if record["id"] in used_ids:
-            record["id"] = normalise_flow_node_id(record["id"], used_ids)
+            tie_seed = extra_fields.get("_order_token", order_token)
+            record["id"] = normalise_flow_node_id(f"{record['id']}-{tie_seed}", used_ids)
         used_ids.add(record["id"])
-        record["_extra_fields"] = {k: copy.deepcopy(v) for k, v in link.items() if k not in _LINK_KNOWN_KEYS}
         out.append(record)
     return out
 

--- a/tests/scenarios/test_visual_flow_planner.py
+++ b/tests/scenarios/test_visual_flow_planner.py
@@ -5,6 +5,7 @@ from modules.scenarios.wizard_steps.scenes.visual_flow_planner import (
     VisualFlowPlanner,
     build_visual_flow_from_scenes,
     export_visual_flow_to_scenes,
+    normalise_flow_links,
     normalise_flow_node_id,
 )
 
@@ -206,6 +207,47 @@ def test_visual_flow_delete_node_removes_links():
 def test_visual_flow_unique_ids():
     used = {"scene", "scene-2"}
     assert normalise_flow_node_id("Scene", used) == "scene-3"
+
+
+def test_normalise_flow_links_keeps_ids_when_unrelated_links_change():
+    nodes = [{"id": "a"}, {"id": "b"}, {"id": "c"}, {"id": "d"}]
+    original_links = [
+        {"id": "link-ab", "source": "a", "target": "b", "label": "AB"},
+        {"id": "link-bc", "source": "b", "target": "c", "label": "BC"},
+    ]
+    base = normalise_flow_links(nodes, original_links)
+    base_by_pair = {(link["source"], link["target"]): link["id"] for link in base}
+
+    mutated_links = [
+        {"id": "link-ab", "source": "a", "target": "b", "label": "AB"},
+        {"id": "new-unrelated", "source": "c", "target": "d", "label": "CD"},
+    ]
+    mutated = normalise_flow_links(nodes, mutated_links)
+    mutated_by_pair = {(link["source"], link["target"]): link["id"] for link in mutated}
+    assert mutated_by_pair[("a", "b")] == base_by_pair[("a", "b")]
+
+
+def test_visual_flow_selected_link_stays_selectable_after_round_trip():
+    flow_payload = {
+        "version": 1,
+        "nodes": [
+            {"id": "start", "scene_index": 0, "title": "Start", "summary": "", "kind": "scene", "x": 0, "y": 0},
+            {"id": "middle", "scene_index": 1, "title": "Middle", "summary": "", "kind": "scene", "x": 0, "y": 0},
+            {"id": "end", "scene_index": 2, "title": "End", "summary": "", "kind": "scene", "x": 0, "y": 0},
+        ],
+        "links": [
+            {"id": "start-middle", "source": "start", "target": "middle", "label": "go", "kind": "scene_link"},
+            {"id": "middle-end", "source": "middle", "target": "end", "label": "continue", "kind": "scene_link"},
+        ],
+    }
+    selected_link_id = "start-middle"
+
+    scenes = export_visual_flow_to_scenes(flow_payload)
+    rebuilt_payload = build_visual_flow_from_scenes(scenes, existing_visual_payload=flow_payload)
+    rebuilt_links = normalise_flow_links(rebuilt_payload["nodes"], rebuilt_payload["links"])
+    rebuilt_ids = {link["id"] for link in rebuilt_links}
+
+    assert selected_link_id in rebuilt_ids
 
 
 def test_model_reorder_nodes_updates_order_without_link_mutation():


### PR DESCRIPTION
### Motivation

- Keep link IDs stable across edits and export/import round-trips so UI selections and references do not break when unrelated links are added or removed.
- Provide deterministic tie-breaking for ID collisions so generated IDs do not depend on ephemeral iteration order.

### Description

- Reworked `normalise_flow_links` in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` to collect candidates and an `identity_to_existing_ids` map keyed by `(source, target)` so existing IDs are reused when the source/target identity is unchanged.
- Added deterministic tie-breaker logic that prefers a stable `_order_token` from `_extra_fields` when present, otherwise uses the original input index as a fallback, and uses that token to resolve ID collisions without relying on current loop order.
- Ensure `_extra_fields` from input links are preserved on output and use `normalise_flow_node_id(f"{source}-{target}", used_ids)` for fresh IDs so identical identities generate consistent base IDs.
- Added tests in `tests/scenarios/test_visual_flow_planner.py` covering preservation of IDs when unrelated links change and that a UI-selected link ID remains selectable after export/build/normalize round-trips, and exported the `normalise_flow_links` symbol for testing.

### Testing

- Ran targeted tests with `pytest -q tests/scenarios/test_visual_flow_planner.py -k "normalise_flow_links_keeps_ids_when_unrelated_links_change or selected_link_stays_selectable_after_round_trip or visual_flow_unique_ids"` and they passed.
- Ran the full file with `pytest -q tests/scenarios/test_visual_flow_planner.py` and the suite passed (`32 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36b69bc84832ba448a78156e622fb)