### PR TITLE
Attach scenarios to referenced validation arcs

### DIFF
--- a/src/ui/validation/campaign_scenario_hierarchy.py
+++ b/src/ui/validation/campaign_scenario_hierarchy.py
@@ -1,0 +1,136 @@
+"""Helpers for attaching referenced scenarios to campaign arc nodes."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping, Sequence
+
+from src.validation import normalize_validator_reference_fields
+
+_SCENARIO_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
+_SCENARIO_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label")
+ScenarioReferenceIndex = Mapping[str, Sequence[tuple[int, Mapping[str, Any]]]]
+
+
+def normalize_scenario_node(item: Mapping[str, Any], index: int) -> dict[str, Any]:
+    """Return a validator-ready scenario node loaded from the scenarios wrapper."""
+
+    node = normalize_validator_reference_fields("scenario", item)
+    identifier = _identifier_for(node, "scenarios", index)
+    node.setdefault("type", "scenario")
+    node.setdefault("entity_type", "scenario")
+    node.setdefault("id", identifier)
+    node.setdefault("name", _display_name_for(node, identifier))
+    return node
+
+
+def build_scenario_reference_index(
+    scenarios: Sequence[Mapping[str, Any]],
+) -> dict[str, tuple[tuple[int, dict[str, Any]], ...]]:
+    """Index scenario nodes by all user-facing reference keys.
+
+    Arc scenario references can point at a scenario by persisted ID-like values or
+    display labels. The validator itself matches exact normalized strings, so the
+    hierarchy builder uses the same stripped text values when resolving children.
+    """
+
+    index: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    for source_index, scenario in enumerate(scenarios):
+        for key in _scenario_lookup_keys(scenario):
+            index.setdefault(key, []).append((source_index, dict(scenario)))
+    return {key: tuple(value) for key, value in index.items()}
+
+
+def attach_referenced_scenarios_to_arcs(
+    arcs: Sequence[dict[str, Any]],
+    scenario_index: ScenarioReferenceIndex,
+) -> None:
+    """Attach resolved scenarios under their referencing arcs in-place.
+
+    Resolved entries are moved from ``arc["scenario_refs"]`` to concrete
+    ``arc["scenarios"]`` children. References with no match remain in
+    ``scenario_refs`` so the reference validator can still report them as
+    missing.
+    """
+
+    for arc in arcs:
+        unresolved_refs: list[Any] = []
+        scenario_children: list[dict[str, Any]] = []
+        attached_signatures: set[tuple[int, str, str]] = set()
+
+        for raw_reference in arc.get("scenario_refs", ()):  # keep original shape
+            reference = _reference_text(raw_reference)
+            matches = scenario_index.get(reference, ()) if reference else ()
+            if not matches:
+                unresolved_refs.append(raw_reference)
+                continue
+
+            for source_index, match in matches:
+                signature = _scenario_signature(source_index, match)
+                if signature in attached_signatures:
+                    continue
+                scenario_children.append(deepcopy(dict(match)))
+                attached_signatures.add(signature)
+
+        if scenario_children:
+            arc["scenarios"] = scenario_children
+        else:
+            arc.pop("scenarios", None)
+        arc["scenario_refs"] = unresolved_refs
+
+
+def _scenario_lookup_keys(scenario: Mapping[str, Any]) -> tuple[str, ...]:
+    keys: list[str] = []
+    for key in _SCENARIO_ID_KEYS + _SCENARIO_NAME_KEYS:
+        value = _clean_text(scenario.get(key))
+        if value and value not in keys:
+            keys.append(value)
+    return tuple(keys)
+
+
+def _scenario_signature(
+    source_index: int, scenario: Mapping[str, Any]
+) -> tuple[int, str, str]:
+    identifier = _clean_text(scenario.get("id")) or _display_name_for(scenario, "")
+    return (
+        source_index,
+        _clean_text(scenario.get("entity_type")) or "scenario",
+        identifier,
+    )
+
+
+def _reference_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        reference_keys = _SCENARIO_ID_KEYS + _SCENARIO_NAME_KEYS + (
+            "ref",
+            "reference",
+            "target",
+        )
+        for key in reference_keys:
+            reference = _clean_text(value.get(key))
+            if reference:
+                return reference
+        return ""
+    return _clean_text(value)
+
+
+def _identifier_for(item: Mapping[str, Any], slug: str, index: int) -> str:
+    for key in _SCENARIO_ID_KEYS + _SCENARIO_NAME_KEYS:
+        value = _clean_text(item.get(key))
+        if value:
+            return value
+    return f"{slug}-{index}"
+
+
+def _display_name_for(item: Mapping[str, Any], fallback: str) -> str:
+    for key in _SCENARIO_NAME_KEYS:
+        value = _clean_text(item.get(key))
+        if value:
+            return value
+    return fallback
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -8,6 +8,11 @@ from typing import Any, Callable, Mapping, Sequence
 
 from modules.helpers.logging_helper import log_exception, log_info
 from src.ui.validation.campaign_arc_hierarchy import build_campaign_arc_nodes
+from src.ui.validation.campaign_scenario_hierarchy import (
+    attach_referenced_scenarios_to_arcs,
+    build_scenario_reference_index,
+    normalize_scenario_node,
+)
 from src.ui.validation.dialogs.ambiguous_reference_dialog import (
     AmbiguousReferenceDialogConfig,
     open_ambiguous_reference_dialog,
@@ -302,11 +307,15 @@ def build_campaign_validation_hierarchy(
     root["id"] = selected.campaign_id
     root["name"] = selected.label
     root["arcs"] = build_campaign_arc_nodes(selected.item.get("Arcs"))
+    scenario_nodes = _load_scenario_nodes(entity_wrappers, progress=progress)
+    attach_referenced_scenarios_to_arcs(
+        root["arcs"], build_scenario_reference_index(scenario_nodes)
+    )
     root["entities"] = []
     entities = root["entities"]
 
     for slug in sorted(entity_wrappers):
-        if slug == "campaigns":
+        if slug in {"campaigns", "scenarios"}:
             continue
         if progress is not None:
             progress.set_phase(_scan_phase_for_slug(slug))
@@ -319,11 +328,32 @@ def build_campaign_validation_hierarchy(
     log_info(
         (
             f"Built validation hierarchy for campaign {selected.campaign_id} "
-            f"with {len(root['arcs'])} arcs and {len(entities)} entities"
+            f"with {len(root['arcs'])} arcs, "
+            f"{sum(len(arc.get('scenarios', ())) for arc in root['arcs'])} "
+            f"arc scenarios, and {len(entities)} entities"
         ),
         func_name="src.ui.validation.campaign_validation_launcher.build_campaign_validation_hierarchy",
     )
     return root
+
+
+def _load_scenario_nodes(
+    entity_wrappers: Mapping[str, Any],
+    *,
+    progress: ValidationScanProgress | None = None,
+) -> tuple[dict[str, Any], ...]:
+    """Load and normalize all scenarios for arc-local hierarchy attachment."""
+
+    wrapper = entity_wrappers.get("scenarios")
+    if wrapper is None:
+        return ()
+    if progress is not None:
+        progress.set_phase(_scan_phase_for_slug("scenarios"))
+    return tuple(
+        normalize_scenario_node(item, index)
+        for index, item in enumerate(_safe_load_items(wrapper))
+        if isinstance(item, Mapping)
+    )
 
 
 def _log_validation_diagnostics(graph: ReferenceValidationResult) -> None:

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -46,12 +46,15 @@ def test_build_campaign_validation_hierarchy_normalizes_wrapper_items():
     assert hierarchy["type"] == "campaign"
     assert hierarchy["id"] == "c1"
     assert hierarchy["name"] == "Dragonfall"
-    assert entities[0]["type"] == "npc"
-    assert entities[0]["id"] == "Asha"
-    assert entities[1]["type"] == "scenario"
-    assert entities[1]["id"] == "Opening Scene"
-    assert entities[1]["npc_refs"] == ["Asha"]
-    assert "NPCs" not in entities[1]
+    assert entities == [
+        {
+            "Name": "Asha",
+            "type": "npc",
+            "entity_type": "npc",
+            "id": "Asha",
+            "name": "Asha",
+        }
+    ]
 
 
 def test_build_campaign_validation_hierarchy_normalizes_campaign_linked_scenarios():
@@ -108,7 +111,16 @@ def test_build_campaign_validation_hierarchy_builds_selected_campaign_arc_nodes(
             "type": "arc",
             "entity_type": "arc",
             "id": "Opening Arc",
-            "scenario_refs": ["Opening Scene", "Hidden Shrine"],
+            "scenario_refs": ["Hidden Shrine"],
+            "scenarios": [
+                {
+                    "Title": "Opening Scene",
+                    "type": "scenario",
+                    "entity_type": "scenario",
+                    "id": "Opening Scene",
+                    "name": "Opening Scene",
+                }
+            ],
         },
         {
             "id": "arc-final",
@@ -119,7 +131,46 @@ def test_build_campaign_validation_hierarchy_builds_selected_campaign_arc_nodes(
             "scenario_refs": ["Boss Fight"],
         },
     ]
-    assert hierarchy["entities"][0]["entity_type"] == "scenario"
+    assert hierarchy["entities"] == []
+
+
+def test_build_campaign_validation_hierarchy_attaches_only_referenced_scenarios():
+    campaign = {
+        "id": "c1",
+        "Name": "Dragonfall",
+        "Arcs": {
+            "arcs": [
+                {"name": "Opening Arc", "scenarios": ["s1", "Missing Scene"]},
+                {"name": "Finale", "scenarios": ["Boss Fight"]},
+                {"name": "Downtime", "scenarios": []},
+            ]
+        },
+    }
+
+    hierarchy = build_campaign_validation_hierarchy(
+        {
+            "campaigns": FakeWrapper([campaign]),
+            "scenarios": FakeWrapper(
+                [
+                    {"id": "s1", "Title": "Opening Scene", "NPCs": ["Asha"]},
+                    {"id": "boss", "Title": "Boss Fight"},
+                    {"id": "unused", "Title": "Unrelated Scene"},
+                ]
+            ),
+        },
+        campaign,
+    )
+
+    opening_arc, finale_arc, downtime_arc = hierarchy["arcs"]
+    assert opening_arc["scenario_refs"] == ["Missing Scene"]
+    assert [scenario["id"] for scenario in opening_arc["scenarios"]] == ["s1"]
+    assert opening_arc["scenarios"][0]["npc_refs"] == ["Asha"]
+    assert "NPCs" not in opening_arc["scenarios"][0]
+    assert finale_arc["scenario_refs"] == []
+    assert [scenario["id"] for scenario in finale_arc["scenarios"]] == ["boss"]
+    assert downtime_arc["scenario_refs"] == []
+    assert "scenarios" not in downtime_arc
+    assert hierarchy["entities"] == []
 
 
 def test_load_campaign_options_reads_campaigns_wrapper_only():
@@ -344,12 +395,12 @@ def test_launcher_summary_includes_scan_metrics(monkeypatch):
     assert run is not None
     assert run.graph.diagnostics.visited_references == len(run.graph.references)
     summary = summaries[0]
-    assert summary.metrics.entities_visited == len(run.graph.entities) == 4
+    assert summary.metrics.entities_visited == len(run.graph.entities) == 3
     assert summary.metrics.references_checked == len(run.graph.references) == 1
     assert summary.metrics.elapsed_seconds >= 0
     assert any(run.graph.debug_summary in message for message in log_messages)
     assert any(
-        "entities_visited=4" in message and "references_checked=1" in message
+        "entities_visited=3" in message and "references_checked=1" in message
         for message in log_messages
     )
     diagnostics = run.graph.diagnostics


### PR DESCRIPTION
### Motivation
- Ensure arc nodes in the validation hierarchy include concrete scenario children when the campaign references them so the validator can reason about arc-local scenarios.
- Keep unresolved arc references visible in `scenario_refs` so missing-reference issues are still reported and resolvable by the UI.

### Description
- Add `src/ui/validation/campaign_scenario_hierarchy.py` implementing `normalize_scenario_node`, `build_scenario_reference_index`, and `attach_referenced_scenarios_to_arcs` to normalize scenarios, build a lookup index, and attach matched scenarios under arc nodes.
- Update `build_campaign_validation_hierarchy` in `src/ui/validation/campaign_validation_launcher.py` to load scenario nodes via a new helper `_load_scenario_nodes`, attach referenced scenarios to `root['arcs']`, and skip `scenarios` from the flat `entities` collection to avoid duplication.
- Preserve unmatched references by replacing `arc['scenario_refs']` with the unresolved items while moving matched scenarios into `arc['scenarios']`, and update logging to include arc scenario counts.
- Extend `tests/ui/validation/test_campaign_validation_launcher.py` with assertions that cover attached scenarios, unresolved reference preservation, omission of unrelated scenarios, and adjusted traversal metric expectations.

### Testing
- Ran static checks with `python -m py_compile src/ui/validation/campaign_validation_launcher.py src/ui/validation/campaign_arc_hierarchy.py src/ui/validation/campaign_scenario_hierarchy.py src/validation/reference_validator.py`, which succeeded.
- Ran targeted tests with `pytest tests/ui/validation/test_campaign_validation_launcher.py tests/validation/test_reference_validator.py -q` and observed the targeted tests passed (20 passed).
- Ran the UI validation test set with `pytest tests/ui/validation -q` and observed all tests passed (35 passed).
- Confirmed `git diff --check` and other local checks showed no errors during test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb789fb7e0832b906d069956a60334)