### PR TITLE
Align hierarchy FIELD_EXPECTED_TYPES with real template/UI fields (preserve aliases)

### DIFF
--- a/src/validation/hierarchy_rules.py
+++ b/src/validation/hierarchy_rules.py
@@ -4,8 +4,28 @@ from __future__ import annotations
 
 from typing import Mapping
 
-# Explicit mapping: field path -> expected referenced entity type
+# Explicit mapping: field path -> expected referenced entity type.
+#
+# The canonical field names mirror the persisted campaign/scenario templates and
+# editor UI.  Legacy ``*_refs`` aliases are kept temporarily so older tests and
+# saved validation fixtures can migrate without losing coverage.
 FIELD_EXPECTED_TYPES: Mapping[str, str] = {
+    # Campaign fields from modules/campaigns/campaigns_template.json.
+    "campaign.Arcs": "arc",
+    "campaign.LinkedScenarios": "scenario",
+    # Scenario fields from modules/scenarios/scenarios_template.json.
+    "scenario.Bases": "base",
+    "scenario.Places": "location",
+    "scenario.Maps": "map",
+    "scenario.NPCs": "npc",
+    "scenario.PCs": "pc",
+    "scenario.Villains": "villain",
+    "scenario.Events": "event",
+    "scenario.Creatures": "creature",
+    "scenario.Factions": "faction",
+    "scenario.Objects": "object",
+    "scenario.Books": "book",
+    # Legacy/test-only aliases retained for safe migration.
     "campaign.arc_refs": "arc",
     "arc.scenario_refs": "scenario",
     "arc.location_refs": "location",

--- a/tests/validation/test_reference_validator.py
+++ b/tests/validation/test_reference_validator.py
@@ -1,6 +1,36 @@
 """Regression tests for deterministic reference validation."""
 
-from src.validation import IssueType, validate_reference_graph, validate_references
+from src.validation import (
+    FIELD_EXPECTED_TYPES,
+    IssueType,
+    validate_reference_graph,
+    validate_references,
+)
+
+
+def test_field_expected_types_include_real_template_and_ui_fields_with_legacy_aliases():
+    """Verify reference rules track persisted model fields while aliases migrate."""
+    expected = {
+        "campaign.Arcs": "arc",
+        "campaign.LinkedScenarios": "scenario",
+        "scenario.NPCs": "npc",
+        "scenario.Places": "location",
+        "scenario.Creatures": "creature",
+        "scenario.Factions": "faction",
+        "scenario.Objects": "object",
+        "scenario.Events": "event",
+        "scenario.Books": "book",
+        "scenario.Maps": "map",
+        "scenario.Bases": "base",
+        "scenario.Villains": "villain",
+        "scenario.PCs": "pc",
+        "campaign.arc_refs": "arc",
+        "arc.scenario_refs": "scenario",
+        "scenario.npc_refs": "npc",
+    }
+
+    for field_path, expected_type in expected.items():
+        assert FIELD_EXPECTED_TYPES[field_path] == expected_type
 
 
 def _sample_hierarchy():


### PR DESCRIPTION
### Motivation

- The reference validator used artificial `*_refs` field names that do not match persisted templates and the editor UI, causing a disconnect between validation rules and real data.
- Update the rules so `FIELD_EXPECTED_TYPES` reflects the actual campaign/scenario fields while keeping legacy aliases to allow a safe migration path for tests and fixtures.

### Description

- Added canonical campaign reference fields to `FIELD_EXPECTED_TYPES`: `campaign.Arcs` and `campaign.LinkedScenarios` to match `modules/campaigns/campaigns_template.json`.
- Added canonical scenario reference fields to `FIELD_EXPECTED_TYPES` for `Bases`, `Places`, `Maps`, `NPCs`, `PCs`, `Villains`, `Events`, `Creatures`, `Factions`, `Objects`, and `Books` to match `modules/scenarios/scenarios_template.json` and UI usage.
- Retained legacy/test-only aliases such as `campaign.arc_refs`, `arc.scenario_refs`, `arc.location_refs`, `scenario.encounter_refs`, and `scenario.npc_refs` so existing tests and fixtures can migrate without breaking.
- Added a regression test `test_field_expected_types_include_real_template_and_ui_fields_with_legacy_aliases` that asserts the expected mapping entries are present in `FIELD_EXPECTED_TYPES`.

### Testing

- Ran compilation checks: `python -m compileall -q src/validation/hierarchy_rules.py tests/validation/test_reference_validator.py` (success).
- Ran targeted tests: `pytest -q tests/validation/test_reference_validator.py` (all tests passed) and the selected validation/relay tests `tests/ui/validation/test_campaign_validation_launcher.py tests/services/test_reference_fix_service.py tests/services/test_session_ignore_store.py` (these passed in the targeted runs).
- Attempted full test run `pytest -q`, which aborted during collection due to unrelated test-environment issues (duplicate test module basenames, incomplete `customtkinter` stubs in the harness, and missing `PIL.ImageEnhance`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6f3d8ca4832bbac0e5db689e151d)