### PR TITLE
Add beginner GM quickstart onboarding tours (MVP + advanced)

### DIFF
--- a/app/onboarding/tours/new_gm_quickstart_tour.py
+++ b/app/onboarding/tours/new_gm_quickstart_tour.py
@@ -1,0 +1,123 @@
+"""Onboarding scenarios focused on first-time GM core actions."""
+
+from __future__ import annotations
+
+from app.onboarding.tour_models import TourPlacement, TourStep
+
+from .tour_i18n_fr import NEW_GM_ADVANCED_TEXTS, NEW_GM_MVP_TEXTS
+
+
+def build_new_gm_mvp_steps() -> list[TourStep]:
+    """5-step MVP quickstart for a new GM."""
+    return [
+        TourStep(
+            id="new_gm_mvp.create_campaign",
+            screen="main_window",
+            target_widget_key="btn_new_campaign",
+            title=NEW_GM_MVP_TEXTS["create_campaign_title"],
+            description=NEW_GM_MVP_TEXTS["create_campaign_description"],
+            placement=TourPlacement.RIGHT,
+        ),
+        TourStep(
+            id="new_gm_mvp.name_campaign",
+            screen="campaign_builder",
+            target_widget_key="input_campaign_name",
+            title=NEW_GM_MVP_TEXTS["name_campaign_title"],
+            description=NEW_GM_MVP_TEXTS["name_campaign_description"],
+            placement=TourPlacement.BOTTOM,
+        ),
+        TourStep(
+            id="new_gm_mvp.hands_on",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_MVP_TEXTS["hands_on_title"],
+            description=NEW_GM_MVP_TEXTS["hands_on_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_mvp.first_scene",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_MVP_TEXTS["first_scene_title"],
+            description=NEW_GM_MVP_TEXTS["first_scene_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_mvp.summary",
+            screen="main_window",
+            target_widget_key="btn_new_campaign",
+            title=NEW_GM_MVP_TEXTS["summary_title"],
+            description=NEW_GM_MVP_TEXTS["summary_description"],
+            placement=TourPlacement.RIGHT,
+        ),
+    ]
+
+
+def build_new_gm_advanced_steps() -> list[TourStep]:
+    """8-step advanced path with planning and review habits."""
+    return [
+        TourStep(
+            id="new_gm_advanced.create_campaign",
+            screen="main_window",
+            target_widget_key="btn_new_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["create_campaign_title"],
+            description=NEW_GM_ADVANCED_TEXTS["create_campaign_description"],
+            placement=TourPlacement.RIGHT,
+        ),
+        TourStep(
+            id="new_gm_advanced.name_campaign",
+            screen="campaign_builder",
+            target_widget_key="input_campaign_name",
+            title=NEW_GM_ADVANCED_TEXTS["name_campaign_title"],
+            description=NEW_GM_ADVANCED_TEXTS["name_campaign_description"],
+            placement=TourPlacement.BOTTOM,
+        ),
+        TourStep(
+            id="new_gm_advanced.hands_on",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["hands_on_title"],
+            description=NEW_GM_ADVANCED_TEXTS["hands_on_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_advanced.create_scene",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["create_scene_title"],
+            description=NEW_GM_ADVANCED_TEXTS["create_scene_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_advanced.add_npc",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["add_npc_title"],
+            description=NEW_GM_ADVANCED_TEXTS["add_npc_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_advanced.link_clue",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["link_clue_title"],
+            description=NEW_GM_ADVANCED_TEXTS["link_clue_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_advanced.review_checklist",
+            screen="campaign_builder",
+            target_widget_key="btn_create_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["review_checklist_title"],
+            description=NEW_GM_ADVANCED_TEXTS["review_checklist_description"],
+            placement=TourPlacement.LEFT,
+        ),
+        TourStep(
+            id="new_gm_advanced.summary",
+            screen="main_window",
+            target_widget_key="btn_new_campaign",
+            title=NEW_GM_ADVANCED_TEXTS["summary_title"],
+            description=NEW_GM_ADVANCED_TEXTS["summary_description"],
+            placement=TourPlacement.RIGHT,
+        ),
+    ]

--- a/app/onboarding/tours/tour_i18n_fr.py
+++ b/app/onboarding/tours/tour_i18n_fr.py
@@ -11,3 +11,36 @@ CAMPAIGN_SETUP_TEXTS = {
     "finish_title": "Prêt à lancer",
     "finish_description": "Validez pour générer la structure initiale de votre campagne.",
 }
+
+
+NEW_GM_MVP_TEXTS = {
+    "create_campaign_title": "Tâche 1/3 : créer une campagne",
+    "create_campaign_description": "Cliquez sur \"Nouvelle campagne\" pour démarrer votre univers.",
+    "name_campaign_title": "Nommer la campagne",
+    "name_campaign_description": "Entrez un nom simple et reconnaissable.",
+    "hands_on_title": "Hands-on : faites l'action",
+    "hands_on_description": "Action requise : cliquez sur \"Créer la campagne\" avant de continuer.",
+    "first_scene_title": "Tâche 2/3 : préparer une première scène",
+    "first_scene_description": "Ajoutez une scène courte : lieu, objectif, obstacle.",
+    "summary_title": "Synthèse",
+    "summary_description": "Prochaines actions : 1) Commencer une nouvelle campagne 2) Revoir le guide.",
+}
+
+NEW_GM_ADVANCED_TEXTS = {
+    "create_campaign_title": "Tâche 1/3 : créer une campagne",
+    "create_campaign_description": "Démarrez une campagne avec un thème en une phrase.",
+    "name_campaign_title": "Nommer et cadrer",
+    "name_campaign_description": "Choisissez un nom + une intention claire pour la session 1.",
+    "hands_on_title": "Hands-on : valider",
+    "hands_on_description": "Action requise : cliquez sur \"Créer la campagne\" puis revenez ici.",
+    "create_scene_title": "Tâche 2/3 : créer la scène d'ouverture",
+    "create_scene_description": "Définissez un lieu, un conflit, et un enjeu immédiat.",
+    "add_npc_title": "Ajouter un PNJ clé",
+    "add_npc_description": "Créez un PNJ avec rôle, motivation, et voix simple.",
+    "link_clue_title": "Tâche 3/3 : poser un indice",
+    "link_clue_description": "Ajoutez un indice relié à la scène pour guider les joueurs.",
+    "review_checklist_title": "Vérifier avant partie",
+    "review_checklist_description": "Contrôlez 3 points : objectif clair, PNJ prêt, indice visible.",
+    "summary_title": "Synthèse finale",
+    "summary_description": "Deux options : \"Commencer une nouvelle campagne\" ou \"Revoir le guide\".",
+}

--- a/app/onboarding/tours/tour_registry.py
+++ b/app/onboarding/tours/tour_registry.py
@@ -7,11 +7,17 @@ from collections.abc import Callable
 from app.onboarding.tour_models import TourStep
 
 from .campaign_setup_tour import build_campaign_setup_steps
+from .new_gm_quickstart_tour import (
+    build_new_gm_advanced_steps,
+    build_new_gm_mvp_steps,
+)
 
 TourBuilder = Callable[[], list[TourStep]]
 
 TOUR_BUILDERS: dict[str, TourBuilder] = {
     "campaign_setup": build_campaign_setup_steps,
+    "new_gm_mvp": build_new_gm_mvp_steps,
+    "new_gm_advanced": build_new_gm_advanced_steps,
 }
 
 

--- a/tests/test_new_gm_quickstart_tours.py
+++ b/tests/test_new_gm_quickstart_tours.py
@@ -1,0 +1,22 @@
+from app.onboarding.tours.new_gm_quickstart_tour import (
+    build_new_gm_advanced_steps,
+    build_new_gm_mvp_steps,
+)
+
+
+def test_new_gm_mvp_tour_has_5_steps_and_hands_on():
+    steps = build_new_gm_mvp_steps()
+
+    assert len(steps) == 5
+    assert any(step.id.endswith("hands_on") for step in steps)
+    summary = steps[-1]
+    assert "Commencer une nouvelle campagne" in summary.description
+    assert "Revoir le guide" in summary.description
+
+
+def test_new_gm_advanced_tour_has_8_steps_and_hands_on():
+    steps = build_new_gm_advanced_steps()
+
+    assert len(steps) == 8
+    hands_on_step = next(step for step in steps if step.id.endswith("hands_on"))
+    assert "Action requise" in hands_on_step.description


### PR DESCRIPTION
### Motivation
- Provide a short guided quickstart for first-time GMs that focuses on the most common starter tasks and keeps onboarding architecture modular and readable.
- Offer two paths (short MVP and fuller advanced) so new users can choose a brief walkthrough or a more thorough prep flow.
- Make the tour explicitly action-oriented with a required hands-on step and a final summary that exposes the two main CTAs.

### Description
- Added a new tour module `app/onboarding/tours/new_gm_quickstart_tour.py` that defines `build_new_gm_mvp_steps()` (5 steps) and `build_new_gm_advanced_steps()` (8 steps).
- Extended `app/onboarding/tours/tour_i18n_fr.py` with `NEW_GM_MVP_TEXTS` and `NEW_GM_ADVANCED_TEXTS` containing concise, action-oriented French micro-copy, with quoting handled correctly.
- Registered the new tours in `app/onboarding/tours/tour_registry.py` under the keys `new_gm_mvp` and `new_gm_advanced` to make them discoverable by the existing onboarding engine.
- Added targeted unit tests in `tests/test_new_gm_quickstart_tours.py` that assert step counts, presence of the hands-on step, and required summary CTAs.

### Testing
- Ran `pytest -q tests/test_new_gm_quickstart_tours.py` which passed: `2 passed`.
- Test coverage verifies the new builders produce the expected number of steps and include the hands-on prompt and summary copy as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f787e66ccc832b9c217abd657c6b60)