### PR TITLE
Ajouter ReferenceFixService et SessionIgnoreStore

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,17 @@
+"""Application services for validation and interactive workflows."""
+
+from .reference_fix_service import (
+    ReferenceActionResult,
+    ReferenceFixAction,
+    ReferenceFixService,
+)
+from .session_ignore_store import IgnoredIssueKey, SessionIgnoreStore, issue_key
+
+__all__ = [
+    "IgnoredIssueKey",
+    "ReferenceActionResult",
+    "ReferenceFixAction",
+    "ReferenceFixService",
+    "SessionIgnoreStore",
+    "issue_key",
+]

--- a/src/services/reference_fix_service.py
+++ b/src/services/reference_fix_service.py
@@ -1,0 +1,314 @@
+"""Services for applying interactive reference fixes.
+
+The validation layer only reports reference issues.  This module owns the small,
+UI-friendly mutations needed after a user chooses how to resolve one issue:
+remap the reference, remove it, or link it to a newly created entity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, MutableMapping, MutableSequence
+
+from src.validation.reference_validator import EntityRecord, ReferenceRecord
+
+
+@dataclass(frozen=True)
+class ReferenceActionResult:
+    """Single action-return contract shared by all reference fix operations.
+
+    Attributes:
+        success: ``True`` when the requested action was applied.
+        changes_applied: Human-readable, deterministic descriptions of each
+            mutation performed. Empty when no mutation happened.
+        ui_message: Short message intended for dialogs, toasts, or status bars.
+    """
+
+    success: bool
+    changes_applied: tuple[str, ...] = field(default_factory=tuple)
+    ui_message: str = ""
+
+    @classmethod
+    def ok(cls, ui_message: str, *changes_applied: str) -> "ReferenceActionResult":
+        """Build a successful action result."""
+
+        return cls(
+            success=True,
+            changes_applied=tuple(change for change in changes_applied if change),
+            ui_message=ui_message,
+        )
+
+    @classmethod
+    def error(cls, ui_message: str) -> "ReferenceActionResult":
+        """Build a failed action result without applied changes."""
+
+        return cls(success=False, changes_applied=(), ui_message=ui_message)
+
+
+class ReferenceFixAction(str, Enum):
+    """Supported interactive reference correction actions."""
+
+    REMAP = "remap"
+    REMOVE = "remove"
+    LINK_CREATED = "link_created"
+
+
+class ReferenceFixService:
+    """Apply user-selected fixes to mutable reference fields.
+
+    The service accepts ``ReferenceRecord`` instances returned by
+    ``validate_reference_graph`` and mutates the source entity node in place.
+    It supports both scalar reference fields and list/tuple-style reference
+    collections. Mapping references keep their original shape where possible:
+    identifiers are updated in an existing ``id``/``ref``/``target``/``name`` key
+    and declared types are synchronized when a type key already exists.
+    """
+
+    def remap_reference(
+        self,
+        reference: ReferenceRecord,
+        target: EntityRecord | MutableMapping[str, Any] | str,
+    ) -> ReferenceActionResult:
+        """Remap one reference occurrence to the chosen target."""
+
+        target_identifier = _extract_target_identifier(target)
+        if not target_identifier:
+            return ReferenceActionResult.error("Impossible de remapper : cible invalide.")
+
+        target_type = _extract_target_type(target)
+        updated = _replace_reference_value(reference, target_identifier, target_type)
+        if not updated:
+            return ReferenceActionResult.error(
+                "Impossible de remapper : référence introuvable ou non modifiable."
+            )
+
+        return ReferenceActionResult.ok(
+            f"Référence remappée vers « {target_identifier} ».",
+            _format_reference_change(
+                ReferenceFixAction.REMAP,
+                reference,
+                target_identifier,
+            ),
+        )
+
+    def remove_reference(self, reference: ReferenceRecord) -> ReferenceActionResult:
+        """Remove one reference occurrence from its source field."""
+
+        removed = _remove_reference_value(reference)
+        if not removed:
+            return ReferenceActionResult.error(
+                "Impossible de supprimer : référence introuvable ou non modifiable."
+            )
+
+        return ReferenceActionResult.ok(
+            f"Référence « {reference.reference_value} » supprimée.",
+            _format_reference_change(ReferenceFixAction.REMOVE, reference),
+        )
+
+    def link_created_entity(
+        self,
+        reference: ReferenceRecord,
+        new_entity: EntityRecord | MutableMapping[str, Any],
+        *,
+        attach_to_source: bool = True,
+    ) -> ReferenceActionResult:
+        """Link a reference to a newly created entity.
+
+        Args:
+            reference: The reference occurrence to resolve.
+            new_entity: Newly created entity record or mutable entity mapping.
+            attach_to_source: When ``True`` and ``new_entity`` is a mutable
+                mapping, append it to the source entity child collection matching
+                ``reference.expected_type`` before remapping the reference.
+        """
+
+        target_identifier = _extract_target_identifier(new_entity)
+        if not target_identifier:
+            return ReferenceActionResult.error("Impossible de relier : nouvelle entité invalide.")
+
+        changes: list[str] = []
+        if attach_to_source and isinstance(new_entity, MutableMapping):
+            attach_change = _attach_child_entity(reference, new_entity)
+            if attach_change:
+                changes.append(attach_change)
+
+        target_type = _extract_target_type(new_entity) or reference.expected_type
+        updated = _replace_reference_value(reference, target_identifier, target_type)
+        if not updated:
+            return ReferenceActionResult.error(
+                "Impossible de relier : référence introuvable ou non modifiable."
+            )
+
+        changes.append(
+            _format_reference_change(
+                ReferenceFixAction.LINK_CREATED,
+                reference,
+                target_identifier,
+            )
+        )
+        return ReferenceActionResult.ok(
+            f"Nouvelle entité « {target_identifier} » reliée.",
+            *changes,
+        )
+
+
+_IDENTIFIER_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
+_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label")
+_REFERENCE_KEYS = _IDENTIFIER_KEYS + _NAME_KEYS + ("ref", "reference", "target")
+_TYPE_KEYS = ("entity_type", "type", "kind", "category", "EntityType", "Type")
+_CHILD_COLLECTION_BY_TYPE = {
+    "arc": "arcs",
+    "scenario": "scenarios",
+    "location": "locations",
+    "encounter": "encounters",
+    "npc": "npcs",
+}
+
+
+def _replace_reference_value(
+    reference: ReferenceRecord,
+    target_identifier: str,
+    target_type: str | None,
+) -> bool:
+    source_node = reference.source.node
+    if not isinstance(source_node, MutableMapping) or reference.field_name not in source_node:
+        return False
+
+    raw_value = source_node[reference.field_name]
+    index = _reference_index(reference)
+    if _is_mutable_reference_collection(raw_value):
+        if index is None or not 0 <= index < len(raw_value):
+            return False
+        raw_value[index] = _updated_reference_object(
+            raw_value[index],
+            target_identifier,
+            target_type,
+        )
+        return True
+
+    source_node[reference.field_name] = _updated_reference_object(
+        raw_value,
+        target_identifier,
+        target_type,
+    )
+    return True
+
+
+def _remove_reference_value(reference: ReferenceRecord) -> bool:
+    source_node = reference.source.node
+    if not isinstance(source_node, MutableMapping) or reference.field_name not in source_node:
+        return False
+
+    raw_value = source_node[reference.field_name]
+    index = _reference_index(reference)
+    if _is_mutable_reference_collection(raw_value):
+        if index is None or not 0 <= index < len(raw_value):
+            return False
+        del raw_value[index]
+        return True
+
+    del source_node[reference.field_name]
+    return True
+
+
+def _is_mutable_reference_collection(value: Any) -> bool:
+    return isinstance(value, MutableSequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    )
+
+
+def _updated_reference_object(value: Any, target_identifier: str, target_type: str | None) -> Any:
+    if not isinstance(value, MutableMapping):
+        return target_identifier
+
+    updated = dict(value)
+    reference_key = _first_present_key(updated, _REFERENCE_KEYS) or "ref"
+    updated[reference_key] = target_identifier
+
+    type_key = _first_present_key(updated, _TYPE_KEYS)
+    if type_key and target_type:
+        updated[type_key] = target_type
+    return updated
+
+
+def _attach_child_entity(
+    reference: ReferenceRecord,
+    new_entity: MutableMapping[str, Any],
+) -> str:
+    source_node = reference.source.node
+    if not isinstance(source_node, MutableMapping):
+        return ""
+
+    collection_name = _CHILD_COLLECTION_BY_TYPE.get(
+        reference.expected_type,
+        f"{reference.expected_type}s",
+    )
+    collection = source_node.setdefault(collection_name, [])
+    if not isinstance(collection, MutableSequence):
+        return ""
+    if any(item is new_entity for item in collection):
+        return ""
+
+    collection.append(new_entity)
+    return f"{collection_name}: entité ajoutée"
+
+
+def _extract_target_identifier(target: EntityRecord | MutableMapping[str, Any] | str) -> str:
+    if isinstance(target, EntityRecord):
+        return target.identifier
+    if isinstance(target, str):
+        return target.strip()
+    if isinstance(target, MutableMapping):
+        return _normalize(_first_present(target, _IDENTIFIER_KEYS + _NAME_KEYS))
+    return ""
+
+
+def _extract_target_type(target: EntityRecord | MutableMapping[str, Any] | str) -> str | None:
+    if isinstance(target, EntityRecord):
+        return target.entity_type
+    if isinstance(target, MutableMapping):
+        return _normalize(_first_present(target, _TYPE_KEYS)) or None
+    return None
+
+
+def _reference_index(reference: ReferenceRecord) -> int | None:
+    if not reference.path:
+        return None
+    raw_index = reference.path[-1]
+    if not raw_index.startswith("[") or not raw_index.endswith("]"):
+        return None
+    try:
+        return int(raw_index[1:-1])
+    except ValueError:
+        return None
+
+
+def _format_reference_change(
+    action: ReferenceFixAction,
+    reference: ReferenceRecord,
+    target_identifier: str = "",
+) -> str:
+    location = f"{reference.source.identifier}.{reference.field_name}"
+    if action is ReferenceFixAction.REMOVE:
+        return f"{location}: référence supprimée"
+    return f"{location}: {reference.reference_value} → {target_identifier}"
+
+
+def _first_present(value: MutableMapping[str, Any], keys: tuple[str, ...]) -> Any:
+    key = _first_present_key(value, keys)
+    return value[key] if key else None
+
+
+def _first_present_key(value: MutableMapping[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        if key in value:
+            return key
+    return None
+
+
+def _normalize(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/src/services/session_ignore_store.py
+++ b/src/services/session_ignore_store.py
@@ -1,0 +1,84 @@
+"""In-memory store for validation issues ignored during the current session."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from src.validation import ValidationIssue
+
+
+@dataclass(frozen=True, order=True)
+class IgnoredIssueKey:
+    """Stable, hashable key identifying one validation issue in this session."""
+
+    issue_type: str
+    source_entity: str
+    source_type: str
+    field: str
+    referenced_name: str
+    expected_type: str
+    hierarchy_path: tuple[str, ...]
+
+
+class SessionIgnoreStore:
+    """Remember ignored issues in memory only.
+
+    The store deliberately has no file path, serializer, or persistence hook.
+    Creating a new instance starts a fresh session with no ignored issues.
+    """
+
+    def __init__(self) -> None:
+        self._ignored: set[IgnoredIssueKey] = set()
+
+    def ignore(self, issue: ValidationIssue) -> IgnoredIssueKey:
+        """Mark an issue as ignored for the lifetime of this store instance."""
+
+        key = issue_key(issue)
+        self._ignored.add(key)
+        return key
+
+    def unignore(self, issue: ValidationIssue) -> bool:
+        """Remove an issue from the ignored set.
+
+        Returns ``True`` only when the issue was previously ignored.
+        """
+
+        key = issue_key(issue)
+        if key not in self._ignored:
+            return False
+        self._ignored.remove(key)
+        return True
+
+    def is_ignored(self, issue: ValidationIssue) -> bool:
+        """Return whether an issue is ignored in the current session."""
+
+        return issue_key(issue) in self._ignored
+
+    def visible_issues(self, issues: Iterable[ValidationIssue]) -> tuple[ValidationIssue, ...]:
+        """Filter ignored issues from an iterable while preserving order."""
+
+        return tuple(issue for issue in issues if not self.is_ignored(issue))
+
+    def clear(self) -> None:
+        """Forget all ignored issues for the current session."""
+
+        self._ignored.clear()
+
+    def __len__(self) -> int:
+        return len(self._ignored)
+
+
+def issue_key(issue: ValidationIssue) -> IgnoredIssueKey:
+    """Create the canonical in-memory key for a validation issue."""
+
+    payload = issue.payload
+    return IgnoredIssueKey(
+        issue_type=str(issue.issue_type.value),
+        source_entity=payload.source_entity,
+        source_type=payload.source_type,
+        field=payload.field,
+        referenced_name=payload.referenced_name,
+        expected_type=payload.expected_type,
+        hierarchy_path=tuple(str(part) for part in payload.hierarchy_path),
+    )

