### PR TITLE
Attach arc scenario references as child nodes

### DIFF
--- a/src/ui/validation/campaign_scenario_hierarchy.py
+++ b/src/ui/validation/campaign_scenario_hierarchy.py
@@ -5,23 +5,10 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Mapping, Sequence
 
-from src.validation import normalize_validator_reference_fields
 
 _SCENARIO_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
 _SCENARIO_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label")
 ScenarioReferenceIndex = Mapping[str, Sequence[tuple[int, Mapping[str, Any]]]]
-
-
-def normalize_scenario_node(item: Mapping[str, Any], index: int) -> dict[str, Any]:
-    """Return a validator-ready scenario node loaded from the scenarios wrapper."""
-
-    node = normalize_validator_reference_fields("scenario", item)
-    identifier = _identifier_for(node, "scenarios", index)
-    node.setdefault("type", "scenario")
-    node.setdefault("entity_type", "scenario")
-    node.setdefault("id", identifier)
-    node.setdefault("name", _display_name_for(node, identifier))
-    return node
 
 
 def build_scenario_reference_index(
@@ -112,14 +99,6 @@ def _reference_text(value: Any) -> str:
                 return reference
         return ""
     return _clean_text(value)
-
-
-def _identifier_for(item: Mapping[str, Any], slug: str, index: int) -> str:
-    for key in _SCENARIO_ID_KEYS + _SCENARIO_NAME_KEYS:
-        value = _clean_text(item.get(key))
-        if value:
-            return value
-    return f"{slug}-{index}"
 
 
 def _display_name_for(item: Mapping[str, Any], fallback: str) -> str:

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -11,7 +11,6 @@ from src.ui.validation.campaign_arc_hierarchy import build_campaign_arc_nodes
 from src.ui.validation.campaign_scenario_hierarchy import (
     attach_referenced_scenarios_to_arcs,
     build_scenario_reference_index,
-    normalize_scenario_node,
 )
 from src.ui.validation.dialogs.ambiguous_reference_dialog import (
     AmbiguousReferenceDialogConfig,
@@ -350,7 +349,7 @@ def _load_scenario_nodes(
     if progress is not None:
         progress.set_phase(_scan_phase_for_slug("scenarios"))
     return tuple(
-        normalize_scenario_node(item, index)
+        _normalize_entity_node("scenarios", item, index)
         for index, item in enumerate(_safe_load_items(wrapper))
         if isinstance(item, Mapping)
     )

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -1,6 +1,7 @@
 """Tests for the campaign validation UI launcher helpers."""
 
 from src.ui.validation import ValidationWizardStatus
+from src.validation import validate_reference_graph
 from src.ui.validation.campaign_validation_launcher import (
     CampaignHierarchyValidationLauncher,
     build_campaign_validation_hierarchy,
@@ -171,6 +172,75 @@ def test_build_campaign_validation_hierarchy_attaches_only_referenced_scenarios(
     assert downtime_arc["scenario_refs"] == []
     assert "scenarios" not in downtime_arc
     assert hierarchy["entities"] == []
+
+
+def test_build_campaign_validation_hierarchy_resolves_arc_scenario_refs_by_key_fields():
+    campaign = {
+        "id": "c1",
+        "Name": "Dragonfall",
+        "Arcs": {
+            "arcs": [
+                {
+                    "name": "Keyed Arc",
+                    "scenarios": [
+                        "scenario-key",
+                        {"slug": "scenario-slug"},
+                        {"title": "Lower Title"},
+                        {"Title": "Missing Scene"},
+                    ],
+                }
+            ]
+        },
+    }
+
+    hierarchy = build_campaign_validation_hierarchy(
+        {
+            "campaigns": FakeWrapper([campaign]),
+            "scenarios": FakeWrapper(
+                [
+                    {"key": "scenario-key", "Title": "Key Match"},
+                    {"slug": "scenario-slug", "Title": "Slug Match"},
+                    {"title": "Lower Title"},
+                ]
+            ),
+        },
+        campaign,
+    )
+
+    arc = hierarchy["arcs"][0]
+
+    assert [scenario["id"] for scenario in arc["scenarios"]] == [
+        "scenario-key",
+        "scenario-slug",
+        "Lower Title",
+    ]
+    assert arc["scenario_refs"] == ["Missing Scene"]
+    assert hierarchy["entities"] == []
+
+
+def test_attached_arc_scenarios_are_not_duplicated_in_flat_entity_catalog():
+    campaign = {
+        "id": "c1",
+        "Name": "Dragonfall",
+        "Arcs": {"arcs": [{"name": "Opening Arc", "scenarios": ["s1"]}]},
+    }
+
+    hierarchy = build_campaign_validation_hierarchy(
+        {
+            "campaigns": FakeWrapper([campaign]),
+            "scenarios": FakeWrapper([{"id": "s1", "Title": "Opening Scene"}]),
+        },
+        campaign,
+    )
+    graph = validate_reference_graph(hierarchy, campaign=campaign)
+
+    assert [entity.identifier for entity in graph.entities] == [
+        "c1",
+        "Opening Arc",
+        "s1",
+    ]
+    assert hierarchy["entities"] == []
+    assert graph.issues == ()
 
 
 def test_load_campaign_options_reads_campaigns_wrapper_only():


### PR DESCRIPTION
### Motivation

- Ensure arc scenario references resolve to real, normalized child scenario nodes so the validator can treat referenced scenarios as concrete children while still reporting missing references.
- Normalize scenarios using the shared entity normalization path so lookup keys (id, name, Title, slug/key) are consistent with other entity processing.

### Description

- Load scenarios from the `scenarios` wrapper using the shared normalization path by calling `_normalize_entity_node("scenarios", item, index)` in `_load_scenario_nodes` instead of the previous `normalize_scenario_node` helper. 
- Use `build_scenario_reference_index` (which indexes normalized scenario nodes by id/name/title/slug/key values) and then call `attach_referenced_scenarios_to_arcs` to append matching normalized scenario nodes into each `arc["scenarios"]` while leaving unmatched references in `arc["scenario_refs"]`.
- Remove the now-redundant local `normalize_scenario_node` and related identifier helpers to centralize normalization.
- Add regression tests to verify resolution by `key`/`slug`/`title` fields and to ensure attached arc scenarios are not duplicated in the flat `root["entities"]` catalog.

### Testing

- Ran targeted unit tests `python -m pytest tests/ui/validation/test_campaign_validation_launcher.py tests/validation/test_reference_validator.py -q` and observed all tests pass (24 passed). 
- Compiled modified modules with `python -m compileall` which completed successfully. 
- Attempted a full test run with `python -m pytest -q`, but collection failed due to unrelated environment/test harness issues (duplicate test module basenames, incomplete UI stubs for `customtkinter`, and missing PIL exports), so only the focused validation tests were used to verify the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82a7ba8c832bb2d8b9fae554ab33)