### PR TITLE
Add campaign hierarchy validation entrypoint and summary dialog

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -3769,6 +3769,15 @@ class MainWindow(ctk.CTk):
             )
             messagebox.showerror("Error", f"Failed to open Scenario Builder:\n{exc}")
 
+    def open_hierarchy_validation(self):
+        """Open the campaign hierarchy consistency validation workflow."""
+        from src.ui.validation.campaign_validation_launcher import (
+            CampaignHierarchyValidationLauncher,
+        )
+
+        launcher = CampaignHierarchyValidationLauncher(self)
+        return launcher.launch()
+
     def open_campaign_builder(self, guided_tour_active: bool = False):
         """Open campaign builder."""
         try:

--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -133,6 +133,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                         _command("Scenario Graph", app.open_scenario_graph_editor, icon_key="scenario_graph"),
                         _command("Scene Flow Viewer", app.open_scene_flow_viewer, icon_key="scene_flow_viewer"),
                         _command("Create Random Table", app.open_random_table_editor, icon_key="create_random_table"),
+                        _command("Vérifier cohérence hiérarchie", app.open_hierarchy_validation, icon_key="campaign_graph"),
                     ],
                 ),
             ],

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -1,0 +1,217 @@
+"""UI entry point for campaign hierarchy validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from modules.helpers.logging_helper import log_exception, log_info
+from src.ui.validation.dialogs.ambiguous_reference_dialog import (
+    AmbiguousReferenceDialogConfig,
+    open_ambiguous_reference_dialog,
+)
+from src.ui.validation.dialogs.missing_reference_dialog import (
+    MissingReferenceDialogConfig,
+    open_missing_reference_dialog,
+)
+from src.ui.validation.dialogs.validation_summary_dialog import open_validation_summary_dialog
+from src.ui.validation.validation_wizard_controller import (
+    ValidationWizardAction,
+    ValidationWizardController,
+    ValidationWizardIssue,
+    ValidationWizardStatus,
+    ValidationWizardStep,
+    resolve_reference_for_issue,
+)
+from src.validation import IssueType, ReferenceValidationResult, validate_reference_graph
+
+
+@dataclass(frozen=True)
+class CampaignValidationRun:
+    """Objects created for one campaign validation launch."""
+
+    graph: ReferenceValidationResult
+    controller: ValidationWizardController
+    first_step: ValidationWizardStep
+
+
+class CampaignHierarchyValidationLauncher:
+    """Instantiate the hierarchy validator and drive the validation wizard UI."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        self._active_run: CampaignValidationRun | None = None
+
+    @property
+    def active_run(self) -> CampaignValidationRun | None:
+        """Return the most recent validation run, if any."""
+
+        return self._active_run
+
+    def launch(self) -> CampaignValidationRun | None:
+        """Validate the current campaign hierarchy and start the wizard controller."""
+
+        try:
+            hierarchy = build_campaign_validation_hierarchy(
+                getattr(self.app, "entity_wrappers", {}) or {}
+            )
+            graph = validate_reference_graph(hierarchy)
+            controller = ValidationWizardController(
+                _wizard_items(graph),
+                reference_resolver=lambda issue: resolve_reference_for_issue(issue, graph.references),
+            )
+            first_step = controller.start()
+            run = CampaignValidationRun(graph=graph, controller=controller, first_step=first_step)
+            self._active_run = run
+            self._handle_step(run, first_step)
+            return run
+        except Exception as exc:
+            log_exception(
+                f"Failed to run hierarchy validation: {exc}",
+                func_name="src.ui.validation.campaign_validation_launcher.CampaignHierarchyValidationLauncher.launch",
+            )
+            from tkinter import messagebox
+
+            messagebox.showerror(
+                "Validation indisponible",
+                f"Impossible de vérifier la cohérence hiérarchique :\n{exc}",
+            )
+            return None
+
+    def _handle_step(self, run: CampaignValidationRun, step: ValidationWizardStep) -> None:
+        if step.status in {ValidationWizardStatus.COMPLETED, ValidationWizardStatus.CANCELED}:
+            if step.summary is not None:
+                open_validation_summary_dialog(self.app, step.summary)
+            return
+
+        if step.status == ValidationWizardStatus.ACTION_FAILED:
+            from tkinter import messagebox
+
+            messagebox.showwarning("Validation", step.message)
+            return
+
+        if step.issue is None:
+            return
+
+        if step.issue.issue_type == IssueType.MISSING_REFERENCE:
+            open_missing_reference_dialog(
+                self.app,
+                run.controller,
+                step,
+                reference=resolve_reference_for_issue(step.issue, run.graph.references),
+                config=MissingReferenceDialogConfig(
+                    on_step=lambda next_step: self._handle_step(run, next_step)
+                ),
+            )
+            return
+
+        if step.issue.issue_type == IssueType.AMBIGUOUS_REFERENCE:
+            open_ambiguous_reference_dialog(
+                self.app,
+                run.controller,
+                step.issue,
+                config=AmbiguousReferenceDialogConfig(
+                    on_step=lambda next_step: self._handle_step(run, next_step)
+                ),
+            )
+            return
+
+        from tkinter import messagebox
+
+        if messagebox.askyesno(
+            "Cohérence hiérarchique",
+            f"{step.message}\n\nIgnorer cette anomalie pour cette session ?",
+        ):
+            next_step = run.controller.submit_action(ValidationWizardAction.SKIP_SESSION)
+            self._handle_step(run, next_step)
+
+
+def build_campaign_validation_hierarchy(entity_wrappers: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a validator-friendly hierarchy from the app's model wrappers."""
+
+    root: dict[str, Any] = {
+        "type": "campaign",
+        "id": "current-campaign",
+        "name": "Current Campaign",
+        "entities": [],
+    }
+    entities = root["entities"]
+
+    for slug in sorted(entity_wrappers):
+        wrapper = entity_wrappers[slug]
+        for index, item in enumerate(_safe_load_items(wrapper)):
+            if not isinstance(item, Mapping):
+                continue
+            entities.append(_normalize_entity_node(slug, item, index))
+
+    log_info(
+        f"Built validation hierarchy with {len(entities)} entities",
+        func_name="src.ui.validation.campaign_validation_launcher.build_campaign_validation_hierarchy",
+    )
+    return root
+
+
+def _wizard_items(graph: ReferenceValidationResult) -> tuple[ValidationWizardIssue, ...]:
+    return tuple(
+        ValidationWizardIssue(
+            issue=issue,
+            reference=resolve_reference_for_issue(issue, graph.references),
+        )
+        for issue in graph.issues
+    )
+
+
+def _safe_load_items(wrapper: Any) -> Sequence[Any]:
+    try:
+        items = wrapper.load_items()
+    except Exception as exc:
+        log_exception(
+            f"Unable to load items for validation from {getattr(wrapper, 'entity_type', '?')}: {exc}",
+            func_name="src.ui.validation.campaign_validation_launcher._safe_load_items",
+        )
+        return ()
+    return items if isinstance(items, Sequence) and not isinstance(items, (str, bytes, bytearray)) else ()
+
+
+def _normalize_entity_node(slug: str, item: Mapping[str, Any], index: int) -> dict[str, Any]:
+    node = dict(item)
+    entity_type = _singular_entity_type(slug)
+    identifier = _identifier_for(node, slug, index)
+    node.setdefault("type", entity_type)
+    node.setdefault("entity_type", entity_type)
+    node.setdefault("id", identifier)
+    node.setdefault("name", _display_name_for(node, identifier))
+    return node
+
+
+def _singular_entity_type(slug: str) -> str:
+    overrides = {
+        "campaigns": "campaign",
+        "scenarios": "scenario",
+        "places": "location",
+        "npcs": "npc",
+        "pcs": "pc",
+    }
+    if slug in overrides:
+        return overrides[slug]
+    if slug.endswith("ies"):
+        return f"{slug[:-3]}y"
+    if slug.endswith("s"):
+        return slug[:-1]
+    return slug
+
+
+def _identifier_for(item: Mapping[str, Any], slug: str, index: int) -> str:
+    for key in ("id", "uuid", "slug", "key", "Name", "name", "Title", "title"):
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return f"{slug}-{index}"
+
+
+def _display_name_for(item: Mapping[str, Any], fallback: str) -> str:
+    for key in ("Name", "name", "Title", "title", "Label", "label"):
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return fallback

--- a/src/ui/validation/dialogs/__init__.py
+++ b/src/ui/validation/dialogs/__init__.py
@@ -19,6 +19,11 @@ from .missing_reference_dialog import (
     MissingReferenceDialogConfig,
     open_missing_reference_dialog,
 )
+from .validation_summary_dialog import (
+    ValidationSummaryCounts,
+    ValidationSummaryDialog,
+    open_validation_summary_dialog,
+)
 
 __all__ = [
     "GenericEditorCreationRequest",
@@ -29,9 +34,12 @@ __all__ = [
     "AmbiguousReferenceDialogConfig",
     "MissingReferenceDialog",
     "MissingReferenceDialogConfig",
+    "ValidationSummaryCounts",
+    "ValidationSummaryDialog",
     "build_prefilled_entity",
     "creation_request_from_issue",
     "entity_slug_for_expected_type",
     "open_ambiguous_reference_dialog",
     "open_missing_reference_dialog",
+    "open_validation_summary_dialog",
 ]

--- a/src/ui/validation/dialogs/validation_summary_dialog.py
+++ b/src/ui/validation/dialogs/validation_summary_dialog.py
@@ -1,0 +1,121 @@
+"""Summary dialog for campaign hierarchy validation runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.ui.validation.validation_wizard_controller import ValidationWizardSummary
+
+
+@dataclass(frozen=True)
+class ValidationSummaryCounts:
+    """Counters displayed at the end of a validation wizard run."""
+
+    corrected: int = 0
+    ignored: int = 0
+    remaining: int = 0
+
+    @classmethod
+    def from_summary(cls, summary: ValidationWizardSummary) -> "ValidationSummaryCounts":
+        """Build visible counters from the wizard summary."""
+
+        handled = summary.resolved + summary.skipped_session
+        return cls(
+            corrected=summary.resolved,
+            ignored=summary.skipped_session,
+            remaining=max(summary.total_issues - handled, 0),
+        )
+
+
+class ValidationSummaryDialog:
+    """CustomTkinter dialog showing corrected, ignored and remaining issues."""
+
+    def __init__(
+        self,
+        master: Any,
+        counts: ValidationSummaryCounts,
+        *,
+        title: str = "Résumé de validation",
+        message: str = "Vérification de cohérence hiérarchique terminée.",
+    ) -> None:
+        self.master = master
+        self.counts = counts
+        self.title = title
+        self.message = message
+        self.window: Any | None = None
+
+    def show(self) -> "ValidationSummaryDialog":
+        """Create and display the validation summary window."""
+
+        import customtkinter as ctk
+
+        window = ctk.CTkToplevel(self.master)
+        self.window = window
+        window.title(self.title)
+        window.transient(self.master)
+        window.grab_set()
+        window.geometry("420x260")
+        window.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            window,
+            text=self.title,
+            font=ctk.CTkFont(size=18, weight="bold"),
+        ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
+        ctk.CTkLabel(
+            window,
+            text=self.message,
+            wraplength=360,
+            justify="left",
+        ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 16))
+
+        counters = ctk.CTkFrame(window)
+        counters.grid(row=2, column=0, sticky="ew", padx=20, pady=4)
+        for column in range(3):
+            counters.grid_columnconfigure(column, weight=1)
+
+        self._render_counter(ctk, counters, 0, "Corrigés", self.counts.corrected)
+        self._render_counter(ctk, counters, 1, "Ignorés", self.counts.ignored)
+        self._render_counter(ctk, counters, 2, "Restants", self.counts.remaining)
+
+        ctk.CTkButton(window, text="Fermer", command=self.close).grid(
+            row=3, column=0, sticky="e", padx=20, pady=(18, 20)
+        )
+        return self
+
+    def close(self) -> None:
+        """Close the summary dialog if it is open."""
+
+        if self.window is not None:
+            self.window.destroy()
+            self.window = None
+
+    @staticmethod
+    def _render_counter(ctk: Any, parent: Any, column: int, label: str, value: int) -> None:
+        cell = ctk.CTkFrame(parent)
+        cell.grid(row=0, column=column, sticky="nsew", padx=4, pady=4)
+        cell.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(
+            cell,
+            text=str(value),
+            font=ctk.CTkFont(size=24, weight="bold"),
+        ).grid(row=0, column=0, pady=(12, 2))
+        ctk.CTkLabel(cell, text=label).grid(row=1, column=0, pady=(0, 12))
+
+
+def open_validation_summary_dialog(
+    master: Any,
+    summary: ValidationWizardSummary,
+    *,
+    title: str = "Résumé de validation",
+    message: str = "Vérification de cohérence hiérarchique terminée.",
+) -> ValidationSummaryDialog:
+    """Open a validation summary dialog from a wizard summary."""
+
+    return ValidationSummaryDialog(
+        master,
+        ValidationSummaryCounts.from_summary(summary),
+        title=title,
+        message=message,
+    ).show()

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -1,0 +1,59 @@
+"""Tests for the campaign validation UI launcher helpers."""
+
+from src.ui.validation import ValidationWizardStatus
+from src.ui.validation.campaign_validation_launcher import (
+    CampaignHierarchyValidationLauncher,
+    build_campaign_validation_hierarchy,
+)
+
+
+class FakeWrapper:
+    def __init__(self, items):
+        self._items = items
+
+    def load_items(self):
+        return list(self._items)
+
+
+class FakeApp:
+    def __init__(self, wrappers):
+        self.entity_wrappers = wrappers
+
+
+def test_build_campaign_validation_hierarchy_normalizes_wrapper_items():
+    hierarchy = build_campaign_validation_hierarchy(
+        {
+            "scenarios": FakeWrapper([{"Title": "Opening Scene", "NPCs": ["Asha"]}]),
+            "npcs": FakeWrapper([{"Name": "Asha"}]),
+        }
+    )
+
+    entities = hierarchy["entities"]
+
+    assert hierarchy["type"] == "campaign"
+    assert entities[0]["type"] == "npc"
+    assert entities[0]["id"] == "Asha"
+    assert entities[1]["type"] == "scenario"
+    assert entities[1]["id"] == "Opening Scene"
+
+
+def test_launcher_instantiates_validator_and_wizard_controller(monkeypatch):
+    summaries = []
+
+    def capture_summary(_master, summary):
+        summaries.append(summary)
+
+    monkeypatch.setattr(
+        "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
+        capture_summary,
+    )
+
+    launcher = CampaignHierarchyValidationLauncher(FakeApp({}))
+
+    run = launcher.launch()
+
+    assert run is not None
+    assert run.graph.issues == ()
+    assert run.first_step.status == ValidationWizardStatus.COMPLETED
+    assert run.controller.summary.total_issues == 0
+    assert summaries == [run.controller.summary]

--- a/tests/ui/validation/test_validation_summary_dialog.py
+++ b/tests/ui/validation/test_validation_summary_dialog.py
@@ -1,0 +1,22 @@
+"""Tests for validation summary counter calculations."""
+
+from src.ui.validation.dialogs.validation_summary_dialog import ValidationSummaryCounts
+from src.ui.validation.validation_wizard_controller import ValidationWizardSummary
+
+
+def test_validation_summary_counts_expose_corrected_ignored_and_remaining():
+    summary = ValidationWizardSummary(total_issues=5, resolved=2, skipped_session=1)
+
+    counts = ValidationSummaryCounts.from_summary(summary)
+
+    assert counts.corrected == 2
+    assert counts.ignored == 1
+    assert counts.remaining == 2
+
+
+def test_validation_summary_remaining_never_goes_negative():
+    summary = ValidationWizardSummary(total_issues=1, resolved=2, skipped_session=1)
+
+    counts = ValidationSummaryCounts.from_summary(summary)
+
+    assert counts.remaining == 0


### PR DESCRIPTION
### Motivation

- Exposer un point d’entrée UI pour lancer la validation des références/hiérarchie de la campagne afin que le GM puisse vérifier et corriger les anomalies depuis le menu Campaign.
- Fournir un petit dialogue de récapitulatif montrant trois compteurs (Corrigés, Ignorés, Restants) quand le wizard se termine pour donner un retour consolidé.

### Description

- Ajout de `src/ui/validation/dialogs/validation_summary_dialog.py` implémentant `ValidationSummaryCounts` et `ValidationSummaryDialog` (corrigés / ignorés / restants calculés depuis `ValidationWizardSummary`).
- Ajout d’un lanceur UI modulaire `src/ui/validation/campaign_validation_launcher.py` qui construit une hiérarchie validator-friendly, exécute `validate_reference_graph`, instancie `ValidationWizardController` et route les étapes vers les dialogues existants (missing / ambiguous) en utilisant des callbacks `on_step` pour poursuivre le wizard.
- Branchement dans l’UI Campaign : nouvelle action de menu `Vérifier cohérence hiérarchie` dans `modules/ui/menu/menu_sections.py` et méthode `open_hierarchy_validation()` ajoutée à `MainWindow` (import lazy pour garder les imports modulaires et limiter l’impact au démarrage).
- Export du nouveau dialogue depuis `src/ui/validation/dialogs/__init__.py` et ajout de tests unitaires ciblés sous `tests/ui/validation/` pour le launcher et les compteurs.

### Testing

- Exécuté les tests ciblés pour la validation et les nouveaux tests : `python -m pytest tests/ui/validation tests/validation tests/services/test_reference_fix_service.py tests/services/test_session_ignore_store.py -q` — résultat : suite ciblée OK (`34 passed`).
- Exécuté les tests spécifiques aux nouveaux modules : `python -m pytest tests/ui/validation/test_campaign_validation_launcher.py tests/ui/validation/test_validation_summary_dialog.py -q` — résultat : `4 passed`.
- Vérification de compilation : `python -m compileall -q src/ui/validation main_window.py modules/ui/menu/menu_sections.py` — OK.
- Note d’environnement : la collecte de certains tests UI globaux a échoué initialement dans cet environnement à cause d’un stub/local `PIL` manquant (`ImageEnhance`), ce qui est externe aux modifications et n’affecte pas les tests unitaires ajoutés ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5bb1724c832bb197be28ab62dad5)