### PR TITLE
Implement real tour overlay and popover visuals

### DIFF
--- a/app/onboarding/tour_overlay.py
+++ b/app/onboarding/tour_overlay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tkinter as tk
 from typing import Any
 
 
@@ -9,21 +10,80 @@ class TourOverlay:
     def __init__(self, root: Any) -> None:
         self._root = root
         self._current_target: Any = None
+        self._overlay_window: tk.Toplevel | None = None
+        self._canvas: tk.Canvas | None = None
         self._configure_bind = self._root.bind("<Configure>", self._on_configure, add="+")
 
     def show_highlight(self, target_widget: Any) -> None:
         self._current_target = target_widget
+        self._ensure_overlay()
         self.refresh_geometry()
 
     def clear(self) -> None:
         self._current_target = None
+        if self._overlay_window is not None:
+            self._overlay_window.withdraw()
 
     def refresh_geometry(self) -> None:
         if self._current_target is None:
             return
-        updater = getattr(self._current_target, "update_idletasks", None)
-        if callable(updater):
-            updater()
+
+        root_updater = getattr(self._root, "update_idletasks", None)
+        if callable(root_updater):
+            root_updater()
+
+        target_updater = getattr(self._current_target, "update_idletasks", None)
+        if callable(target_updater):
+            target_updater()
+
+        if self._overlay_window is None or self._canvas is None:
+            return
+
+        try:
+            x = int(self._current_target.winfo_rootx())
+            y = int(self._current_target.winfo_rooty())
+            width = int(self._current_target.winfo_width())
+            height = int(self._current_target.winfo_height())
+        except tk.TclError:
+            self.clear()
+            return
+
+        if width <= 1 or height <= 1:
+            self._overlay_window.withdraw()
+            return
+
+        pad = 4
+        self._overlay_window.deiconify()
+        self._overlay_window.geometry(f"{width + (pad * 2)}x{height + (pad * 2)}+{x - pad}+{y - pad}")
+        self._canvas.configure(width=width + (pad * 2), height=height + (pad * 2))
+        self._canvas.delete("highlight")
+        self._canvas.create_rectangle(
+            pad,
+            pad,
+            width + pad,
+            height + pad,
+            outline="#5CC8FF",
+            width=3,
+            tags="highlight",
+        )
+
+    def _ensure_overlay(self) -> None:
+        if self._overlay_window is not None and self._canvas is not None:
+            return
+
+        self._overlay_window = tk.Toplevel(self._root)
+        self._overlay_window.overrideredirect(True)
+        self._overlay_window.attributes("-topmost", True)
+        self._overlay_window.configure(bg="magenta")
+        self._overlay_window.wm_attributes("-transparentcolor", "magenta")
+
+        self._canvas = tk.Canvas(
+            self._overlay_window,
+            highlightthickness=0,
+            borderwidth=0,
+            bg="magenta",
+        )
+        self._canvas.pack(fill="both", expand=True)
 
     def _on_configure(self, _event: Any) -> None:
         self.refresh_geometry()

--- a/app/onboarding/tour_popover.py
+++ b/app/onboarding/tour_popover.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import tkinter as tk
+from tkinter import ttk
 from typing import Any, Callable
 
-from .tour_models import TourStep
+from .tour_models import TourPlacement, TourStep
 
 
 class TourPopover:
@@ -21,24 +23,107 @@ class TourPopover:
         self._on_close = on_close
         self._visible = False
         self._target_widget: Any = None
+        self._step: TourStep | None = None
+
+        self._window: tk.Toplevel | None = None
+        self._title_var = tk.StringVar(value="")
+        self._description_var = tk.StringVar(value="")
+
         self._configure_bind = self._root.bind("<Configure>", self._on_configure, add="+")
 
     def show(self, step: TourStep, target_widget: Any) -> None:
-        _ = step
+        self._ensure_window()
         self._visible = True
+        self._step = step
         self._target_widget = target_widget
+        self._title_var.set(step.title)
+        self._description_var.set(step.description)
+
+        if self._window is not None:
+            self._window.deiconify()
+            self._window.lift()
         self.refresh_geometry()
 
     def hide(self) -> None:
         self._visible = False
         self._target_widget = None
+        self._step = None
+        if self._window is not None:
+            self._window.withdraw()
 
     def refresh_geometry(self) -> None:
-        if not self._visible or self._target_widget is None:
+        if not self._visible or self._target_widget is None or self._window is None:
             return
