### PR TITLE
Reference validator: use selected campaign root, deterministic child traversal, and diagnostics

### DIFF
--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -22,6 +22,7 @@ from .similarity_matcher import (
 from .reference_validator import (
     EntityRecord,
     ReferenceRecord,
+    ReferenceTraversalDiagnostics,
     ReferenceValidationResult,
     ReferenceValidatorConfig,
     validate_reference_graph,
@@ -35,6 +36,7 @@ __all__ = [
     "IssuePayload",
     "IssueType",
     "ReferenceRecord",
+    "ReferenceTraversalDiagnostics",
     "ReferenceValidationResult",
     "ReferenceValidatorConfig",
     "score_similarity",

--- a/src/validation/reference_validator.py
+++ b/src/validation/reference_validator.py
@@ -6,6 +6,7 @@ hierarchy and leaves correction choices to the interactive layer.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -15,6 +16,15 @@ from .issue_models import IssuePayload, IssueType, ValidationIssue
 ENTITY_TYPE_KEYS = ("entity_type", "type", "kind", "category", "EntityType", "Type")
 ENTITY_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
 ENTITY_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label")
+MODEL_CHILD_COLLECTIONS: Mapping[str, tuple[str, ...]] = {
+    "campaign": ("arcs",),
+    "arc": ("scenarios", "locations"),
+    "scenario": ("encounters", "npcs"),
+}
+FALLBACK_CHILD_COLLECTIONS = ("children", "items")
+SUPPORTED_ENTITY_TYPES = frozenset(
+    {"campaign", "arc", "scenario", "location", "encounter", "npc"}
+)
 STRUCTURAL_KEYS = frozenset(
     {
         "children",
@@ -80,6 +90,36 @@ class ReferenceRecord:
 
 
 @dataclass(frozen=True)
+class ReferenceTraversalDiagnostics:
+    """Internal counters captured during validation traversal."""
+
+    visited_campaigns: int = 0
+    visited_arcs: int = 0
+    visited_scenarios: int = 0
+    visited_references: int = 0
+    root_path: tuple[str, ...] = ()
+
+    @property
+    def debug_summary_path(self) -> tuple[str, ...]:
+        """Return a compact path QA can inspect to confirm traversal work."""
+
+        return (
+            "reference-validator",
+            f"root={' > '.join(self.root_path) if self.root_path else '<none>'}",
+            f"campaigns={self.visited_campaigns}",
+            f"arcs={self.visited_arcs}",
+            f"scenarios={self.visited_scenarios}",
+            f"references={self.visited_references}",
+        )
+
+    @property
+    def debug_summary(self) -> str:
+        """Return a human-readable traversal counter summary."""
+
+        return " | ".join(self.debug_summary_path)
+
+
+@dataclass(frozen=True)
 class ReferenceValidationResult:
     """Full validation result for interactive tools."""
 
@@ -87,6 +127,21 @@ class ReferenceValidationResult:
     entities: tuple[EntityRecord, ...]
     references: tuple[ReferenceRecord, ...]
     campaign: Mapping[str, Any]
+    diagnostics: ReferenceTraversalDiagnostics = field(
+        default_factory=ReferenceTraversalDiagnostics
+    )
+
+    @property
+    def debug_summary_path(self) -> tuple[str, ...]:
+        """Expose traversal diagnostics in a stable path-like form for QA."""
+
+        return self.diagnostics.debug_summary_path
+
+    @property
+    def debug_summary(self) -> str:
+        """Expose traversal diagnostics as a readable debug summary."""
+
+        return self.diagnostics.debug_summary
 
 
 def validate_references(
@@ -107,7 +162,9 @@ def validate_references(
         reference order inside each source entity.
     """
 
-    return list(validate_reference_graph(hierarchy, campaign=campaign, config=config).issues)
+    return list(
+        validate_reference_graph(hierarchy, campaign=campaign, config=config).issues
+    )
 
 
 def validate_reference_graph(
@@ -119,17 +176,24 @@ def validate_reference_graph(
     """Validate references for an explicit campaign and return traversal metadata."""
 
     active_config = config or ReferenceValidatorConfig()
-    entities = tuple(_walk_entities(hierarchy))
+    traversal_root = _resolve_traversal_root(hierarchy, campaign)
+    entities = tuple(_walk_entities(traversal_root))
     entity_index = _build_entity_index(entities)
     references = tuple(_walk_references(entities, active_config.field_expected_types))
+    diagnostics = _build_traversal_diagnostics(entities, references)
     issues: list[ValidationIssue] = []
 
     for reference in references:
-        if reference.declared_type and reference.declared_type != reference.expected_type:
+        if (
+            reference.declared_type
+            and reference.declared_type != reference.expected_type
+        ):
             issues.append(_build_type_issue(reference))
             continue
 
-        candidates = entity_index.get((reference.expected_type, reference.reference_value), ())
+        candidates = entity_index.get(
+            (reference.expected_type, reference.reference_value), ()
+        )
         if not candidates:
             issues.append(_build_missing_issue(reference))
             continue
@@ -150,20 +214,132 @@ def validate_reference_graph(
         entities=entities,
         references=references,
         campaign=dict(campaign),
+        diagnostics=diagnostics,
+    )
+
+
+def _resolve_traversal_root(hierarchy: Any, campaign: Mapping[str, Any]) -> Any:
+    """Return the selected campaign node instead of a global registry container."""
+
+    if _mapping_is_campaign(hierarchy):
+        if _campaign_matches(hierarchy, campaign) or not _mapping_is_campaign(campaign):
+            return hierarchy
+        return _campaign_with_defaults(campaign)
+
+    selected_campaign = _find_selected_campaign(hierarchy, campaign)
+    if selected_campaign is not None:
+        return selected_campaign
+
+    if _mapping_has_supported_entity_record(hierarchy):
+        return hierarchy
+
+    if isinstance(campaign, Mapping):
+        return _campaign_with_defaults(campaign)
+
+    return hierarchy
+
+
+def _find_selected_campaign(
+    hierarchy: Any,
+    campaign: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Find the matching selected campaign within a registry-shaped hierarchy."""
+
+    for candidate in _iter_mapping_nodes(hierarchy):
+        if _mapping_is_campaign(candidate) and _campaign_matches(candidate, campaign):
+            return candidate
+    return None
+
+
+def _iter_mapping_nodes(value: Any) -> Iterable[Mapping[str, Any]]:
+    if isinstance(value, Mapping):
+        yield value
+        for key in _stable_mapping_keys(value):
+            child = value.get(key)
+            if isinstance(child, (Mapping, list, tuple)):
+                yield from _iter_mapping_nodes(child)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            yield from _iter_mapping_nodes(item)
+
+
+def _campaign_with_defaults(campaign: Mapping[str, Any]) -> Mapping[str, Any]:
+    root = dict(campaign)
+    root.setdefault("type", "campaign")
+    root.setdefault("entity_type", "campaign")
+    identifier = _extract_identifier(root)
+    if identifier:
+        root.setdefault("id", identifier)
+    label = _extract_label(root)
+    if label:
+        root.setdefault("name", label)
+    return root
+
+
+def _mapping_is_campaign(value: Any) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and _normalize_text(_first_present(value, ENTITY_TYPE_KEYS)) == "campaign"
+    )
+
+
+def _mapping_has_supported_entity_record(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    entity_type = _normalize_text(_first_present(value, ENTITY_TYPE_KEYS))
+    return entity_type in SUPPORTED_ENTITY_TYPES and bool(_extract_identifier(value))
+
+
+def _campaign_matches(
+    candidate: Mapping[str, Any], campaign: Mapping[str, Any]
+) -> bool:
+    campaign_identifiers = _identity_values(campaign)
+    if not campaign_identifiers:
+        return True
+    return bool(_identity_values(candidate) & campaign_identifiers)
+
+
+def _identity_values(value: Mapping[str, Any]) -> set[str]:
+    return {
+        normalized
+        for key in ENTITY_ID_KEYS + ENTITY_NAME_KEYS
+        if key in value
+        for normalized in (_normalize_text(value.get(key)),)
+        if normalized
+    }
+
+
+def _build_traversal_diagnostics(
+    entities: Sequence[EntityRecord],
+    references: Sequence[ReferenceRecord],
+) -> ReferenceTraversalDiagnostics:
+    counts = Counter(entity.entity_type for entity in entities)
+    return ReferenceTraversalDiagnostics(
+        visited_campaigns=counts.get("campaign", 0),
+        visited_arcs=counts.get("arc", 0),
+        visited_scenarios=counts.get("scenario", 0),
+        visited_references=len(references),
+        root_path=entities[0].path if entities else (),
     )
 
 
 def _walk_entities(root: Any) -> Iterable[EntityRecord]:
-    """Yield entities in stable hierarchy order."""
+    """Yield selected-campaign entities in explicit model hierarchy order."""
 
     counter = 0
 
-    def visit(value: Any, path: tuple[str, ...], parent: EntityRecord | None) -> Iterable[EntityRecord]:
+    def visit(
+        value: Any,
+        path: tuple[str, ...],
+        parent: EntityRecord | None,
+    ) -> Iterable[EntityRecord]:
         nonlocal counter
-        current_parent = parent
         if isinstance(value, Mapping):
             entity_type = _normalize_text(_first_present(value, ENTITY_TYPE_KEYS))
             identifier = _extract_identifier(value)
+            current = parent
+            child_base_path = path
+
             if entity_type and identifier:
                 label = _extract_label(value) or identifier
                 current = EntityRecord(
@@ -179,17 +355,19 @@ def _walk_entities(root: Any) -> Iterable[EntityRecord]:
                 )
                 counter += 1
                 yield current
-                current_parent = current
                 child_base_path = current.path
-            else:
-                child_base_path = path
 
-            for key in _stable_mapping_keys(value):
-                if _should_descend_into_key(key, value.get(key)):
-                    yield from visit(value[key], child_base_path + (str(key),), current_parent)
-        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-            for index, item in enumerate(value):
-                yield from visit(item, path + (f"[{index}]",), current_parent)
+            for key in _child_collection_keys(entity_type, value):
+                child_value = value.get(key, ())
+                for child_segment, child in _ordered_collection_items(child_value):
+                    yield from visit(
+                        child, child_base_path + (key, child_segment), current
+                    )
+        elif isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            for segment, item in _ordered_collection_items(value):
+                yield from visit(item, path + (segment,), parent)
 
     yield from visit(root, (), None)
 
@@ -207,7 +385,9 @@ def _walk_references(
             source_type, field_name = _split_field_path(field_path)
             if source_type != entity.entity_type or field_name not in entity.node:
                 continue
-            for ref_index, raw_reference in enumerate(_coerce_reference_values(entity.node[field_name])):
+            for ref_index, raw_reference in enumerate(
+                _coerce_reference_values(entity.node[field_name])
+            ):
                 reference_value = _extract_reference_value(raw_reference)
                 if not reference_value:
                     continue
@@ -303,7 +483,9 @@ def _build_ambiguous_issue(
     )
 
 
-def _build_hierarchy_issue(reference: ReferenceRecord, target: EntityRecord) -> ValidationIssue:
+def _build_hierarchy_issue(
+    reference: ReferenceRecord, target: EntityRecord
+) -> ValidationIssue:
     return ValidationIssue(
         issue_type=IssueType.INVALID_HIERARCHY,
         payload=IssuePayload(
@@ -332,12 +514,55 @@ def _is_valid_hierarchy_position(
     allowed_children = allowed_hierarchy_children.get(source.entity_type, set())
     if target.entity_type not in allowed_children:
         return False
-    return target.parent_type == source.entity_type and target.parent_identifier == source.identifier
+    return (
+        target.parent_type == source.entity_type
+        and target.parent_identifier == source.identifier
+    )
 
 
 def _split_field_path(field_path: str) -> tuple[str, str]:
     source_type, _, field_name = field_path.partition(".")
     return source_type, field_name
+
+
+def _child_collection_keys(
+    entity_type: str,
+    value: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return explicit child collections for the current model entity."""
+
+    explicit_keys = MODEL_CHILD_COLLECTIONS.get(entity_type, ())
+    fallback_keys = tuple(key for key in FALLBACK_CHILD_COLLECTIONS if key in value)
+    if entity_type:
+        return tuple(dict.fromkeys(explicit_keys + fallback_keys))
+    return tuple(
+        key
+        for key in _stable_mapping_keys(value)
+        if _should_descend_into_key(key, value.get(key))
+    )
+
+
+def _ordered_collection_items(value: Any) -> tuple[tuple[str, Any], ...]:
+    """Return collection items in deterministic entity order with stable path segments."""
+
+    if isinstance(value, Mapping):
+        items = tuple((str(key), item) for key, item in value.items())
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items = tuple((f"[{index}]", item) for index, item in enumerate(value))
+    else:
+        return ()
+    return tuple(
+        sorted(items, key=lambda item: _collection_item_sort_key(item[1], item[0]))
+    )
+
+
+def _collection_item_sort_key(value: Any, segment: str) -> tuple[str, str, str, str]:
+    if isinstance(value, Mapping):
+        entity_type = _normalize_text(_first_present(value, ENTITY_TYPE_KEYS))
+        identifier = _extract_identifier(value)
+        label = _extract_label(value)
+        return (entity_type, identifier, label, segment)
+    return (type(value).__name__, _normalize_text(value), "", segment)
 
 
 def _stable_mapping_keys(value: Mapping[str, Any]) -> list[str]:
@@ -362,7 +587,9 @@ def _coerce_reference_values(value: Any) -> Iterable[Any]:
 
 
 def _extract_identifier(value: Mapping[str, Any]) -> str:
-    return _normalize_text(_first_present(value, ENTITY_ID_KEYS)) or _extract_label(value)
+    return _normalize_text(_first_present(value, ENTITY_ID_KEYS)) or _extract_label(
+        value
+    )
 
 
 def _extract_label(value: Mapping[str, Any]) -> str:
@@ -371,7 +598,9 @@ def _extract_label(value: Mapping[str, Any]) -> str:
 
 def _extract_reference_value(value: Any) -> str:
     if isinstance(value, Mapping):
-        reference_keys = ENTITY_ID_KEYS + ENTITY_NAME_KEYS + ("ref", "reference", "target")
+        reference_keys = (
+            ENTITY_ID_KEYS + ENTITY_NAME_KEYS + ("ref", "reference", "target")
+        )
         return _normalize_text(_first_present(value, reference_keys))
     return _normalize_text(value)
 

--- a/tests/validation/test_reference_validator.py
+++ b/tests/validation/test_reference_validator.py
@@ -43,7 +43,11 @@ def test_validate_references_reports_missing_type_and_hierarchy_in_traversal_ord
         IssueType.INVALID_REFERENCE_TYPE,
         IssueType.INVALID_HIERARCHY,
     ]
-    assert [issue.payload.referenced_name for issue in issues] == ["Missing Arc", "S1", "S2"]
+    assert [issue.payload.referenced_name for issue in issues] == [
+        "Missing Arc",
+        "S1",
+        "S2",
+    ]
     assert issues[1].payload.expected_type == "scenario"
     assert issues[1].payload.actual_type == "location"
     assert issues[2].payload.source_entity == "A1"
@@ -55,8 +59,19 @@ def test_validate_reference_graph_exposes_entities_and_references_for_interactiv
     """Verify traversal metadata is available to interactive resolution UIs."""
     result = validate_reference_graph(_sample_hierarchy(), campaign={"id": "sample"})
 
-    assert [entity.identifier for entity in result.entities] == ["C1", "A1", "S1", "A2", "S2"]
-    assert [reference.reference_value for reference in result.references] == ["A1", "Missing Arc", "S1", "S2"]
+    assert [entity.identifier for entity in result.entities] == [
+        "C1",
+        "A1",
+        "S1",
+        "A2",
+        "S2",
+    ]
+    assert [reference.reference_value for reference in result.references] == [
+        "A1",
+        "Missing Arc",
+        "S1",
+        "S2",
+    ]
     assert result.references[0].path == ("campaign:C1", "arc_refs", "[0]")
 
 
@@ -77,3 +92,86 @@ def test_validate_references_returns_empty_list_for_valid_direct_children():
     }
 
     assert validate_references(hierarchy, campaign={"id": "sample"}) == []
+
+
+def test_validate_reference_graph_uses_selected_campaign_root_not_registry_placeholder():
+    """Verify global registry siblings are not scanned as selected campaign children."""
+    hierarchy = {
+        "type": "registry",
+        "id": "global",
+        "campaigns": [
+            {"type": "campaign", "id": "C1", "name": "Selected", "arc_refs": ["A1"]},
+        ],
+        "arcs": [
+            {
+                "type": "arc",
+                "id": "A1",
+                "scenario_refs": ["Global Scenario Should Not Be Visited"],
+                "scenarios": [
+                    {"type": "scenario", "id": "S1", "name": "Registry Scenario"},
+                ],
+            }
+        ],
+    }
+
+    result = validate_reference_graph(hierarchy, campaign={"id": "C1"})
+
+    assert [entity.identifier for entity in result.entities] == ["C1"]
+    assert [reference.reference_value for reference in result.references] == ["A1"]
+    assert result.diagnostics.visited_campaigns == 1
+    assert result.diagnostics.visited_arcs == 0
+    assert result.diagnostics.visited_scenarios == 0
+    assert result.diagnostics.visited_references == 1
+    assert "campaigns=1" in result.debug_summary
+    assert "references=1" in result.debug_summary_path[-1]
+
+
+def test_validate_reference_graph_walks_explicit_children_without_optional_collections():
+    """Verify missing optional collections are treated as empty while siblings scan."""
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arcs": [
+            {
+                "type": "arc",
+                "id": "A2",
+                "name": "Second Arc",
+                "location_refs": ["L2"],
+                "locations": [{"type": "location", "id": "L2"}],
+            },
+            {
+                "type": "arc",
+                "id": "A1",
+                "name": "First Arc",
+                "scenario_refs": ["S1"],
+                "scenarios": [
+                    {
+                        "type": "scenario",
+                        "id": "S1",
+                        "npc_refs": ["N1"],
+                        "npcs": [{"type": "npc", "id": "N1"}],
+                    }
+                ],
+            },
+        ],
+    }
+
+    result = validate_reference_graph(hierarchy, campaign={"id": "C1"})
+
+    assert [entity.identifier for entity in result.entities] == [
+        "C1",
+        "A1",
+        "S1",
+        "N1",
+        "A2",
+        "L2",
+    ]
+    assert [reference.reference_value for reference in result.references] == [
+        "S1",
+        "N1",
+        "L2",
+    ]
+    assert result.issues == ()
+    assert result.diagnostics.visited_arcs == 2
+    assert result.diagnostics.visited_scenarios == 1
+    assert result.diagnostics.visited_references == 3


### PR DESCRIPTION
### Motivation
- Ensure reference validation scans the explicitly selected campaign object rather than a surrounding registry placeholder so only the intended campaign children are visited.
- Make traversal deterministic by iterating model child collections in a defined order (arcs → scenarios → deeper entities) and avoid skipping sibling collections when optional collections are missing.
- Provide QA-visible counters so testers can confirm the validator actually walked campaigns/arcs/scenarios and processed references.

### Description
- Resolve the traversal root with `_resolve_traversal_root` to pick the selected campaign node (or sensible campaign defaults) instead of scanning a global registry container, and add `_find_selected_campaign`/helpers to locate it. (edited `src/validation/reference_validator.py`)
- Add explicit model children and ordering via `MODEL_CHILD_COLLECTIONS`, `FALLBACK_CHILD_COLLECTIONS`, `_child_collection_keys`, and `_ordered_collection_items` to iterate `arcs`, then `scenarios`/`locations`, then deeper collections deterministically. (edited `src/validation/reference_validator.py`)
- Treat missing optional child collections as empty (callers get `()`), so traversal continues across siblings instead of early-returning. (edited `src/validation/reference_validator.py`)
- Add `ReferenceTraversalDiagnostics` with counters for `visited_campaigns`, `visited_arcs`, `visited_scenarios`, and `visited_references`, expose `debug_summary`/`debug_summary_path`, and attach diagnostics to `ReferenceValidationResult`; export diagnostics in the validation package. (edited `src/validation/reference_validator.py` and `src/validation/__init__.py`)
- Introduce deterministic collection sorting keys via `_collection_item_sort_key` so mapping vs sequence items are ordered stably by entity type/identifier/label. (edited `src/validation/reference_validator.py`)
- Add regression tests covering registry roots, deterministic child ordering, missing optional collections handling, and diagnostics population. (edited `tests/validation/test_reference_validator.py`)

### Testing
- Ran focused validation unit tests with `pytest -q tests/validation/test_reference_validator.py` and all tests passed (`5 passed`).
- Ran the validator + UI validation controller focused tests with `pytest -q tests/validation/test_reference_validator.py tests/ui/validation/test_missing_reference_dialog.py tests/ui/validation/test_validation_wizard_controller.py` and observed `16 passed` for that run.
- Ran a wider set including validation services with `pytest -q tests/validation tests/ui/validation tests/services/test_reference_fix_service.py tests/services/test_session_ignore_store.py` and observed `42 passed` for that run. 
- Attempted a full `pytest -q` run which failed collection due to unrelated environmental/test-suite issues (duplicate test module basenames and missing CustomTkinter/Pillow test stubs), so global collection errors were reported but are not caused by these validator changes. 

Files changed: `src/validation/reference_validator.py`, `src/validation/__init__.py`, `tests/validation/test_reference_validator.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb66399a94832bac977634f190ca0e)