### PR TITLE
Allow arc.scenario_refs to match scenarios already present in selected campaign graph

### DIFF
--- a/src/validation/reference_validator.py
+++ b/src/validation/reference_validator.py
@@ -203,7 +203,7 @@ def validate_reference_graph(
 
         target = candidates[0]
         if not _is_valid_hierarchy_position(
-            reference.source,
+            reference,
             target,
             active_config.allowed_hierarchy_children,
         ):
@@ -507,17 +507,43 @@ def _build_hierarchy_issue(
 
 
 def _is_valid_hierarchy_position(
-    source: EntityRecord,
+    reference: ReferenceRecord,
     target: EntityRecord,
     allowed_hierarchy_children: Mapping[str, set[str]],
 ) -> bool:
+    source = reference.source
     allowed_children = allowed_hierarchy_children.get(source.entity_type, set())
     if target.entity_type not in allowed_children:
         return False
-    return (
+    if (
         target.parent_type == source.entity_type
         and target.parent_identifier == source.identifier
+    ):
+        return True
+    return _is_valid_arc_scenario_ref_membership(reference, target)
+
+
+def _is_valid_arc_scenario_ref_membership(
+    reference: ReferenceRecord, target: EntityRecord
+) -> bool:
+    """Accept graph-level scenarios that an arc explicitly lists by name or ID."""
+
+    return (
+        reference.field_path == "arc.scenario_refs"
+        and reference.source.entity_type == "arc"
+        and target.entity_type == "scenario"
+        and reference.reference_value in _entity_reference_values(target)
     )
+
+
+def _entity_reference_values(entity: EntityRecord) -> frozenset[str]:
+    values = {entity.identifier, entity.label}
+    values.update(
+        _normalize_text(entity.node.get(key))
+        for key in ENTITY_ID_KEYS + ENTITY_NAME_KEYS
+        if key in entity.node
+    )
+    return frozenset(value for value in values if value)
 
 
 def _split_field_path(field_path: str) -> tuple[str, str]:

--- a/tests/ui/validation/fixtures/minimal_validation_dataset.py
+++ b/tests/ui/validation/fixtures/minimal_validation_dataset.py
@@ -14,7 +14,7 @@ from src.validation import IssueType, ReferenceValidationResult, validate_refere
 EXPECTED_ISSUE_SEQUENCE = (
     (IssueType.MISSING_REFERENCE, "Arc To Remove"),
     (IssueType.AMBIGUOUS_REFERENCE, "Shared Place"),
-    (IssueType.INVALID_HIERARCHY, "Sibling Scenario"),
+    (IssueType.INVALID_HIERARCHY, "Sibling Place"),
     (IssueType.MISSING_REFERENCE, "Scenario To Create"),
     (IssueType.MISSING_REFERENCE, "Scenario To Ignore"),
 )
@@ -26,14 +26,14 @@ EXPECTED_DECISION_SUMMARY = {
     "changes_applied": (
         "C1.arc_refs: référence supprimée",
         "A1.location_refs: Shared Place → L2",
-        "A1.scenario_refs: Sibling Scenario → S-valid",
+        "A1.location_refs: Sibling Place → L1",
         "scenarios: entité ajoutée",
         "A1.scenario_refs: Scenario To Create → S-created",
     ),
     "messages": (
         "Référence « Arc To Remove » supprimée.",
         "Référence remappée vers « L2 ».",
-        "Référence remappée vers « S-valid ».",
+        "Référence remappée vers « L1 ».",
         "Nouvelle entité « S-created » reliée.",
         "Issue ignored for this session: Scenario To Ignore",
     ),
@@ -53,7 +53,7 @@ def build_minimal_validation_hierarchy() -> dict[str, Any]:
                 "type": "arc",
                 "id": "A1",
                 "name": "Main Arc",
-                "location_refs": ["Shared Place"],
+                "location_refs": ["Shared Place", "Sibling Place"],
                 "scenario_refs": [
                     "Sibling Scenario",
                     "Scenario To Create",
@@ -71,6 +71,9 @@ def build_minimal_validation_hierarchy() -> dict[str, Any]:
                 "type": "arc",
                 "id": "A2",
                 "name": "Sibling Arc",
+                "locations": [
+                    {"type": "location", "id": "L-sibling", "name": "Sibling Place"},
+                ],
                 "scenarios": [
                     {
                         "type": "scenario",

--- a/tests/ui/validation/test_minimal_validation_dataset.py
+++ b/tests/ui/validation/test_minimal_validation_dataset.py
@@ -86,9 +86,9 @@ def test_minimal_dataset_actions_chain_to_next_problem_and_exact_summary():
         ),
     )
     step = ambiguous_dialog.choose_right()
-    _assert_problem(step, IssueType.INVALID_HIERARCHY, "Sibling Scenario")
+    _assert_problem(step, IssueType.INVALID_HIERARCHY, "Sibling Place")
 
-    step = controller.submit_action(ValidationWizardAction.REMAP, target="S-valid")
+    step = controller.submit_action(ValidationWizardAction.REMAP, target="L1")
     observed_steps.append(step)
     _assert_problem(step, IssueType.MISSING_REFERENCE, "Scenario To Create")
 
@@ -124,9 +124,9 @@ def test_minimal_dataset_actions_chain_to_next_problem_and_exact_summary():
     assert step.summary.changes_applied == EXPECTED_DECISION_SUMMARY["changes_applied"]
     assert step.summary.messages == EXPECTED_DECISION_SUMMARY["messages"]
     assert hierarchy["arc_refs"] == []
-    assert hierarchy["arcs"][0]["location_refs"] == ["L2"]
+    assert hierarchy["arcs"][0]["location_refs"] == ["L2", "L1"]
     assert hierarchy["arcs"][0]["scenario_refs"] == [
-        "S-valid",
+        "Sibling Scenario",
         "S-created",
         "Scenario To Ignore",
     ]

--- a/tests/validation/test_reference_validator.py
+++ b/tests/validation/test_reference_validator.py
@@ -49,7 +49,12 @@ def _sample_hierarchy():
                     "S2",
                 ],
                 "scenarios": [
-                    {"type": "scenario", "id": "S1", "name": "Scenario One"},
+                    {
+                        "type": "scenario",
+                        "id": "S1",
+                        "name": "Scenario One",
+                        "npc_refs": ["N2"],
+                    },
                 ],
             },
             {
@@ -57,7 +62,12 @@ def _sample_hierarchy():
                 "id": "A2",
                 "name": "Arc Two",
                 "scenarios": [
-                    {"type": "scenario", "id": "S2", "name": "Scenario Two"},
+                    {
+                        "type": "scenario",
+                        "id": "S2",
+                        "name": "Scenario Two",
+                        "npcs": [{"type": "npc", "id": "N2"}],
+                    },
                 ],
             },
         ],
@@ -76,12 +86,12 @@ def test_validate_references_reports_missing_type_and_hierarchy_in_traversal_ord
     assert [issue.payload.referenced_name for issue in issues] == [
         "Missing Arc",
         "S1",
-        "S2",
+        "N2",
     ]
     assert issues[1].payload.expected_type == "scenario"
     assert issues[1].payload.actual_type == "location"
-    assert issues[2].payload.source_entity == "A1"
-    assert issues[2].payload.target_path[-1] == "scenario:S2"
+    assert issues[2].payload.source_entity == "S1"
+    assert issues[2].payload.target_path[-1] == "npc:N2"
     assert issues[2].payload.resolution_hint
 
 
@@ -95,12 +105,14 @@ def test_validate_reference_graph_exposes_entities_and_references_for_interactiv
         "S1",
         "A2",
         "S2",
+        "N2",
     ]
     assert [reference.reference_value for reference in result.references] == [
         "A1",
         "Missing Arc",
         "S1",
         "S2",
+        "N2",
     ]
     assert result.references[0].path == ("campaign:C1", "arc_refs", "[0]")
 
@@ -122,6 +134,53 @@ def test_validate_references_returns_empty_list_for_valid_direct_children():
     }
 
     assert validate_references(hierarchy, campaign={"id": "sample"}) == []
