### PR TITLE
Require campaign selection before validation

### DIFF
--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from modules.helpers.logging_helper import log_exception, log_info
 from src.ui.validation.dialogs.ambiguous_reference_dialog import (
     AmbiguousReferenceDialogConfig,
     open_ambiguous_reference_dialog,
+)
+from src.ui.validation.dialogs.campaign_selector_dialog import (
+    CampaignSelectorOption,
+    open_campaign_selector_dialog,
 )
 from src.ui.validation.dialogs.missing_reference_dialog import (
     MissingReferenceDialogConfig,
@@ -25,11 +29,17 @@ from src.ui.validation.validation_wizard_controller import (
 )
 from src.validation import IssueType, ReferenceValidationResult, validate_reference_graph
 
+CampaignSelector = Callable[
+    [Any, Sequence[CampaignSelectorOption]],
+    CampaignSelectorOption | None,
+]
+
 
 @dataclass(frozen=True)
 class CampaignValidationRun:
     """Objects created for one campaign validation launch."""
 
+    campaign: CampaignSelectorOption
     graph: ReferenceValidationResult
     controller: ValidationWizardController
     first_step: ValidationWizardStep
@@ -38,8 +48,9 @@ class CampaignValidationRun:
 class CampaignHierarchyValidationLauncher:
     """Instantiate the hierarchy validator and drive the validation wizard UI."""
 
-    def __init__(self, app: Any) -> None:
+    def __init__(self, app: Any, *, campaign_selector: CampaignSelector | None = None) -> None:
         self.app = app
+        self._campaign_selector = campaign_selector or open_campaign_selector_dialog
         self._active_run: CampaignValidationRun | None = None
 
     @property
@@ -48,20 +59,41 @@ class CampaignHierarchyValidationLauncher:
 
         return self._active_run
 
-    def launch(self) -> CampaignValidationRun | None:
-        """Validate the current campaign hierarchy and start the wizard controller."""
+    def launch(
+        self,
+        campaign: Mapping[str, Any] | CampaignSelectorOption | None = None,
+    ) -> CampaignValidationRun | None:
+        """Validate a selected campaign hierarchy and start the wizard controller.
+
+        Global launchers call this without a campaign, which opens a blocking
+        selector dialog. Campaign-screen actions should pass the current
+        campaign explicitly.
+        """
 
         try:
+            selected_campaign = self._resolve_campaign_selection(campaign)
+            if selected_campaign is None:
+                return None
+
             hierarchy = build_campaign_validation_hierarchy(
-                getattr(self.app, "entity_wrappers", {}) or {}
+                getattr(self.app, "entity_wrappers", {}) or {},
+                selected_campaign,
             )
-            graph = validate_reference_graph(hierarchy)
+            graph = validate_reference_graph(hierarchy, campaign=selected_campaign.item)
             controller = ValidationWizardController(
                 _wizard_items(graph),
-                reference_resolver=lambda issue: resolve_reference_for_issue(issue, graph.references),
+                campaign=selected_campaign.item,
+                reference_resolver=lambda issue: resolve_reference_for_issue(
+                    issue, graph.references
+                ),
             )
             first_step = controller.start()
-            run = CampaignValidationRun(graph=graph, controller=controller, first_step=first_step)
+            run = CampaignValidationRun(
+                campaign=selected_campaign,
+                graph=graph,
+                controller=controller,
+                first_step=first_step,
+            )
             self._active_run = run
             self._handle_step(run, first_step)
             return run
@@ -77,6 +109,29 @@ class CampaignHierarchyValidationLauncher:
                 f"Impossible de vérifier la cohérence hiérarchique :\n{exc}",
             )
             return None
+
+    def _resolve_campaign_selection(
+        self,
+        campaign: Mapping[str, Any] | CampaignSelectorOption | None,
+    ) -> CampaignSelectorOption | None:
+        if isinstance(campaign, CampaignSelectorOption):
+            return campaign
+        if campaign is not None:
+            return campaign_option_from_item(campaign)
+
+        campaigns = load_campaign_options(getattr(self.app, "entity_wrappers", {}) or {})
+        if not campaigns:
+            from tkinter import messagebox
+
+            messagebox.showinfo(
+                "Aucune campagne",
+                (
+                    "Aucune campagne n’existe encore. Créez ou importez une campagne "
+                    "avant de lancer la validation."
+                ),
+            )
+            return None
+        return self._campaign_selector(self.app, campaigns)
 
     def _handle_step(self, run: CampaignValidationRun, step: ValidationWizardStep) -> None:
         if step.status in {ValidationWizardStatus.COMPLETED, ValidationWizardStatus.CANCELED}:
