### PR TITLE
Fix guided tour launcher dict widget registry crash

### DIFF
--- a/app/ui/help/guided_tour_entry.py
+++ b/app/ui/help/guided_tour_entry.py
@@ -1,6 +1,9 @@
 """UI entrypoint for launching onboarding tours."""
 from __future__ import annotations
+
+from collections.abc import Callable, Mapping
 from tkinter import messagebox
+
 from app.onboarding import TourEngine, TourStateStore, build_tour_registry
 
 DEFAULT_TOUR_ID = "new_gm_mvp"
@@ -10,6 +13,15 @@ class GuidedTourLauncher:
     def __init__(self) -> None:
         self._engine: TourEngine | None = None
 
+    @staticmethod
+    def _build_widget_resolver(widget_registry) -> Callable[[str, str], object | None]:
+        """Build a widget resolver callable from either a function or a mapping."""
+        if callable(widget_registry):
+            return widget_registry
+        if isinstance(widget_registry, Mapping):
+            return lambda _screen, key: widget_registry.get(key)
+        raise TypeError("widget_registry must be callable or mapping-like")
+
     def launch_guided_tour(self, root_window, widget_registry, current_screen_getter, *, tour_id: str = DEFAULT_TOUR_ID) -> bool:
         if self._engine is not None and getattr(self._engine, "_tour_id", None):
             return False
@@ -17,10 +29,11 @@ class GuidedTourLauncher:
         if tour_id not in tours:
             messagebox.showwarning("Guided Tour", f"Tour '{tour_id}' is unavailable.")
             return False
+        widget_resolver = self._build_widget_resolver(widget_registry)
         self._engine = TourEngine(
             root_window,
             tours,
-            widget_registry,
+            widget_resolver,
             screen_resolver=current_screen_getter,
             state_store=TourStateStore(),
         )


### PR DESCRIPTION
### Motivation
- The onboarding `TourEngine` expects a callable `widget_resolver` but `MainWindow` supplies a dict-like `self._tour_widget_registry`, causing `TypeError: 'dict' object is not callable` during guided tour startup.
- Make the guided tour launcher robust to both callable and mapping-style widget registries so tours launched from the main window don't crash.

### Description
- Add `GuidedTourLauncher._build_widget_resolver` to adapt either a callable `(screen, key) -> widget` or a mapping `{key: widget}` into a normalized callable resolver.
- Use the adapter inside `launch_guided_tour` and pass the normalized `widget_resolver` to `TourEngine` so `WidgetLocator` always receives a callable.
- Fail fast with a `TypeError` when an unsupported `widget_registry` type is provided.
- Change made in `app/ui/help/guided_tour_entry.py`.

### Testing
- Ran `python -m py_compile app/ui/help/guided_tour_entry.py app/onboarding/widget_locator.py app/onboarding/tour_engine.py main_window.py` which succeeded.
- Ran `pytest -q tests -k tour -q` which failed during collection due to unrelated environment/test-suite issues (missing `CustomTkinter` attributes, PIL import errors, and duplicate test module-name collisions), so automated suite failures are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f796df1990832b9dcb8436087b688d)