### PR TITLE
Add validation wizard controller

### DIFF
--- a/src/ui/validation/__init__.py
+++ b/src/ui/validation/__init__.py
@@ -1,0 +1,27 @@
+"""Validation UI controllers."""
+
+from .validation_wizard_controller import (
+    ValidationWizardAction,
+    ValidationWizardActionRequest,
+    ValidationWizardController,
+    ValidationWizardIssue,
+    ValidationWizardPresenter,
+    ValidationWizardProgress,
+    ValidationWizardStatus,
+    ValidationWizardStep,
+    ValidationWizardSummary,
+    resolve_reference_for_issue,
+)
+
+__all__ = [
+    "ValidationWizardAction",
+    "ValidationWizardActionRequest",
+    "ValidationWizardController",
+    "ValidationWizardIssue",
+    "ValidationWizardPresenter",
+    "ValidationWizardProgress",
+    "ValidationWizardStatus",
+    "ValidationWizardStep",
+    "ValidationWizardSummary",
+    "resolve_reference_for_issue",
+]

--- a/src/ui/validation/validation_wizard_controller.py
+++ b/src/ui/validation/validation_wizard_controller.py
@@ -1,0 +1,453 @@
+"""State controller for the interactive reference validation wizard.
+
+The controller is intentionally UI-agnostic: dialogs, CustomTkinter views, or
+other front-ends render the returned steps and feed the selected GM actions back
+through :meth:`submit_action`.  This keeps the workflow deterministic and easy to
+test while the mutation work remains delegated to ``ReferenceFixService``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Iterable, Protocol, Sequence
+
+from src.services import ReferenceActionResult, ReferenceFixService, SessionIgnoreStore
+from src.validation import ValidationIssue
+from src.validation.reference_validator import EntityRecord, ReferenceRecord
+
+ReferenceResolver = Callable[[ValidationIssue], ReferenceRecord | None]
+
+
+class ValidationWizardAction(str, Enum):
+    """Actions that can be selected by the GM for the current issue."""
+
+    REMAP = "remap"
+    REMOVE = "remove"
+    CREATE_ENTITY = "create_entity"
+    LINK_CREATED = "link_created"
+    SKIP_SESSION = "skip_session"
+    CANCEL = "cancel"
+
+
+class ValidationWizardStatus(str, Enum):
+    """High-level state returned to the UI layer after every transition."""
+
+    SHOW_ISSUE = "show_issue"
+    AWAITING_GM_ACTION = "awaiting_gm_action"
+    AWAITING_ENTITY_CREATION = "awaiting_entity_creation"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+    ACTION_FAILED = "action_failed"
+
+
+@dataclass(frozen=True)
+class ValidationWizardIssue:
+    """Pair one displayed validation issue with its mutable reference record.
+
+    ``ValidationIssue`` is the user-facing problem emitted by validation;
+    ``ReferenceRecord`` is the mutable location required by
+    ``ReferenceFixService`` to apply the chosen fix.
+    """
+
+    issue: ValidationIssue
+    reference: ReferenceRecord | None = None
+
+
+@dataclass(frozen=True)
+class ValidationWizardProgress:
+    """Progress metadata for the currently displayed issue."""
+
+    current_index: int
+    visible_total: int
+    raw_total: int
+
+
+@dataclass(frozen=True)
+class ValidationWizardSummary:
+    """Deterministic summary emitted when the wizard finishes or is canceled."""
+
+    total_issues: int
+    resolved: int = 0
+    skipped_session: int = 0
+    canceled: bool = False
+    changes_applied: tuple[str, ...] = field(default_factory=tuple)
+    messages: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def completed(self) -> bool:
+        """Return ``True`` when the wizard reached a normal, non-canceled end."""
+
+        return not self.canceled
+
+
+@dataclass(frozen=True)
+class ValidationWizardStep:
+    """Current step returned to the UI after a controller transition."""
+
+    status: ValidationWizardStatus
+    issue: ValidationIssue | None = None
+    progress: ValidationWizardProgress | None = None
+    summary: ValidationWizardSummary | None = None
+    action_result: ReferenceActionResult | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationWizardActionRequest:
+    """Payload submitted by the UI when the GM chooses an action."""
+
+    action: ValidationWizardAction | str
+    target: EntityRecord | dict[str, Any] | str | None = None
+    created_entity: EntityRecord | dict[str, Any] | None = None
+    attach_to_source: bool = True
+
+
+class ValidationWizardPresenter(Protocol):
+    """Optional UI callback contract used by the controller."""
+
+    def show_issue(self, step: ValidationWizardStep) -> None:
+        """Render the issue and wait for a subsequent GM action."""
+
+    def show_summary(self, summary: ValidationWizardSummary) -> None:
+        """Render the final summary."""
+
+
+class ValidationWizardController:
+    """Coordinate interactive validation fixes issue by issue.
+
+    The controller takes an ordered issue list, skips anything ignored by the
+    session store, exposes the first visible issue, then waits for the UI to call
+    :meth:`submit_action`.  Successful mutating actions are delegated to
+    ``ReferenceFixService`` and the controller advances to the next visible
+    issue.  ``CREATE_ENTITY`` pauses the workflow so an entity editor can open;
+    :meth:`resume_after_entity_creation` links the created entity and continues.
+    """
+
+    def __init__(
+        self,
+        issues: Iterable[ValidationIssue | ValidationWizardIssue],
+        *,
+        reference_fix_service: ReferenceFixService | None = None,
+        ignore_store: SessionIgnoreStore | None = None,
+        reference_resolver: ReferenceResolver | None = None,
+        presenter: ValidationWizardPresenter | None = None,
+    ) -> None:
+        self._items = tuple(_coerce_issue_item(issue) for issue in issues)
+        self._reference_fix_service = reference_fix_service or ReferenceFixService()
+        self._ignore_store = ignore_store or SessionIgnoreStore()
+        self._reference_resolver = reference_resolver
+        self._presenter = presenter
+        self._cursor = -1
+        self._summary = ValidationWizardSummary(total_issues=len(self._items))
+        self._awaiting_entity_creation = False
+        self._active_step: ValidationWizardStep | None = None
+
+    @property
+    def summary(self) -> ValidationWizardSummary:
+        """Return the current accumulated summary."""
+
+        return self._summary
+
+    @property
+    def current_issue(self) -> ValidationIssue | None:
+        """Return the currently displayed issue, if any."""
+
+        return self._active_step.issue if self._active_step else None
+
+    def start(self) -> ValidationWizardStep:
+        """Start the wizard at the first non-ignored issue."""
+
+        self._cursor = -1
+        self._awaiting_entity_creation = False
+        return self._advance_to_next_issue()
+
+    def submit_action(
+        self,
+        request: ValidationWizardActionRequest | ValidationWizardAction | str,
+        *,
+        target: EntityRecord | dict[str, Any] | str | None = None,
+        created_entity: EntityRecord | dict[str, Any] | None = None,
+        attach_to_source: bool = True,
+    ) -> ValidationWizardStep:
+        """Apply the GM action for the current issue and return the next step."""
+
+        action_request = _coerce_action_request(
+            request,
+            target=target,
+            created_entity=created_entity,
+            attach_to_source=attach_to_source,
+        )
+        action = ValidationWizardAction(action_request.action)
+
+        if action == ValidationWizardAction.CANCEL:
+            return self.cancel()
+        if self._awaiting_entity_creation:
+            if action != ValidationWizardAction.LINK_CREATED:
+                return self._action_failed(
+                    "Création d’entité en attente : reliez l’entité créée ou annulez."
+                )
+            return self.resume_after_entity_creation(
+                action_request.created_entity or action_request.target,
+                attach_to_source=action_request.attach_to_source,
+            )
+
+        current_item = self._current_item()
+        if current_item is None:
+            return self._complete()
+
+        if action == ValidationWizardAction.SKIP_SESSION:
+            self._ignore_store.ignore(current_item.issue)
+            self._summary = _summary_with_skip(
+                self._summary,
+                f"Issue ignorée pour cette session : {current_item.issue.payload.referenced_name}",
+            )
+            return self._advance_to_next_issue()
+
+        if action == ValidationWizardAction.CREATE_ENTITY:
+            self._awaiting_entity_creation = True
+            step = ValidationWizardStep(
+                status=ValidationWizardStatus.AWAITING_ENTITY_CREATION,
+                issue=current_item.issue,
+                progress=self._progress_for_cursor(),
+                message="Création d’entité demandée. Reprise prévue après sauvegarde.",
+            )
+            self._active_step = step
+            return step
+
+        reference = self._resolve_reference(current_item)
+        if reference is None:
+            return self._action_failed(
+                "Impossible d’appliquer l’action : référence de validation introuvable."
+            )
+
+        if action == ValidationWizardAction.REMAP:
+            result = self._reference_fix_service.remap_reference(
+                reference,
+                action_request.target or "",
+            )
+        elif action == ValidationWizardAction.REMOVE:
+            result = self._reference_fix_service.remove_reference(reference)
+        elif action == ValidationWizardAction.LINK_CREATED:
+            result = self._reference_fix_service.link_created_entity(
+                reference,
+                action_request.created_entity or action_request.target or {},
+                attach_to_source=action_request.attach_to_source,
+            )
+        else:
+            return self._action_failed(f"Action inconnue : {action.value}")
+
+        return self._handle_action_result(result)
+
+    def resume_after_entity_creation(
+        self,
+        created_entity: EntityRecord | dict[str, Any] | str | None,
+        *,
+        attach_to_source: bool = True,
+    ) -> ValidationWizardStep:
+        """Resume a paused wizard after the entity creation UI returns."""
+
+        current_item = self._current_item()
+        if current_item is None:
+            return self._complete()
+        if created_entity is None:
+            return self._action_failed("Impossible de reprendre : aucune entité créée fournie.")
+
+        reference = self._resolve_reference(current_item)
+        if reference is None:
+            return self._action_failed(
+                "Impossible de reprendre : référence de validation introuvable."
+            )
+
+        result = self._reference_fix_service.link_created_entity(
+            reference,
+            created_entity,
+            attach_to_source=attach_to_source,
+        )
+        if result.success:
+            self._awaiting_entity_creation = False
+        return self._handle_action_result(result)
+
+    def cancel(self) -> ValidationWizardStep:
+        """Cancel the wizard and return a final canceled summary."""
+
+        self._awaiting_entity_creation = False
+        self._summary = _summary_canceled(self._summary)
+        step = ValidationWizardStep(
+            status=ValidationWizardStatus.CANCELED,
+            summary=self._summary,
+            message="Validation annulée par le GM.",
+        )
+        self._active_step = step
+        self._notify_summary(step)
+        return step
+
+    def _advance_to_next_issue(self) -> ValidationWizardStep:
+        self._awaiting_entity_creation = False
+        self._cursor += 1
+        while self._cursor < len(self._items):
+            item = self._items[self._cursor]
+            if not self._ignore_store.is_ignored(item.issue):
+                step = ValidationWizardStep(
+                    status=ValidationWizardStatus.SHOW_ISSUE,
+                    issue=item.issue,
+                    progress=self._progress_for_cursor(),
+                    message=_format_issue_message(item.issue),
+                )
+                self._active_step = step
+                if self._presenter is not None:
+                    self._presenter.show_issue(step)
+                return step
+            self._cursor += 1
+        return self._complete()
+
+    def _complete(self) -> ValidationWizardStep:
+        step = ValidationWizardStep(
+            status=ValidationWizardStatus.COMPLETED,
+            summary=self._summary,
+            message="Validation terminée.",
+        )
+        self._active_step = step
+        self._notify_summary(step)
+        return step
+
+    def _handle_action_result(self, result: ReferenceActionResult) -> ValidationWizardStep:
+        if not result.success:
+            return self._action_failed(result.ui_message, result)
+        self._summary = _summary_with_result(self._summary, result)
+        return self._advance_to_next_issue()
+
+    def _action_failed(
+        self,
+        message: str,
+        result: ReferenceActionResult | None = None,
+    ) -> ValidationWizardStep:
+        current_item = self._current_item()
+        step = ValidationWizardStep(
+            status=ValidationWizardStatus.ACTION_FAILED,
+            issue=current_item.issue if current_item else None,
+            progress=self._progress_for_cursor() if current_item else None,
+            action_result=result,
+            message=message,
+        )
+        self._active_step = step
+        return step
+
+    def _current_item(self) -> ValidationWizardIssue | None:
+        if 0 <= self._cursor < len(self._items):
+            return self._items[self._cursor]
+        return None
+
+    def _resolve_reference(self, item: ValidationWizardIssue) -> ReferenceRecord | None:
+        if item.reference is not None:
+            return item.reference
+        if self._reference_resolver is None:
+            return None
+        return self._reference_resolver(item.issue)
+
+    def _progress_for_cursor(self) -> ValidationWizardProgress:
+        visible_indices = [
+            index
+            for index, item in enumerate(self._items)
+            if not self._ignore_store.is_ignored(item.issue)
+        ]
+        current_index = (
+            visible_indices.index(self._cursor) + 1
+            if self._cursor in visible_indices
+            else 0
+        )
+        return ValidationWizardProgress(
+            current_index=current_index,
+            visible_total=len(visible_indices),
+            raw_total=len(self._items),
+        )
+
+    def _notify_summary(self, step: ValidationWizardStep) -> None:
+        if self._presenter is not None and step.summary is not None:
+            self._presenter.show_summary(step.summary)
+
+
+def resolve_reference_for_issue(
+    issue: ValidationIssue,
+    references: Sequence[ReferenceRecord],
+) -> ReferenceRecord | None:
+    """Find the reference record matching a validation issue payload."""
+
+    payload = issue.payload
+    for reference in references:
+        if (
+            reference.source.identifier == payload.source_entity
+            and reference.field_name == payload.field
+            and reference.reference_value == payload.referenced_name
+            and reference.expected_type == payload.expected_type
+            and reference.path == tuple(payload.hierarchy_path)
+        ):
+            return reference
+    return None
+
+
+def _coerce_issue_item(issue: ValidationIssue | ValidationWizardIssue) -> ValidationWizardIssue:
+    if isinstance(issue, ValidationWizardIssue):
+        return issue
+    return ValidationWizardIssue(issue=issue)
+
+
+def _coerce_action_request(
+    request: ValidationWizardActionRequest | ValidationWizardAction | str,
+    *,
+    target: EntityRecord | dict[str, Any] | str | None,
+    created_entity: EntityRecord | dict[str, Any] | None,
+    attach_to_source: bool,
+) -> ValidationWizardActionRequest:
+    if isinstance(request, ValidationWizardActionRequest):
+        return request
+    return ValidationWizardActionRequest(
+        action=request,
+        target=target,
+        created_entity=created_entity,
+        attach_to_source=attach_to_source,
+    )
+
+
+def _summary_with_result(
+    summary: ValidationWizardSummary,
+    result: ReferenceActionResult,
+) -> ValidationWizardSummary:
+    return ValidationWizardSummary(
+        total_issues=summary.total_issues,
+        resolved=summary.resolved + 1,
+        skipped_session=summary.skipped_session,
+        canceled=summary.canceled,
+        changes_applied=summary.changes_applied + result.changes_applied,
+        messages=summary.messages + ((result.ui_message,) if result.ui_message else ()),
+    )
+
+
+def _summary_with_skip(summary: ValidationWizardSummary, message: str) -> ValidationWizardSummary:
+    return ValidationWizardSummary(
+        total_issues=summary.total_issues,
+        resolved=summary.resolved,
+        skipped_session=summary.skipped_session + 1,
+        canceled=summary.canceled,
+        changes_applied=summary.changes_applied,
+        messages=summary.messages + (message,),
+    )
+
+
+def _summary_canceled(summary: ValidationWizardSummary) -> ValidationWizardSummary:
+    return ValidationWizardSummary(
+        total_issues=summary.total_issues,
+        resolved=summary.resolved,
+        skipped_session=summary.skipped_session,
+        canceled=True,
+        changes_applied=summary.changes_applied,
+        messages=summary.messages + ("Validation annulée par le GM.",),
+    )
+
+
+def _format_issue_message(issue: ValidationIssue) -> str:
+    payload = issue.payload
+    return (
+        f"{issue.issue_type.value}: {payload.source_entity}.{payload.field} "
+        f"référence « {payload.referenced_name} » ({payload.expected_type})."
+    )

--- a/tests/ui/validation/test_validation_wizard_controller.py
+++ b/tests/ui/validation/test_validation_wizard_controller.py
@@ -1,0 +1,138 @@
+"""Regression tests for the validation wizard controller workflow."""
+
+from src.services import SessionIgnoreStore
+from src.ui.validation import (
+    ValidationWizardAction,
+    ValidationWizardController,
+    ValidationWizardIssue,
+    ValidationWizardStatus,
+    resolve_reference_for_issue,
+)
+from src.validation import validate_reference_graph
+
+
+def _graph_for(hierarchy):
+    return validate_reference_graph(hierarchy)
+
+
+def _wizard_items(graph):
+    return tuple(
+        ValidationWizardIssue(
+            issue=issue,
+            reference=resolve_reference_for_issue(issue, graph.references),
+        )
+        for issue in graph.issues
+    )
+
+
+def test_wizard_starts_on_first_non_ignored_issue_and_finishes_with_summary():
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["Missing One", "Missing Two"],
+    }
+    graph = _graph_for(hierarchy)
+    ignore_store = SessionIgnoreStore()
+    ignore_store.ignore(graph.issues[0])
+    controller = ValidationWizardController(_wizard_items(graph), ignore_store=ignore_store)
+
+    first_step = controller.start()
+    assert first_step.status == ValidationWizardStatus.SHOW_ISSUE
+    assert first_step.issue == graph.issues[1]
+    assert first_step.progress.current_index == 1
+    assert first_step.progress.visible_total == 1
+
+    summary_step = controller.submit_action(ValidationWizardAction.REMOVE)
+    assert summary_step.status == ValidationWizardStatus.COMPLETED
+    assert hierarchy["arc_refs"] == ["Missing One"]
+    assert summary_step.summary.resolved == 1
+    assert summary_step.summary.skipped_session == 0
+    assert summary_step.summary.changes_applied == ("C1.arc_refs: référence supprimée",)
+
+
+def test_wizard_skip_session_ignores_current_issue_and_advances():
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["Missing One", "Missing Two"],
+    }
+    graph = _graph_for(hierarchy)
+    controller = ValidationWizardController(_wizard_items(graph))
+
+    assert controller.start().issue == graph.issues[0]
+    next_step = controller.submit_action(ValidationWizardAction.SKIP_SESSION)
+
+    assert next_step.status == ValidationWizardStatus.SHOW_ISSUE
+    assert next_step.issue == graph.issues[1]
+    assert controller.summary.skipped_session == 1
+    assert hierarchy["arc_refs"] == ["Missing One", "Missing Two"]
+
+
+def test_wizard_cancel_returns_canceled_summary_without_mutating():
+    hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing"]}
+    graph = _graph_for(hierarchy)
+    controller = ValidationWizardController(_wizard_items(graph))
+
+    controller.start()
+    step = controller.submit_action(ValidationWizardAction.CANCEL)
+
+    assert step.status == ValidationWizardStatus.CANCELED
+    assert step.summary.canceled is True
+    assert step.summary.resolved == 0
+    assert hierarchy["arc_refs"] == ["Missing"]
+
+
+def test_wizard_remap_applies_reference_fix_and_advances():
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["Wrong Arc"],
+        "arcs": [{"type": "arc", "id": "A1", "name": "Arc One"}],
+    }
+    graph = _graph_for(hierarchy)
+    controller = ValidationWizardController(_wizard_items(graph))
+
+    controller.start()
+    step = controller.submit_action(ValidationWizardAction.REMAP, target="A1")
+
+    assert step.status == ValidationWizardStatus.COMPLETED
+    assert hierarchy["arc_refs"] == ["A1"]
+    assert step.summary.resolved == 1
+    assert step.summary.messages == ("Référence remappée vers « A1 ».",)
+
+
+def test_wizard_resumes_after_entity_creation_and_links_created_entity():
+    hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    graph = _graph_for(hierarchy)
+    controller = ValidationWizardController(_wizard_items(graph))
+
+    controller.start()
+    paused = controller.submit_action(ValidationWizardAction.CREATE_ENTITY)
+    assert paused.status == ValidationWizardStatus.AWAITING_ENTITY_CREATION
+
+    new_entity = {"type": "arc", "id": "A1", "name": "Created Arc"}
+    final_step = controller.resume_after_entity_creation(new_entity)
+
+    assert final_step.status == ValidationWizardStatus.COMPLETED
+    assert hierarchy["arc_refs"] == ["A1"]
+    assert hierarchy["arcs"] == [new_entity]
+    assert final_step.summary.resolved == 1
+    assert final_step.summary.changes_applied == (
+        "arcs: entité ajoutée",
+        "C1.arc_refs: Missing Arc → A1",
+    )
+
+
+def test_wizard_can_use_reference_resolver_for_plain_issue_lists():
+    hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing"]}
+    graph = _graph_for(hierarchy)
+    controller = ValidationWizardController(
+        graph.issues,
+        reference_resolver=lambda issue: resolve_reference_for_issue(issue, graph.references),
+    )
+
+    controller.start()
+    step = controller.submit_action(ValidationWizardAction.REMOVE)
+
+    assert step.status == ValidationWizardStatus.COMPLETED
+    assert hierarchy["arc_refs"] == []


### PR DESCRIPTION
### Motivation
- Provide a UI-agnostic controller to walk an ordered list of validation issues, present the first non-ignored issue to the GM, and apply their chosen fix programmatically. 
- Centralize interactions with `ReferenceFixService` and `SessionIgnoreStore` so UI code (Tk/CustomTkinter) can render steps and only feed actions back to the controller. 

### Description
- Add `src/ui/validation/validation_wizard_controller.py` implementing `ValidationWizardController`, step/result models (`ValidationWizardStep`, `ValidationWizardSummary`, `ValidationWizardProgress`, etc.), actions (`ValidationWizardAction`), and the `resolve_reference_for_issue` helper used to map simple issue lists to `ReferenceRecord`s. 
- Controller supports `skip_session`, `cancel`, `remap`, `remove`, `create_entity` (pauses workflow) and `link_created_entity` (resume after creation), and aggregates deterministic summary and human-readable messages. 
- Export controller symbols via `src/ui/validation/__init__.py` and add tests in `tests/ui/validation/test_validation_wizard_controller.py` that exercise skip, cancel, remap, remove, create-then-resume, and plain-issue-list resolver usage. 

### Testing
- Compiled and ran the new unit tests with `python -m compileall -q src/ui/validation tests/ui/validation` and executed `pytest` on the new test file via `python -m pytest tests/ui/validation/test_validation_wizard_controller.py`, which passed. 
- Ran a targeted test set `python -m pytest tests/ui/validation/test_validation_wizard_controller.py tests/services/test_reference_fix_service.py tests/services/test_session_ignore_store.py tests/validation/test_reference_validator.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0302ffa0832b9b0579f8fc2df0e8)