@@ -126,18 +181,49 @@ class CampaignHierarchyValidationLauncher:
             self._handle_step(run, next_step)
 
 
-def build_campaign_validation_hierarchy(entity_wrappers: Mapping[str, Any]) -> dict[str, Any]:
-    """Build a validator-friendly hierarchy from the app's model wrappers."""
+def load_campaign_options(entity_wrappers: Mapping[str, Any]) -> tuple[CampaignSelectorOption, ...]:
+    """Load selectable campaigns from the explicit campaigns wrapper."""
 
-    root: dict[str, Any] = {
-        "type": "campaign",
-        "id": "current-campaign",
-        "name": "Current Campaign",
-        "entities": [],
-    }
+    wrapper = entity_wrappers.get("campaigns")
+    if wrapper is None:
+        return ()
+    return tuple(
+        campaign_option_from_item(item)
+        for item in _safe_load_items(wrapper)
+        if isinstance(item, Mapping)
+    )
+
+
+def campaign_option_from_item(item: Mapping[str, Any]) -> CampaignSelectorOption:
+    """Create a selector option preserving the selected campaign object."""
+
+    campaign_id = _identifier_for(item, "campaigns", 0)
+    label = _display_name_for(item, campaign_id)
+    return CampaignSelectorOption(campaign_id=campaign_id, label=label, item=dict(item))
+
+
+def build_campaign_validation_hierarchy(
+    entity_wrappers: Mapping[str, Any],
+    campaign: Mapping[str, Any] | CampaignSelectorOption,
+) -> dict[str, Any]:
+    """Build a validator-friendly hierarchy for one explicitly selected campaign."""
+
+    selected = (
+        campaign
+        if isinstance(campaign, CampaignSelectorOption)
+        else campaign_option_from_item(campaign)
+    )
+    root: dict[str, Any] = dict(selected.item)
+    root["type"] = "campaign"
+    root["entity_type"] = "campaign"
+    root["id"] = selected.campaign_id
+    root["name"] = selected.label
+    root["entities"] = []
     entities = root["entities"]
 
     for slug in sorted(entity_wrappers):
+        if slug == "campaigns":
+            continue
         wrapper = entity_wrappers[slug]
         for index, item in enumerate(_safe_load_items(wrapper)):
             if not isinstance(item, Mapping):
@@ -145,7 +231,10 @@ def build_campaign_validation_hierarchy(entity_wrappers: Mapping[str, Any]) -> d
             entities.append(_normalize_entity_node(slug, item, index))
 
     log_info(
-        f"Built validation hierarchy with {len(entities)} entities",
+        (
+            f"Built validation hierarchy for campaign {selected.campaign_id} "
+            f"with {len(entities)} entities"
+        ),
         func_name="src.ui.validation.campaign_validation_launcher.build_campaign_validation_hierarchy",
     )
     return root
@@ -166,11 +255,16 @@ def _safe_load_items(wrapper: Any) -> Sequence[Any]:
         items = wrapper.load_items()
     except Exception as exc:
         log_exception(
-            f"Unable to load items for validation from {getattr(wrapper, 'entity_type', '?')}: {exc}",
+            (
+                "Unable to load items for validation from "
+                f"{getattr(wrapper, 'entity_type', '?')}: {exc}"
+            ),
             func_name="src.ui.validation.campaign_validation_launcher._safe_load_items",
         )
         return ()
-    return items if isinstance(items, Sequence) and not isinstance(items, (str, bytes, bytearray)) else ()
+    if isinstance(items, Sequence) and not isinstance(items, (str, bytes, bytearray)):
+        return items
+    return ()
 
 
 def _normalize_entity_node(slug: str, item: Mapping[str, Any], index: int) -> dict[str, Any]:

