### PR TITLE
Wire guided tour notifier and unify unresolved-step notifications

### DIFF
--- a/app/onboarding/tour_engine.py
+++ b/app/onboarding/tour_engine.py
@@ -91,7 +91,9 @@ class TourEngine:
 
     def _try_show_step(self, step: TourStep) -> bool:
         if self._screen_resolver() != step.screen:
-            self._log_skipped_step(step, f"screen '{step.screen}' is not active")
+            reason = f"screen '{step.screen}' is not active"
+            self._log_skipped_step(step, reason)
+            self._notify_unresolved_target(step, reason)
             return False
 
         if step.before_hook:
@@ -100,14 +102,19 @@ class TourEngine:
         resolved = self._widget_locator.resolve(step.screen, step.target_widget_key)
         target_widget = resolved.widget
         if target_widget is None:
-            self._log_skipped_step(step, f"widget '{step.target_widget_key}' not visible")
-            if resolved.message:
-                self._user_notifier(resolved.message)
+            reason = f"widget '{step.target_widget_key}' not visible"
+            self._log_skipped_step(step, reason)
+            self._notify_unresolved_target(step, reason, resolved.message)
             return False
 
         self._overlay.show_highlight(target_widget)
         self._popover.show(step, target_widget)
         return True
+
+
+    def _notify_unresolved_target(self, step: TourStep, reason: str, resolver_message: str | None = None) -> None:
+        message = resolver_message or f"Unable to show guided tour step '{step.id}': {reason}."
+        self._user_notifier(message)
 
     def _log_skipped_step(self, step: TourStep, reason: str) -> None:
         logger.info("Skipping step '%s': %s.", step.id, reason)

--- a/app/ui/help/guided_tour_entry.py
+++ b/app/ui/help/guided_tour_entry.py
@@ -36,6 +36,7 @@ class GuidedTourLauncher:
             widget_resolver,
             screen_resolver=current_screen_getter,
             state_store=TourStateStore(),
+            user_notifier=lambda message: messagebox.showinfo("Guided Tour", message),
         )
         self._engine.start(tour_id)
         return True


### PR DESCRIPTION
### Motivation
- Surface user-facing messages when a guided-tour step cannot be resolved so the user is informed (e.g., via a dialog or toast) rather than silently skipping steps.
- Preserve existing logging for skipped steps while ensuring unresolved-target reasons are consistently delivered to a user-visible notifier.

### Description
- Add an optional `user_notifier` callback to `TourEngine` and default it to a no-op, allowing callers to supply UI notification functions when available (`app/onboarding/tour_engine.py`).
- Wire a concrete notifier from the UI entrypoint by passing `user_notifier=lambda message: messagebox.showinfo("Guided Tour", message)` when constructing `TourEngine` in `app/ui/help/guided_tour_entry.py`.
- Introduce `_notify_unresolved_target(step, reason, resolver_message=None)` to centralize message formatting and fallback behavior, and call it for both inactive-screen and unresolved-widget cases so users always see an explanatory message.
- Keep `_log_skipped_step(...)` logging behavior unchanged so telemetry and logs still reflect why steps were skipped.

### Testing
- Ran `python -m compileall app/ui/help/guided_tour_entry.py app/onboarding/tour_engine.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a58d97f8832b89bd202c9b03b9b9)