### PR TITLE
Replace French validation UI strings with English labels (i18n-ready)

### DIFF
--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -23,6 +23,18 @@ from src.ui.validation.dialogs.missing_reference_dialog import (
 from src.ui.validation.dialogs.validation_summary_dialog import (
     open_validation_summary_dialog,
 )
+from src.ui.validation.labels import (
+    CAMPAIGN_DATA_UNAVAILABLE_MESSAGE,
+    CAMPAIGN_DATA_UNAVAILABLE_TITLE,
+    CAMPAIGN_REQUIRED_MESSAGE,
+    CAMPAIGN_REQUIRED_TITLE,
+    HIERARCHY_CONSISTENCY_TITLE,
+    IGNORE_ISSUE_PROMPT,
+    TECHNICAL_DETAIL_LABEL,
+    VALIDATION_IMPOSSIBLE_TITLE,
+    VALIDATION_UNAVAILABLE_MESSAGE,
+    VALIDATION_UNAVAILABLE_TITLE,
+)
 from src.ui.validation.progress import ValidationScanProgress
 from src.ui.validation.validation_wizard_controller import (
     ValidationWizardAction,
@@ -89,11 +101,8 @@ class CampaignHierarchyValidationLauncher:
             entity_wrappers = self._resolve_entity_wrappers()
             if entity_wrappers is None:
                 step = validation_setup_failed_step(
-                    "Données de campagne indisponibles",
-                    (
-                        "Le dépôt de données ou les services d’entités sont introuvables. "
-                        "Ouvrez ou rechargez un projet de campagne avant de relancer la validation."
-                    ),
+                    CAMPAIGN_DATA_UNAVAILABLE_TITLE,
+                    CAMPAIGN_DATA_UNAVAILABLE_MESSAGE,
                 )
                 self._handle_step(None, step)
                 return None
@@ -103,11 +112,8 @@ class CampaignHierarchyValidationLauncher:
             )
             if selected_campaign is None:
                 step = validation_setup_failed_step(
-                    "Campagne requise",
-                    (
-                        "Aucune campagne n’a été sélectionnée pour la validation. "
-                        "Sélectionnez une campagne active, puis relancez la validation."
-                    ),
+                    CAMPAIGN_REQUIRED_TITLE,
+                    CAMPAIGN_REQUIRED_MESSAGE,
                 )
                 self._handle_step(None, step)
                 return None
@@ -155,12 +161,8 @@ class CampaignHierarchyValidationLauncher:
                 func_name="src.ui.validation.campaign_validation_launcher.CampaignHierarchyValidationLauncher.launch",
             )
             step = validation_setup_failed_step(
-                "Validation indisponible",
-                (
-                    "La validation n’a pas pu démarrer à cause d’une erreur d’initialisation. "
-                    "Vérifiez que le projet est chargé, puis relancez la validation.\n\n"
-                    f"Détail technique : {exc}"
-                ),
+                VALIDATION_UNAVAILABLE_TITLE,
+                f"{VALIDATION_UNAVAILABLE_MESSAGE}\n\n{TECHNICAL_DETAIL_LABEL}: {exc}",
             )
             self._handle_step(None, step)
             return None
@@ -197,7 +199,7 @@ class CampaignHierarchyValidationLauncher:
             title = (
                 step.setup_failure.title
                 if step.setup_failure
-                else "Validation impossible"
+                else VALIDATION_IMPOSSIBLE_TITLE
             )
             messagebox.showerror(title, step.message)
             return