+
+
+def test_validate_references_accepts_arc_scenario_refs_to_graph_scenarios():
+    """Verify arc scenario_refs can target scenarios already in the selected graph."""
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arcs": [
+            {
+                "type": "arc",
+                "id": "A1",
+                "scenario_refs": ["S1", "Scenario Two"],
+            }
+        ],
+        "entities": [
+            {"type": "scenario", "id": "S1", "name": "Scenario One"},
+            {"type": "scenario", "id": "S2", "name": "Scenario Two"},
+        ],
+    }
+
+    result = validate_reference_graph(hierarchy, campaign={"id": "C1"})
+
+    assert [entity.identifier for entity in result.entities] == [
+        "C1",
+        "A1",
+        "S1",
+        "S2",
+    ]
+    assert [reference.reference_value for reference in result.references] == [
+        "S1",
+        "Scenario Two",
+    ]
+    assert result.issues == ()
+
+
+def test_validate_references_keeps_non_arc_scenario_refs_strict():
+    """Verify graph-membership hierarchy relief is limited to arc scenario refs."""
+    hierarchy = _sample_hierarchy()
+
+    issues = validate_references(hierarchy, campaign={"id": "sample"})
+
+    assert [issue.issue_type for issue in issues] == [
+        IssueType.MISSING_REFERENCE,
+        IssueType.INVALID_REFERENCE_TYPE,
+        IssueType.INVALID_HIERARCHY,
+    ]
+    assert issues[-1].payload.referenced_name == "N2"
 
 
 def test_validate_reference_graph_uses_selected_campaign_root_not_registry_placeholder():


