### PR TITLE
Add minimal validation workflow dataset

### DIFF
--- a/tests/ui/validation/fixtures/__init__.py
+++ b/tests/ui/validation/fixtures/__init__.py
@@ -1,0 +1,15 @@
+"""Fixtures for validation UI workflow tests."""
+
+from .minimal_validation_dataset import (
+    EXPECTED_DECISION_SUMMARY,
+    EXPECTED_ISSUE_SEQUENCE,
+    build_minimal_validation_hierarchy,
+    build_minimal_validation_wizard,
+)
+
+__all__ = [
+    "EXPECTED_DECISION_SUMMARY",
+    "EXPECTED_ISSUE_SEQUENCE",
+    "build_minimal_validation_hierarchy",
+    "build_minimal_validation_wizard",
+]

--- a/tests/ui/validation/fixtures/minimal_validation_dataset.py
+++ b/tests/ui/validation/fixtures/minimal_validation_dataset.py
@@ -1,0 +1,107 @@
+"""Minimal campaign hierarchy covering the validation wizard decision matrix."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.ui.validation import (
+    ValidationWizardController,
+    ValidationWizardIssue,
+    resolve_reference_for_issue,
+)
+from src.validation import IssueType, ReferenceValidationResult, validate_reference_graph
+
+EXPECTED_ISSUE_SEQUENCE = (
+    (IssueType.MISSING_REFERENCE, "Arc To Remove"),
+    (IssueType.AMBIGUOUS_REFERENCE, "Shared Place"),
+    (IssueType.INVALID_HIERARCHY, "Sibling Scenario"),
+    (IssueType.MISSING_REFERENCE, "Scenario To Create"),
+    (IssueType.MISSING_REFERENCE, "Scenario To Ignore"),
+)
+
+EXPECTED_DECISION_SUMMARY = {
+    "total_issues": 5,
+    "resolved": 4,
+    "skipped_session": 1,
+    "changes_applied": (
+        "C1.arc_refs: référence supprimée",
+        "A1.location_refs: Shared Place → L2",
+        "A1.scenario_refs: Sibling Scenario → S-valid",
+        "scenarios: entité ajoutée",
+        "A1.scenario_refs: Scenario To Create → S-created",
+    ),
+    "messages": (
+        "Référence « Arc To Remove » supprimée.",
+        "Référence remappée vers « L2 ».",
+        "Référence remappée vers « S-valid ».",
+        "Nouvelle entité « S-created » reliée.",
+        "Issue ignorée pour cette session : Scenario To Ignore",
+    ),
+}
+
+
+def build_minimal_validation_hierarchy() -> dict[str, Any]:
+    """Return a tiny mutable campaign graph with all wizard issue classes."""
+
+    return {
+        "type": "campaign",
+        "id": "C1",
+        "name": "Minimal Validation Campaign",
+        "arc_refs": ["Arc To Remove"],
+        "arcs": [
+            {
+                "type": "arc",
+                "id": "A1",
+                "name": "Main Arc",
+                "location_refs": ["Shared Place"],
+                "scenario_refs": [
+                    "Sibling Scenario",
+                    "Scenario To Create",
+                    "Scenario To Ignore",
+                ],
+                "locations": [
+                    {"type": "location", "id": "L1", "name": "Shared Place"},
+                    {"type": "location", "id": "L2", "name": "Shared Place"},
+                ],
+                "scenarios": [
+                    {"type": "scenario", "id": "S-valid", "name": "Valid Scenario"},
+                ],
+            },
+            {
+                "type": "arc",
+                "id": "A2",
+                "name": "Sibling Arc",
+                "scenarios": [
+                    {
+                        "type": "scenario",
+                        "id": "S-sibling",
+                        "name": "Sibling Scenario",
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def build_minimal_validation_wizard(
+    hierarchy: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], ReferenceValidationResult, ValidationWizardController]:
+    """Build the graph and controller bound to the minimal hierarchy."""
+
+    campaign_hierarchy = (
+        hierarchy if hierarchy is not None else build_minimal_validation_hierarchy()
+    )
+    graph = validate_reference_graph(campaign_hierarchy)
+    controller = ValidationWizardController(
+        tuple(
+            ValidationWizardIssue(
+                issue=issue,
+                reference=resolve_reference_for_issue(issue, graph.references),
+            )
+            for issue in graph.issues
+        ),
+        reference_resolver=lambda issue: resolve_reference_for_issue(
+            issue, graph.references
+        ),
+    )
+    return campaign_hierarchy, graph, controller

--- a/tests/ui/validation/test_minimal_validation_dataset.py
+++ b/tests/ui/validation/test_minimal_validation_dataset.py
@@ -1,0 +1,143 @@
+"""End-to-end coverage for the minimal validation decision dataset."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.ui.validation import (
+    ValidationWizardAction,
+    ValidationWizardStatus,
+    ValidationWizardStep,
+)
+from src.ui.validation.dialogs import (
+    AmbiguousReferenceDialog,
+    AmbiguousReferenceDialogConfig,
+    GenericEditorCreationResult,
+    MissingReferenceDialog,
+    MissingReferenceDialogConfig,
+)
+from src.validation import IssueType
+
+from tests.ui.validation.fixtures import (
+    EXPECTED_DECISION_SUMMARY,
+    EXPECTED_ISSUE_SEQUENCE,
+    build_minimal_validation_wizard,
+)
+
+
+@dataclass
+class FakeGenericEditorLauncher:
+    """Generic Editor test double returning one saved scenario entity."""
+
+    created_entity: dict[str, str]
+    requests: list[object]
+
+    def create_entity(self, master, request) -> GenericEditorCreationResult:
+        self.requests.append(request)
+        return GenericEditorCreationResult(
+            entity=self.created_entity, entity_slug="scenarios"
+        )
+
+
+def _assert_problem(
+    step: ValidationWizardStep, expected_type: IssueType, expected_name: str
+) -> None:
+    assert step.status == ValidationWizardStatus.SHOW_ISSUE
+    assert step.issue is not None
+    assert step.issue.issue_type == expected_type
+    assert step.issue.payload.referenced_name == expected_name
+
+
+def test_minimal_dataset_exposes_all_required_problems_in_order():
+    """The fixture is small but still covers all validation issue scenarios."""
+
+    _hierarchy, graph, _controller = build_minimal_validation_wizard()
+
+    assert tuple(
+        (issue.issue_type, issue.payload.referenced_name) for issue in graph.issues
+    ) == EXPECTED_ISSUE_SEQUENCE
+    assert len(graph.issues[1].payload.candidates) == 2
+    assert graph.issues[2].issue_type == IssueType.INVALID_HIERARCHY
+
+
+def test_minimal_dataset_actions_chain_to_next_problem_and_exact_summary():
+    """Simulate GM decisions and verify each transition plus final counters/logs."""
+
+    hierarchy, graph, controller = build_minimal_validation_wizard()
+    observed_steps = []
+
+    step = controller.start()
+    observed_steps.append(step)
+    _assert_problem(step, IssueType.MISSING_REFERENCE, "Arc To Remove")
+
+    step = controller.submit_action(ValidationWizardAction.REMOVE)
+    observed_steps.append(step)
+    _assert_problem(step, IssueType.AMBIGUOUS_REFERENCE, "Shared Place")
+
+    ambiguous_dialog = AmbiguousReferenceDialog(
+        None,
+        controller,
+        step.issue,
+        config=AmbiguousReferenceDialogConfig(
+            candidates=[
+                entity for entity in graph.entities if entity.entity_type == "location"
+            ],
+            on_step=observed_steps.append,
+        ),
+    )
+    step = ambiguous_dialog.choose_right()
+    _assert_problem(step, IssueType.INVALID_HIERARCHY, "Sibling Scenario")
+
+    step = controller.submit_action(ValidationWizardAction.REMAP, target="S-valid")
+    observed_steps.append(step)
+    _assert_problem(step, IssueType.MISSING_REFERENCE, "Scenario To Create")
+
+    generic_editor = FakeGenericEditorLauncher(
+        created_entity={
+            "type": "scenario",
+            "id": "S-created",
+            "name": "Scenario To Create",
+        },
+        requests=[],
+    )
+    missing_dialog = MissingReferenceDialog(
+        None,
+        controller,
+        step.issue,
+        reference=graph.references[3],
+        config=MissingReferenceDialogConfig(
+            generic_editor_launcher=generic_editor,
+            on_step=observed_steps.append,
+        ),
+    )
+    step = missing_dialog.create_via_generic_editor()
+    _assert_problem(step, IssueType.MISSING_REFERENCE, "Scenario To Ignore")
+
+    step = controller.submit_action(ValidationWizardAction.SKIP_SESSION)
+    observed_steps.append(step)
+
+    assert step.status == ValidationWizardStatus.COMPLETED
+    assert step.summary is not None
+    assert step.summary.total_issues == EXPECTED_DECISION_SUMMARY["total_issues"]
+    assert step.summary.resolved == EXPECTED_DECISION_SUMMARY["resolved"]
+    assert step.summary.skipped_session == EXPECTED_DECISION_SUMMARY["skipped_session"]
+    assert step.summary.changes_applied == EXPECTED_DECISION_SUMMARY["changes_applied"]
+    assert step.summary.messages == EXPECTED_DECISION_SUMMARY["messages"]
+    assert hierarchy["arc_refs"] == []
+    assert hierarchy["arcs"][0]["location_refs"] == ["L2"]
+    assert hierarchy["arcs"][0]["scenario_refs"] == [
+        "S-valid",
+        "S-created",
+        "Scenario To Ignore",
+    ]
+    assert hierarchy["arcs"][0]["scenarios"][-1] == generic_editor.created_entity
+    assert generic_editor.requests[0].referenced_name == "Scenario To Create"
+    assert [observed.status for observed in observed_steps] == [
+        ValidationWizardStatus.SHOW_ISSUE,
+        ValidationWizardStatus.SHOW_ISSUE,
+        ValidationWizardStatus.SHOW_ISSUE,
+        ValidationWizardStatus.SHOW_ISSUE,
+        ValidationWizardStatus.AWAITING_ENTITY_CREATION,
+        ValidationWizardStatus.SHOW_ISSUE,
+        ValidationWizardStatus.COMPLETED,
+    ]