-        updater = getattr(self._target_widget, "update_idletasks", None)
-        if callable(updater):
-            updater()
+
+        root_updater = getattr(self._root, "update_idletasks", None)
+        if callable(root_updater):
+            root_updater()
+
+        target_updater = getattr(self._target_widget, "update_idletasks", None)
+        if callable(target_updater):
+            target_updater()
+
+        self._window.update_idletasks()
+
+        try:
+            tx = int(self._target_widget.winfo_rootx())
+            ty = int(self._target_widget.winfo_rooty())
+            tw = int(self._target_widget.winfo_width())
+            th = int(self._target_widget.winfo_height())
+        except tk.TclError:
+            self.hide()
+            return
+
+        ww = self._window.winfo_width()
+        wh = self._window.winfo_height()
+        gap = 12
+        placement = self._step.placement if self._step else TourPlacement.BOTTOM
+
+        if placement == TourPlacement.TOP:
+            x = tx + (tw - ww) // 2
+            y = ty - wh - gap
+        elif placement == TourPlacement.LEFT:
+            x = tx - ww - gap
+            y = ty + (th - wh) // 2
+        elif placement == TourPlacement.RIGHT:
+            x = tx + tw + gap
+            y = ty + (th - wh) // 2
+        else:
+            x = tx + (tw - ww) // 2
+            y = ty + th + gap
+
+        screen_w = self._root.winfo_screenwidth()
+        screen_h = self._root.winfo_screenheight()
+        x = max(8, min(x, screen_w - ww - 8))
+        y = max(8, min(y, screen_h - wh - 8))
+        self._window.geometry(f"+{x}+{y}")
+
+    def _ensure_window(self) -> None:
+        if self._window is not None:
+            return
+
+        self._window = tk.Toplevel(self._root)
+        self._window.withdraw()
+        self._window.overrideredirect(True)
+        self._window.attributes("-topmost", True)
+
+        card = ttk.Frame(self._window, padding=12, relief="solid", borderwidth=1)
+        card.grid(row=0, column=0, sticky="nsew")
+
+        title = ttk.Label(card, textvariable=self._title_var, font=("TkDefaultFont", 11, "bold"))
+        title.grid(row=0, column=0, columnspan=3, sticky="w")
+
+        desc = ttk.Label(card, textvariable=self._description_var, wraplength=300, justify="left")
+        desc.grid(row=1, column=0, columnspan=3, sticky="w", pady=(8, 12))
+
+        prev_button = ttk.Button(card, text="Back", command=self._on_prev)
+        prev_button.grid(row=2, column=0, sticky="w")
+
+        next_button = ttk.Button(card, text="Next", command=self._on_next)
+        next_button.grid(row=2, column=1, sticky="w", padx=(8, 0))
+
+        close_button = ttk.Button(card, text="Close", command=self._on_close)
+        close_button.grid(row=2, column=2, sticky="e", padx=(8, 0))
 
     def _on_configure(self, _event: Any) -> None:
         self.refresh_geometry()


### PR DESCRIPTION
### Motivation
- Provide a usable onboarding UI by replacing placeholders with real visual widgets that highlight target controls and show step content. 
- Keep the overlay/popover geometry in sync as the app window or target widgets move or resize so the tour remains visually accurate.

### Description
- Implemented `TourOverlay` using a transparent, topmost `tk.Toplevel` and `tk.Canvas` that draws a highlighted rectangle around the target widget using `winfo_rootx/y` and `winfo_width/height` and a small padding. 
- Added lifecycle and safety handling in `TourOverlay`: `_ensure_overlay()` to create the window, `refresh_geometry()` to recompute and position the overlay, and `clear()` to withdraw the overlay when the target is gone or hidden. 
- Implemented `TourPopover` as a floating `tk.Toplevel` card containing title and description bound to `tk.StringVar`s and `ttk` buttons for `Back`/`Next`/`Close` wired to `on_prev`, `on_next`, and `on_close`. 
- Added placement-aware positioning in `TourPopover` (top/left/right/bottom using `TourStep.placement`) with screen-bound clamping and `refresh_geometry()` that repositions the popover relative to the target on root `<Configure>` events. 

### Testing
- Compiled the modified modules with `python -m compileall app/onboarding/tour_overlay.py app/onboarding/tour_popover.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a42d4b88832b90b1154490431704)