### PR TITLE
Add missing-reference resolution dialog and Generic Editor launcher

### DIFF
--- a/src/ui/validation/dialogs/__init__.py
+++ b/src/ui/validation/dialogs/__init__.py
@@ -1,0 +1,27 @@
+"""Validation dialogs."""
+
+from .generic_editor_launcher import (
+    GenericEditorCreationRequest,
+    GenericEditorCreationResult,
+    GenericEditorLauncher,
+    build_prefilled_entity,
+    creation_request_from_issue,
+    entity_slug_for_expected_type,
+)
+from .missing_reference_dialog import (
+    MissingReferenceDialog,
+    MissingReferenceDialogConfig,
+    open_missing_reference_dialog,
+)
+
+__all__ = [
+    "GenericEditorCreationRequest",
+    "GenericEditorCreationResult",
+    "GenericEditorLauncher",
+    "MissingReferenceDialog",
+    "MissingReferenceDialogConfig",
+    "build_prefilled_entity",
+    "creation_request_from_issue",
+    "entity_slug_for_expected_type",
+    "open_missing_reference_dialog",
+]

--- a/src/ui/validation/dialogs/generic_editor_launcher.py
+++ b/src/ui/validation/dialogs/generic_editor_launcher.py
@@ -1,0 +1,269 @@
+"""Launch helpers for creating validation targets with the Generic Editor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Protocol
+
+from src.validation import ValidationIssue
+from src.validation.reference_validator import ReferenceRecord
+
+TemplateLoader = Callable[[str], Mapping[str, Any]]
+WrapperFactory = Callable[[str], Any]
+
+
+class EditorFactory(Protocol):
+    """Factory contract for ``GenericEditorWindow`` compatible editors."""
+
+    def __call__(
+        self,
+        master: Any,
+        item: dict[str, Any],
+        template: Mapping[str, Any],
+        wrapper: Any,
+        *,
+        creation_mode: bool = False,
+    ) -> Any:
+        """Create an editor window."""
+
+
+class PersistableWrapper(Protocol):
+    """Persistence contract used by the Generic Editor launcher."""
+
+    entity_type: str
+
+    def save_item(self, item: dict[str, Any], **kwargs: Any) -> None:
+        """Persist one item."""
+
+
+@dataclass(frozen=True)
+class GenericEditorCreationRequest:
+    """Context required to open a pre-filled creation editor."""
+
+    expected_type: str
+    referenced_name: str
+    parent_identifier: str = ""
+    parent_type: str = ""
+    source_identifier: str = ""
+    source_type: str = ""
+    extra_values: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GenericEditorCreationResult:
+    """Entity returned by the Generic Editor after a successful save."""
+
+    entity: dict[str, Any]
+    entity_slug: str
+
+
+class GenericEditorLauncher:
+    """Open the app Generic Editor for validation-driven entity creation.
+
+    Dependencies are injectable so validation dialogs stay easy to unit-test and
+    the heavyweight CustomTkinter editor is imported only when a real UI action
+    needs it.
+    """
+
+    def __init__(
+        self,
+        *,
+        editor_factory: EditorFactory | None = None,
+        template_loader: TemplateLoader | None = None,
+        wrapper_factory: WrapperFactory | None = None,
+        wait_for_editor: bool = True,
+    ) -> None:
+        self._editor_factory = editor_factory
+        self._template_loader = template_loader
+        self._wrapper_factory = wrapper_factory
+        self._wait_for_editor = wait_for_editor
+
+    def create_entity(
+        self,
+        master: Any,
+        request: GenericEditorCreationRequest,
+    ) -> GenericEditorCreationResult | None:
+        """Open the Generic Editor and return the saved entity, if any."""
+
+        entity_slug = entity_slug_for_expected_type(request.expected_type)
+        template = self._load_template(entity_slug)
+        wrapper = self._create_wrapper(entity_slug)
+        item = build_prefilled_entity(template, request)
+        editor = self._create_editor(master, item, template, wrapper)
+
+        if self._wait_for_editor:
+            _wait_window(master, editor)
+
+        if not getattr(editor, "saved", False):
+            return None
+
+        saved_entity = getattr(editor, "item", item)
+        if not isinstance(saved_entity, dict):
+            saved_entity = item
+        wrapper.save_item(saved_entity)
+        return GenericEditorCreationResult(entity=saved_entity, entity_slug=entity_slug)
+
+    def _load_template(self, entity_slug: str) -> Mapping[str, Any]:
+        if self._template_loader is not None:
+            return self._template_loader(entity_slug)
+
+        from modules.helpers.template_loader import load_template
+
+        return load_template(entity_slug)
+
+    def _create_wrapper(self, entity_slug: str) -> PersistableWrapper:
+        if self._wrapper_factory is not None:
+            return self._wrapper_factory(entity_slug)
+
+        from modules.generic.generic_model_wrapper import GenericModelWrapper
+
+        return GenericModelWrapper(entity_slug)
+
+    def _create_editor(
+        self,
+        master: Any,
+        item: dict[str, Any],
+        template: Mapping[str, Any],
+        wrapper: PersistableWrapper,
+    ) -> Any:
+        if self._editor_factory is not None:
+            return self._editor_factory(master, item, template, wrapper, creation_mode=True)
+
+        from modules.generic.generic_editor_window import GenericEditorWindow
+
+        return GenericEditorWindow(master, item, template, wrapper, creation_mode=True)
+
+
+_ENTITY_SLUG_OVERRIDES = {
+    "npc": "npcs",
+    "pc": "pcs",
+    "scenario": "scenarios",
+    "location": "places",
+    "place": "places",
+    "object": "objects",
+    "information": "informations",
+    "info": "informations",
+    "clue": "clues",
+    "faction": "factions",
+    "creature": "creatures",
+    "villain": "villains",
+    "map": "maps",
+    "book": "books",
+    "event": "events",
+    "campaign": "campaigns",
+}
+_NAME_FIELD_CANDIDATES = ("Name", "Title", "name", "title", "Label", "label")
+_PARENT_FIELD_CANDIDATES = (
+    "Parent",
+    "ParentId",
+    "Parent ID",
+    "ParentIdentifier",
+    "parent",
+    "parent_id",
+    "parent_identifier",
+)
+_TYPE_FIELD_CANDIDATES = ("type", "entity_type", "Type", "EntityType")
+
+
+def creation_request_from_issue(
+    issue: ValidationIssue,
+    reference: ReferenceRecord | None = None,
+) -> GenericEditorCreationRequest:
+    """Build a Generic Editor creation request from a missing-reference issue."""
+
+    payload = issue.payload
+    parent_identifier = ""
+    parent_type = ""
+    source_identifier = payload.source_entity
+    source_type = payload.source_type
+
+    if reference is not None:
+        parent_identifier = reference.source.identifier
+        parent_type = reference.source.entity_type
+        source_identifier = reference.source.identifier or source_identifier
+        source_type = reference.source.entity_type or source_type
+
+    if not parent_identifier:
+        parent_identifier = source_identifier
+    if not parent_type:
+        parent_type = source_type
+
+    return GenericEditorCreationRequest(
+        expected_type=payload.expected_type,
+        referenced_name=payload.referenced_name,
+        parent_identifier=parent_identifier,
+        parent_type=parent_type,
+        source_identifier=source_identifier,
+        source_type=source_type,
+    )
+
+
+def entity_slug_for_expected_type(expected_type: str) -> str:
+    """Return the Generic Editor entity slug for a validator expected type."""
+
+    normalized = str(expected_type or "").strip().lower().replace(" ", "_")
+    if not normalized:
+        raise ValueError("expected_type is required")
+    if normalized in _ENTITY_SLUG_OVERRIDES:
+        return _ENTITY_SLUG_OVERRIDES[normalized]
+    if normalized.endswith("s"):
+        return normalized
+    if normalized.endswith("y"):
+        return f"{normalized[:-1]}ies"
+    return f"{normalized}s"
+
+
+def build_prefilled_entity(
+    template: Mapping[str, Any],
+    request: GenericEditorCreationRequest,
+) -> dict[str, Any]:
+    """Create the item passed to Generic Editor with name and parent pre-filled."""
+
+    field_names = _template_field_names(template)
+    entity: dict[str, Any] = dict(request.extra_values)
+    name_field = _first_existing(field_names, _NAME_FIELD_CANDIDATES) or "Name"
+    entity.setdefault(name_field, request.referenced_name)
+
+    type_field = _first_existing(field_names, _TYPE_FIELD_CANDIDATES)
+    if type_field:
+        entity.setdefault(type_field, request.expected_type)
+
+    parent_field = _first_existing(field_names, _PARENT_FIELD_CANDIDATES)
+    if parent_field and request.parent_identifier:
+        entity.setdefault(parent_field, request.parent_identifier)
+
+    if request.parent_identifier:
+        entity.setdefault("__validation_parent", request.parent_identifier)
+    if request.parent_type:
+        entity.setdefault("__validation_parent_type", request.parent_type)
+    if request.source_identifier:
+        entity.setdefault("__validation_source", request.source_identifier)
+    if request.source_type:
+        entity.setdefault("__validation_source_type", request.source_type)
+    entity.setdefault("__validation_expected_type", request.expected_type)
+    return entity
+
+
+def _template_field_names(template: Mapping[str, Any]) -> tuple[str, ...]:
+    fields = template.get("fields", ())
+    names: list[str] = []
+    if not isinstance(fields, (list, tuple)):
+        return ()
+    for field in fields:
+        if isinstance(field, Mapping):
+            name = str(field.get("name", "")).strip()
+            if name:
+                names.append(name)
+    return tuple(names)
+
+
+def _first_existing(field_names: tuple[str, ...], candidates: tuple[str, ...]) -> str:
+    existing = set(field_names)
+    return next((candidate for candidate in candidates if candidate in existing), "")
+
+
+def _wait_window(master: Any, editor: Any) -> None:
+    wait_owner = master if hasattr(master, "wait_window") else editor
+    wait = getattr(wait_owner, "wait_window", None)
+    if callable(wait):
+        wait(editor)

--- a/src/ui/validation/dialogs/missing_reference_dialog.py
+++ b/src/ui/validation/dialogs/missing_reference_dialog.py
@@ -1,0 +1,221 @@
+"""Dialog for resolving one missing-reference validation issue."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+from src.ui.validation.validation_wizard_controller import (
+    ValidationWizardAction,
+    ValidationWizardActionRequest,
+    ValidationWizardController,
+    ValidationWizardStep,
+)
+from src.validation import IssueType, ValidationIssue
+from src.validation.reference_validator import EntityRecord, ReferenceRecord
+
+from .generic_editor_launcher import (
+    GenericEditorLauncher,
+    creation_request_from_issue,
+)
+
+RemapTarget = EntityRecord | dict[str, Any] | str
+RemapTargetProvider = Callable[[ValidationIssue], RemapTarget | None]
+StepCallback = Callable[[ValidationWizardStep], None]
+ErrorCallback = Callable[[str], None]
+
+
+class DialogWindow(Protocol):
+    """Tiny window contract used to keep callbacks testable."""
+
+    def destroy(self) -> None:
+        """Close the dialog."""
+
+
+@dataclass(frozen=True)
+class MissingReferenceDialogConfig:
+    """Dependencies and callbacks for :class:`MissingReferenceDialog`."""
+
+    generic_editor_launcher: GenericEditorLauncher | None = None
+    remap_target_provider: RemapTargetProvider | None = None
+    on_step: StepCallback | None = None
+    on_error: ErrorCallback | None = None
+
+
+class MissingReferenceDialog:
+    """Resolve a missing reference with create, remap, remove, or ignore actions.
+
+    The dialog delegates mutations to ``ValidationWizardController``.  The
+    ``Créer`` action opens the Generic Editor for the issue expected type with
+    the referenced value pre-filled as the entity name.  When the editor saves,
+    the created entity is returned to the controller so it can auto-link the
+    original reference.
+    """
+
+    def __init__(
+        self,
+        master: Any,
+        controller: ValidationWizardController,
+        issue: ValidationIssue,
+        *,
+        reference: ReferenceRecord | None = None,
+        config: MissingReferenceDialogConfig | None = None,
+    ) -> None:
+        if issue.issue_type != IssueType.MISSING_REFERENCE:
+            raise ValueError("MissingReferenceDialog only handles missing references")
+
+        self.master = master
+        self.controller = controller
+        self.issue = issue
+        self.reference = reference
+        self.config = config or MissingReferenceDialogConfig()
+        self.generic_editor_launcher = (
+            self.config.generic_editor_launcher or GenericEditorLauncher()
+        )
+        self.window: DialogWindow | None = None
+        self.last_step: ValidationWizardStep | None = None
+        self.last_created_entity: dict[str, Any] | None = None
+
+    def show(self) -> "MissingReferenceDialog":
+        """Create and display the CustomTkinter dialog window."""
+
+        import customtkinter as ctk
+
+        window = ctk.CTkToplevel(self.master)
+        self.window = window
+        window.title("Référence manquante")
+        window.transient(self.master)
+        window.grab_set()
+        window.geometry("560x320")
+        window.grid_columnconfigure(0, weight=1)
+
+        payload = self.issue.payload
+        ctk.CTkLabel(
+            window,
+            text="Référence manquante",
+            font=ctk.CTkFont(size=18, weight="bold"),
+        ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
+        ctk.CTkLabel(
+            window,
+            text=(
+                f"« {payload.referenced_name} » est attendu comme "
+                f"{payload.expected_type} depuis {payload.source_entity}."
+            ),
+            wraplength=500,
+            justify="left",
+        ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 16))
+
+        actions = ctk.CTkFrame(window)
+        actions.grid(row=2, column=0, sticky="ew", padx=20, pady=8)
+        for index in range(4):
+            actions.grid_columnconfigure(index, weight=1)
+
+        ctk.CTkButton(actions, text="Créer", command=self.create_via_generic_editor).grid(
+            row=0, column=0, sticky="ew", padx=4, pady=4
+        )
+        ctk.CTkButton(actions, text="Remapper", command=self.remap).grid(
+            row=0, column=1, sticky="ew", padx=4, pady=4
+        )
+        ctk.CTkButton(actions, text="Supprimer", command=self.remove_reference).grid(
+            row=0, column=2, sticky="ew", padx=4, pady=4
+        )
+        ctk.CTkButton(actions, text="Ignorer", command=self.ignore).grid(
+            row=0, column=3, sticky="ew", padx=4, pady=4
+        )
+        return self
+
+    def create_via_generic_editor(self) -> ValidationWizardStep | None:
+        """Open Generic Editor and auto-link the saved entity through controller."""
+
+        paused_step = self._submit(ValidationWizardAction.CREATE_ENTITY, close=False)
+        request = creation_request_from_issue(self.issue, self.reference)
+        result = self.generic_editor_launcher.create_entity(self.master, request)
+        if result is None:
+            return paused_step
+
+        self.last_created_entity = result.entity
+        linked_step = self.controller.resume_after_entity_creation(result.entity)
+        return self._publish_step(linked_step, close=True)
+
+    def remap(self) -> ValidationWizardStep | None:
+        """Ask the host for a target and remap the missing reference to it."""
+
+        if self.config.remap_target_provider is None:
+            self._publish_error("Aucun sélecteur de cible n’est configuré pour le remapping.")
+            return None
+
+        target = self.config.remap_target_provider(self.issue)
+        if target is None:
+            return None
+        return self._submit(
+            ValidationWizardActionRequest(ValidationWizardAction.REMAP, target=target)
+        )
+
+    def remove_reference(self) -> ValidationWizardStep:
+        """Remove the missing reference from its source."""
+
+        return self._submit(ValidationWizardAction.REMOVE)
+
+    def ignore(self) -> ValidationWizardStep:
+        """Ignore the missing reference for the current validation session."""
+
+        return self._submit(ValidationWizardAction.SKIP_SESSION)
+
+    def _submit(
+        self,
+        request: ValidationWizardActionRequest | ValidationWizardAction,
+        *,
+        close: bool = True,
+    ) -> ValidationWizardStep:
+        step = self.controller.submit_action(request)
+        return self._publish_step(step, close=close)
+
+    def _publish_step(
+        self,
+        step: ValidationWizardStep,
+        *,
+        close: bool,
+    ) -> ValidationWizardStep:
+        self.last_step = step
+        if self.config.on_step is not None:
+            self.config.on_step(step)
+        if close:
+            self.close()
+        return step
+
+    def _publish_error(self, message: str) -> None:
+        if self.config.on_error is not None:
+            self.config.on_error(message)
+            return
+
+        from tkinter import messagebox
+
+        messagebox.showwarning("Remapping indisponible", message)
+
+    def close(self) -> None:
+        """Close the dialog window if it has been displayed."""
+
+        if self.window is not None:
+            self.window.destroy()
+            self.window = None
+
+
+def open_missing_reference_dialog(
+    master: Any,
+    controller: ValidationWizardController,
+    step: ValidationWizardStep,
+    *,
+    reference: ReferenceRecord | None = None,
+    config: MissingReferenceDialogConfig | None = None,
+) -> MissingReferenceDialog:
+    """Open a dialog for a wizard step carrying a missing-reference issue."""
+
+    if step.issue is None:
+        raise ValueError("Cannot open a missing-reference dialog without an issue")
+    return MissingReferenceDialog(
+        master,
+        controller,
+        step.issue,
+        reference=reference,
+        config=config,
+    ).show()

