### PR TITLE
Add validator similarity matcher

### DIFF
--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -7,6 +7,18 @@ from .hierarchy_rules import (
     format_parent_child_context,
 )
 from .issue_models import IssuePayload, IssueType, ValidationIssue
+from .similarity_matcher import (
+    SimilarityCandidate,
+    SimilarityDecision,
+    SimilarityMatch,
+    SimilarityMatcherConfig,
+    SimilarityMatchResult,
+    classify_similarity_matches,
+    coerce_similarity_candidate,
+    match_reference,
+    normalize_similarity_text,
+    score_similarity,
+)
 from .reference_validator import (
     EntityRecord,
     ReferenceRecord,
@@ -25,6 +37,16 @@ __all__ = [
     "ReferenceRecord",
     "ReferenceValidationResult",
     "ReferenceValidatorConfig",
+    "score_similarity",
+    "normalize_similarity_text",
+    "match_reference",
+    "coerce_similarity_candidate",
+    "classify_similarity_matches",
+    "SimilarityMatchResult",
+    "SimilarityMatcherConfig",
+    "SimilarityMatch",
+    "SimilarityDecision",
+    "SimilarityCandidate",
     "ValidationIssue",
     "format_hierarchy_context",
     "format_parent_child_context",

--- a/src/validation/similarity_matcher.py
+++ b/src/validation/similarity_matcher.py
@@ -1,0 +1,267 @@
+"""Similarity matching helpers for validator reference resolution.
+
+The module keeps fuzzy matching deterministic and side-effect free so validator
+callers can safely use it to propose corrections without mutating campaign data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from enum import Enum
+import re
+import unicodedata
+from typing import Any, Iterable, Mapping, Sequence
+
+_PUNCTUATION_RE = re.compile(r"[\W_]+", re.UNICODE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class SimilarityDecision(str, Enum):
+    """Decision bands returned by the similarity matcher."""
+
+    STRONG_MATCH = "STRONG_MATCH"
+    AMBIGUOUS = "AMBIGUOUS"
+    NO_MATCH = "NO_MATCH"
+
+
+@dataclass(frozen=True)
+class SimilarityMatcherConfig:
+    """Thresholds used to classify similarity results.
+
+    Attributes:
+        strong_match_threshold: Minimum score for an automatic, high-confidence
+            match when no close competitor exists.
+        ambiguity_threshold: Minimum score for showing candidates as plausible
+            but requiring a human decision.
+        ambiguity_margin: Maximum score gap between the two best candidates that
+            still counts as ambiguous, even when the best score is strong.
+    """
+
+    strong_match_threshold: float = 0.88
+    ambiguity_threshold: float = 0.72
+    ambiguity_margin: float = 0.05
+
+
+@dataclass(frozen=True)
+class SimilarityCandidate:
+    """Minimal candidate shape accepted by validator-facing APIs."""
+
+    entity_type: str
+    identifier: str
+    label: str = ""
+    payload: Any = None
+
+    @property
+    def display_name(self) -> str:
+        """Return the best user-facing name for this candidate."""
+
+        return self.label or self.identifier
+
+
+@dataclass(frozen=True)
+class SimilarityMatch:
+    """Scored candidate returned by the matcher."""
+
+    candidate: SimilarityCandidate
+    score: float
+    matched_text: str
+
+
+@dataclass(frozen=True)
+class SimilarityMatchResult:
+    """Decision and sorted matches for one query."""
+
+    query: str
+    expected_type: str
+    decision: SimilarityDecision
+    matches: tuple[SimilarityMatch, ...] = field(default_factory=tuple)
+
+    @property
+    def best_match(self) -> SimilarityMatch | None:
+        """Return the top-scoring match, if any."""
+
+        return self.matches[0] if self.matches else None
+
+
+CandidateInput = Any
+
+
+def normalize_similarity_text(value: Any) -> str:
+    """Normalize text before exact or fuzzy comparison.
+
+    Normalization intentionally removes sources of cosmetic mismatch:
+    lowercasing, accents/diacritics, punctuation, and repeated whitespace.
+    """
+
+    if value is None:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", str(value).casefold())
+    without_accents = "".join(
+        char for char in decomposed if not unicodedata.combining(char)
+    )
+    without_punctuation = _PUNCTUATION_RE.sub(" ", without_accents)
+    return _WHITESPACE_RE.sub(" ", without_punctuation).strip()
+
+
+def score_similarity(left: Any, right: Any) -> float:
+    """Return a deterministic proximity score between 0.0 and 1.0."""
+
+    normalized_left = normalize_similarity_text(left)
+    normalized_right = normalize_similarity_text(right)
+    if not normalized_left or not normalized_right:
+        return 0.0
+    if normalized_left == normalized_right:
+        return 1.0
+    return SequenceMatcher(None, normalized_left, normalized_right).ratio()
+
+
+def match_reference(
+    query: Any,
+    expected_type: str,
+    candidates: Iterable[CandidateInput],
+    *,
+    config: SimilarityMatcherConfig | None = None,
+    limit: int | None = None,
+) -> SimilarityMatchResult:
+    """Score candidates of the expected type and return a decision.
+
+    Candidates are filtered by ``expected_type`` before any scoring happens.
+    Results are sorted by descending score, then by stable candidate metadata so
+    UIs and validators get reproducible ordering.
+    """
+
+    active_config = config or SimilarityMatcherConfig()
+    normalized_expected_type = normalize_similarity_text(expected_type)
+    canonical_query = normalize_similarity_text(query)
+    if not canonical_query or not normalized_expected_type:
+        return SimilarityMatchResult(
+            query=str(query or ""),
+            expected_type=normalized_expected_type,
+            decision=SimilarityDecision.NO_MATCH,
+        )
+
+    all_matches = tuple(
+        sorted(
+            _iter_scored_matches(canonical_query, normalized_expected_type, candidates),
+            key=_match_sort_key,
+        )
+    )
+    decision = classify_similarity_matches(all_matches, config=active_config)
+    visible_matches = all_matches
+    if limit is not None:
+        visible_matches = visible_matches[: max(limit, 0)]
+
+    return SimilarityMatchResult(
+        query=str(query),
+        expected_type=normalized_expected_type,
+        decision=decision,
+        matches=visible_matches,
+    )
+
+
+def classify_similarity_matches(
+    matches: Sequence[SimilarityMatch],
+    *,
+    config: SimilarityMatcherConfig | None = None,
+) -> SimilarityDecision:
+    """Classify sorted matches into strong, ambiguous, or no-match bands."""
+
+    active_config = config or SimilarityMatcherConfig()
+    if not matches:
+        return SimilarityDecision.NO_MATCH
+
+    best_score = matches[0].score
+    if best_score < active_config.ambiguity_threshold:
+        return SimilarityDecision.NO_MATCH
+
+    if (
+        best_score >= active_config.strong_match_threshold
+        and not _has_close_competitor(matches, active_config.ambiguity_margin)
+    ):
+        return SimilarityDecision.STRONG_MATCH
+
+    return SimilarityDecision.AMBIGUOUS
+
+
+def _iter_scored_matches(
+    normalized_query: str,
+    normalized_expected_type: str,
+    candidates: Iterable[CandidateInput],
+) -> Iterable[SimilarityMatch]:
+    for raw_candidate in candidates:
+        candidate = coerce_similarity_candidate(raw_candidate)
+        if normalize_similarity_text(candidate.entity_type) != normalized_expected_type:
+            continue
+        scored_options = tuple(
+            _score_candidate_text(normalized_query, text)
+            for text in _candidate_scored_texts(candidate)
+            if normalize_similarity_text(text)
+        )
+        if not scored_options:
+            continue
+        matched_text, score = max(
+            scored_options,
+            key=lambda item: (item[1], normalize_similarity_text(item[0])),
+        )
+        yield SimilarityMatch(
+            candidate=candidate,
+            score=score,
+            matched_text=matched_text,
+        )
+
+
+def _score_candidate_text(normalized_query: str, text: str) -> tuple[str, float]:
+    normalized_text = normalize_similarity_text(text)
+    if normalized_text == normalized_query:
+        return text, 1.0
+    return text, SequenceMatcher(None, normalized_query, normalized_text).ratio()
+
+
+def coerce_similarity_candidate(candidate: CandidateInput) -> SimilarityCandidate:
+    """Convert validator entities, mappings, or custom objects into candidates."""
+
+    if isinstance(candidate, SimilarityCandidate):
+        return candidate
+
+    entity_type = _read_candidate_value(candidate, "entity_type")
+    identifier = _read_candidate_value(candidate, "identifier")
+    label = _read_candidate_value(candidate, "label")
+    if not label:
+        label = _read_candidate_value(candidate, "name")
+    return SimilarityCandidate(
+        entity_type=str(entity_type or ""),
+        identifier=str(identifier or label or ""),
+        label=str(label or ""),
+        payload=candidate,
+    )
+
+
+def _read_candidate_value(candidate: CandidateInput, key: str) -> Any:
+    if isinstance(candidate, Mapping):
+        return candidate.get(key)
+    return getattr(candidate, key, None)
+
+
+def _candidate_scored_texts(candidate: SimilarityCandidate) -> tuple[str, ...]:
+    values = (candidate.identifier, candidate.label, candidate.display_name)
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _match_sort_key(match: SimilarityMatch) -> tuple[float, str, str, str]:
+    candidate = match.candidate
+    return (
+        -match.score,
+        normalize_similarity_text(candidate.display_name),
+        normalize_similarity_text(candidate.identifier),
+        normalize_similarity_text(candidate.entity_type),
+    )
+
+
+def _has_close_competitor(
+    matches: Sequence[SimilarityMatch],
+    ambiguity_margin: float,
+) -> bool:
+    if len(matches) < 2:
+        return False
+    return (matches[0].score - matches[1].score) <= ambiguity_margin

--- a/tests/validation/test_similarity_matcher.py
+++ b/tests/validation/test_similarity_matcher.py
@@ -1,0 +1,90 @@
+"""Regression tests for validator similarity matching."""
+
+from src.validation import (
+    SimilarityCandidate,
+    SimilarityDecision,
+    SimilarityMatcherConfig,
+    match_reference,
+    normalize_similarity_text,
+    score_similarity,
+)
+from src.validation.reference_validator import EntityRecord
+
+
+def test_normalize_similarity_text_removes_case_accents_punctuation_and_extra_spaces():
+    assert normalize_similarity_text("  Épée-du Roi!!!  ") == "epee du roi"
+
+
+def test_score_similarity_returns_full_score_after_cosmetic_normalization():
+    assert score_similarity("L'Épée du Roi", "l epee du roi") == 1.0
+
+
+def test_match_reference_filters_expected_type_before_scoring_and_sorts_results():
+    candidates = [
+        SimilarityCandidate(entity_type="npc", identifier="mara", label="Mara Jade"),
+        SimilarityCandidate(
+            entity_type="place",
+            identifier="mara-shrine",
+            label="Mara Shrine",
+        ),
+        SimilarityCandidate(entity_type="npc", identifier="marra", label="Mara Jadde"),
+    ]
+
+    result = match_reference("Mara Jade", "npc", candidates)
+
+    assert result.decision == SimilarityDecision.STRONG_MATCH
+    assert [match.candidate.entity_type for match in result.matches] == ["npc", "npc"]
+    assert [match.candidate.identifier for match in result.matches] == ["mara", "marra"]
+    assert result.matches[0].score >= result.matches[1].score
+
+
+def test_match_reference_marks_close_high_scores_as_ambiguous():
+    candidates = [
+        SimilarityCandidate(entity_type="scenario", identifier="s1", label="Dawnspire Heist"),
+        SimilarityCandidate(entity_type="scenario", identifier="s2", label="Dawnspire Feast"),
+    ]
+
+    result = match_reference(
+        "Dawnspire Hest",
+        "scenario",
+        candidates,
+        config=SimilarityMatcherConfig(
+            strong_match_threshold=0.85,
+            ambiguity_threshold=0.70,
+            ambiguity_margin=0.12,
+        ),
+    )
+
+    assert result.decision == SimilarityDecision.AMBIGUOUS
+    assert [match.candidate.identifier for match in result.matches] == ["s1", "s2"]
+
+
+def test_match_reference_returns_no_match_below_ambiguity_threshold():
+    result = match_reference(
+        "Completely Different",
+        "arc",
+        [SimilarityCandidate(entity_type="arc", identifier="a1", label="Quiet Road")],
+        config=SimilarityMatcherConfig(ambiguity_threshold=0.80),
+    )
+
+    assert result.decision == SimilarityDecision.NO_MATCH
+
+
+def test_match_reference_accepts_validator_entity_records_as_candidates():
+    entity = EntityRecord(
+        entity_type="npc",
+        identifier="captain-voss",
+        label="Captain Voss",
+        node={},
+        path=("npc:captain-voss",),
+        parent_path=(),
+        parent_type=None,
+        parent_identifier=None,
+        order=0,
+    )
+
+    result = match_reference("Captain Vos", "npc", [entity])
+
+    assert result.decision == SimilarityDecision.STRONG_MATCH
+    assert result.best_match is not None
+    assert result.best_match.candidate.payload is entity


### PR DESCRIPTION
### Motivation
- Provide a deterministic, side-effect-free fuzzy matcher to help the reference validator and UIs resolve ambiguous names by normalizing and scoring candidate strings.
- Surface simple decision bands (strong/ambiguous/no-match) and make it easy for the validator to filter and present candidates of the expected type.

### Description
- Add `src/validation/similarity_matcher.py` implementing `normalize_similarity_text`, `score_similarity`, `SimilarityCandidate`, `SimilarityMatch`, `SimilarityMatchResult`, `match_reference`, `classify_similarity_matches`, and `SimilarityMatcherConfig` with configurable thresholds and normalization that lowercases, strips accents, removes punctuation, and collapses whitespace.
- Filter candidates by `expected_type` before scoring, score and sort matches deterministically, and ensure classification uses the full scored set while `limit` only trims the returned matches.
- Accept and coerce a variety of inputs (existing `SimilarityCandidate`, mappings, or `EntityRecord`) into `SimilarityCandidate` for broad compatibility with the validator and UI code.
- Export the new matcher API from the `src.validation` package (`src/validation/__init__.py`) and add regression tests in `tests/validation/test_similarity_matcher.py` covering normalization, scoring, type filtering, ordering, ambiguity and no-match thresholds, and `EntityRecord` compatibility.

### Testing
- Ran `python -m pytest tests/validation/test_similarity_matcher.py tests/validation/test_reference_validator.py` and all tests passed (`9 passed`).
- Ran `python -m compileall src/validation` with no compilation errors.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafc8ce01c832bbd41eb141629eeb8)