--- a/tests/services/test_reference_fix_service.py
+++ b/tests/services/test_reference_fix_service.py
@@ -1,0 +1,81 @@
+"""Regression tests for interactive reference fix actions."""
+
+from src.services import ReferenceActionResult, ReferenceFixService
+from src.validation import validate_reference_graph
+
+
+def _reference_for(hierarchy, value):
+    graph = validate_reference_graph(hierarchy)
+    return next(reference for reference in graph.references if reference.reference_value == value)
+
+
+def test_remap_reference_updates_selected_list_occurrence_and_reports_contract():
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["Missing Arc"],
+        "arcs": [{"type": "arc", "id": "A1", "name": "Arc One"}],
+    }
+    reference = _reference_for(hierarchy, "Missing Arc")
+
+    result = ReferenceFixService().remap_reference(reference, "A1")
+
+    assert isinstance(result, ReferenceActionResult)
+    assert result.success is True
+    assert hierarchy["arc_refs"] == ["A1"]
+    assert result.changes_applied == ("C1.arc_refs: Missing Arc → A1",)
+    assert "A1" in result.ui_message
+
+
+def test_remap_reference_preserves_mapping_shape_and_updates_declared_type():
+    hierarchy = {
+        "type": "arc",
+        "id": "A1",
+        "scenario_refs": [{"ref": "Wrong", "type": "location", "note": "keep"}],
+    }
+    reference = _reference_for(hierarchy, "Wrong")
+
+    result = ReferenceFixService().remap_reference(
+        reference,
+        {"type": "scenario", "id": "S1"},
+    )
+
+    assert result.success is True
+    assert hierarchy["scenario_refs"] == [
+        {"ref": "S1", "type": "scenario", "note": "keep"}
+    ]
+
+
+def test_remove_reference_deletes_only_the_selected_occurrence():
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["A1", "Missing Arc", "A2"],
+    }
+    reference = _reference_for(hierarchy, "Missing Arc")
+
+    result = ReferenceFixService().remove_reference(reference)
+
+    assert result.success is True
+    assert hierarchy["arc_refs"] == ["A1", "A2"]
+    assert result.changes_applied == ("C1.arc_refs: référence supprimée",)
+
+
+def test_link_created_entity_attaches_child_and_remaps_reference():
+    hierarchy = {
+        "type": "arc",
+        "id": "A1",
+        "scenario_refs": ["Missing Scenario"],
+    }
+    new_entity = {"type": "scenario", "id": "S1", "name": "New Scenario"}
+    reference = _reference_for(hierarchy, "Missing Scenario")
+
+    result = ReferenceFixService().link_created_entity(reference, new_entity)
+
+    assert result.success is True
+    assert hierarchy["scenario_refs"] == ["S1"]
+    assert hierarchy["scenarios"] == [new_entity]
+    assert result.changes_applied == (
+        "scenarios: entité ajoutée",
+        "A1.scenario_refs: Missing Scenario → S1",
+    )

