### PR TITLE
Add shared guided-tour widget registry and register CampaignBuilderWizard widgets

### DIFF
--- a/app/ui/help/tour_widget_registry.py
+++ b/app/ui/help/tour_widget_registry.py
@@ -1,0 +1,42 @@
+"""Shared registry for guided-tour target widgets across windows/dialogs."""
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+
+
+class TourWidgetRegistry:
+    """Register and resolve widgets by stable (screen, key) identifiers."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, dict[str, object]] = defaultdict(dict)
+
+    def register(self, screen: str, key: str, widget: object) -> None:
+        """Register or replace a widget target."""
+        if not screen or not key:
+            return
+        self._entries[screen][key] = widget
+
+    def unregister(self, screen: str, key: str) -> None:
+        """Unregister a widget target if present."""
+        per_screen = self._entries.get(screen)
+        if not per_screen:
+            return
+        per_screen.pop(key, None)
+        if not per_screen:
+            self._entries.pop(screen, None)
+
+    def resolver(self) -> Callable[[str, str], object | None]:
+        """Build a guided-tour resolver callable."""
+
+        def _resolve(screen: str, key: str) -> object | None:
+            widget = self._entries.get(screen, {}).get(key)
+            if widget is None:
+                return None
+            exists = getattr(widget, "winfo_exists", None)
+            if callable(exists) and not exists():
+                self.unregister(screen, key)
+                return None
+            return widget
+
+        return _resolve

--- a/main_window.py
+++ b/main_window.py
@@ -74,6 +74,7 @@ from modules.ui.ambiance.importer.dialog import AmbianceWallpaperImporterDialog
 from modules.ui.sidebar.accordion_sections import SidebarAccordion, SidebarItemSpec, SidebarSectionSpec
 from modules.ui.controllers import AIRunWindowController
 from app.ui.help.guided_tour_entry import launch_guided_tour
+from app.ui.help.tour_widget_registry import TourWidgetRegistry
 from modules.events.ui.dock import CalendarDock
 from modules.events.models.event_types import get_event_type
 from modules.events.services.timeline_simulator import CampaignTimelineSimulator
@@ -211,7 +212,8 @@ class MainWindow(ctk.CTk):
         root.bind_all("<Control-i>", self._on_ctrl_i)
         root.bind_all("<Control-I>", self._on_ctrl_i)
         self._bind_global_shortcuts()
-        self._tour_widget_registry = {"btn_new_campaign": self}
+        self._tour_widget_registry = TourWidgetRegistry()
+        self.register_tour_widget("main_window", "btn_new_campaign", self)
 
         self._system_listener_unsub = register_system_change_listener(self._on_system_changed)
         # Rebuild colorized UI bits when theme changes
@@ -315,13 +317,32 @@ class MainWindow(ctk.CTk):
         ctk.CTkButton(btns, text="Defaults", command=reset_defaults).pack(side="right", padx=6)
         ctk.CTkButton(btns, text="Close", command=top.destroy).pack(side="right", padx=6)
 
+    def register_tour_widget(self, screen: str, key: str, widget):
+        """Register a guided-tour target widget by stable key."""
+        self._tour_widget_registry.register(screen, key, widget)
+
+    def unregister_tour_widget(self, screen: str, key: str):
+        """Unregister a guided-tour target widget."""
+        self._tour_widget_registry.unregister(screen, key)
+
     def launch_guided_tour(self):
         """Launch guided onboarding tour."""
         launch_guided_tour(
             self,
-            self._tour_widget_registry,
-            current_screen_getter=lambda: "main_window",
+            self._tour_widget_registry.resolver(),
+            current_screen_getter=self._resolve_tour_screen,
         )
+
+    def _resolve_tour_screen(self) -> str:
+        """Resolve which UI screen is currently active for guided tours."""
+        for child in reversed(self.winfo_children()):
+            try:
+                if child.winfo_exists() and child.winfo_viewable() and child.wm_state() != "withdrawn":
+                    if child.__class__.__name__ == "CampaignBuilderWizard":
+                        return "campaign_builder"
+            except Exception:
+                continue
+        return "main_window"
 
     # ---------------------------
     # Setup and Layout Methods

--- a/modules/campaigns/ui/campaign_builder_wizard.py
+++ b/modules/campaigns/ui/campaign_builder_wizard.py
@@ -77,9 +77,12 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
         self._interactive_controls: list[ctk.CTkBaseClass] = []
         self._generation_defaults_service = CampaignGenerationDefaultsService()
         self.generation_defaults = self._generation_defaults_service.load()
+        self._tour_keys_registered = False
 
         self._build_layout()
         self._show_step(0)
+        self._register_tour_widgets()
+        self.bind("<Destroy>", self._on_destroy, add="+")
 
         self.transient(master)
         self.grab_set()
@@ -193,7 +196,7 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
 
         row1 = ctk.CTkFrame(form_body, fg_color="transparent")
         row1.pack(fill="x", pady=4)
-        self._labeled_entry(row1, "Campaign Name", "name", 0)
+        self.campaign_name_entry = self._labeled_entry(row1, "Campaign Name", "name", 0)
         self._labeled_entry(row1, "Genre", "genre", 1)
 
         row2 = ctk.CTkFrame(form_body, fg_color="transparent")
@@ -465,6 +468,32 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
 
         return frame
 
+    def _register_tour_widgets(self):
+        """Register guided-tour widgets in the shared host registry."""
+        if self._tour_keys_registered:
+            return
+        register = getattr(self.master, "register_tour_widget", None)
+        if not callable(register):
+            return
+        register("campaign_builder", "input_campaign_name", getattr(self, "campaign_name_entry", None))
+        register("campaign_builder", "btn_create_campaign", self.next_btn)
+        self._tour_keys_registered = True
+
+    def _unregister_tour_widgets(self):
+        """Unregister guided-tour widgets from the shared host registry."""
+        if not self._tour_keys_registered:
+            return
+        unregister = getattr(self.master, "unregister_tour_widget", None)
+        if callable(unregister):
+            unregister("campaign_builder", "input_campaign_name")
+            unregister("campaign_builder", "btn_create_campaign")
+        self._tour_keys_registered = False
+
+    def _on_destroy(self, event):
+        """Cleanup shared guided-tour registrations when dialog is destroyed."""
+        if event.widget is self:
+            self._unregister_tour_widgets()
+
     def _build_review_step(self, parent):
         """Build review step."""
         frame = ctk.CTkFrame(parent, **section_style())
@@ -477,8 +506,10 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
     def _labeled_entry(self, parent, label: str, key: str, col: int):
         """Internal helper for labeled entry."""
         ctk.CTkLabel(parent, text=label, text_color=EDITOR_PALETTE["text"]).grid(row=0, column=col, sticky="w", padx=(8 if col else 0, 4))
-        ctk.CTkEntry(parent, textvariable=self.form_vars[key], **toolbar_entry_style()).grid(row=1, column=col, sticky="ew", padx=(8 if col else 0, 4))
+        entry = ctk.CTkEntry(parent, textvariable=self.form_vars[key], **toolbar_entry_style())
+        entry.grid(row=1, column=col, sticky="ew", padx=(8 if col else 0, 4))
         parent.grid_columnconfigure(col, weight=1)
+        return entry
 
     def _labeled_box(self, parent, label: str, height: int):
         """Internal helper for labeled box."""


### PR DESCRIPTION
### Motivation
- Guided-tour steps referenced widgets only via a main-window mapping, which prevented resolving targets hosted in active dialogs (like the campaign builder).
- Provide a stable API to register/unregister widgets by (screen, key) so tours can locate live widgets across windows.

### Description
- Added `TourWidgetRegistry` (`app/ui/help/tour_widget_registry.py`) that stores widgets by `screen`/`key` and exposes a `resolver()` callable for the tour engine.
- Updated `MainWindow` to instantiate the shared registry, expose `register_tour_widget`/`unregister_tour_widget` helpers, and pass `self._tour_widget_registry.resolver()` plus a `_resolve_tour_screen` active-screen resolver into the guided-tour launcher.
- Modified `CampaignBuilderWizard` to return the created entry widget from `_labeled_entry`, store a reference as `campaign_name_entry`, register `input_campaign_name` and `btn_create_campaign` with the host registry on creation, and unregister them when the dialog is destroyed.
- Kept existing tour step keys intact while enabling cross-window resolution without changing the guided-tour engine API (it already accepts callable resolvers).

### Testing
- Ran `python -m py_compile main_window.py modules/campaigns/ui/campaign_builder_wizard.py app/ui/help/tour_widget_registry.py` which succeeded.
- Committed changes to the repository; no additional automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a4efb6a0832ba1e8c1504012474c)