### PR TITLE
Clarify INVALID_HIERARCHY validation messages

### DIFF
--- a/src/ui/validation/messages/__init__.py
+++ b/src/ui/validation/messages/__init__.py
@@ -1,0 +1,5 @@
+"""User-facing validation message formatters."""
+
+from .hierarchy_issue_formatter import format_hierarchy_issue_message
+
+__all__ = ["format_hierarchy_issue_message"]

--- a/src/ui/validation/messages/hierarchy_issue_formatter.py
+++ b/src/ui/validation/messages/hierarchy_issue_formatter.py
@@ -1,0 +1,112 @@
+"""Format INVALID_HIERARCHY issues with placement-specific guidance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from src.validation import ValidationIssue
+
+
+@dataclass(frozen=True)
+class EntityPathSegment:
+    """Parsed entity segment from a validator hierarchy path."""
+
+    entity_type: str
+    identifier: str
+
+
+@dataclass(frozen=True)
+class HierarchyPlacement:
+    """Best-effort location details for a hierarchy validation target."""
+
+    target: EntityPathSegment | None
+    parent: EntityPathSegment | None
+    path: tuple[str, ...]
+
+
+def format_hierarchy_issue_message(issue: ValidationIssue) -> str:
+    """Return a focused INVALID_HIERARCHY message for the UI wizard.
+
+    The validator emits INVALID_HIERARCHY when a reference resolves to a target
+    that is not valid at the source's position. Older or synthetic issues may
+    lack a target path, so this formatter keeps the missing-target wording
+    separate from the two misplaced-target cases.
+    """
+
+    payload = issue.payload
+    expected_parent = _entity_label(payload.source_type, payload.source_entity)
+    target_label = _entity_label(payload.expected_type, payload.referenced_name)
+    placement = _target_placement(payload.target_path, payload.candidates)
+
+    if placement.target is None:
+        return (
+            f'{target_label} is not present under {expected_parent} '
+            "in the validation hierarchy."
+        )
+
+    if _is_other_parent(placement.parent, payload.source_type, payload.source_entity):
+        actual_parent = _entity_label(
+            placement.parent.entity_type,
+            placement.parent.identifier,
+        )
+        return (
+            f"{target_label} is attached under {actual_parent}, not "
+            f"{expected_parent}, in the validation hierarchy."
+        )
+
+    return (
+        f"{target_label} exists, but it is not attached under "
+        f"{expected_parent} in the validation hierarchy."
+    )
+
+
+def _target_placement(
+    target_path: Sequence[str],
+    candidates: Sequence[str],
+) -> HierarchyPlacement:
+    path = tuple(str(part) for part in target_path if str(part))
+    if not path:
+        path = _path_from_candidates(candidates)
+    entity_segments = tuple(
+        segment for part in path if (segment := _parse_entity_segment(part)) is not None
+    )
+    target = entity_segments[-1] if entity_segments else None
+    parent = entity_segments[-2] if len(entity_segments) > 1 else None
+    return HierarchyPlacement(target=target, parent=parent, path=path)
+
+
+def _path_from_candidates(candidates: Sequence[str]) -> tuple[str, ...]:
+    for candidate in candidates:
+        _prefix, separator, raw_path = str(candidate).partition("@")
+        if separator and raw_path:
+            return tuple(part.strip() for part in raw_path.split(">") if part.strip())
+    return ()
+
+
+def _parse_entity_segment(segment: str) -> EntityPathSegment | None:
+    entity_type, separator, identifier = segment.partition(":")
+    if not separator or not entity_type.strip() or not identifier.strip():
+        return None
+    return EntityPathSegment(
+        entity_type=entity_type.strip(),
+        identifier=identifier.strip(),
+    )
+
+
+def _is_other_parent(
+    parent: EntityPathSegment | None,
+    source_type: str,
+    source_identifier: str,
+) -> bool:
+    return (
+        parent is not None
+        and parent.entity_type == source_type
+        and parent.identifier != source_identifier
+    )
+
+
+def _entity_label(entity_type: str, identifier: str) -> str:
+    normalized_type = entity_type.strip() or "target"
+    normalized_identifier = identifier.strip() or "<unknown>"
+    return f'{normalized_type.capitalize()} "{normalized_identifier}"'

--- a/src/ui/validation/validation_wizard_controller.py
+++ b/src/ui/validation/validation_wizard_controller.py
@@ -26,7 +26,8 @@ from src.ui.validation.labels import (
     VALIDATION_CANCELED_MESSAGE,
     VALIDATION_COMPLETED_MESSAGE,
 )
-from src.validation import ValidationIssue
+from src.ui.validation.messages import format_hierarchy_issue_message
+from src.validation import IssueType, ValidationIssue
 from src.validation.reference_validator import EntityRecord, ReferenceRecord
 
 ReferenceResolver = Callable[[ValidationIssue], ReferenceRecord | None]
@@ -539,6 +540,9 @@ def _summary_canceled(summary: ValidationWizardSummary) -> ValidationWizardSumma
 
 
 def _format_issue_message(issue: ValidationIssue) -> str:
+    if issue.issue_type == IssueType.INVALID_HIERARCHY:
+        return format_hierarchy_issue_message(issue)
+
     payload = issue.payload
     return ISSUE_REFERENCE_MESSAGE.format(
         issue_type=issue.issue_type.value,

--- a/tests/ui/validation/test_hierarchy_issue_formatter.py
+++ b/tests/ui/validation/test_hierarchy_issue_formatter.py
@@ -1,0 +1,105 @@
+"""Tests for INVALID_HIERARCHY wizard messages."""
+
+from src.ui.validation import ValidationWizardController, ValidationWizardIssue
+from src.ui.validation.messages import format_hierarchy_issue_message
+from src.validation import (
+    IssuePayload,
+    IssueType,
+    ValidationIssue,
+    validate_reference_graph,
+)
+
+
+def _hierarchy_issue(**payload_overrides) -> ValidationIssue:
+    payload = {
+        "source_entity": "This is the end",
+        "field": "scenario_refs",
+        "referenced_name": "Missing Finale",
+        "expected_type": "scenario",
+        "source_type": "arc",
+        "hierarchy_path": ("campaign:C1", "arc:This is the end", "scenario_refs", "[0]"),
+        "source_path": ("campaign:C1", "arc:This is the end"),
+    }
+    payload.update(payload_overrides)
+    return ValidationIssue(
+        issue_type=IssueType.INVALID_HIERARCHY,
+        payload=IssuePayload(**payload),
+    )
+
+
+def test_hierarchy_message_distinguishes_missing_target() -> None:
+    issue = _hierarchy_issue()
+
+    assert format_hierarchy_issue_message(issue) == (
+        'Scenario "Missing Finale" is not present under Arc "This is the end" '
+        "in the validation hierarchy."
+    )
+
+
+def test_hierarchy_message_distinguishes_global_target_not_under_expected_parent() -> None:
+    issue = _hierarchy_issue(
+        referenced_name="Final Scene",
+        target_path=("campaign:C1", "entities", "[0]", "scenario:S-final"),
+    )
+
+    assert format_hierarchy_issue_message(issue) == (
+        'Scenario "Final Scene" exists, but it is not attached under '
+        'Arc "This is the end" in the validation hierarchy.'
+    )
+
+
+def test_hierarchy_message_distinguishes_target_under_another_parent() -> None:
+    issue = _hierarchy_issue(
+        referenced_name="Final Scene",
+        target_path=(
+            "campaign:C1",
+            "arcs",
+            "[1]",
+            "arc:Sibling Arc",
+            "scenarios",
+            "[0]",
+            "scenario:S-final",
+        ),
+    )
+
+    assert format_hierarchy_issue_message(issue) == (
+        'Scenario "Final Scene" is attached under Arc "Sibling Arc", not '
+        'Arc "This is the end", in the validation hierarchy.'
+    )
+
+
+def test_wizard_step_uses_specific_hierarchy_message() -> None:
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arcs": [
+            {
+                "type": "arc",
+                "id": "A1",
+                "name": "Main Arc",
+                "location_refs": ["Sibling Place"],
+            },
+            {
+                "type": "arc",
+                "id": "A2",
+                "name": "Sibling Arc",
+                "locations": [
+                    {"type": "location", "id": "L2", "name": "Sibling Place"}
+                ],
+            },
+        ],
+    }
+    graph = validate_reference_graph(hierarchy, campaign={"id": "C1"})
+    controller = ValidationWizardController(
+        tuple(ValidationWizardIssue(issue=issue) for issue in graph.issues),
+        campaign=graph.campaign,
+    )
+
+    step = controller.start()
+
+    assert step.issue is not None
+    assert step.issue.issue_type == IssueType.INVALID_HIERARCHY
+    assert step.message == (
+        'Location "Sibling Place" is attached under Arc "A2", not Arc "A1", '
+        "in the validation hierarchy."
+    )


### PR DESCRIPTION
### Motivation
- Improve user-facing validation wording so INVALID_HIERARCHY cases clearly indicate whether the target is missing, present globally but not under the expected parent, or present under another parent.

### Description
- Add a new message formatter `src/ui/validation/messages/hierarchy_issue_formatter.py` that parses validator payloads and produces three distinct phrasings for `INVALID_HIERARCHY` issues (missing target, found but not under expected parent, found under another parent). 
- Export the formatter via `src/ui/validation/messages/__init__.py` for a small, testable messages package surface. 
- Route `INVALID_HIERARCHY` display through the new formatter in the wizard by updating `_format_issue_message` in `src/ui/validation/validation_wizard_controller.py` while keeping existing generic messages for other issue types. 
- Add targeted unit tests `tests/ui/validation/test_hierarchy_issue_formatter.py` covering the three wording branches and an integration check that the wizard step message uses the specific formatter.

### Testing
- Ran targeted validation tests with `pytest tests/ui/validation/test_hierarchy_issue_formatter.py tests/ui/validation/test_campaign_validation_launcher.py tests/ui/validation/test_minimal_validation_dataset.py tests/validation/test_reference_validator.py` and the targeted suite passed (28 tests passed). 
- Compiled the modified modules with `python -m compileall src/ui/validation` and the new test file to verify syntax. 
- Running the full `python -m pytest` collection in this environment produced unrelated collection/import errors (duplicate test module names and missing GUI/PIL test stubs), so broader suite collection failed due to environment/test harness constraints rather than the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8017b36c832b8e8553b03c227cd9)