### PR DESCRIPTION
### Motivation
- Hierarchy validation should accept an `arc.scenario_refs` reference when the referenced scenario exists in the selected campaign graph and the arc explicitly names that scenario, without weakening general parent/child rules.
- Keep `_is_valid_hierarchy_position()` strict for ordinary parent/child relationships while permitting a narrowly scoped exception for arc→scenario references that prove membership by name/ID.

### Description
- Change validation call site to pass the full `ReferenceRecord` into `_is_valid_hierarchy_position()` so the function can inspect the original reference context.
- Update `_is_valid_hierarchy_position()` to preserve the strict parent/child check first and then delegate to a new `_is_valid_arc_scenario_ref_membership()` fallback when appropriate.
- Add `_is_valid_arc_scenario_ref_membership()` which accepts the match only if `reference.field_path == "arc.scenario_refs"`, the source entity is an `arc`, the target is a `scenario`, and the reference value matches one of the target scenario’s identifier/name/label values (via `_entity_reference_values`).
- Add regression tests and update UI fixture/test expectations: extend `tests/validation/test_reference_validator.py` with a case showing `arc.scenario_refs` can target graph scenarios, and update `tests/ui/validation/fixtures/minimal_validation_dataset.py` and `tests/ui/validation/test_minimal_validation_dataset.py` to keep wizard expectations aligned with the new, tightly scoped rule.

### Testing
- Ran `python -m pytest tests/validation/test_reference_validator.py` and the new/modified validation tests passed.
- Ran `python -m pytest tests/validation tests/services/test_reference_fix_service.py tests/ui/validation/test_minimal_validation_dataset.py` and those suites passed.
- Ran `python -m compileall` on the changed modules and files with no syntax errors.
- Attempted a full `python -m pytest` run but collection of the entire repository is blocked by unrelated environment/import issues (duplicate test module basenames, incomplete CustomTkinter stubs, missing PIL ImageEnhance), so only focused validation and UI tests were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7a0a2844832bbd3e006d7cb42402)