### PR TITLE
Build validation hierarchy arcs from selected campaign

### DIFF
--- a/src/ui/validation/campaign_arc_hierarchy.py
+++ b/src/ui/validation/campaign_arc_hierarchy.py
@@ -1,0 +1,85 @@
+"""Helpers for projecting campaign arc fields into validation hierarchy nodes."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from modules.campaigns.shared.arc_parser import coerce_arc_list
+
+_ARC_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
+_ARC_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label", "arc_name")
+_REFERENCE_KEYS = _ARC_ID_KEYS + _ARC_NAME_KEYS + ("ref", "reference", "target")
+
+
+def build_campaign_arc_nodes(raw_arcs: Any) -> list[dict[str, Any]]:
+    """Return validation-ready arc nodes parsed from a campaign ``Arcs`` value."""
+
+    return [
+        _build_arc_node(arc, index)
+        for index, arc in enumerate(coerce_arc_list(raw_arcs))
+        if isinstance(arc, Mapping)
+    ]
+
+
+def _build_arc_node(arc: Mapping[str, Any], index: int) -> dict[str, Any]:
+    node = dict(arc)
+    identifier = _identifier_for_arc(node, index)
+    node["type"] = "arc"
+    node["entity_type"] = "arc"
+    node["id"] = identifier
+    node["name"] = _display_name_for_arc(node, identifier)
+    node["scenario_refs"] = _scenario_references_from_arc(node)
+    node.pop("scenarios", None)
+    return node
+
+
+def _identifier_for_arc(arc: Mapping[str, Any], index: int) -> str:
+    for key in _ARC_ID_KEYS + _ARC_NAME_KEYS:
+        value = _clean_text(arc.get(key))
+        if value:
+            return value
+    return f"arc-{index + 1}"
+
+
+def _display_name_for_arc(arc: Mapping[str, Any], fallback: str) -> str:
+    for key in _ARC_NAME_KEYS:
+        value = _clean_text(arc.get(key))
+        if value:
+            return value
+    return fallback
+
+
+def _scenario_references_from_arc(arc: Mapping[str, Any]) -> list[str]:
+    raw_scenarios = arc.get("scenarios", arc.get("scenario_refs"))
+    if raw_scenarios is None:
+        return []
+
+    if isinstance(raw_scenarios, Sequence) and not isinstance(
+        raw_scenarios, (str, bytes, bytearray)
+    ):
+        raw_values = raw_scenarios
+    else:
+        raw_values = (raw_scenarios,)
+
+    refs: list[str] = []
+    for raw_value in raw_values:
+        reference = _reference_text(raw_value)
+        if reference:
+            refs.append(reference)
+    return refs
+
+
+def _reference_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        for key in _REFERENCE_KEYS:
+            reference = _clean_text(value.get(key))
+            if reference:
+                return reference
+        return ""
+    return _clean_text(value)
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -7,6 +7,7 @@ from time import monotonic
 from typing import Any, Callable, Mapping, Sequence
 
 from modules.helpers.logging_helper import log_exception, log_info
+from src.ui.validation.campaign_arc_hierarchy import build_campaign_arc_nodes
 from src.ui.validation.dialogs.ambiguous_reference_dialog import (
     AmbiguousReferenceDialogConfig,
     open_ambiguous_reference_dialog,
@@ -281,6 +282,7 @@ def build_campaign_validation_hierarchy(
     root["entity_type"] = "campaign"
     root["id"] = selected.campaign_id
     root["name"] = selected.label
+    root["arcs"] = build_campaign_arc_nodes(selected.item.get("Arcs"))
     root["entities"] = []
     entities = root["entities"]
 
@@ -298,7 +300,7 @@ def build_campaign_validation_hierarchy(
     log_info(
         (
             f"Built validation hierarchy for campaign {selected.campaign_id} "
-            f"with {len(entities)} entities"
+            f"with {len(root['arcs'])} arcs and {len(entities)} entities"
         ),
         func_name="src.ui.validation.campaign_validation_launcher.build_campaign_validation_hierarchy",
     )

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -52,6 +52,55 @@ def test_build_campaign_validation_hierarchy_normalizes_wrapper_items():
     assert entities[1]["id"] == "Opening Scene"
 
 
+def test_build_campaign_validation_hierarchy_builds_selected_campaign_arc_nodes():
+    campaign = {
+        "id": "c1",
+        "Name": "Dragonfall",
+        "Arcs": {
+            "arcs": [
+                {
+                    "name": "Opening Arc",
+                    "status": "Running",
+                    "scenarios": ["Opening Scene", {"Title": "Hidden Shrine"}],
+                },
+                {
+                    "id": "arc-final",
+                    "name": "Finale",
+                    "scenarios": "Boss Fight",
+                },
+            ]
+        },
+    }
+
+    hierarchy = build_campaign_validation_hierarchy(
+        {
+            "campaigns": FakeWrapper([campaign]),
+            "scenarios": FakeWrapper([{"Title": "Opening Scene"}]),
+        },
+        campaign,
+    )
+
+    assert hierarchy["arcs"] == [
+        {
+            "name": "Opening Arc",
+            "status": "In Progress",
+            "type": "arc",
+            "entity_type": "arc",
+            "id": "Opening Arc",
+            "scenario_refs": ["Opening Scene", "Hidden Shrine"],
+        },
+        {
+            "id": "arc-final",
+            "name": "Finale",
+            "status": "Planned",
+            "type": "arc",
+            "entity_type": "arc",
+            "scenario_refs": ["Boss Fight"],
+        },
+    ]
+    assert hierarchy["entities"][0]["entity_type"] == "scenario"
+
+
 def test_load_campaign_options_reads_campaigns_wrapper_only():
     options = load_campaign_options(
         {


### PR DESCRIPTION
### Motivation
- Validation needs the selected campaign's `Arcs` field to be projected into the validator hierarchy so arc → scenario references are checked in-context. 
- Preserve the existing flat `entities` catalog for lookup while providing an explicit `campaign -> arcs -> scenario_refs` projection for hierarchy-aware validation and interactive resolution.

### Description
- Add `src/ui/validation/campaign_arc_hierarchy.py` which parses `Arcs` via `modules.campaigns.shared.arc_parser.coerce_arc_list` and projects each parsed arc into a validation-ready node with `type="arc"`, `entity_type="arc"`, stable `id`, `name`, and `scenario_refs` derived from `scenarios`/`scenario_refs` fields. 
- Update `build_campaign_validation_hierarchy` to read `selected.item.get("Arcs")`, call `build_campaign_arc_nodes(...)`, and attach the result to `root["arcs"]` while keeping the flat `root["entities"]` populated from wrappers. 
- Improve the summary log to report both the number of selected-campaign arcs and the flat entity catalog size. 
- Add a focused regression test in `tests/ui/validation/test_campaign_validation_launcher.py` to validate arc node construction and that `entities` scanning remains intact.

### Testing
- Ran targeted tests with `pytest -q tests/ui/validation/test_campaign_validation_launcher.py tests/validation/test_reference_validator.py tests/scenarios/dashboard/test_campaign_arc_field.py`, and they all passed (`21 passed`).
- Compiled the modified modules with `python -m compileall -q src/ui/validation/campaign_validation_launcher.py src/ui/validation/campaign_arc_hierarchy.py` with no syntax errors. 
- Attempting a full `pytest -q` collection failed in this environment due to unrelated test-suite/environment issues (duplicate test module basenames and incomplete `customtkinter` / `PIL` test stubs), so only the focused validation tests were exercised here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb71a11e20832ba66d0ad73eac242a)