### PR DESCRIPTION
### Motivation

- Provide a small, deterministic dataset that exercises the full validation wizard decision flow including a missing reference, a 2-candidate ambiguity, an invalid hierarchy, creation via the Generic Editor, and session-only ignore handling.
- Make it easy to reuse and simulate GM decisions in unit tests so UI/dialog code and the `ValidationWizardController` can be validated end-to-end.

### Description

- Added a reusable fixture package at `tests/ui/validation/fixtures` containing a minimal campaign hierarchy and helpers: `build_minimal_validation_hierarchy` and `build_minimal_validation_wizard` in `tests/ui/validation/fixtures/minimal_validation_dataset.py` and exported them via `tests/ui/validation/fixtures/__init__.py`.
- Added `tests/ui/validation/test_minimal_validation_dataset.py`, an end-to-end test that simulates GM choices across the wizard and asserts that each action advances to the next problem and that the final `ValidationWizardSummary` and the in-memory hierarchy mutations exactly match the expected decisions.
- Tests use lightweight test doubles (a `FakeGenericEditorLauncher`) and existing dialog classes such as `AmbiguousReferenceDialog` and `MissingReferenceDialog` to drive the controller flow without a real UI.
- Minor test adjustments to candidate selection and type hints to make the simulated flow deterministic (filtering `graph.entities` by `entity_type` where appropriate).

### Testing

- Ran `pytest -q tests/ui/validation/test_minimal_validation_dataset.py tests/ui/validation/test_validation_wizard_controller.py tests/ui/validation/test_missing_reference_dialog.py tests/ui/validation/test_ambiguous_reference_dialog.py` and observed all tests in that group pass (`17 passed`).
- Compiled test fixtures for sanity with `python -m compileall -q tests/ui/validation/fixtures tests/ui/validation/test_minimal_validation_dataset.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5e39dc04832b8a986bd965f9b6f3)