### PR TITLE
Consolidate Campaign Builder modal ownership in MainWindow

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -3688,8 +3688,10 @@ class MainWindow(ctk.CTk):
                 self,
                 campaign_wrapper=campaign_wrapper,
                 scenario_wrapper=scenario_wrapper,
-                modal=not guided_tour_active,
+                modal=False,
             )
+            if not guided_tour_active:
+                wizard.grab_set()
             wizard.focus_force()
         except Exception as exc:
             log_exception(

--- a/modules/campaigns/ui/campaign_builder_wizard.py
+++ b/modules/campaigns/ui/campaign_builder_wizard.py
@@ -85,8 +85,6 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
         self.bind("<Destroy>", self._on_destroy, add="+")
 
         self.transient(master)
-        if modal:
-            self.grab_set()
         self.focus_force()
         position_window_at_top(self)
 


### PR DESCRIPTION
### Motivation
- Prevent duplicated modality ownership between the wizard and its caller which can cause focus/grab conflicts.
- Keep a single well-defined owner for the modal grab and leave window focus ordering stable after creation.

### Description
- Stop setting the grab in the wizard constructor by removing `grab_set()` from `CampaignBuilderWizard.__init__` and keep `transient(master)` followed by `focus_force()` and positioning.
- Make the caller (`MainWindow.open_campaign_builder`) responsible for modality by constructing the wizard with `modal=False` and calling `wizard.grab_set()` only when `guided_tour_active` is `False`.
- Preserve `wizard.focus_force()` ordering so focus is applied consistently after instantiation.
- Files changed: `main_window.py` and `modules/campaigns/ui/campaign_builder_wizard.py`.

### Testing
- Verified there are no syntax errors by running `python -m py_compile modules/campaigns/ui/campaign_builder_wizard.py main_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ac2c1d40832b8843304baacb4f84)