--- a/tests/services/test_session_ignore_store.py
+++ b/tests/services/test_session_ignore_store.py
@@ -1,0 +1,39 @@
+"""Regression tests for session-only ignored validation issues."""
+
+from src.services import SessionIgnoreStore, issue_key
+from src.validation import validate_references
+
+
+def _missing_issue():
+    hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    return validate_references(hierarchy)[0]
+
+
+def test_session_ignore_store_filters_ignored_issues_without_persistence_contract():
+    issue = _missing_issue()
+    store = SessionIgnoreStore()
+
+    key = store.ignore(issue)
+
+    assert key == issue_key(issue)
+    assert store.is_ignored(issue) is True
+    assert store.visible_issues([issue]) == ()
+    assert len(store) == 1
+
+    fresh_store = SessionIgnoreStore()
+    assert fresh_store.is_ignored(issue) is False
+    assert fresh_store.visible_issues([issue]) == (issue,)
+
+
+def test_session_ignore_store_can_unignore_and_clear():
+    issue = _missing_issue()
+    store = SessionIgnoreStore()
+    store.ignore(issue)
+
+    assert store.unignore(issue) is True
+    assert store.unignore(issue) is False
+    assert store.is_ignored(issue) is False
+
+    store.ignore(issue)
+    store.clear()
+    assert len(store) == 0


