### PR TITLE
Support campaign -> entities traversal and use graph metrics for validation UI

### DIFF
--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -32,7 +32,6 @@ from src.ui.validation.validation_wizard_controller import (
     validation_setup_failed_step,
 )
 from src.validation import IssueType, ReferenceValidationResult, validate_reference_graph
-from src.validation.hierarchy_rules import FIELD_EXPECTED_TYPES
 
 CampaignSelector = Callable[
     [Any, Sequence[CampaignSelectorOption]],
@@ -110,6 +109,7 @@ class CampaignHierarchyValidationLauncher:
             )
             progress.set_phase("Checking references…")
             graph = validate_reference_graph(hierarchy, campaign=selected_campaign.item)
+            diagnostics = graph.diagnostics
             controller = ValidationWizardController(
                 _wizard_items(graph),
                 campaign=selected_campaign.item,
@@ -117,10 +117,14 @@ class CampaignHierarchyValidationLauncher:
                     issue, graph.references
                 ),
                 metrics=ValidationWizardMetrics(
-                    entities_visited=_count_flat_entities(hierarchy),
-                    references_checked=_count_flat_references(hierarchy),
+                    entities_visited=len(graph.entities),
+                    references_checked=len(graph.references),
                 ),
                 started_at=started_at,
+            )
+            log_info(
+                f"Campaign validation traversal metrics: {diagnostics.debug_summary}",
+                func_name="src.ui.validation.campaign_validation_launcher.CampaignHierarchyValidationLauncher.launch",
             )
             first_step = controller.start()
             run = CampaignValidationRun(
@@ -299,53 +303,6 @@ def build_campaign_validation_hierarchy(
         func_name="src.ui.validation.campaign_validation_launcher.build_campaign_validation_hierarchy",
     )
     return root
-
-
-def _count_flat_entities(hierarchy: Mapping[str, Any]) -> int:
-    entities = _flat_entities(hierarchy)
-    return len(entities)
-
-
-def _count_flat_references(hierarchy: Mapping[str, Any]) -> int:
-    total = 0
-    fields_by_type = _reference_fields_by_entity_type()
-    for entity in _flat_entities(hierarchy):
-        entity_type = (
-            str(entity.get("entity_type") or entity.get("type") or "")
-            .strip()
-            .lower()
-        )
-        for field in fields_by_type.get(entity_type, ()):
-            if field in entity:
-                total += _reference_value_count(entity[field])
-    return total
-
-
-def _flat_entities(hierarchy: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
-    entities = hierarchy.get("entities", ())
-    if not isinstance(entities, Sequence) or isinstance(
-        entities, (str, bytes, bytearray)
-    ):
-        return ()
-    return tuple(entity for entity in entities if isinstance(entity, Mapping))
-
-
-def _reference_fields_by_entity_type() -> dict[str, tuple[str, ...]]:
-    by_type: dict[str, list[str]] = {}
-    for field_path in FIELD_EXPECTED_TYPES:
-        entity_type, field = field_path.split(".", 1)
-        by_type.setdefault(entity_type, []).append(field)
-    return {entity_type: tuple(fields) for entity_type, fields in by_type.items()}
-
-
-def _reference_value_count(value: Any) -> int:
-    if value is None:
-        return 0
-    if isinstance(value, Mapping):
-        return 1
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return sum(1 for item in value if item is not None and str(item).strip())
-    return 1 if str(value).strip() else 0
 
 
 def _wizard_items(graph: ReferenceValidationResult) -> tuple[ValidationWizardIssue, ...]:

--- a/src/validation/reference_validator.py
+++ b/src/validation/reference_validator.py
@@ -17,7 +17,7 @@ ENTITY_TYPE_KEYS = ("entity_type", "type", "kind", "category", "EntityType", "Ty
 ENTITY_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
 ENTITY_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label")
 MODEL_CHILD_COLLECTIONS: Mapping[str, tuple[str, ...]] = {
-    "campaign": ("arcs",),
+    "campaign": ("arcs", "entities"),
     "arc": ("scenarios", "locations"),
     "scenario": ("encounters", "npcs"),
 }

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -25,6 +25,12 @@ def _campaign():
     return {"id": "c1", "Name": "Dragonfall"}
 
 
+def _campaign_with_arc_reference():
+    campaign = _campaign()
+    campaign["arc_refs"] = ["Arc One"]
+    return campaign
+
+
 def test_build_campaign_validation_hierarchy_normalizes_wrapper_items():
     hierarchy = build_campaign_validation_hierarchy(
         {
@@ -246,20 +252,21 @@ def test_launcher_summary_includes_scan_metrics(monkeypatch):
     launcher = CampaignHierarchyValidationLauncher(
         FakeApp(
             {
-                "campaigns": FakeWrapper([_campaign()]),
+                "campaigns": FakeWrapper([_campaign_with_arc_reference()]),
                 "arcs": FakeWrapper([{"Name": "Arc One"}]),
-                "scenarios": FakeWrapper([{"Name": "Opening", "npc_refs": ["Asha"]}]),
+                "scenarios": FakeWrapper([{"Name": "Opening"}]),
                 "npcs": FakeWrapper([{"Name": "Asha"}]),
             }
         )
     )
 
-    run = launcher.launch(_campaign())
+    run = launcher.launch(_campaign_with_arc_reference())
 
     assert run is not None
+    assert run.graph.diagnostics.visited_references == len(run.graph.references)
     summary = summaries[0]
-    assert summary.metrics.entities_visited == 3
-    assert summary.metrics.references_checked == 1
+    assert summary.metrics.entities_visited == len(run.graph.entities) == 4
+    assert summary.metrics.references_checked == len(run.graph.references) == 1
     assert summary.metrics.elapsed_seconds >= 0
 
 

--- a/tests/validation/test_reference_validator.py
+++ b/tests/validation/test_reference_validator.py
@@ -156,6 +156,27 @@ def test_validate_reference_graph_uses_selected_campaign_root_not_registry_place
     assert "references=1" in result.debug_summary_path[-1]
 
 
+def test_validate_reference_graph_walks_validator_built_entities_collection():
+    """Verify campaign roots descend into flat UI launcher entity collections."""
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arc_refs": ["A1"],
+        "entities": [
+            {"type": "arc", "id": "A1", "name": "Arc One"},
+            {"type": "npc", "id": "N1", "name": "Asha"},
+        ],
+    }
+
+    result = validate_reference_graph(hierarchy, campaign={"id": "C1"})
+
+    assert [entity.identifier for entity in result.entities] == ["C1", "A1", "N1"]
+    assert [reference.reference_value for reference in result.references] == ["A1"]
+    assert result.diagnostics.visited_campaigns == 1
+    assert result.diagnostics.visited_arcs == 1
+    assert result.diagnostics.visited_references == 1
+
+
 def test_validate_reference_graph_walks_explicit_children_without_optional_collections():
     """Verify missing optional collections are treated as empty while siblings scan."""
     hierarchy = {


### PR DESCRIPTION
### Motivation
- The validator-built campaign roots created by `build_campaign_validation_hierarchy` put items into an `entities` collection that the traversal should descend into so referenced targets are discovered correctly.
- The UI should report metrics based on the actual validation result rather than pre-validation flat counts to avoid showing entities as visited when the validator did not traverse them.

### Description
- Added `"entities"` to `MODEL_CHILD_COLLECTIONS["campaign"]` so campaign roots descend into the launcher-built `entities` collection (change in `src/validation/reference_validator.py`).
- Updated the launcher to source metrics from the validation graph (`graph.diagnostics`, `len(graph.entities)`, `len(graph.references)`) instead of using `_count_flat_entities()` / `_count_flat_references()` (changes in `src/ui/validation/campaign_validation_launcher.py`).
- Removed the pre-validation flat-count helpers from the launcher and added a debug `log_info` line to surface the `diagnostics.debug_summary` for accountability.
- Added tests to assert traversal into `entities` and to verify the UI summary metrics match the actual `graph.entities` / `graph.references` (changes in `tests/validation/test_reference_validator.py` and `tests/ui/validation/test_campaign_validation_launcher.py`).

### Testing
- Ran `pytest -q tests/validation/test_reference_validator.py tests/ui/validation/test_campaign_validation_launcher.py` and the targeted tests passed (`17 passed`).
- Verified syntax with `python -m py_compile src/validation/reference_validator.py src/ui/validation/campaign_validation_launcher.py` which completed without errors.
- Ran `ruff check` on the modified files which reported no issues.
- A full `pytest -q` run was attempted but test collection fails are unrelated to these changes (duplicate test module names and missing UI/PIL stubs in the environment), so full-suite failures are not caused by this diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7029a6a0832bb70f687b35c09084)