### PR TITLE
Allow spaces in arc name entry (campaign wizard)

### DIFF
--- a/modules/campaigns/ui/arc_studio/detail_form.py
+++ b/modules/campaigns/ui/arc_studio/detail_form.py
@@ -34,6 +34,7 @@ class ArcDetailForm(ctk.CTkFrame):
 
         self.name_entry = ctk.CTkEntry(row, textvariable=self.name_var, **toolbar_entry_style())
         self.name_entry.grid(row=1, column=0, sticky="ew", pady=(2, 8))
+        self.name_entry.bind("<space>", self._allow_space_character, add="+")
         self.status_menu = ctk.CTkOptionMenu(
             row,
             variable=self.status_var,
@@ -176,6 +177,13 @@ class ArcDetailForm(ctk.CTkFrame):
             "status": canonicalize_arc_status(self.status_var.get()),
             "scenarios": list(self._scenario_items),
         }
+
+
+    def _allow_space_character(self, _event):
+        """Allow typing spaces even if parent-level bindings consume them."""
+        self.name_entry.insert(tk.INSERT, " ")
+        self._notify_change()
+        return "break"
 
     def _notify_change(self):
         """Notify change."""


### PR DESCRIPTION
### Motivation
- Users could not type the space character into an arc name in the campaign wizard because parent/global key bindings were swallowing the `<space>` event, so the field must explicitly accept spaces.

### Description
- In `modules/campaigns/ui/arc_studio/detail_form.py` bind the arc name entry to `<space>` via `self.name_entry.bind("<space>", self._allow_space_character, add="+")` and add `_allow_space_character` which inserts a space at the cursor, calls `_notify_change()`, and returns `"break"` to stop propagation.

### Testing
- Ran `pytest -q tests/test_campaign_builder_wizard.py`, which failed with 8 pre-existing failures unrelated to this change (missing methods/attributes in `CampaignBuilderWizard`), and no new failures attributable to the `ArcDetailForm` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa12cfd548832b9971b5adab8c09b2)