### PR TITLE
Handle validation setup failures distinctly

### DIFF
--- a/src/ui/validation/__init__.py
+++ b/src/ui/validation/__init__.py
@@ -7,9 +7,11 @@ from .validation_wizard_controller import (
     ValidationWizardIssue,
     ValidationWizardPresenter,
     ValidationWizardProgress,
+    ValidationWizardSetupFailure,
     ValidationWizardStatus,
     ValidationWizardStep,
     ValidationWizardSummary,
+    validation_setup_failed_step,
     resolve_reference_for_issue,
 )
 
@@ -20,8 +22,10 @@ __all__ = [
     "ValidationWizardIssue",
     "ValidationWizardPresenter",
     "ValidationWizardProgress",
+    "ValidationWizardSetupFailure",
     "ValidationWizardStatus",
     "ValidationWizardStep",
     "ValidationWizardSummary",
+    "validation_setup_failed_step",
     "resolve_reference_for_issue",
 ]

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -26,6 +26,7 @@ from src.ui.validation.validation_wizard_controller import (
     ValidationWizardStatus,
     ValidationWizardStep,
     resolve_reference_for_issue,
+    validation_setup_failed_step,
 )
 from src.validation import IssueType, ReferenceValidationResult, validate_reference_graph
 
@@ -71,12 +72,32 @@ class CampaignHierarchyValidationLauncher:
         """
 
         try:
-            selected_campaign = self._resolve_campaign_selection(campaign)
+            entity_wrappers = self._resolve_entity_wrappers()
+            if entity_wrappers is None:
+                step = validation_setup_failed_step(
+                    "Données de campagne indisponibles",
+                    (
+                        "Le dépôt de données ou les services d’entités sont introuvables. "
+                        "Ouvrez ou rechargez un projet de campagne avant de relancer la validation."
+                    ),
+                )
+                self._handle_step(None, step)
+                return None
+
+            selected_campaign = self._resolve_campaign_selection(campaign, entity_wrappers)
             if selected_campaign is None:
+                step = validation_setup_failed_step(
+                    "Campagne requise",
+                    (
+                        "Aucune campagne n’a été sélectionnée pour la validation. "
+                        "Sélectionnez une campagne active, puis relancez la validation."
+                    ),
+                )
+                self._handle_step(None, step)
                 return None
 
             hierarchy = build_campaign_validation_hierarchy(
-                getattr(self.app, "entity_wrappers", {}) or {},
+                entity_wrappers,
                 selected_campaign,
             )
             graph = validate_reference_graph(hierarchy, campaign=selected_campaign.item)
@@ -102,39 +123,56 @@ class CampaignHierarchyValidationLauncher:
                 f"Failed to run hierarchy validation: {exc}",
                 func_name="src.ui.validation.campaign_validation_launcher.CampaignHierarchyValidationLauncher.launch",
             )
-            from tkinter import messagebox
-
-            messagebox.showerror(
+            step = validation_setup_failed_step(
                 "Validation indisponible",
-                f"Impossible de vérifier la cohérence hiérarchique :\n{exc}",
+                (
+                    "La validation n’a pas pu démarrer à cause d’une erreur d’initialisation. "
+                    "Vérifiez que le projet est chargé, puis relancez la validation.\n\n"
+                    f"Détail technique : {exc}"
+                ),
             )
+            self._handle_step(None, step)
             return None
+
+    def _resolve_entity_wrappers(self) -> Mapping[str, Any] | None:
+        wrappers = getattr(self.app, "entity_wrappers", None)
+        if not isinstance(wrappers, Mapping) or not wrappers:
+            return None
+        return wrappers
 
     def _resolve_campaign_selection(
         self,
         campaign: Mapping[str, Any] | CampaignSelectorOption | None,
+        entity_wrappers: Mapping[str, Any],
     ) -> CampaignSelectorOption | None:
         if isinstance(campaign, CampaignSelectorOption):
             return campaign
         if campaign is not None:
             return campaign_option_from_item(campaign)
 
-        campaigns = load_campaign_options(getattr(self.app, "entity_wrappers", {}) or {})
+        campaigns = load_campaign_options(entity_wrappers)
         if not campaigns:
-            from tkinter import messagebox
-
-            messagebox.showinfo(
-                "Aucune campagne",
-                (
-                    "Aucune campagne n’existe encore. Créez ou importez une campagne "
-                    "avant de lancer la validation."
-                ),
-            )
             return None
         return self._campaign_selector(self.app, campaigns)
 
-    def _handle_step(self, run: CampaignValidationRun, step: ValidationWizardStep) -> None:
-        if step.status in {ValidationWizardStatus.COMPLETED, ValidationWizardStatus.CANCELED}:
+    def _handle_step(
+        self,
+        run: CampaignValidationRun | None,
+        step: ValidationWizardStep,
+    ) -> None:
+        if step.status == ValidationWizardStatus.SETUP_FAILED:
+            from tkinter import messagebox
+
+            title = step.setup_failure.title if step.setup_failure else "Validation impossible"
+            messagebox.showerror(title, step.message)
+            return
+
+        if step.status == ValidationWizardStatus.COMPLETED:
+            if step.summary is not None:
+                open_validation_summary_dialog(self.app, step.summary)
+            return
+
+        if step.status == ValidationWizardStatus.CANCELED:
             if step.summary is not None:
                 open_validation_summary_dialog(self.app, step.summary)
             return
@@ -145,7 +183,7 @@ class CampaignHierarchyValidationLauncher:
             messagebox.showwarning("Validation", step.message)
             return
 
-        if step.issue is None:
+        if step.issue is None or run is None:
             return
 
         if step.issue.issue_type == IssueType.MISSING_REFERENCE:

--- a/src/ui/validation/validation_wizard_controller.py
+++ b/src/ui/validation/validation_wizard_controller.py
@@ -39,6 +39,7 @@ class ValidationWizardStatus(str, Enum):
     COMPLETED = "completed"
     CANCELED = "canceled"
     ACTION_FAILED = "action_failed"
+    SETUP_FAILED = "setup_failed"
 
 
 @dataclass(frozen=True)
@@ -82,6 +83,14 @@ class ValidationWizardSummary:
 
 
 @dataclass(frozen=True)
+class ValidationWizardSetupFailure:
+    """Actionable setup error that prevents a validation scan from running."""
+
+    title: str
+    message: str
+
+
+@dataclass(frozen=True)
 class ValidationWizardStep:
     """Current step returned to the UI after a controller transition."""
 
@@ -90,7 +99,19 @@ class ValidationWizardStep:
     progress: ValidationWizardProgress | None = None
     summary: ValidationWizardSummary | None = None
     action_result: ReferenceActionResult | None = None
+    setup_failure: ValidationWizardSetupFailure | None = None
     message: str = ""
+
+
+def validation_setup_failed_step(title: str, message: str) -> ValidationWizardStep:
+    """Return a terminal step for invalid setup/input before a scan is executed."""
+
+    failure = ValidationWizardSetupFailure(title=title, message=message)
+    return ValidationWizardStep(
+        status=ValidationWizardStatus.SETUP_FAILED,
+        setup_failure=failure,
+        message=message,
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -112,9 +112,16 @@ def test_launcher_accepts_campaign_screen_selection_without_global_dialog(monkey
 
 
 def test_launcher_aborts_cleanly_when_user_cancels_selection(monkeypatch):
+    messages = []
+    summaries = []
+
     monkeypatch.setattr(
         "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
-        lambda *_args, **_kwargs: None,
+        lambda *_args, **_kwargs: summaries.append(_args),
+    )
+    monkeypatch.setattr(
+        "tkinter.messagebox.showerror",
+        lambda title, message: messages.append((title, message)),
     )
     launcher = CampaignHierarchyValidationLauncher(
         FakeApp({"campaigns": FakeWrapper([_campaign()])}),
@@ -123,25 +130,108 @@ def test_launcher_aborts_cleanly_when_user_cancels_selection(monkeypatch):
 
     assert launcher.launch() is None
     assert launcher.active_run is None
+    assert summaries == []
+    assert messages == [
+        (
+            "Campagne requise",
+            (
+                "Aucune campagne n’a été sélectionnée pour la validation. "
+                "Sélectionnez une campagne active, puis relancez la validation."
+            ),
+        )
+    ]
 
 
 def test_launcher_aborts_when_no_campaigns_exist(monkeypatch):
     messages = []
+    summaries = []
 
     monkeypatch.setattr(
-        "tkinter.messagebox.showinfo",
+        "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
+        lambda *_args, **_kwargs: summaries.append(_args),
+    )
+    monkeypatch.setattr(
+        "tkinter.messagebox.showerror",
+        lambda title, message: messages.append((title, message)),
+    )
+    launcher = CampaignHierarchyValidationLauncher(FakeApp({"campaigns": FakeWrapper([])}))
+
+    assert launcher.launch() is None
+    assert launcher.active_run is None
+    assert summaries == []
+    assert messages == [
+        (
+            "Campagne requise",
+            (
+                "Aucune campagne n’a été sélectionnée pour la validation. "
+                "Sélectionnez une campagne active, puis relancez la validation."
+            ),
+        )
+    ]
+
+
+def test_launcher_reports_unresolved_repository_for_explicit_campaign(monkeypatch):
+    messages = []
+    summaries = []
+
+    monkeypatch.setattr(
+        "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
+        lambda *_args, **_kwargs: summaries.append(_args),
+    )
+    monkeypatch.setattr(
+        "tkinter.messagebox.showerror",
         lambda title, message: messages.append((title, message)),
     )
     launcher = CampaignHierarchyValidationLauncher(FakeApp({}))
 
-    assert launcher.launch() is None
+    assert launcher.launch(_campaign()) is None
     assert launcher.active_run is None
+    assert summaries == []
     assert messages == [
         (
-            "Aucune campagne",
+            "Données de campagne indisponibles",
             (
-                "Aucune campagne n’existe encore. Créez ou importez une campagne "
-                "avant de lancer la validation."
+                "Le dépôt de données ou les services d’entités sont introuvables. "
+                "Ouvrez ou rechargez un projet de campagne avant de relancer la validation."
+            ),
+        )
+    ]
+
+
+def test_launcher_reports_bootstrap_exception_without_summary(monkeypatch):
+    messages = []
+    summaries = []
+
+    monkeypatch.setattr(
+        "src.ui.validation.campaign_validation_launcher.open_validation_summary_dialog",
+        lambda *_args, **_kwargs: summaries.append(_args),
+    )
+    monkeypatch.setattr(
+        "tkinter.messagebox.showerror",
+        lambda title, message: messages.append((title, message)),
+    )
+
+    def fail_validation(*_args, **_kwargs):
+        raise RuntimeError("validator offline")
+
+    monkeypatch.setattr(
+        "src.ui.validation.campaign_validation_launcher.validate_reference_graph",
+        fail_validation,
+    )
+    launcher = CampaignHierarchyValidationLauncher(
+        FakeApp({"campaigns": FakeWrapper([_campaign()])})
+    )
+
+    assert launcher.launch(_campaign()) is None
+    assert launcher.active_run is None
+    assert summaries == []
+    assert messages == [
+        (
+            "Validation indisponible",
+            (
+                "La validation n’a pas pu démarrer à cause d’une erreur d’initialisation. "
+                "Vérifiez que le projet est chargé, puis relancez la validation.\n\n"
+                "Détail technique : validator offline"
             ),
         )
     ]

--- a/tests/ui/validation/test_validation_wizard_controller.py
+++ b/tests/ui/validation/test_validation_wizard_controller.py
@@ -141,3 +141,17 @@ def test_wizard_can_use_reference_resolver_for_plain_issue_lists():
 
     assert step.status == ValidationWizardStatus.COMPLETED
     assert hierarchy["arc_refs"] == []
+
+
+def test_setup_failed_step_marks_scan_as_not_executed():
+    from src.ui.validation import validation_setup_failed_step
+
+    step = validation_setup_failed_step(
+        "Campagne requise",
+        "Sélectionnez une campagne active, puis relancez la validation.",
+    )
+
+    assert step.status == ValidationWizardStatus.SETUP_FAILED
+    assert step.summary is None
+    assert step.setup_failure.title == "Campagne requise"
+    assert step.message == "Sélectionnez une campagne active, puis relancez la validation."


### PR DESCRIPTION
### Motivation
- Validation should distinguish a completed scan that found zero issues from a scan that never ran due to invalid setup or bootstrap errors, and surface actionable error dialogs for the latter case.
- The UI must not display the final `validation_summary_dialog` when a scan was not executed, to avoid misleading the user with a summary for a non-run scan.

### Description
- Add a new `SETUP_FAILED` status, `ValidationWizardSetupFailure` data model and `validation_setup_failed_step(...)` helper so setup errors are represented as a terminal, non-summary wizard step (changes in `validation_wizard_controller`).
- Update the campaign validation launcher to check for missing/invalid entity wrappers, missing campaign selection, and bootstrap exceptions, and route those cases to an error dialog using the new setup-failed step rather than opening the summary dialog (`campaign_validation_launcher`).
- Ensure the launcher only calls `open_validation_summary_dialog(...)` for completed/canceled runs after a scan has actually been initialized, and show `messagebox.showerror(...)` for setup failures.
- Export the new setup-failure symbols from the validation package and add tests that assert the new behavior for missing campaign, unresolved repositories/services, bootstrap exceptions, and the new `validation_setup_failed_step` (changes in `src/ui/validation/__init__.py` and added/updated tests).

### Testing
- Ran unit tests: `pytest tests/ui/validation -q`, all tests passed (`28 passed`).
- Verified modules compile with `python -m py_compile src/ui/validation/validation_wizard_controller.py src/ui/validation/campaign_validation_launcher.py src/ui/validation/__init__.py` and there were no syntax errors.
- Ran repository checks (`git diff --check`) and test assertions included for the new setup-failed behavior (`tests/ui/validation/test_campaign_validation_launcher.py` and `tests/ui/validation/test_validation_wizard_controller.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb67cbc8f4832b91d09c6ce56c940b)