### PR TITLE
Optimize FlowHierarchyPanel node ordering lookup and add regression micro-check

### DIFF
--- a/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
+++ b/modules/scenarios/wizard_steps/scenes/visual_flow_planner.py
@@ -584,6 +584,7 @@ class FlowHierarchyPanel(ctk.CTkFrame):
                 incoming[target] = incoming.get(target, 0) + 1
 
         stable_ids = [str(node.get("id") or "") for node in sorted(nodes, key=lambda n: (int(n.get("scene_index", 0)), str(n.get("id") or "")))]
+        rank_by_id = {node_id: rank for rank, node_id in enumerate(stable_ids)}
         roots = [nid for nid in stable_ids if nid and incoming.get(nid, 0) == 0] or stable_ids
 
         ordered = []
@@ -595,7 +596,7 @@ class FlowHierarchyPanel(ctk.CTkFrame):
             seen.add(node_id)
             node = by_id[node_id]
             ordered.append((depth, node))
-            for child in sorted(outgoing.get(node_id, []), key=lambda cid: stable_ids.index(cid) if cid in stable_ids else 10**6):
+            for child in sorted(outgoing.get(node_id, []), key=lambda cid: rank_by_id.get(cid, 10**6)):
                 if child in by_id:
                     by_id[child]["_parent_id"] = node_id
                 walk(child, depth + 1)

--- a/tests/scenarios/wizard_steps/scenes/test_visual_flow_hierarchy_commands.py
+++ b/tests/scenarios/wizard_steps/scenes/test_visual_flow_hierarchy_commands.py
@@ -69,3 +69,26 @@ def test_visual_planner_routes_context_commands_to_expected_operations():
         ("reorder_rel", "n1", "n2", True),
         ("paste", {"node_id": "n1"}),
     ]
+
+
+def test_order_nodes_large_synthetic_graph_microcheck():
+    import time
+
+    panel = FlowHierarchyPanel.__new__(FlowHierarchyPanel)
+    node_count = 700
+    nodes = [
+        {"id": f"n-{idx}", "title": f"Node {idx}", "scene_index": idx, "kind": "scene"}
+        for idx in range(node_count)
+    ]
+    links = []
+    for idx in range(node_count - 1):
+        links.append({"source": f"n-{idx}", "target": f"n-{idx + 1}"})
+        if idx + 10 < node_count:
+            links.append({"source": f"n-{idx}", "target": f"n-{idx + 10}"})
+
+    start = time.perf_counter()
+    ordered = FlowHierarchyPanel._order_nodes(panel, nodes, links)
+    elapsed = time.perf_counter() - start
+
+    assert len(ordered) == node_count
+    assert elapsed < 1.5


### PR DESCRIPTION
### Motivation
- Reduce repeated O(n) `list.index` lookups in `FlowHierarchyPanel._order_nodes` which caused poor performance on large graphs while preserving existing ordering semantics.
- Guard against future regressions in traversal performance with a lightweight benchmark-style test that exercises a large synthetic graph.

### Description
- Precompute `rank_by_id = {node_id: rank}` from `stable_ids` in `FlowHierarchyPanel._order_nodes` and use it for sorting children. 
- Replace the repeated `stable_ids.index(cid) if cid in stable_ids else 10**6` with `rank_by_id.get(cid, 10**6)` to keep the same fallback rank behavior for unknown IDs. 
- Add a micro-check test `test_order_nodes_large_synthetic_graph_microcheck` that builds a synthetic graph (chain plus skip edges) and asserts full traversal and a crude time bound. 
- Changes made in `modules/scenarios/wizard_steps/scenes/visual_flow_planner.py` and `tests/scenarios/wizard_steps/scenes/test_visual_flow_hierarchy_commands.py`.

### Testing
- Ran `pytest -q tests/scenarios/wizard_steps/scenes/test_visual_flow_hierarchy_commands.py -q` and the test suite passed. 
- The new micro-check asserts the ordered output length and a simple performance bound (`elapsed < 1.5s`) to detect regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3893bee6c832ba9f5391e34a203ca)