### PR TITLE
Support arc scenario refs hierarchy membership

### DIFF
--- a/src/validation/reference_validator.py
+++ b/src/validation/reference_validator.py
@@ -526,14 +526,41 @@ def _is_valid_hierarchy_position(
 def _is_valid_arc_scenario_ref_membership(
     reference: ReferenceRecord, target: EntityRecord
 ) -> bool:
-    """Accept graph-level scenarios that an arc explicitly lists by name or ID."""
+    """Accept graph-level scenarios only when the source arc proves membership."""
 
-    return (
-        reference.field_path == "arc.scenario_refs"
-        and reference.source.entity_type == "arc"
-        and target.entity_type == "scenario"
-        and reference.reference_value in _entity_reference_values(target)
+    if (
+        reference.field_path != "arc.scenario_refs"
+        or reference.source.entity_type != "arc"
+        or target.entity_type != "scenario"
+    ):
+        return False
+
+    return _arc_scenario_ref_matches_target(reference, target)
+
+
+def _arc_scenario_ref_matches_target(
+    reference: ReferenceRecord, target: EntityRecord
+) -> bool:
+    """Return whether this arc reference explicitly identifies the target scenario."""
+
+    target_values = _entity_reference_values(target)
+    if reference.reference_value not in target_values:
+        return False
+
+    raw_scenario_refs = reference.source.node.get(reference.field_name, ())
+    return any(
+        _raw_reference_matches_target(reference, raw_reference, target_values)
+        for raw_reference in _coerce_reference_values(raw_scenario_refs)
     )
+
+
+def _raw_reference_matches_target(
+    reference: ReferenceRecord,
+    raw_reference: Any,
+    target_values: frozenset[str],
+) -> bool:
+    raw_values = _reference_identity_values(raw_reference)
+    return reference.reference_value in raw_values and bool(target_values & raw_values)
 
 
 def _entity_reference_values(entity: EntityRecord) -> frozenset[str]:
@@ -544,6 +571,24 @@ def _entity_reference_values(entity: EntityRecord) -> frozenset[str]:
         if key in entity.node
     )
     return frozenset(value for value in values if value)
+
+
+def _reference_identity_values(value: Any) -> frozenset[str]:
+    if isinstance(value, Mapping):
+        reference_keys = ENTITY_ID_KEYS + ENTITY_NAME_KEYS + (
+            "ref",
+            "reference",
+            "target",
+        )
+        return frozenset(
+            normalized
+            for key in reference_keys
+            if key in value
+            for normalized in (_normalize_text(value.get(key)),)
+            if normalized
+        )
+    normalized = _normalize_text(value)
+    return frozenset((normalized,)) if normalized else frozenset()
 
 
 def _split_field_path(field_path: str) -> tuple[str, str]:

--- a/tests/validation/test_reference_validator.py
+++ b/tests/validation/test_reference_validator.py
@@ -169,6 +169,31 @@ def test_validate_references_accepts_arc_scenario_refs_to_graph_scenarios():
     assert result.issues == ()
 
 
+def test_validate_references_accepts_arc_scenario_refs_by_scenario_title():
+    """Verify arc scenario_refs can prove graph membership with scenario Title."""
+    hierarchy = {
+        "type": "campaign",
+        "id": "C1",
+        "arcs": [
+            {
+                "type": "arc",
+                "id": "A1",
+                "scenario_refs": [{"Title": "Hidden Shrine"}],
+            }
+        ],
+        "entities": [
+            {"type": "scenario", "id": "S1", "Title": "Hidden Shrine"},
+        ],
+    }
+
+    result = validate_reference_graph(hierarchy, campaign={"id": "C1"})
+
+    assert [reference.reference_value for reference in result.references] == [
+        "Hidden Shrine",
+    ]
+    assert result.issues == ()
+
+
 def test_validate_references_keeps_non_arc_scenario_refs_strict():
     """Verify graph-membership hierarchy relief is limited to arc scenario refs."""
     hierarchy = _sample_hierarchy()


### PR DESCRIPTION
### Motivation

- Preserve strict parent/child hierarchy validation as the default while addressing the app model where `arc.scenario_refs` may point at scenarios in a flat entity catalog. 
- Allow an `arc -> scenario` reference to be considered valid only when the arc's raw `scenario_refs` entry explicitly proves membership by matching the target scenario's identifier, label/name, or `Title` field. 

### Description

- Tighten `_is_valid_arc_scenario_ref_membership` to require the source `field_path`/type conditions and delegate to `_arc_scenario_ref_matches_target` for membership checking. 
- Add `_arc_scenario_ref_matches_target`, `_raw_reference_matches_target`, and `_reference_identity_values` to match a target scenario only when the arc's raw reference entry both references the same normalized reference value and shares an identity token with the target. 
- Keep `_entity_reference_values` usage for collecting a scenario's canonical identities and add a regression test `test_validate_references_accepts_arc_scenario_refs_by_scenario_title` to cover `Title`-based references. 

### Testing

- Ran `python -m pytest tests/validation/test_reference_validator.py` and the test suite for that file completed successfully (`10 passed`). 
- Ran `python -m compileall src/validation/reference_validator.py` and Python compilation succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb85351974832bbec68a6eb38659dd)