### PR TITLE
Add onboarding tour package (engine, models, overlay, popover, state)

### DIFF
--- a/app/onboarding/__init__.py
+++ b/app/onboarding/__init__.py
@@ -1,0 +1,13 @@
+"""Onboarding tour package for Tkinter/CustomTkinter applications."""
+
+from .tour_engine import TourEngine
+from .tour_models import TourHook, TourPlacement, TourStep
+from .tour_state import TourStateStore
+
+__all__ = [
+    "TourEngine",
+    "TourHook",
+    "TourPlacement",
+    "TourStateStore",
+    "TourStep",
+]

--- a/app/onboarding/tour_engine.py
+++ b/app/onboarding/tour_engine.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Iterable
+
+from .tour_models import TourStep
+from .tour_overlay import TourOverlay
+from .tour_popover import TourPopover
+from .tour_state import TourStateStore
+
+logger = logging.getLogger(__name__)
+
+
+class TourEngine:
+    def __init__(
+        self,
+        root: Any,
+        tours: dict[str, list[TourStep]],
+        widget_resolver: Callable[[str, str], Any],
+        screen_resolver: Callable[[], str],
+        state_store: TourStateStore | None = None,
+    ) -> None:
+        self._root = root
+        self._tours = tours
+        self._widget_resolver = widget_resolver
+        self._screen_resolver = screen_resolver
+        self._state_store = state_store or TourStateStore()
+        self._overlay = TourOverlay(root)
+        self._popover = TourPopover(root, self.next_step, self.prev_step, self.stop)
+        self._tour_id: str | None = None
+        self._steps: list[TourStep] = []
+        self._step_index = -1
+
+    def start(self, tour_id: str) -> None:
+        if tour_id not in self._tours:
+            logger.warning("Tour '%s' does not exist.", tour_id)
+            return
+        self._tour_id = tour_id
+        self._steps = self._tours[tour_id]
+        self._step_index = -1
+        self.next_step()
+
+    def next_step(self) -> None:
+        if not self._steps:
+            return
+        self._advance(1)
+
+    def prev_step(self) -> None:
+        if not self._steps:
+            return
+        self._advance(-1)
+
+    def stop(self) -> None:
+        current_step = self.current_step
+        if current_step and current_step.after_hook:
+            current_step.after_hook(current_step)
+
+        self._overlay.clear()
+        self._popover.hide()
+
+        if self._tour_id and self._step_index >= len(self._steps) - 1:
+            self._state_store.mark_tour_completed(self._tour_id)
+
+        self._tour_id = None
+        self._steps = []
+        self._step_index = -1
+
+    @property
+    def current_step(self) -> TourStep | None:
+        if 0 <= self._step_index < len(self._steps):
+            return self._steps[self._step_index]
+        return None
+
+    def _advance(self, direction: int) -> None:
+        next_index = self._step_index + direction
+        while 0 <= next_index < len(self._steps):
+            step = self._steps[next_index]
+            if self._try_show_step(step):
+                self._step_index = next_index
+                return
+            next_index += direction
+        self.stop()
+
+    def _try_show_step(self, step: TourStep) -> bool:
+        if self._screen_resolver() != step.screen:
+            logger.info(
+                "Skipping step '%s': screen '%s' is not active.",
+                step.id,
+                step.screen,
+            )
+            return False
+
+        target_widget = self._widget_resolver(step.screen, step.target_widget_key)
+        if target_widget is None:
+            logger.info(
+                "Skipping step '%s': target widget '%s' was not found.",
+                step.id,
+                step.target_widget_key,
+            )
+            return False
+
+        if step.before_hook:
+            step.before_hook(step)
+
+        self._overlay.show_highlight(target_widget)
+        self._popover.show(step, target_widget)
+        return True

--- a/app/onboarding/tour_models.py
+++ b/app/onboarding/tour_models.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Optional
+
+
+class TourPlacement(str, Enum):
+    TOP = "top"
+    BOTTOM = "bottom"
+    LEFT = "left"
+    RIGHT = "right"
+
+
+TourHook = Callable[["TourStep"], None]
+
+
+@dataclass(frozen=True)
+class TourStep:
+    id: str
+    screen: str
+    target_widget_key: str
+    title: str
+    description: str
+    placement: TourPlacement = TourPlacement.BOTTOM
+    before_hook: Optional[TourHook] = None
+    after_hook: Optional[TourHook] = None