--- a/src/ui/validation/dialogs/__init__.py
+++ b/src/ui/validation/dialogs/__init__.py
@@ -14,6 +14,11 @@ from .ambiguous_reference_dialog import (
     AmbiguousReferenceDialogConfig,
     open_ambiguous_reference_dialog,
 )
+from .campaign_selector_dialog import (
+    CampaignSelectorDialog,
+    CampaignSelectorOption,
+    open_campaign_selector_dialog,
+)
 from .missing_reference_dialog import (
     MissingReferenceDialog,
     MissingReferenceDialogConfig,
@@ -29,6 +34,8 @@ __all__ = [
     "GenericEditorCreationRequest",
     "GenericEditorCreationResult",
     "GenericEditorLauncher",
+    "CampaignSelectorDialog",
+    "CampaignSelectorOption",
     "AmbiguousReferenceCandidate",
     "AmbiguousReferenceDialog",
     "AmbiguousReferenceDialogConfig",
@@ -40,6 +47,7 @@ __all__ = [
     "creation_request_from_issue",
     "entity_slug_for_expected_type",
     "open_ambiguous_reference_dialog",
+    "open_campaign_selector_dialog",
     "open_missing_reference_dialog",
     "open_validation_summary_dialog",
 ]

--- a/src/ui/validation/dialogs/campaign_selector_dialog.py
+++ b/src/ui/validation/dialogs/campaign_selector_dialog.py
@@ -1,0 +1,129 @@
+"""Campaign selector dialog used before global validation runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class CampaignSelectorOption:
+    """One campaign candidate available for validation."""
+
+    campaign_id: str
+    label: str
+    item: dict[str, Any]
+
+    @property
+    def display_text(self) -> str:
+        """Return a stable user-facing label for dropdowns and lists."""
+
+        if self.label == self.campaign_id:
+            return self.label
+        return f"{self.label} ({self.campaign_id})"
+
+
+class CampaignSelectorDialog:
+    """Blocking CustomTkinter dialog that requires a campaign before Run."""
+
+    def __init__(self, master: Any, campaigns: Sequence[CampaignSelectorOption]) -> None:
+        self.master = master
+        self.campaigns = tuple(campaigns)
+        self.selected_campaign: CampaignSelectorOption | None = None
+        self.window: Any | None = None
+        self._selected_text: Any | None = None
+        self._run_button: Any | None = None
+        self._display_to_option = {campaign.display_text: campaign for campaign in self.campaigns}
+
+    def show(self) -> CampaignSelectorOption | None:
+        """Open the modal selector and return the chosen campaign, or ``None``."""
+
+        import customtkinter as ctk
+
+        window = ctk.CTkToplevel(self.master)
+        self.window = window
+        window.title("Choisir une campagne")
+        window.transient(self.master)
+        window.grab_set()
+        window.geometry("480x260")
+        window.grid_columnconfigure(0, weight=1)
+        window.protocol("WM_DELETE_WINDOW", self.cancel)
+
+        ctk.CTkLabel(
+            window,
+            text="Choisir une campagne",
+            font=ctk.CTkFont(size=18, weight="bold"),
+        ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
+
+        if self.campaigns:
+            ctk.CTkLabel(
+                window,
+                text=(
+                    "Sélectionnez la campagne à vérifier. La validation ne "
+                    "démarrera qu’après ce choix."
+                ),
+                wraplength=420,
+                justify="left",
+            ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
+            self._selected_text = ctk.StringVar(value="")
+            dropdown = ctk.CTkOptionMenu(
+                window,
+                values=[campaign.display_text for campaign in self.campaigns],
+                variable=self._selected_text,
+                command=self._on_selection_changed,
+            )
+            dropdown.grid(row=2, column=0, sticky="ew", padx=20, pady=4)
+        else:
+            ctk.CTkLabel(
+                window,
+                text=(
+                    "Aucune campagne n’existe encore. Créez ou importez une campagne "
+                    "avant de lancer la validation."
+                ),
+                wraplength=420,
+                justify="left",
+            ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
+
+        actions = ctk.CTkFrame(window)
+        actions.grid(row=3, column=0, sticky="e", padx=20, pady=(22, 20))
+        self._run_button = ctk.CTkButton(actions, text="Run", command=self.run, state="disabled")
+        self._run_button.grid(row=0, column=0, padx=(0, 8))
+        ctk.CTkButton(actions, text="Annuler", command=self.cancel).grid(row=0, column=1)
+
+        window.wait_window()
+        return self.selected_campaign
+
+    def _on_selection_changed(self, selected_text: str) -> None:
+        if self._run_button is not None:
+            state = "normal" if selected_text in self._display_to_option else "disabled"
+            self._run_button.configure(state=state)
+
+    def run(self) -> None:
+        """Accept the current selection and close the dialog."""
+
+        selected_text = self._selected_text.get() if self._selected_text is not None else ""
+        selected_campaign = self._display_to_option.get(selected_text)
+        if selected_campaign is None:
+            return
+        self.selected_campaign = selected_campaign
+        self._close()
+
+    def cancel(self) -> None:
+        """Abort validation cleanly without a selected campaign."""
+
+        self.selected_campaign = None
+        self._close()
+
+    def _close(self) -> None:
+        if self.window is not None:
+            self.window.destroy()
+            self.window = None
+
+
+def open_campaign_selector_dialog(
+    master: Any,
+    campaigns: Sequence[CampaignSelectorOption],
+) -> CampaignSelectorOption | None:
+    """Open the dedicated campaign selector dialog."""
+
+    return CampaignSelectorDialog(master, campaigns).show()

--- a/src/ui/validation/validation_wizard_controller.py
+++ b/src/ui/validation/validation_wizard_controller.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Iterable, Protocol, Sequence
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
 
 from src.services import ReferenceActionResult, ReferenceFixService, SessionIgnoreStore
 from src.validation import ValidationIssue
@@ -128,12 +128,14 @@ class ValidationWizardController:
         self,
         issues: Iterable[ValidationIssue | ValidationWizardIssue],
         *,
+        campaign: Mapping[str, Any],
         reference_fix_service: ReferenceFixService | None = None,
         ignore_store: SessionIgnoreStore | None = None,
         reference_resolver: ReferenceResolver | None = None,
         presenter: ValidationWizardPresenter | None = None,
     ) -> None:
         self._items = tuple(_coerce_issue_item(issue) for issue in issues)
+        self._campaign = dict(campaign)
         self._reference_fix_service = reference_fix_service or ReferenceFixService()
         self._ignore_store = ignore_store or SessionIgnoreStore()
         self._reference_resolver = reference_resolver
@@ -142,6 +144,12 @@ class ValidationWizardController:
         self._summary = ValidationWizardSummary(total_issues=len(self._items))
         self._awaiting_entity_creation = False
         self._active_step: ValidationWizardStep | None = None
+
+    @property
+    def campaign(self) -> Mapping[str, Any]:
+        """Return the explicit campaign selected for this validation run."""
+
+        return dict(self._campaign)
 
     @property
     def summary(self) -> ValidationWizardSummary:

--- a/src/validation/reference_validator.py
+++ b/src/validation/reference_validator.py
@@ -86,17 +86,20 @@ class ReferenceValidationResult:
     issues: tuple[ValidationIssue, ...]
     entities: tuple[EntityRecord, ...]
     references: tuple[ReferenceRecord, ...]
+    campaign: Mapping[str, Any]
 
 
 def validate_references(
     hierarchy: Any,
     *,
+    campaign: Mapping[str, Any],
     config: ReferenceValidatorConfig | None = None,
 ) -> list[ValidationIssue]:
     """Validate references found during a deterministic hierarchy traversal.
 
     Args:
         hierarchy: Nested campaign data made of mappings/sequences/scalars.
+        campaign: Explicit campaign object selected by the user for this run.
         config: Optional validation rules override.
 
     Returns:
@@ -104,15 +107,16 @@ def validate_references(
         reference order inside each source entity.
     """
 
-    return list(validate_reference_graph(hierarchy, config=config).issues)
+    return list(validate_reference_graph(hierarchy, campaign=campaign, config=config).issues)
 
 
 def validate_reference_graph(
     hierarchy: Any,
     *,
+    campaign: Mapping[str, Any],
     config: ReferenceValidatorConfig | None = None,
 ) -> ReferenceValidationResult:
-    """Validate references and return issues plus traversal metadata."""
+    """Validate references for an explicit campaign and return traversal metadata."""
 
     active_config = config or ReferenceValidatorConfig()
     entities = tuple(_walk_entities(hierarchy))
@@ -141,7 +145,12 @@ def validate_reference_graph(
         ):
             issues.append(_build_hierarchy_issue(reference, target))
 
-    return ReferenceValidationResult(issues=tuple(issues), entities=entities, references=references)
+    return ReferenceValidationResult(
+        issues=tuple(issues),
+        entities=entities,
+        references=references,
+        campaign=dict(campaign),
+    )
 
 
 def _walk_entities(root: Any) -> Iterable[EntityRecord]:

--- a/tests/services/test_reference_fix_service.py
+++ b/tests/services/test_reference_fix_service.py
@@ -5,7 +5,7 @@ from src.validation import validate_reference_graph
 
 
 def _reference_for(hierarchy, value):
-    graph = validate_reference_graph(hierarchy)
+    graph = validate_reference_graph(hierarchy, campaign={"id": "sample"})
     return next(reference for reference in graph.references if reference.reference_value == value)
 
 

--- a/tests/services/test_session_ignore_store.py
+++ b/tests/services/test_session_ignore_store.py
@@ -6,7 +6,7 @@ from src.validation import validate_references
 
 def _missing_issue():
     hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
-    return validate_references(hierarchy)[0]
+    return validate_references(hierarchy, campaign={"id": "sample"})[0]
 
 
 def test_session_ignore_store_filters_ignored_issues_without_persistence_contract():

--- a/tests/ui/validation/fixtures/minimal_validation_dataset.py
+++ b/tests/ui/validation/fixtures/minimal_validation_dataset.py
@@ -91,7 +91,7 @@ def build_minimal_validation_wizard(
     campaign_hierarchy = (
         hierarchy if hierarchy is not None else build_minimal_validation_hierarchy()
     )
-    graph = validate_reference_graph(campaign_hierarchy)
+    graph = validate_reference_graph(campaign_hierarchy, campaign={"id": "sample"})
     controller = ValidationWizardController(
         tuple(
             ValidationWizardIssue(
@@ -100,6 +100,7 @@ def build_minimal_validation_wizard(
             )
             for issue in graph.issues
         ),
+        campaign=graph.campaign,
         reference_resolver=lambda issue: resolve_reference_for_issue(
             issue, graph.references
         ),

--- a/tests/ui/validation/test_ambiguous_reference_dialog.py
+++ b/tests/ui/validation/test_ambiguous_reference_dialog.py
@@ -36,10 +36,11 @@ def _ambiguous_wizard():
             {"type": "scenario", "id": "S3", "name": "Duplicate"},
         ],
     }
-    graph = validate_reference_graph(hierarchy)
+    graph = validate_reference_graph(hierarchy, campaign={"id": "sample"})
     reference = resolve_reference_for_issue(graph.issues[0], graph.references)
     controller = ValidationWizardController(
-        [ValidationWizardIssue(issue=graph.issues[0], reference=reference)]
+        [ValidationWizardIssue(issue=graph.issues[0], reference=reference)],
+        campaign=graph.campaign,
     )
     controller.start()
     return hierarchy, graph, controller

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -4,6 +4,7 @@ from src.ui.validation import ValidationWizardStatus
 from src.ui.validation.campaign_validation_launcher import (
     CampaignHierarchyValidationLauncher,
     build_campaign_validation_hierarchy,
+    load_campaign_options,
 )
 
 
@@ -20,24 +21,46 @@ class FakeApp:
         self.entity_wrappers = wrappers
 
 
+def _campaign():
+    return {"id": "c1", "Name": "Dragonfall"}
+
+
 def test_build_campaign_validation_hierarchy_normalizes_wrapper_items():
     hierarchy = build_campaign_validation_hierarchy(
         {
+            "campaigns": FakeWrapper([_campaign()]),
             "scenarios": FakeWrapper([{"Title": "Opening Scene", "NPCs": ["Asha"]}]),
             "npcs": FakeWrapper([{"Name": "Asha"}]),
-        }
+        },
+        _campaign(),
     )
 
     entities = hierarchy["entities"]
 
     assert hierarchy["type"] == "campaign"
+    assert hierarchy["id"] == "c1"
+    assert hierarchy["name"] == "Dragonfall"
     assert entities[0]["type"] == "npc"
     assert entities[0]["id"] == "Asha"
     assert entities[1]["type"] == "scenario"
     assert entities[1]["id"] == "Opening Scene"
 
 
-def test_launcher_instantiates_validator_and_wizard_controller(monkeypatch):
+def test_load_campaign_options_reads_campaigns_wrapper_only():
+    options = load_campaign_options(
+        {
+            "campaigns": FakeWrapper([_campaign()]),
+            "npcs": FakeWrapper([{"Name": "Asha"}]),
+        }
+    )
+
+    assert len(options) == 1
+    assert options[0].campaign_id == "c1"
+    assert options[0].label == "Dragonfall"
+    assert options[0].item == _campaign()
+
+
+def test_launcher_opens_selector_for_global_action_and_passes_campaign(monkeypatch):
     summaries = []
 
     def capture_summary(_master, summary):
@@ -48,12 +71,77 @@ def test_launcher_instantiates_validator_and_wizard_controller(monkeypatch):
         capture_summary,
     )
 
-    launcher = CampaignHierarchyValidationLauncher(FakeApp({}))
+    wrappers = {"campaigns": FakeWrapper([_campaign()])}
+    selector_options = []
+
+    def selector(_master, campaigns):
+        selector_options.extend(campaigns)
+        return campaigns[0]
+
+    launcher = CampaignHierarchyValidationLauncher(FakeApp(wrappers), campaign_selector=selector)
 
     run = launcher.launch()
 
     assert run is not None
+    assert run.campaign.campaign_id == "c1"
+    assert run.graph.campaign == _campaign()
+    assert run.controller.campaign == _campaign()
     assert run.graph.issues == ()
     assert run.first_step.status == ValidationWizardStatus.COMPLETED
     assert run.controller.summary.total_issues == 0
+    assert selector_options[0].campaign_id == "c1"
     assert summaries == [run.controller.summary]
+
+
+def test_launcher_accepts_campaign_screen_selection_without_global_dialog(monkeypatch):
+    monkeypatch.setattr(
+        "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
+        lambda *_args, **_kwargs: None,
+    )
+    selector_calls = []
+    launcher = CampaignHierarchyValidationLauncher(
+        FakeApp({"campaigns": FakeWrapper([_campaign()])}),
+        campaign_selector=lambda _master, campaigns: selector_calls.append(campaigns),
+    )
+
+    run = launcher.launch(_campaign())
+
+    assert run is not None
+    assert run.campaign.campaign_id == "c1"
+    assert selector_calls == []
+
+
+def test_launcher_aborts_cleanly_when_user_cancels_selection(monkeypatch):
+    monkeypatch.setattr(
+        "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
+        lambda *_args, **_kwargs: None,
+    )
+    launcher = CampaignHierarchyValidationLauncher(
+        FakeApp({"campaigns": FakeWrapper([_campaign()])}),
+        campaign_selector=lambda _master, _campaigns: None,
+    )
+
+    assert launcher.launch() is None
+    assert launcher.active_run is None
+
+
+def test_launcher_aborts_when_no_campaigns_exist(monkeypatch):
+    messages = []
+
+    monkeypatch.setattr(
+        "tkinter.messagebox.showinfo",
+        lambda title, message: messages.append((title, message)),
+    )
+    launcher = CampaignHierarchyValidationLauncher(FakeApp({}))
+
+    assert launcher.launch() is None
+    assert launcher.active_run is None
+    assert messages == [
+        (
+            "Aucune campagne",
+            (
+                "Aucune campagne n’existe encore. Créez ou importez une campagne "
+                "avant de lancer la validation."
+            ),
+        )
+    ]

--- a/tests/ui/validation/test_missing_reference_dialog.py
+++ b/tests/ui/validation/test_missing_reference_dialog.py
@@ -18,10 +18,11 @@ from src.validation import validate_reference_graph
 
 
 def _wizard_for(hierarchy):
-    graph = validate_reference_graph(hierarchy)
+    graph = validate_reference_graph(hierarchy, campaign={"id": "sample"})
     reference = resolve_reference_for_issue(graph.issues[0], graph.references)
     controller = ValidationWizardController(
-        [ValidationWizardIssue(issue=graph.issues[0], reference=reference)]
+        [ValidationWizardIssue(issue=graph.issues[0], reference=reference)],
+        campaign=graph.campaign,
     )
     controller.start()
     return graph, reference, controller
@@ -52,7 +53,8 @@ def test_entity_slug_for_expected_type_maps_validator_types_to_generic_slugs():
 def test_build_prefilled_entity_sets_referenced_name_parent_and_metadata():
     request = creation_request_from_issue(
         validate_reference_graph(
-            {"type": "arc", "id": "A1", "scenario_refs": ["Missing Scenario"]}
+            {"type": "arc", "id": "A1", "scenario_refs": ["Missing Scenario"]},
+            campaign={"id": "sample"},
         ).issues[0]
     )
     template = {
@@ -92,7 +94,8 @@ def test_generic_editor_launcher_returns_saved_entity_and_persists_it():
         wait_for_editor=False,
     )
     graph = validate_reference_graph(
-        {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+        {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]},
+        campaign={"id": "sample"},
     )
     request = creation_request_from_issue(graph.issues[0])
 

--- a/tests/ui/validation/test_validation_wizard_controller.py
+++ b/tests/ui/validation/test_validation_wizard_controller.py
@@ -12,7 +12,7 @@ from src.validation import validate_reference_graph
 
 
 def _graph_for(hierarchy):
-    return validate_reference_graph(hierarchy)
+    return validate_reference_graph(hierarchy, campaign={"id": "sample"})
 
 
 def _wizard_items(graph):
@@ -34,7 +34,11 @@ def test_wizard_starts_on_first_non_ignored_issue_and_finishes_with_summary():
     graph = _graph_for(hierarchy)
     ignore_store = SessionIgnoreStore()
     ignore_store.ignore(graph.issues[0])
-    controller = ValidationWizardController(_wizard_items(graph), ignore_store=ignore_store)
+    controller = ValidationWizardController(
+        _wizard_items(graph),
+        campaign=graph.campaign,
+        ignore_store=ignore_store,
+    )
 
     first_step = controller.start()
     assert first_step.status == ValidationWizardStatus.SHOW_ISSUE
@@ -57,7 +61,7 @@ def test_wizard_skip_session_ignores_current_issue_and_advances():
         "arc_refs": ["Missing One", "Missing Two"],
     }
     graph = _graph_for(hierarchy)
-    controller = ValidationWizardController(_wizard_items(graph))
+    controller = ValidationWizardController(_wizard_items(graph), campaign=graph.campaign)
 
     assert controller.start().issue == graph.issues[0]
     next_step = controller.submit_action(ValidationWizardAction.SKIP_SESSION)
@@ -71,7 +75,7 @@ def test_wizard_skip_session_ignores_current_issue_and_advances():
 def test_wizard_cancel_returns_canceled_summary_without_mutating():
     hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing"]}
     graph = _graph_for(hierarchy)
-    controller = ValidationWizardController(_wizard_items(graph))
+    controller = ValidationWizardController(_wizard_items(graph), campaign=graph.campaign)
 
     controller.start()
     step = controller.submit_action(ValidationWizardAction.CANCEL)
@@ -90,7 +94,7 @@ def test_wizard_remap_applies_reference_fix_and_advances():
         "arcs": [{"type": "arc", "id": "A1", "name": "Arc One"}],
     }
     graph = _graph_for(hierarchy)
-    controller = ValidationWizardController(_wizard_items(graph))
+    controller = ValidationWizardController(_wizard_items(graph), campaign=graph.campaign)
 
     controller.start()
     step = controller.submit_action(ValidationWizardAction.REMAP, target="A1")
@@ -104,7 +108,7 @@ def test_wizard_remap_applies_reference_fix_and_advances():
 def test_wizard_resumes_after_entity_creation_and_links_created_entity():
     hierarchy = {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
     graph = _graph_for(hierarchy)
-    controller = ValidationWizardController(_wizard_items(graph))
+    controller = ValidationWizardController(_wizard_items(graph), campaign=graph.campaign)
 
     controller.start()
     paused = controller.submit_action(ValidationWizardAction.CREATE_ENTITY)
@@ -128,6 +132,7 @@ def test_wizard_can_use_reference_resolver_for_plain_issue_lists():
     graph = _graph_for(hierarchy)
     controller = ValidationWizardController(
         graph.issues,
+        campaign=graph.campaign,
         reference_resolver=lambda issue: resolve_reference_for_issue(issue, graph.references),
     )
 

--- a/tests/validation/test_reference_validator.py
+++ b/tests/validation/test_reference_validator.py
@@ -36,7 +36,7 @@ def _sample_hierarchy():
 
 def test_validate_references_reports_missing_type_and_hierarchy_in_traversal_order():
     """Verify missing, typed and misplaced references are reported deterministically."""
-    issues = validate_references(_sample_hierarchy())
+    issues = validate_references(_sample_hierarchy(), campaign={"id": "sample"})
 
     assert [issue.issue_type for issue in issues] == [
         IssueType.MISSING_REFERENCE,
@@ -53,7 +53,7 @@ def test_validate_references_reports_missing_type_and_hierarchy_in_traversal_ord
 
 def test_validate_reference_graph_exposes_entities_and_references_for_interactive_resolution():
     """Verify traversal metadata is available to interactive resolution UIs."""
-    result = validate_reference_graph(_sample_hierarchy())
+    result = validate_reference_graph(_sample_hierarchy(), campaign={"id": "sample"})
 
     assert [entity.identifier for entity in result.entities] == ["C1", "A1", "S1", "A2", "S2"]
     assert [reference.reference_value for reference in result.references] == ["A1", "Missing Arc", "S1", "S2"]
@@ -76,4 +76,4 @@ def test_validate_references_returns_empty_list_for_valid_direct_children():
         ],
     }
 
-    assert validate_references(hierarchy) == []
+    assert validate_references(hierarchy, campaign={"id": "sample"}) == []


### PR DESCRIPTION
### Motivation
- Prevent running validation without an explicit campaign selected when launched from global actions and remove implicit/global fallback campaign behavior. 
- Provide a clear, blocking UI flow for choosing a campaign and guardrails for empty-state and cancellation so validation cannot start accidentally. 
- Make validation logic and the interactive wizard receive explicit campaign context so fixes and reporting are deterministic and testable.

### Description
- Add a dedicated selector UI `CampaignSelectorDialog` and helper `CampaignSelectorOption` that disables the `Run` button until a campaign is chosen and supports clean cancelation (`src/ui/validation/dialogs/campaign_selector_dialog.py`).
- Update `CampaignHierarchyValidationLauncher.launch` to accept an optional `campaign` argument, open the selector when invoked globally, abort cleanly if the user cancels, show a clear message if no campaigns exist, and pass the selected campaign forward (`src/ui/validation/campaign_validation_launcher.py`).
- Add `load_campaign_options` and `campaign_option_from_item` helpers and change `build_campaign_validation_hierarchy` to build the root from the explicit campaign and exclude the `campaigns` wrapper from child aggregation (`src/ui/validation/campaign_validation_launcher.py`).
- Require explicit campaign context in validation APIs by adding a `campaign` parameter to `validate_reference_graph`/`validate_references` and include `campaign` in `ReferenceValidationResult` (`src/validation/reference_validator.py`).
- Require `campaign` in the `ValidationWizardController` constructor and expose `controller.campaign` so the wizard has explicit run context (`src/ui/validation/validation_wizard_controller.py`).
- Export the new selector helpers from the validation dialogs package and add unit tests to cover global launch, explicit screen launch, cancelation, and no-campaign guards (`src/ui/validation/dialogs/__init__.py`, `tests/ui/validation/test_campaign_validation_launcher.py` plus updated fixtures/tests).

### Testing
- Compiled the modified validation modules with `python -m compileall` and ran the focused validation/unit suites `pytest tests/validation tests/ui/validation tests/services/test_reference_fix_service.py tests/services/test_session_ignore_store.py`, which passed (`40 passed`).
- Ran the targeted launcher/reference/controller tests `pytest tests/ui/validation/test_campaign_validation_launcher.py tests/validation/test_reference_validator.py tests/ui/validation/test_validation_wizard_controller.py`, which passed (`15 passed`).
- The broad full test collection in this environment is known to be hampered by unrelated external stubs (CustomTkinter/PIL and duplicate test module name issues), but the validation-focused tests above succeeded and the code compiles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb62de1b7c832b9afb2353b18f5ade)