@@ -247,8 +249,8 @@ class CampaignHierarchyValidationLauncher:
         from tkinter import messagebox
 
         if messagebox.askyesno(
-            "Cohérence hiérarchique",
-            f"{step.message}\n\nIgnorer cette anomalie pour cette session ?",
+            HIERARCHY_CONSISTENCY_TITLE,
+            f"{step.message}\n\n{IGNORE_ISSUE_PROMPT}",
         ):
             next_step = run.controller.submit_action(
                 ValidationWizardAction.SKIP_SESSION

--- a/src/ui/validation/dialogs/ambiguous_reference_dialog.py
+++ b/src/ui/validation/dialogs/ambiguous_reference_dialog.py
@@ -5,6 +5,20 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
+from src.ui.validation.labels import (
+    AMBIGUOUS_REFERENCE_MESSAGE,
+    AMBIGUOUS_REFERENCE_TITLE,
+    CANDIDATE_UNAVAILABLE_MESSAGE,
+    CHOOSE_LEFT_LABEL,
+    CHOOSE_RIGHT_LABEL,
+    IGNORE_LABEL,
+    NO_KEY_INFO_MESSAGE,
+    NO_OTHER_CANDIDATE_SELECTOR_MESSAGE,
+    PATH_LABEL,
+    TAGS_LABEL,
+    TYPE_LABEL,
+    VIEW_OTHER_CANDIDATES_LABEL,
+)
 from src.ui.validation.validation_wizard_controller import (
     ValidationWizardAction,
     ValidationWizardActionRequest,
@@ -62,7 +76,7 @@ class AmbiguousReferenceCandidate:
         if self.description:
             infos.append(self.description)
         if self.tags:
-            infos.append(f"Tags : {', '.join(self.tags)}")
+            infos.append(f"{TAGS_LABEL}: {', '.join(self.tags)}")
         return tuple(infos)
 
     @property
@@ -133,7 +147,7 @@ class AmbiguousReferenceDialog:
 
         window = ctk.CTkToplevel(self.master)
         self.window = window
-        window.title("Référence ambiguë")
+        window.title(AMBIGUOUS_REFERENCE_TITLE)
         window.transient(self.master)
         window.grab_set()
         window.geometry("760x460")
@@ -142,14 +156,14 @@ class AmbiguousReferenceDialog:
         payload = self.issue.payload
         ctk.CTkLabel(
             window,
-            text="Référence ambiguë",
+            text=AMBIGUOUS_REFERENCE_TITLE,
             font=ctk.CTkFont(size=18, weight="bold"),
         ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
         ctk.CTkLabel(
             window,
-            text=(
-                f"« {payload.referenced_name} » correspond à plusieurs "
-                f"{payload.expected_type}. Choisissez la cible à remapper."
+            text=AMBIGUOUS_REFERENCE_MESSAGE.format(
+                referenced_name=payload.referenced_name,
+                expected_type=payload.expected_type,
             ),
             wraplength=700,
             justify="left",
@@ -167,18 +181,18 @@ class AmbiguousReferenceDialog:
         for index in range(4):
             actions.grid_columnconfigure(index, weight=1)
 
-        ctk.CTkButton(actions, text="Choisir gauche", command=self.choose_left).grid(
+        ctk.CTkButton(actions, text=CHOOSE_LEFT_LABEL, command=self.choose_left).grid(
             row=0, column=0, sticky="ew", padx=4, pady=4
         )
-        ctk.CTkButton(actions, text="Choisir droite", command=self.choose_right).grid(
+        ctk.CTkButton(actions, text=CHOOSE_RIGHT_LABEL, command=self.choose_right).grid(
             row=0, column=1, sticky="ew", padx=4, pady=4
         )
         ctk.CTkButton(
             actions,
-            text="Voir autres candidats",
+            text=VIEW_OTHER_CANDIDATES_LABEL,
             command=self.show_other_candidates,
         ).grid(row=0, column=2, sticky="ew", padx=4, pady=4)
-        ctk.CTkButton(actions, text="Ignorer", command=self.ignore).grid(
+        ctk.CTkButton(actions, text=IGNORE_LABEL, command=self.ignore).grid(
             row=0, column=3, sticky="ew", padx=4, pady=4
         )
         return self
@@ -197,7 +211,7 @@ class AmbiguousReferenceDialog:
         """Submit the selected candidate identifier to the controller."""
 
         if index < 0 or index >= len(self.displayed_candidates):
-            self._publish_error("Candidat indisponible pour cette référence ambiguë.")
+            self._publish_error(CANDIDATE_UNAVAILABLE_MESSAGE)
             return None
 
         candidate = self.displayed_candidates[index]
@@ -213,7 +227,7 @@ class AmbiguousReferenceDialog:
         """Notify the host that a broader candidate picker should be shown."""
 
         if self.config.on_show_other_candidates is None:
-            self._publish_error("Aucun sélecteur d’autres candidats n’est configuré.")
+            self._publish_error(NO_OTHER_CANDIDATE_SELECTOR_MESSAGE)
             return
         self.config.on_show_other_candidates(self.issue, self.candidates)
 
@@ -247,17 +261,17 @@ class AmbiguousReferenceDialog:
             font=ctk.CTkFont(size=15, weight="bold"),
             anchor="w",
         ).grid(row=0, column=0, sticky="ew", padx=12, pady=(12, 4))
-        ctk.CTkLabel(card, text=f"Type : {candidate.entity_type or '—'}", anchor="w").grid(
+        ctk.CTkLabel(card, text=f"{TYPE_LABEL}: {candidate.entity_type or '—'}", anchor="w").grid(
             row=1, column=0, sticky="ew", padx=12, pady=2
         )
         ctk.CTkLabel(
             card,
-            text=f"Chemin : {candidate.display_path}",
+            text=f"{PATH_LABEL}: {candidate.display_path}",
             wraplength=320,
             justify="left",
             anchor="w",
         ).grid(row=2, column=0, sticky="ew", padx=12, pady=2)
-        infos = candidate.key_infos or ("Aucune info clé disponible.",)
+        infos = candidate.key_infos or (NO_KEY_INFO_MESSAGE,)
         ctk.CTkLabel(
             card,
             text="\n".join(infos),

--- a/src/ui/validation/dialogs/campaign_selector_dialog.py
+++ b/src/ui/validation/dialogs/campaign_selector_dialog.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+from src.ui.validation.labels import (
+    CANCEL_LABEL,
+    CHOOSE_CAMPAIGN_MESSAGE,
+    CHOOSE_CAMPAIGN_TITLE,
+    NO_CAMPAIGNS_MESSAGE,
+    RUN_LABEL,
+)
+
 
 @dataclass(frozen=True)
 class CampaignSelectorOption:
@@ -33,7 +41,9 @@ class CampaignSelectorDialog:
         self.window: Any | None = None
         self._selected_text: Any | None = None
         self._run_button: Any | None = None
-        self._display_to_option = {campaign.display_text: campaign for campaign in self.campaigns}
+        self._display_to_option = {
+            campaign.display_text: campaign for campaign in self.campaigns
+        }
 
     def show(self) -> CampaignSelectorOption | None:
         """Open the modal selector and return the chosen campaign, or ``None``."""
@@ -42,7 +52,7 @@ class CampaignSelectorDialog:
 
         window = ctk.CTkToplevel(self.master)
         self.window = window
-        window.title("Choisir une campagne")
+        window.title(CHOOSE_CAMPAIGN_TITLE)
         window.transient(self.master)
         window.grab_set()
         window.geometry("480x260")
@@ -51,17 +61,14 @@ class CampaignSelectorDialog:
 
         ctk.CTkLabel(
             window,
-            text="Choisir une campagne",
+            text=CHOOSE_CAMPAIGN_TITLE,
             font=ctk.CTkFont(size=18, weight="bold"),
         ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
 
         if self.campaigns:
             ctk.CTkLabel(
                 window,
-                text=(
-                    "Sélectionnez la campagne à vérifier. La validation ne "
-                    "démarrera qu’après ce choix."
-                ),
+                text=CHOOSE_CAMPAIGN_MESSAGE,
                 wraplength=420,
                 justify="left",
             ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
@@ -76,19 +83,20 @@ class CampaignSelectorDialog:
         else:
             ctk.CTkLabel(
                 window,
-                text=(
-                    "Aucune campagne n’existe encore. Créez ou importez une campagne "
-                    "avant de lancer la validation."
-                ),
+                text=NO_CAMPAIGNS_MESSAGE,
                 wraplength=420,
                 justify="left",
             ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
 
         actions = ctk.CTkFrame(window)
         actions.grid(row=3, column=0, sticky="e", padx=20, pady=(22, 20))
-        self._run_button = ctk.CTkButton(actions, text="Run", command=self.run, state="disabled")
+        self._run_button = ctk.CTkButton(
+            actions, text=RUN_LABEL, command=self.run, state="disabled"
+        )
         self._run_button.grid(row=0, column=0, padx=(0, 8))
-        ctk.CTkButton(actions, text="Annuler", command=self.cancel).grid(row=0, column=1)
+        ctk.CTkButton(actions, text=CANCEL_LABEL, command=self.cancel).grid(
+            row=0, column=1
+        )
 
         window.wait_window()
         return self.selected_campaign
@@ -101,7 +109,9 @@ class CampaignSelectorDialog:
     def run(self) -> None:
         """Accept the current selection and close the dialog."""
 
-        selected_text = self._selected_text.get() if self._selected_text is not None else ""
+        selected_text = (
+            self._selected_text.get() if self._selected_text is not None else ""
+        )
         selected_campaign = self._display_to_option.get(selected_text)
         if selected_campaign is None:
             return

--- a/src/ui/validation/dialogs/missing_reference_dialog.py
+++ b/src/ui/validation/dialogs/missing_reference_dialog.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
+from src.ui.validation.labels import (
+    CREATE_LABEL,
+    IGNORE_LABEL,
+    MISSING_REFERENCE_MESSAGE,
+    MISSING_REFERENCE_TITLE,
+    NO_REMAP_TARGET_SELECTOR_MESSAGE,
+    REMAP_LABEL,
+    REMAPPING_UNAVAILABLE_TITLE,
+    REMOVE_LABEL,
+)
 from src.ui.validation.validation_wizard_controller import (
     ValidationWizardAction,
     ValidationWizardActionRequest,
@@ -46,7 +56,7 @@ class MissingReferenceDialog:
     """Resolve a missing reference with create, remap, remove, or ignore actions.
 
     The dialog delegates mutations to ``ValidationWizardController``.  The
-    ``Créer`` action opens the Generic Editor for the issue expected type with
+    ``Create`` action opens the Generic Editor for the issue expected type with
     the referenced value pre-filled as the entity name.  When the editor saves,
     the created entity is returned to the controller so it can auto-link the
     original reference.
@@ -83,7 +93,7 @@ class MissingReferenceDialog:
 
         window = ctk.CTkToplevel(self.master)
         self.window = window
-        window.title("Référence manquante")
+        window.title(MISSING_REFERENCE_TITLE)
         window.transient(self.master)
         window.grab_set()
         window.geometry("560x320")
@@ -92,14 +102,15 @@ class MissingReferenceDialog:
         payload = self.issue.payload
         ctk.CTkLabel(
             window,
-            text="Référence manquante",
+            text=MISSING_REFERENCE_TITLE,
             font=ctk.CTkFont(size=18, weight="bold"),
         ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
         ctk.CTkLabel(
             window,
-            text=(
-                f"« {payload.referenced_name} » est attendu comme "
-                f"{payload.expected_type} depuis {payload.source_entity}."
+            text=MISSING_REFERENCE_MESSAGE.format(
+                referenced_name=payload.referenced_name,
+                expected_type=payload.expected_type,
+                source_entity=payload.source_entity,
             ),
             wraplength=500,
             justify="left",
@@ -110,16 +121,18 @@ class MissingReferenceDialog:
         for index in range(4):
             actions.grid_columnconfigure(index, weight=1)
 
-        ctk.CTkButton(actions, text="Créer", command=self.create_via_generic_editor).grid(
+        ctk.CTkButton(
+            actions, text=CREATE_LABEL, command=self.create_via_generic_editor
+        ).grid(
             row=0, column=0, sticky="ew", padx=4, pady=4
         )
-        ctk.CTkButton(actions, text="Remapper", command=self.remap).grid(
+        ctk.CTkButton(actions, text=REMAP_LABEL, command=self.remap).grid(
             row=0, column=1, sticky="ew", padx=4, pady=4
         )
-        ctk.CTkButton(actions, text="Supprimer", command=self.remove_reference).grid(
+        ctk.CTkButton(actions, text=REMOVE_LABEL, command=self.remove_reference).grid(
             row=0, column=2, sticky="ew", padx=4, pady=4
         )
-        ctk.CTkButton(actions, text="Ignorer", command=self.ignore).grid(
+        ctk.CTkButton(actions, text=IGNORE_LABEL, command=self.ignore).grid(
             row=0, column=3, sticky="ew", padx=4, pady=4
         )
         return self
@@ -141,7 +154,7 @@ class MissingReferenceDialog:
         """Ask the host for a target and remap the missing reference to it."""
 
         if self.config.remap_target_provider is None:
-            self._publish_error("Aucun sélecteur de cible n’est configuré pour le remapping.")
+            self._publish_error(NO_REMAP_TARGET_SELECTOR_MESSAGE)
             return None
 
         target = self.config.remap_target_provider(self.issue)
@@ -190,7 +203,7 @@ class MissingReferenceDialog:
 
         from tkinter import messagebox
 
-        messagebox.showwarning("Remapping indisponible", message)
+        messagebox.showwarning(REMAPPING_UNAVAILABLE_TITLE, message)
 
     def close(self) -> None:
         """Close the dialog window if it has been displayed."""

--- a/src/ui/validation/dialogs/validation_summary_dialog.py
+++ b/src/ui/validation/dialogs/validation_summary_dialog.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from src.ui.validation.labels import (
+    CLOSE_LABEL,
+    CORRECTED_LABEL,
+    ELAPSED_TIME_LABEL,
+    ENTITIES_VISITED_LABEL,
+    IGNORED_LABEL,
+    NO_ENTITIES_FOUND_MESSAGE,
+    REFERENCES_CHECKED_LABEL,
+    REMAINING_LABEL,
+    VALIDATION_SUMMARY_MESSAGE,
+    VALIDATION_SUMMARY_TITLE,
+)
 from src.ui.validation.validation_wizard_controller import ValidationWizardSummary
 
 
@@ -48,8 +60,8 @@ class ValidationSummaryDialog:
         master: Any,
         counts: ValidationSummaryCounts,
         *,
-        title: str = "Résumé de validation",
-        message: str = "Vérification de cohérence hiérarchique terminée.",
+        title: str = VALIDATION_SUMMARY_TITLE,
+        message: str = VALIDATION_SUMMARY_MESSAGE,
     ) -> None:
         self.master = master
         self.counts = counts
@@ -88,11 +100,11 @@ class ValidationSummaryDialog:
             issue_counters.grid_columnconfigure(column, weight=1)
 
         self._render_counter(
-            ctk, issue_counters, 0, "Corrigés", self.counts.corrected
+            ctk, issue_counters, 0, CORRECTED_LABEL, self.counts.corrected
         )
-        self._render_counter(ctk, issue_counters, 1, "Ignorés", self.counts.ignored)
+        self._render_counter(ctk, issue_counters, 1, IGNORED_LABEL, self.counts.ignored)
         self._render_counter(
-            ctk, issue_counters, 2, "Restants", self.counts.remaining
+            ctk, issue_counters, 2, REMAINING_LABEL, self.counts.remaining
         )
 
         metrics = ctk.CTkFrame(window)
@@ -101,16 +113,16 @@ class ValidationSummaryDialog:
             metrics.grid_columnconfigure(column, weight=1)
 
         self._render_counter(
-            ctk, metrics, 0, "Entités visitées", self.counts.entities_visited
+            ctk, metrics, 0, ENTITIES_VISITED_LABEL, self.counts.entities_visited
         )
         self._render_counter(
-            ctk, metrics, 1, "Références vérifiées", self.counts.references_checked
+            ctk, metrics, 1, REFERENCES_CHECKED_LABEL, self.counts.references_checked
         )
         self._render_counter(
-            ctk, metrics, 2, "Temps écoulé", _format_elapsed(self.counts.elapsed_seconds)
+            ctk, metrics, 2, ELAPSED_TIME_LABEL, _format_elapsed(self.counts.elapsed_seconds)
         )
 
-        ctk.CTkButton(window, text="Fermer", command=self.close).grid(
+        ctk.CTkButton(window, text=CLOSE_LABEL, command=self.close).grid(
             row=4, column=0, sticky="e", padx=20, pady=(18, 20)
         )
         return self
@@ -124,7 +136,7 @@ class ValidationSummaryDialog:
 
     def _status_message(self) -> str:
         if self.counts.no_entities_found:
-            return f"{self.message}\n\n⚠️ No entities found under selected campaign."
+            return f"{self.message}\n\n⚠️ {NO_ENTITIES_FOUND_MESSAGE}"
         return self.message
 
     @staticmethod
@@ -150,8 +162,8 @@ def open_validation_summary_dialog(
     master: Any,
     summary: ValidationWizardSummary,
     *,
-    title: str = "Résumé de validation",
-    message: str = "Vérification de cohérence hiérarchique terminée.",
+    title: str = VALIDATION_SUMMARY_TITLE,
+    message: str = VALIDATION_SUMMARY_MESSAGE,
 ) -> ValidationSummaryDialog:
     """Open a validation summary dialog from a wizard summary."""
 

--- a/src/ui/validation/labels.py
+++ b/src/ui/validation/labels.py
@@ -1,0 +1,93 @@
+"""English default labels and messages for validation UI surfaces."""
+
+VALIDATION_TITLE = "Validation"
+VALIDATION_SUMMARY_TITLE = "Validation summary"
+VALIDATION_SUMMARY_MESSAGE = "Hierarchy consistency check completed."
+VALIDATION_CAMPAIGN_TITLE = "Campaign validation"
+
+CORRECTED_LABEL = "Corrected"
+IGNORED_LABEL = "Ignored"
+REMAINING_LABEL = "Remaining"
+ENTITIES_VISITED_LABEL = "Entities visited"
+REFERENCES_CHECKED_LABEL = "References checked"
+ELAPSED_TIME_LABEL = "Elapsed time"
+CLOSE_LABEL = "Close"
+
+NO_ENTITIES_FOUND_MESSAGE = "No entities found under selected campaign."
+CAMPAIGN_DATA_UNAVAILABLE_TITLE = "Campaign data unavailable"
+CAMPAIGN_DATA_UNAVAILABLE_MESSAGE = (
+    "The data store or entity services could not be found. "
+    "Open or reload a campaign project before running validation again."
+)
+CAMPAIGN_REQUIRED_TITLE = "Campaign required"
+CAMPAIGN_REQUIRED_MESSAGE = (
+    "No campaign was selected for validation. "
+    "Select an active campaign, then run validation again."
+)
+VALIDATION_UNAVAILABLE_TITLE = "Validation unavailable"
+VALIDATION_UNAVAILABLE_MESSAGE = (
+    "Validation could not start because of an initialization error. "
+    "Verify that the project is loaded, then run validation again."
+)
+TECHNICAL_DETAIL_LABEL = "Technical detail"
+VALIDATION_IMPOSSIBLE_TITLE = "Validation unavailable"
+HIERARCHY_CONSISTENCY_TITLE = "Hierarchy consistency"
+IGNORE_ISSUE_PROMPT = "Ignore this issue for this session?"
+
+AMBIGUOUS_REFERENCE_TITLE = "Ambiguous reference"
+AMBIGUOUS_REFERENCE_MESSAGE = (
+    "\u201c{referenced_name}\u201d matches multiple {expected_type} entities. "
+    "Choose the target to remap."
+)
+CHOOSE_LEFT_LABEL = "Choose left"
+CHOOSE_RIGHT_LABEL = "Choose right"
+VIEW_OTHER_CANDIDATES_LABEL = "View other candidates"
+IGNORE_LABEL = "Ignore"
+CANDIDATE_UNAVAILABLE_MESSAGE = "Candidate unavailable for this ambiguous reference."
+NO_OTHER_CANDIDATE_SELECTOR_MESSAGE = "No other-candidate selector is configured."
+NO_KEY_INFO_MESSAGE = "No key info available."
+TYPE_LABEL = "Type"
+PATH_LABEL = "Path"
+TAGS_LABEL = "Tags"
+
+MISSING_REFERENCE_TITLE = "Missing reference"
+MISSING_REFERENCE_MESSAGE = (
+    "\u201c{referenced_name}\u201d is expected as {expected_type} from {source_entity}."
+)
+CREATE_LABEL = "Create"
+REMAP_LABEL = "Remap"
+REMOVE_LABEL = "Remove"
+NO_REMAP_TARGET_SELECTOR_MESSAGE = "No target selector is configured for remapping."
+REMAPPING_UNAVAILABLE_TITLE = "Remapping unavailable"
+
+CHOOSE_CAMPAIGN_TITLE = "Choose a campaign"
+CHOOSE_CAMPAIGN_MESSAGE = (
+    "Select the campaign to check. Validation will start only after this choice."
+)
+NO_CAMPAIGNS_MESSAGE = (
+    "No campaigns exist yet. Create or import a campaign before running validation."
+)
+CANCEL_LABEL = "Cancel"
+RUN_LABEL = "Run"
+
+ENTITY_CREATION_PENDING_MESSAGE = (
+    "Entity creation is pending: link the created entity or cancel."
+)
+ISSUE_IGNORED_MESSAGE = "Issue ignored for this session: {referenced_name}"
+ENTITY_CREATION_REQUESTED_MESSAGE = (
+    "Entity creation requested. Validation will resume after saving."
+)
+REFERENCE_NOT_FOUND_ACTION_MESSAGE = (
+    "Cannot apply action: validation reference not found."
+)
+RESUME_NO_ENTITY_MESSAGE = "Cannot resume: no created entity was provided."
+REFERENCE_NOT_FOUND_RESUME_MESSAGE = (
+    "Cannot resume: validation reference not found."
+)
+VALIDATION_CANCELED_MESSAGE = "Validation canceled by the GM."
+VALIDATION_COMPLETED_MESSAGE = "Validation completed."
+UNKNOWN_ACTION_MESSAGE = "Unknown action: {action}"
+ISSUE_REFERENCE_MESSAGE = (
+    "{issue_type}: {source_entity}.{field} references "
+    "\u201c{referenced_name}\u201d ({expected_type})."
+)

--- a/src/ui/validation/progress.py
+++ b/src/ui/validation/progress.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.ui.validation.labels import VALIDATION_CAMPAIGN_TITLE, VALIDATION_TITLE
+
 
 class ValidationScanProgress:
     """Tiny, best-effort progress dialog that reports validation phases.
@@ -14,7 +16,7 @@ class ValidationScanProgress:
     no-op object when the master is not a Tk widget.
     """
 
-    def __init__(self, master: Any, *, title: str = "Validation") -> None:
+    def __init__(self, master: Any, *, title: str = VALIDATION_TITLE) -> None:
         self.master = master
         self.title = title
         self.window: Any | None = None
@@ -38,7 +40,7 @@ class ValidationScanProgress:
         frame.grid(row=0, column=0, sticky="nsew")
         tk.Label(
             frame,
-            text="Validation de campagne",
+            text=VALIDATION_CAMPAIGN_TITLE,
             font=("TkDefaultFont", 12, "bold"),
         ).grid(row=0, column=0, sticky="w", pady=(0, 8))
         self._phase_label = tk.Label(frame, text=phase, anchor="w")

--- a/src/ui/validation/validation_wizard_controller.py
+++ b/src/ui/validation/validation_wizard_controller.py
@@ -14,6 +14,18 @@ from time import monotonic
 from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
 
 from src.services import ReferenceActionResult, ReferenceFixService, SessionIgnoreStore
+from src.ui.validation.labels import (
+    ENTITY_CREATION_PENDING_MESSAGE,
+    ENTITY_CREATION_REQUESTED_MESSAGE,
+    ISSUE_IGNORED_MESSAGE,
+    ISSUE_REFERENCE_MESSAGE,
+    REFERENCE_NOT_FOUND_ACTION_MESSAGE,
+    REFERENCE_NOT_FOUND_RESUME_MESSAGE,
+    RESUME_NO_ENTITY_MESSAGE,
+    UNKNOWN_ACTION_MESSAGE,
+    VALIDATION_CANCELED_MESSAGE,
+    VALIDATION_COMPLETED_MESSAGE,
+)
 from src.validation import ValidationIssue
 from src.validation.reference_validator import EntityRecord, ReferenceRecord
 
@@ -231,7 +243,7 @@ class ValidationWizardController:
         if self._awaiting_entity_creation:
             if action != ValidationWizardAction.LINK_CREATED:
                 return self._action_failed(
-                    "Création d’entité en attente : reliez l’entité créée ou annulez."
+                    ENTITY_CREATION_PENDING_MESSAGE
                 )
             return self.resume_after_entity_creation(
                 action_request.created_entity or action_request.target,
@@ -246,7 +258,9 @@ class ValidationWizardController:
             self._ignore_store.ignore(current_item.issue)
             self._summary = _summary_with_skip(
                 self._summary,
-                f"Issue ignorée pour cette session : {current_item.issue.payload.referenced_name}",
+                ISSUE_IGNORED_MESSAGE.format(
+                    referenced_name=current_item.issue.payload.referenced_name
+                ),
             )
             return self._advance_to_next_issue()
 
@@ -256,7 +270,7 @@ class ValidationWizardController:
                 status=ValidationWizardStatus.AWAITING_ENTITY_CREATION,
                 issue=current_item.issue,
                 progress=self._progress_for_cursor(),
-                message="Création d’entité demandée. Reprise prévue après sauvegarde.",
+                message=ENTITY_CREATION_REQUESTED_MESSAGE,
             )
             self._active_step = step
             return step
@@ -264,7 +278,7 @@ class ValidationWizardController:
         reference = self._resolve_reference(current_item)
         if reference is None:
             return self._action_failed(
-                "Impossible d’appliquer l’action : référence de validation introuvable."
+                REFERENCE_NOT_FOUND_ACTION_MESSAGE
             )
 
         if action == ValidationWizardAction.REMAP:
@@ -281,7 +295,7 @@ class ValidationWizardController:
                 attach_to_source=action_request.attach_to_source,
             )
         else:
-            return self._action_failed(f"Action inconnue : {action.value}")
+            return self._action_failed(UNKNOWN_ACTION_MESSAGE.format(action=action.value))
 
         return self._handle_action_result(result)
 
@@ -297,12 +311,12 @@ class ValidationWizardController:
         if current_item is None:
             return self._complete()
         if created_entity is None:
-            return self._action_failed("Impossible de reprendre : aucune entité créée fournie.")
+            return self._action_failed(RESUME_NO_ENTITY_MESSAGE)
 
         reference = self._resolve_reference(current_item)
         if reference is None:
             return self._action_failed(
-                "Impossible de reprendre : référence de validation introuvable."
+                REFERENCE_NOT_FOUND_RESUME_MESSAGE
             )
 
         result = self._reference_fix_service.link_created_entity(
@@ -322,7 +336,7 @@ class ValidationWizardController:
         step = ValidationWizardStep(
             status=ValidationWizardStatus.CANCELED,
             summary=self._summary,
-            message="Validation annulée par le GM.",
+            message=VALIDATION_CANCELED_MESSAGE,
         )
         self._active_step = step
         self._notify_summary(step)
@@ -351,7 +365,7 @@ class ValidationWizardController:
         step = ValidationWizardStep(
             status=ValidationWizardStatus.COMPLETED,
             summary=self._final_summary(),
-            message="Validation terminée.",
+            message=VALIDATION_COMPLETED_MESSAGE,
         )
         self._summary = step.summary or self._summary
         self._active_step = step
@@ -520,13 +534,16 @@ def _summary_canceled(summary: ValidationWizardSummary) -> ValidationWizardSumma
         canceled=True,
         metrics=summary.metrics,
         changes_applied=summary.changes_applied,
-        messages=summary.messages + ("Validation annulée par le GM.",),
+        messages=summary.messages + (VALIDATION_CANCELED_MESSAGE,),
     )
 
 
 def _format_issue_message(issue: ValidationIssue) -> str:
     payload = issue.payload
-    return (
-        f"{issue.issue_type.value}: {payload.source_entity}.{payload.field} "
-        f"référence « {payload.referenced_name} » ({payload.expected_type})."
+    return ISSUE_REFERENCE_MESSAGE.format(
+        issue_type=issue.issue_type.value,
+        source_entity=payload.source_entity,
+        field=payload.field,
+        referenced_name=payload.referenced_name,
+        expected_type=payload.expected_type,
     )

--- a/tests/ui/validation/fixtures/minimal_validation_dataset.py
+++ b/tests/ui/validation/fixtures/minimal_validation_dataset.py
@@ -35,7 +35,7 @@ EXPECTED_DECISION_SUMMARY = {
         "Référence remappée vers « L2 ».",
         "Référence remappée vers « S-valid ».",
         "Nouvelle entité « S-created » reliée.",
-        "Issue ignorée pour cette session : Scenario To Ignore",
+        "Issue ignored for this session: Scenario To Ignore",
     ),
 }
 

--- a/tests/ui/validation/test_ambiguous_reference_dialog.py
+++ b/tests/ui/validation/test_ambiguous_reference_dialog.py
@@ -65,7 +65,7 @@ def test_dialog_normalizes_candidates_and_displays_two_side_by_side():
     assert dialog.displayed_candidates[0].display_path.endswith("scenario:S1")
     assert dialog.displayed_candidates[0].key_infos == (
         "Première piste",
-        "Tags : politique, intro",
+        "Tags: politique, intro",
     )
     assert hierarchy["scenario_refs"] == ["Duplicate"]
 

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -211,10 +211,10 @@ def test_launcher_aborts_cleanly_when_user_cancels_selection(monkeypatch):
     assert summaries == []
     assert messages == [
         (
-            "Campagne requise",
+            "Campaign required",
             (
-                "Aucune campagne n’a été sélectionnée pour la validation. "
-                "Sélectionnez une campagne active, puis relancez la validation."
+                "No campaign was selected for validation. "
+                "Select an active campaign, then run validation again."
             ),
         )
     ]
@@ -241,10 +241,10 @@ def test_launcher_aborts_when_no_campaigns_exist(monkeypatch):
     assert summaries == []
     assert messages == [
         (
-            "Campagne requise",
+            "Campaign required",
             (
-                "Aucune campagne n’a été sélectionnée pour la validation. "
-                "Sélectionnez une campagne active, puis relancez la validation."
+                "No campaign was selected for validation. "
+                "Select an active campaign, then run validation again."
             ),
         )
     ]
@@ -269,10 +269,10 @@ def test_launcher_reports_unresolved_repository_for_explicit_campaign(monkeypatc
     assert summaries == []
     assert messages == [
         (
-            "Données de campagne indisponibles",
+            "Campaign data unavailable",
             (
-                "Le dépôt de données ou les services d’entités sont introuvables. "
-                "Ouvrez ou rechargez un projet de campagne avant de relancer la validation."
+                "The data store or entity services could not be found. "
+                "Open or reload a campaign project before running validation again."
             ),
         )
     ]
@@ -307,11 +307,11 @@ def test_launcher_reports_bootstrap_exception_without_summary(monkeypatch):
     assert summaries == []
     assert messages == [
         (
-            "Validation indisponible",
+            "Validation unavailable",
             (
-                "La validation n’a pas pu démarrer à cause d’une erreur d’initialisation. "
-                "Vérifiez que le projet est chargé, puis relancez la validation.\n\n"
-                "Détail technique : validator offline"
+                "Validation could not start because of an initialization error. "
+                "Verify that the project is loaded, then run validation again.\n\n"
+                "Technical detail: validator offline"
             ),
         )
     ]


### PR DESCRIPTION
### Motivation
- Remove hardcoded French UI strings in the validation UI and provide English defaults to make the UI consistent and ready for future i18n.
- Centralize labels/messages so other dialogs and controllers can share the same keys and be translated or overridden later.

### Description
- Added `src/ui/validation/labels.py` containing English default messages and label constants (e.g. `Validation summary`, `Hierarchy consistency check completed.`, `Corrected`, `Ignored`, `Remaining`, `Entities visited`, `References checked`, `Elapsed time`, `Close`).
- Replaced hardcoded French strings with constants from `src.ui.validation.labels` in the following modules: `dialogs/validation_summary_dialog.py`, `campaign_validation_launcher.py`, `validation_wizard_controller.py`, `dialogs/ambiguous_reference_dialog.py`, `dialogs/missing_reference_dialog.py`, `dialogs/campaign_selector_dialog.py`, and `progress.py`.
- Kept message formatting and behaviour unchanged; only the textual constants were replaced and some dialog labels/titles were parameterized to use the centralized constants.
- Updated a few unit test expectations and a fixture to match the new English messages.

### Testing
- Ran the targeted test suite: `pytest -q tests/ui/validation` which completed successfully with `34 passed`.
- Verified code compiles: `python -m compileall src/ui/validation` completed with no syntax errors.
- Checked for leftover French characters with `rg -n "[À-ÿ]" src/ui/validation` and no matches were found in the validation package.
- Also performed `git diff --check` to ensure there are no whitespace or diff warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb757d5084832bae14391226018af2)