--- a/app/onboarding/tour_overlay.py
+++ b/app/onboarding/tour_overlay.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class TourOverlay:
+    """Visual overlay helper used to focus/highlight a target widget."""
+
+    def __init__(self, root: Any) -> None:
+        self._root = root
+        self._current_target: Any = None
+
+    def show_highlight(self, target_widget: Any) -> None:
+        self._current_target = target_widget
+
+    def clear(self) -> None:
+        self._current_target = None

--- a/app/onboarding/tour_popover.py
+++ b/app/onboarding/tour_popover.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .tour_models import TourStep
+
+
+class TourPopover:
+    """Text card + navigation controls for a tour step."""
+
+    def __init__(
+        self,
+        root: Any,
+        on_next: Callable[[], None],
+        on_prev: Callable[[], None],
+        on_close: Callable[[], None],
+    ) -> None:
+        self._root = root
+        self._on_next = on_next
+        self._on_prev = on_prev
+        self._on_close = on_close
+        self._visible = False
+
+    def show(self, step: TourStep, target_widget: Any) -> None:
+        _ = (step, target_widget)
+        self._visible = True
+
+    def hide(self) -> None:
+        self._visible = False

--- a/app/onboarding/tour_state.py
+++ b/app/onboarding/tour_state.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class TourStateStore:
+    """Simple JSON persistence for onboarding preferences and completion state."""
+
+    def __init__(self, storage_path: str | Path = "config/onboarding_state.json") -> None:
+        self._storage_path = Path(storage_path)
+        self._state = self._load()
+
+    def is_tour_completed(self, tour_id: str) -> bool:
+        completed = self._state.get("completed_tours", [])
+        return tour_id in completed
+
+    def mark_tour_completed(self, tour_id: str) -> None:
+        completed = set(self._state.get("completed_tours", []))
+        completed.add(tour_id)
+        self._state["completed_tours"] = sorted(completed)
+        self.save()
+
+    def is_auto_launch_enabled(self) -> bool:
+        return bool(self._state.get("auto_launch_onboarding", True))
+
+    def set_auto_launch_enabled(self, enabled: bool) -> None:
+        self._state["auto_launch_onboarding"] = bool(enabled)
+        self.save()
+
+    def save(self) -> None:
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self._storage_path.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
+
+    def _load(self) -> dict[str, Any]:
+        if not self._storage_path.exists():
+            return {"completed_tours": [], "auto_launch_onboarding": True}
+        try:
+            raw_state = json.loads(self._storage_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"completed_tours": [], "auto_launch_onboarding": True}
+
+        if not isinstance(raw_state, dict):
+            return {"completed_tours": [], "auto_launch_onboarding": True}
+
+        raw_state.setdefault("completed_tours", [])
+        raw_state.setdefault("auto_launch_onboarding", True)
+        return raw_state


### PR DESCRIPTION
### Motivation
- Provide a modular onboarding/tour subsystem to guide users through the Tkinter/CustomTkinter UI with step-by-step highlights and explanations.
- Keep UI rendering, orchestration and persistence separated so the tour can be integrated incrementally without tightly coupling to existing windows.

### Description
- Added new package `app/onboarding/` and exported core types from `__init__.py` to make the API discoverable.
- Implemented `TourStep` dataclass with `id`, `screen`, `target_widget_key`, `title`, `description`, `placement`, and optional `before_hook`/`after_hook` in `tour_models.py`.
- Implemented `TourEngine` in `tour_engine.py` with `start(tour_id)`, `next_step()`, `prev_step()`, and `stop()`, with active-screen validation and graceful skipping/logging when target widgets are missing, and invocation of hooks.
- Added light-weight UI primitives `TourOverlay` and `TourPopover` as separated placeholders, and a JSON-backed `TourStateStore` in `tour_state.py` to persist completed tours and an `auto_launch_onboarding` preference.

### Testing
- Compiled the new modules with `python -m py_compile app/onboarding/*.py` and the compilation succeeded.
- No additional automated UI or unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f782a79294832bbef503d9576ab1ae)