--- a/tests/ui/validation/test_missing_reference_dialog.py
+++ b/tests/ui/validation/test_missing_reference_dialog.py
@@ -1,0 +1,184 @@
+"""Regression tests for missing-reference validation dialog helpers."""
+
+from src.ui.validation import (
+    ValidationWizardController,
+    ValidationWizardIssue,
+    ValidationWizardStatus,
+    resolve_reference_for_issue,
+)
+from src.ui.validation.dialogs import (
+    GenericEditorLauncher,
+    MissingReferenceDialog,
+    MissingReferenceDialogConfig,
+    build_prefilled_entity,
+    creation_request_from_issue,
+    entity_slug_for_expected_type,
+)
+from src.validation import validate_reference_graph
+
+
+def _wizard_for(hierarchy):
+    graph = validate_reference_graph(hierarchy)
+    reference = resolve_reference_for_issue(graph.issues[0], graph.references)
+    controller = ValidationWizardController(
+        [ValidationWizardIssue(issue=graph.issues[0], reference=reference)]
+    )
+    controller.start()
+    return graph, reference, controller
+
+
+class _SavedEditor:
+    def __init__(self, item):
+        self.item = item
+        self.saved = True
+
+
+class _Wrapper:
+    def __init__(self, slug):
+        self.entity_type = slug
+        self.saved_items = []
+
+    def save_item(self, item, **kwargs):
+        self.saved_items.append(dict(item))
+
+
+def test_entity_slug_for_expected_type_maps_validator_types_to_generic_slugs():
+    assert entity_slug_for_expected_type("scenario") == "scenarios"
+    assert entity_slug_for_expected_type("npc") == "npcs"
+    assert entity_slug_for_expected_type("location") == "places"
+    assert entity_slug_for_expected_type("arc") == "arcs"
+
+
+def test_build_prefilled_entity_sets_referenced_name_parent_and_metadata():
+    request = creation_request_from_issue(
+        validate_reference_graph(
+            {"type": "arc", "id": "A1", "scenario_refs": ["Missing Scenario"]}
+        ).issues[0]
+    )
+    template = {
+        "fields": [
+            {"name": "Title", "type": "text"},
+            {"name": "Parent", "type": "text"},
+            {"name": "type", "type": "text"},
+        ]
+    }
+
+    entity = build_prefilled_entity(template, request)
+
+    assert entity["Title"] == "Missing Scenario"
+    assert entity["Parent"] == "A1"
+    assert entity["type"] == "scenario"
+    assert entity["__validation_parent"] == "A1"
+    assert entity["__validation_expected_type"] == "scenario"
+
+
+def test_generic_editor_launcher_returns_saved_entity_and_persists_it():
+    wrappers = {}
+
+    def wrapper_factory(slug):
+        wrapper = _Wrapper(slug)
+        wrappers[slug] = wrapper
+        return wrapper
+
+    def editor_factory(master, item, template, wrapper, creation_mode=False):
+        assert creation_mode is True
+        item["Name"] = f"{item['Name']} Saved"
+        return _SavedEditor(item)
+
+    launcher = GenericEditorLauncher(
+        editor_factory=editor_factory,
+        template_loader=lambda slug: {"fields": [{"name": "Name", "type": "text"}]},
+        wrapper_factory=wrapper_factory,
+        wait_for_editor=False,
+    )
+    graph = validate_reference_graph(
+        {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    )
+    request = creation_request_from_issue(graph.issues[0])
+
+    result = launcher.create_entity(None, request)
+
+    assert result is not None
+    assert result.entity_slug == "arcs"
+    assert result.entity["Name"] == "Missing Arc Saved"
+    assert wrappers["arcs"].saved_items == [result.entity]
+
+
+def test_dialog_create_opens_generic_editor_and_returns_entity_to_controller():
+    hierarchy = {"type": "arc", "id": "A1", "scenario_refs": ["Missing Scenario"]}
+    graph, reference, controller = _wizard_for(hierarchy)
+    observed_steps = []
+
+    def editor_factory(master, item, template, wrapper, creation_mode=False):
+        item["id"] = "S1"
+        item["type"] = "scenario"
+        return _SavedEditor(item)
+
+    launcher = GenericEditorLauncher(
+        editor_factory=editor_factory,
+        template_loader=lambda slug: {
+            "fields": [
+                {"name": "Name", "type": "text"},
+                {"name": "Parent", "type": "text"},
+            ]
+        },
+        wrapper_factory=_Wrapper,
+        wait_for_editor=False,
+    )
+    dialog = MissingReferenceDialog(
+        None,
+        controller,
+        graph.issues[0],
+        reference=reference,
+        config=MissingReferenceDialogConfig(
+            generic_editor_launcher=launcher,
+            on_step=observed_steps.append,
+        ),
+    )
+
+    step = dialog.create_via_generic_editor()
+
+    assert step.status == ValidationWizardStatus.COMPLETED
+    assert hierarchy["scenario_refs"] == ["S1"]
+    assert hierarchy["scenarios"] == [dialog.last_created_entity]
+    assert dialog.last_created_entity["Name"] == "Missing Scenario"
+    assert dialog.last_created_entity["Parent"] == "A1"
+    assert [observed.status for observed in observed_steps] == [
+        ValidationWizardStatus.AWAITING_ENTITY_CREATION,
+        ValidationWizardStatus.COMPLETED,
+    ]
+
+
+def test_dialog_actions_delegate_remap_remove_and_ignore_to_controller():
+    remap_hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["Missing Arc"],
+        "arcs": [{"type": "arc", "id": "A1", "name": "Arc One"}],
+    }
+    graph, reference, controller = _wizard_for(remap_hierarchy)
+    dialog = MissingReferenceDialog(
+        None,
+        controller,
+        graph.issues[0],
+        reference=reference,
+        config=MissingReferenceDialogConfig(remap_target_provider=lambda issue: "A1"),
+    )
+
+    assert dialog.remap().status == ValidationWizardStatus.COMPLETED
+    assert remap_hierarchy["arc_refs"] == ["A1"]
+
+    remove_hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    graph, reference, controller = _wizard_for(remove_hierarchy)
+    dialog = MissingReferenceDialog(None, controller, graph.issues[0], reference=reference)
+
+    assert dialog.remove_reference().status == ValidationWizardStatus.COMPLETED
+    assert remove_hierarchy["arc_refs"] == []
+
+    ignore_hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    graph, reference, controller = _wizard_for(ignore_hierarchy)
+    dialog = MissingReferenceDialog(None, controller, graph.issues[0], reference=reference)
+
+    assert dialog.ignore().status == ValidationWizardStatus.COMPLETED
+    assert controller.summary.skipped_session == 1
+    assert ignore_hierarchy["arc_refs"] == ["Missing Arc"]


