### PR TITLE
Focus scenario picker search input on open

### DIFF
--- a/modules/campaigns/ui/arc_studio/scenario_picker_dialog.py
+++ b/modules/campaigns/ui/arc_studio/scenario_picker_dialog.py
@@ -30,6 +30,7 @@ class ScenarioPickerDialog(ctk.CTkToplevel):
         self.transient(master)
         self.grab_set()
         self.focus_force()
+        self.after(0, self._focus_search_entry)
         position_window_at_top(self)
 
     def _build_ui(self) -> None:
@@ -88,6 +89,14 @@ class ScenarioPickerDialog(ctk.CTkToplevel):
         ).grid(row=0, column=1, padx=(8, 0))
         self.add_button = ctk.CTkButton(button_row, text="Add", command=self._confirm_selection, **primary_button_style())
         self.add_button.grid(row=0, column=2, padx=(8, 0))
+
+    def _focus_search_entry(self) -> None:
+        """Place keyboard focus in the search field when dialog opens."""
+        try:
+            self.search_entry.focus_set()
+            self.search_entry.icursor("end")
+        except Exception:
+            return
 
     def _refresh_list(self) -> None:
         """Refresh list."""


### PR DESCRIPTION
### Motivation
- Ensure the scenario picker used in the Arcs step places keyboard focus in the search field when opened so users can start typing immediately after clicking Add a scenario.

### Description
- Updated `modules/campaigns/ui/arc_studio/scenario_picker_dialog.py` to add a `_focus_search_entry()` helper that calls `search_entry.focus_set()` and `search_entry.icursor("end")`, and scheduled it via `self.after(0, self._focus_search_entry)` during dialog initialization.

### Testing
- Ran `python -m py_compile modules/campaigns/ui/arc_studio/scenario_picker_dialog.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa141e6074832b923bd648ddebf529)