### PR TITLE
Externaliser la définition des tours onboarding

### DIFF
--- a/app/onboarding/__init__.py
+++ b/app/onboarding/__init__.py
@@ -3,6 +3,7 @@
 from .tour_engine import TourEngine
 from .tour_models import TourHook, TourPlacement, TourStep
 from .tour_state import TourStateStore
+from .tours import build_tour_registry
 
 __all__ = [
     "TourEngine",
@@ -10,4 +11,5 @@ __all__ = [
     "TourPlacement",
     "TourStateStore",
     "TourStep",
+    "build_tour_registry",
 ]

--- a/app/onboarding/tours/__init__.py
+++ b/app/onboarding/tours/__init__.py
@@ -1,0 +1,5 @@
+"""Onboarding tour definitions and registry."""
+
+from .tour_registry import TOUR_BUILDERS, build_tour_registry
+
+__all__ = ["TOUR_BUILDERS", "build_tour_registry"]

--- a/app/onboarding/tours/campaign_setup_tour.py
+++ b/app/onboarding/tours/campaign_setup_tour.py
@@ -1,0 +1,37 @@
+"""Onboarding steps for the campaign setup flow."""
+
+from __future__ import annotations
+
+from app.onboarding.tour_models import TourPlacement, TourStep
+
+from .tour_i18n_fr import CAMPAIGN_SETUP_TEXTS
+
+
+def build_campaign_setup_steps() -> list[TourStep]:
+    """Return an immutable definition of steps for the campaign setup tour."""
+    return [
+        TourStep(
+            id="campaign_setup.open_wizard",
+            screen="main_window",
+            target_widget_key="btn_new_campaign",
+            title=CAMPAIGN_SETUP_TEXTS["welcome_title"],
+            description=CAMPAIGN_SETUP_TEXTS["welcome_description"],
+            placement=TourPlacement.RIGHT,
+        ),
+        TourStep(
+            id="campaign_setup.name",
+            screen="campaign_builder",
+            target_widget_key="input_campaign_name",
+            title=CAMPAIGN_SETUP_TEXTS["name_title"],
+            description=CAMPAIGN_SETUP_TEXTS["name_description"],
+            placement=TourPlacement.BOTTOM,
+        ),
+        TourStep(
+            id="campaign_setup.finish",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=CAMPAIGN_SETUP_TEXTS["finish_title"],
+            description=CAMPAIGN_SETUP_TEXTS["finish_description"],
+            placement=TourPlacement.LEFT,
+        ),
+    ]

--- a/app/onboarding/tours/tour_i18n_fr.py
+++ b/app/onboarding/tours/tour_i18n_fr.py
@@ -1,0 +1,13 @@
+"""French copy for onboarding tours.
+
+Kept separate from step builders to make future i18n additions trivial.
+"""
+
+CAMPAIGN_SETUP_TEXTS = {
+    "welcome_title": "Créer une campagne",
+    "welcome_description": "Commencez ici pour ouvrir l'assistant de création de campagne.",
+    "name_title": "Nom de la campagne",
+    "name_description": "Définissez un nom clair pour retrouver rapidement votre univers.",
+    "finish_title": "Prêt à lancer",
+    "finish_description": "Validez pour générer la structure initiale de votre campagne.",
+}

--- a/app/onboarding/tours/tour_registry.py
+++ b/app/onboarding/tours/tour_registry.py
@@ -1,0 +1,20 @@
+"""Central tour builder registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from app.onboarding.tour_models import TourStep
+
+from .campaign_setup_tour import build_campaign_setup_steps
+
+TourBuilder = Callable[[], list[TourStep]]
+
+TOUR_BUILDERS: dict[str, TourBuilder] = {
+    "campaign_setup": build_campaign_setup_steps,
+}
+
+
+def build_tour_registry() -> dict[str, list[TourStep]]:
+    """Build concrete tour steps from registered builders."""
+    return {tour_id: builder() for tour_id, builder in TOUR_BUILDERS.items()}


### PR DESCRIPTION
### Motivation
- Séparer le contenu pédagogique (texte et étapes) de la logique UI pour éviter le mélange des responsabilités et faciliter la maintenance.
- Autoriser des définitions de parcours pures réutilisables et testables en dehors du moteur d'affichage.
- Préparer l'internationalisation en externalisant les textes et en utilisant des clés stables pour référencer les widgets.

### Description
- Création du répertoire `app/onboarding/tours/` et ajout de `campaign_setup_tour.py` exposant la fonction pure `build_campaign_setup_steps()` qui retourne une liste de `TourStep`.
- Ajout de `tour_i18n_fr.py` contenant `CAMPAIGN_SETUP_TEXTS` pour séparer les libellés FR du code des étapes.
- Ajout de `tour_registry.py` qui définit `TOUR_BUILDERS` et `build_tour_registry()` pour mapper `tour_id -> builder` et construire le dictionnaire final de tours.
- Export de `build_tour_registry` depuis `app/onboarding/__init__.py` pour faciliter l'intégration avec le `TourEngine` existant et garder la résolution des widgets basée sur des clés stables (`target_widget_key`).

### Testing
- Compilation des modules concernés avec `python -m compileall -q app/onboarding` (succès).
- Aucun test automatisé supplémentaire n'a été modifié ou échoué par cette refactorisation (aucune suite de tests unitaires exécutée dans ce PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f784dc712c832b9b298d2b15c09ae1)