### PR DESCRIPTION
### Motivation
- Provide a focused dialog to resolve `MISSING_REFERENCE` issues with the four GM actions requested: create via Generic Editor, remap, remove, and ignore.
- Keep mutation logic centralized in the existing `ValidationWizardController`/`ReferenceFixService` while enabling an editor-driven create + auto-link workflow.

### Description
- Add a new validation dialogs package `src/ui/validation/dialogs` and export the helpers and dialog via `__init__.py`.
- Implement `GenericEditorLauncher` in `generic_editor_launcher.py` with dependency-injectable `editor_factory`/`wrapper_factory` and helpers `creation_request_from_issue`, `build_prefilled_entity`, and `entity_slug_for_expected_type` to prefill name/parent and persist the created entity.
- Implement `MissingReferenceDialog` in `missing_reference_dialog.py` which renders the four actions, pauses the wizard on `CREATE_ENTITY`, launches the Generic Editor, and returns the saved entity to `ValidationWizardController.resume_after_entity_creation()` for auto-linking, while delegating remap/remove/ignore back to the controller.
- Add regression tests `tests/ui/validation/test_missing_reference_dialog.py` covering slug mapping, prefill behavior, `GenericEditorLauncher` persistence, the create+auto-link flow, and remap/remove/ignore delegation.

### Testing
- Ran the dialog unit tests: `pytest -q tests/ui/validation/test_missing_reference_dialog.py` which passed (5 passed).
- Ran the wider validation/service tests: `pytest -q tests/ui/validation tests/services/test_reference_fix_service.py tests/validation/test_reference_validator.py tests/validation/test_similarity_matcher.py` which passed (24 passed total for that run).
- Compiled modules with `python -m compileall src/ui/validation src/services src/validation` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb573b0bb4832bbd389d6ba12905e3)