### PR TITLE
Ajout des modèles d'issues et des règles de hiérarchie de validation

### DIFF
--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -1,0 +1,19 @@
+"""Validation package for cross-entity consistency checks."""
+
+from .hierarchy_rules import (
+    ALLOWED_HIERARCHY_CHILDREN,
+    FIELD_EXPECTED_TYPES,
+    format_hierarchy_context,
+    format_parent_child_context,
+)
+from .issue_models import IssuePayload, IssueType, ValidationIssue
+
+__all__ = [
+    "ALLOWED_HIERARCHY_CHILDREN",
+    "FIELD_EXPECTED_TYPES",
+    "IssuePayload",
+    "IssueType",
+    "ValidationIssue",
+    "format_hierarchy_context",
+    "format_parent_child_context",
+]

--- a/src/validation/hierarchy_rules.py
+++ b/src/validation/hierarchy_rules.py
@@ -1,0 +1,33 @@
+"""Reference and hierarchy rules for campaign entities."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+# Explicit mapping: field path -> expected referenced entity type
+FIELD_EXPECTED_TYPES: Mapping[str, str] = {
+    "campaign.arc_refs": "arc",
+    "arc.scenario_refs": "scenario",
+    "arc.location_refs": "location",
+    "scenario.encounter_refs": "encounter",
+    "scenario.npc_refs": "npc",
+}
+
+# Parent type -> allowed child types
+ALLOWED_HIERARCHY_CHILDREN: Mapping[str, set[str]] = {
+    "campaign": {"arc"},
+    "arc": {"scenario", "location"},
+    "scenario": {"encounter", "npc"},
+}
+
+
+def format_hierarchy_context(path: list[str] | tuple[str, ...]) -> str:
+    """Formats hierarchy path for UI display (e.g. campaign > arc > scenario)."""
+
+    return " > ".join(path)
+
+
+def format_parent_child_context(parent_type: str, child_type: str) -> str:
+    """Formats a parent/child relation for readable validation messages."""
+
+    return f"{parent_type} > {child_type}"

--- a/src/validation/issue_models.py
+++ b/src/validation/issue_models.py
@@ -1,0 +1,35 @@
+"""Validation issue models shared across cross-entity validators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Sequence
+
+
+class IssueType(str, Enum):
+    """Normalized issue types emitted by validation pipelines."""
+
+    MISSING_REFERENCE = "MISSING_REFERENCE"
+    AMBIGUOUS_REFERENCE = "AMBIGUOUS_REFERENCE"
+    INVALID_HIERARCHY = "INVALID_HIERARCHY"
+
+
+@dataclass(frozen=True)
+class IssuePayload:
+    """Structured payload used to surface validation issues in UI/logs."""
+
+    source_entity: str
+    field: str
+    referenced_name: str
+    expected_type: str
+    candidates: Sequence[str] = field(default_factory=tuple)
+    hierarchy_path: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """Top-level issue object carrying type + payload."""
+
+    issue_type: IssueType
+    payload: IssuePayload


### PR DESCRIPTION
### Motivation
- Centraliser les types d'issues et le payload utilisé par les validateurs cross-entity pour faciliter l'affichage UI et le traitement des erreurs.
- Définir explicitement quelles références de champ attendent quel type d'entité et quelles relations parent/enfant sont autorisées pour valider la cohérence de la campagne.

### Description
- Ajout de `src/validation/issue_models.py` qui définit l'énumération `IssueType` (`MISSING_REFERENCE`, `AMBIGUOUS_REFERENCE`, `INVALID_HIERARCHY`) et les dataclasses `IssuePayload` et `ValidationIssue` contenant `source_entity`, `field`, `referenced_name`, `expected_type`, `candidates` et `hierarchy_path`.
- Ajout de `src/validation/hierarchy_rules.py` avec le mapping explicite `FIELD_EXPECTED_TYPES` (ex: `arc.scenario_refs -> scenario`) et la table `ALLOWED_HIERARCHY_CHILDREN` des types enfants permis pour chaque parent.
- Ajout de helpers de formatage pour l'UI `format_hierarchy_context` et `format_parent_child_context` qui rendent les chemins lisibles (`campaign > arc > scenario`).
- Ajout de `src/validation/__init__.py` pour exposer proprement les constantes, modèles et helpers du package.

### Testing
- Compilation des modules avec `python -m compileall src/validation` exécutée et réussie.
- Les modules se chargent et sont exportés via `src/validation/__init__.py` sans erreurs de compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa16297a90832b8be904ad370aa334)