### PR TITLE
Normalize validation linked-list fields

### DIFF
--- a/src/ui/validation/campaign_arc_hierarchy.py
+++ b/src/ui/validation/campaign_arc_hierarchy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Mapping, Sequence
 
 from modules.campaigns.shared.arc_parser import coerce_arc_list
+from src.validation import normalize_validator_reference_fields
 
 _ARC_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
 _ARC_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label", "arc_name")
@@ -22,7 +23,7 @@ def build_campaign_arc_nodes(raw_arcs: Any) -> list[dict[str, Any]]:
 
 
 def _build_arc_node(arc: Mapping[str, Any], index: int) -> dict[str, Any]:
-    node = dict(arc)
+    node = normalize_validator_reference_fields("arc", arc, remove_source_fields=False)
     identifier = _identifier_for_arc(node, index)
     node["type"] = "arc"
     node["entity_type"] = "arc"

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -32,7 +32,12 @@ from src.ui.validation.validation_wizard_controller import (
     resolve_reference_for_issue,
     validation_setup_failed_step,
 )
-from src.validation import IssueType, ReferenceValidationResult, validate_reference_graph
+from src.validation import (
+    IssueType,
+    ReferenceValidationResult,
+    normalize_validator_reference_fields,
+    validate_reference_graph,
+)
 
 CampaignSelector = Callable[
     [Any, Sequence[CampaignSelectorOption]],
@@ -277,7 +282,9 @@ def build_campaign_validation_hierarchy(
         if isinstance(campaign, CampaignSelectorOption)
         else campaign_option_from_item(campaign)
     )
-    root: dict[str, Any] = dict(selected.item)
+    root: dict[str, Any] = normalize_validator_reference_fields(
+        "campaign", selected.item
+    )
     root["type"] = "campaign"
     root["entity_type"] = "campaign"
     root["id"] = selected.campaign_id
@@ -343,8 +350,8 @@ def _safe_load_items(wrapper: Any) -> Sequence[Any]:
 
 
 def _normalize_entity_node(slug: str, item: Mapping[str, Any], index: int) -> dict[str, Any]:
-    node = dict(item)
     entity_type = _singular_entity_type(slug)
+    node = normalize_validator_reference_fields(entity_type, item)
     identifier = _identifier_for(node, slug, index)
     node.setdefault("type", entity_type)
     node.setdefault("entity_type", entity_type)

--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -1,5 +1,10 @@
 """Validation package for cross-entity consistency checks."""
 
+from .field_normalization import (
+    FIELD_NORMALIZATION_RULES,
+    FieldNormalizationRule,
+    normalize_validator_reference_fields,
+)
 from .hierarchy_rules import (
     ALLOWED_HIERARCHY_CHILDREN,
     FIELD_EXPECTED_TYPES,
@@ -31,8 +36,10 @@ from .reference_validator import (
 
 __all__ = [
     "ALLOWED_HIERARCHY_CHILDREN",
+    "FIELD_NORMALIZATION_RULES",
     "FIELD_EXPECTED_TYPES",
     "EntityRecord",
+    "FieldNormalizationRule",
     "IssuePayload",
     "IssueType",
     "ReferenceRecord",
@@ -50,6 +57,7 @@ __all__ = [
     "SimilarityDecision",
     "SimilarityCandidate",
     "ValidationIssue",
+    "normalize_validator_reference_fields",
     "format_hierarchy_context",
     "format_parent_child_context",
     "validate_reference_graph",

--- a/src/validation/field_normalization.py
+++ b/src/validation/field_normalization.py
@@ -1,0 +1,63 @@
+"""Normalize persisted linked-list fields into validator reference fields."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class FieldNormalizationRule:
+    """Map one persisted linked-list field to one canonical validator field."""
+
+    entity_type: str
+    source_field: str
+    canonical_field: str
+
+
+FIELD_NORMALIZATION_RULES: tuple[FieldNormalizationRule, ...] = (
+    FieldNormalizationRule("campaign", "LinkedScenarios", "scenario_refs"),
+    FieldNormalizationRule("scenario", "Bases", "base_refs"),
+    FieldNormalizationRule("scenario", "Places", "location_refs"),
+    FieldNormalizationRule("scenario", "Maps", "map_refs"),
+    FieldNormalizationRule("scenario", "NPCs", "npc_refs"),
+    FieldNormalizationRule("scenario", "PCs", "pc_refs"),
+    FieldNormalizationRule("scenario", "Villains", "villain_refs"),
+    FieldNormalizationRule("scenario", "Events", "event_refs"),
+    FieldNormalizationRule("scenario", "Creatures", "creature_refs"),
+    FieldNormalizationRule("scenario", "Factions", "faction_refs"),
+    FieldNormalizationRule("scenario", "Objects", "object_refs"),
+    FieldNormalizationRule("scenario", "Books", "book_refs"),
+    FieldNormalizationRule("arc", "scenarios", "scenario_refs"),
+)
+
+_RULES_BY_TYPE: Mapping[str, tuple[FieldNormalizationRule, ...]] = {
+    entity_type: tuple(
+        rule for rule in FIELD_NORMALIZATION_RULES if rule.entity_type == entity_type
+    )
+    for entity_type in {rule.entity_type for rule in FIELD_NORMALIZATION_RULES}
+}
+
+
+def normalize_validator_reference_fields(
+    entity_type: str,
+    item: Mapping[str, Any],
+    *,
+    remove_source_fields: bool = True,
+) -> dict[str, Any]:
+    """Return ``item`` with real linked-list fields projected to canonical refs.
+
+    The normalization is intentionally shallow: reference values are copied as-is
+    so strings, IDs, and mapping-shaped references remain compatible with
+    ``reference_validator._extract_reference_value()``.
+    """
+
+    normalized = dict(item)
+    for rule in _RULES_BY_TYPE.get(entity_type, ()):
+        if rule.source_field not in normalized:
+            continue
+        if rule.canonical_field not in normalized:
+            normalized[rule.canonical_field] = normalized[rule.source_field]
+        if remove_source_fields and rule.source_field != rule.canonical_field:
+            normalized.pop(rule.source_field, None)
+    return normalized

--- a/src/validation/hierarchy_rules.py
+++ b/src/validation/hierarchy_rules.py
@@ -6,9 +6,9 @@ from typing import Mapping
 
 # Explicit mapping: field path -> expected referenced entity type.
 #
-# The canonical field names mirror the persisted campaign/scenario templates and
-# editor UI.  Legacy ``*_refs`` aliases are kept temporarily so older tests and
-# saved validation fixtures can migrate without losing coverage.
+# Persisted campaign/scenario template fields are accepted for direct validator
+# callers. UI validation normalizes linked-list fields into canonical ``*_refs``
+# aliases before traversal so reference records use stable validator fields.
 FIELD_EXPECTED_TYPES: Mapping[str, str] = {
     # Campaign fields from modules/campaigns/campaigns_template.json.
     "campaign.Arcs": "arc",
@@ -25,12 +25,23 @@ FIELD_EXPECTED_TYPES: Mapping[str, str] = {
     "scenario.Factions": "faction",
     "scenario.Objects": "object",
     "scenario.Books": "book",
-    # Legacy/test-only aliases retained for safe migration.
+    # Canonical validator aliases populated by field normalization.
     "campaign.arc_refs": "arc",
+    "campaign.scenario_refs": "scenario",
     "arc.scenario_refs": "scenario",
     "arc.location_refs": "location",
+    "scenario.base_refs": "base",
+    "scenario.location_refs": "location",
+    "scenario.map_refs": "map",
     "scenario.encounter_refs": "encounter",
     "scenario.npc_refs": "npc",
+    "scenario.pc_refs": "pc",
+    "scenario.villain_refs": "villain",
+    "scenario.event_refs": "event",
+    "scenario.creature_refs": "creature",
+    "scenario.faction_refs": "faction",
+    "scenario.object_refs": "object",
+    "scenario.book_refs": "book",
 }
 
 # Parent type -> allowed child types

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -50,6 +50,27 @@ def test_build_campaign_validation_hierarchy_normalizes_wrapper_items():
     assert entities[0]["id"] == "Asha"
     assert entities[1]["type"] == "scenario"
     assert entities[1]["id"] == "Opening Scene"
+    assert entities[1]["npc_refs"] == ["Asha"]
+    assert "NPCs" not in entities[1]
+
+
+def test_build_campaign_validation_hierarchy_normalizes_campaign_linked_scenarios():
+    campaign = {
+        "id": "c1",
+        "Name": "Dragonfall",
+        "LinkedScenarios": ["Opening Scene", {"Title": "Hidden Shrine"}],
+    }
+
+    hierarchy = build_campaign_validation_hierarchy(
+        {
+            "campaigns": FakeWrapper([campaign]),
+            "scenarios": FakeWrapper([{"Title": "Opening Scene"}]),
+        },
+        campaign,
+    )
+
+    assert hierarchy["scenario_refs"] == ["Opening Scene", {"Title": "Hidden Shrine"}]
+    assert "LinkedScenarios" not in hierarchy
 
 
 def test_build_campaign_validation_hierarchy_builds_selected_campaign_arc_nodes():

--- a/tests/validation/test_field_normalization.py
+++ b/tests/validation/test_field_normalization.py
@@ -1,0 +1,39 @@
+"""Tests for validation linked-field normalization."""
+
+from src.validation.field_normalization import normalize_validator_reference_fields
+
+
+def test_normalize_scenario_linked_fields_to_canonical_reference_fields():
+    scenario = {
+        "Title": "Opening Scene",
+        "NPCs": ["Asha", {"Name": "Borin"}],
+        "Places": ["Old Mill"],
+        "Creatures": [{"id": "owlbear-1", "type": "creature"}],
+    }
+
+    normalized = normalize_validator_reference_fields("scenario", scenario)
+
+    assert normalized["npc_refs"] == ["Asha", {"Name": "Borin"}]
+    assert normalized["location_refs"] == ["Old Mill"]
+    assert normalized["creature_refs"] == [{"id": "owlbear-1", "type": "creature"}]
+    assert "NPCs" not in normalized
+    assert "Places" not in normalized
+    assert "Creatures" not in normalized
+
+
+def test_normalize_campaign_linked_scenarios_to_scenario_refs():
+    campaign = {"Name": "Dragonfall", "LinkedScenarios": ["Opening Scene"]}
+
+    normalized = normalize_validator_reference_fields("campaign", campaign)
+
+    assert normalized["scenario_refs"] == ["Opening Scene"]
+    assert "LinkedScenarios" not in normalized
+
+
+def test_normalize_preserves_existing_canonical_field_over_source_field():
+    scenario = {"Title": "Opening Scene", "NPCs": ["Asha"], "npc_refs": ["Borin"]}
+
+    normalized = normalize_validator_reference_fields("scenario", scenario)
+
+    assert normalized["npc_refs"] == ["Borin"]
+    assert "NPCs" not in normalized


### PR DESCRIPTION
### Motivation

- Validation traversals expect stable canonical `*_refs` fields while persisted templates and UI use a mix of linked-list fields, so normalized validator fields are needed to make reference extraction deterministic and backward-compatible.

### Description

- Add a dedicated normalization module `src/validation/field_normalization.py` with rules mapping persisted linked-list fields to canonical validator fields (examples: `scenario.NPCs -> npc_refs`, `scenario.Places -> location_refs`, `scenario.Creatures -> creature_refs`, `campaign.LinkedScenarios -> scenario_refs`, and parsed arc `scenarios -> scenario_refs`).
- Integrate normalization into the validation pipeline by applying `normalize_validator_reference_fields` to the selected campaign root and each loaded entity in `src/ui/validation/campaign_validation_launcher.py` and to parsed arc nodes in `src/ui/validation/campaign_arc_hierarchy.py` so the validator sees canonical reference fields.
- Register canonical `*_refs` aliases in `src/validation/hierarchy_rules.py` and export the normalization API from `src/validation/__init__.py` for shared use across validation/UI code.
- Add focused unit tests `tests/validation/test_field_normalization.py` and extend existing launcher tests to assert normalization behaviour, while keeping normalization shallow so values remain names/IDs that `reference_validator._extract_reference_value()` can resolve.

### Testing

- Ran `pytest tests/validation/test_field_normalization.py tests/ui/validation/test_campaign_validation_launcher.py tests/validation/test_reference_validator.py` and all tests passed (`22 passed`).
- Compiled modified modules with `python -m py_compile src/validation/field_normalization.py src/validation/hierarchy_rules.py src/ui/validation/campaign_validation_launcher.py src/ui/validation/campaign_arc_hierarchy.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb72d51024832bbaa470a67cd27e47)