### PR DESCRIPTION
### Motivation

- Fournir des opérations programatiques pour appliquer les corrections de références signalées par le validateur (remapper vers une cible, supprimer une référence, ou relier une nouvelle entité). 
- Permettre à l'interface d'avoir un contrat unique et stable de retour d'action pour afficher des messages et lister les modifications applicables. 
- Mémoriser les issues ignorées uniquement en mémoire de session sans aucune persistance disque.

### Description

- Ajout du package de services `src/services` et export des API publiques via `src/services/__init__.py`.
- Création de `src/services/reference_fix_service.py` fournissant `ReferenceFixService` avec les méthodes `remap_reference`, `remove_reference` et `link_created_entity`, et du contrat de retour `ReferenceActionResult` (`success`, `changes_applied`, `ui_message`).
- Implémentation des helpers de mutation pour gérer les références scalaires et collections, préserver la forme des références mapping (mise à jour de la clé id/ref), attacher une nouvelle entité au bon collection enfant, et produire des descriptions déterministes des changements.
- Création de `src/services/session_ignore_store.py` offrant `SessionIgnoreStore` et `issue_key` pour marquer/unmarker/filtrer les issues ignorées en mémoire uniquement.
- Ajout de tests de régression dans `tests/services` couvrant les cas de remap, suppression, préservation des mappings, liaison d'entité créée, et le comportement d'ignoré session-only.

### Testing

- Tests unitaires exécutés avec `python -m pytest tests/services tests/validation` et réussis sans régression; la suite lancée a passé tous les cas exécutés (15 passed).
- Tests ciblés `tests/services/test_reference_fix_service.py` et `tests/services/test_session_ignore_store.py` exécutés et validés (passés).
- Vérifications de compilation (`python -m compileall`) et checks rapides du diff effectués pendant le développement et n'ont révélé aucune erreur automatique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0158b3e0832b924c4c571595d4bb)