### PR TITLE
Add 'Update existing files' option to image directory import

### DIFF
--- a/modules/image_assets/repository.py
+++ b/modules/image_assets/repository.py
@@ -33,7 +33,31 @@ class ImageAssetsRepository:
 
         if existing:
             merged["AssetId"] = existing.get("AssetId")
-            merged["ImportedAt"] = existing.get("ImportedAt") or payload.get("ImportedAt") or now
+            merged["ImportedAt"] = (
+                existing.get("ImportedAt") or payload.get("ImportedAt") or now
+            )
+        else:
+            merged["AssetId"] = str(payload.get("AssetId") or uuid.uuid4())
+            merged["ImportedAt"] = payload.get("ImportedAt") or now
+
+        merged["UpdatedAt"] = payload.get("UpdatedAt") or now
+        self.wrapper.save_item(merged, key_field="AssetId")
+        return merged
+
+    def replace_by_path(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Replace the existing row for a path, or create it when absent."""
+        path = str(payload.get("Path") or "").strip()
+        existing = self._find_existing_by_path(path) if path else None
+
+        now = self._utc_now_iso()
+        merged = dict(existing or {})
+        merged.update(payload)
+
+        if existing:
+            merged["AssetId"] = existing.get("AssetId")
+            merged["ImportedAt"] = (
+                existing.get("ImportedAt") or payload.get("ImportedAt") or now
+            )
         else:
             merged["AssetId"] = str(payload.get("AssetId") or uuid.uuid4())
             merged["ImportedAt"] = payload.get("ImportedAt") or now
@@ -89,13 +113,23 @@ class ImageAssetsRepository:
                 if str(item.get("Hash") or "").strip() == hash_value:
                     return item
         if path:
-            for item in items:
-                if str(item.get("Path") or "").strip() == path:
-                    return item
+            return self._find_existing_by_path(path)
+        return None
+
+    def _find_existing_by_path(self, path: str) -> dict[str, Any] | None:
+        """Find one row by exact path."""
+        normalized_path = str(path or "").strip()
+        if not normalized_path:
+            return None
+        for item in self.list_all():
+            if str(item.get("Path") or "").strip() == normalized_path:
+                return item
         return None
 
     @staticmethod
-    def _apply_search(items: list[dict[str, Any]], search: str | None) -> list[dict[str, Any]]:
+    def _apply_search(
+        items: list[dict[str, Any]], search: str | None
+    ) -> list[dict[str, Any]]:
         """Filter items on common textual fields."""
         term = str(search or "").strip().lower()
         if not term:

--- a/modules/image_assets/service.py
+++ b/modules/image_assets/service.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any, Iterable
 
 from modules.image_assets.repository import ImageAssetsRepository
-from modules.image_assets.services.import_service import ImageAssetImportService, ImageAssetsImportSummary
+from modules.image_assets.services.import_service import (
+    ImageAssetImportService,
+    ImageAssetsImportSummary,
+)
 from modules.image_assets.services.search_service import (
     ImageAssetSearchResultDTO,
     ImageAssetSearchService,
@@ -39,7 +42,9 @@ class ImageAssetsService:
         search: str | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """List/search assets with pagination."""
-        return self.repository.list_paginated(page=page, page_size=page_size, search=search)
+        return self.repository.list_paginated(
+            page=page, page_size=page_size, search=search
+        )
 
     def search_images(
         self,
@@ -63,10 +68,12 @@ class ImageAssetsService:
         paths: list[str],
         recursive: bool,
         reindex_changed_only: bool,
+        update_existing_files: bool = True,
     ) -> ImageAssetsImportSummary:
         """Import many directories through the dedicated import workflow."""
         return self.import_service.import_directories(
             paths=paths,
             recursive=recursive,
             reindex_changed_only=reindex_changed_only,
+            update_existing_files=update_existing_files,
         )

--- a/modules/image_assets/services/import_options.py
+++ b/modules/image_assets/services/import_options.py
@@ -1,0 +1,14 @@
+"""Options for image asset directory imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ImageDirectoryImportOptions:
+    """User-selected options that control directory import behavior."""
+
+    recursive: bool
+    reindex_changed_only: bool
+    update_existing_files: bool = True

--- a/modules/image_assets/services/import_service.py
+++ b/modules/image_assets/services/import_service.py
@@ -10,6 +10,7 @@ from typing import Iterable
 from PIL import Image, UnidentifiedImageError
 
 from modules.image_assets.repository import ImageAssetsRepository
+from modules.image_assets.services.import_options import ImageDirectoryImportOptions
 from modules.image_assets.search.indexing import (
     build_search_tokens,
     build_searchable_blob,
@@ -40,6 +41,7 @@ class ImageAssetsImportSummary:
     updated: int
     skipped_unchanged: int
     skipped_duplicate: int
+    skipped_existing: int
     errors: list[AssetImportError]
 
     def as_dict(self) -> dict[str, object]:
@@ -53,9 +55,9 @@ class ImageAssetsImportSummary:
             "updated": self.updated,
             "skipped_unchanged": self.skipped_unchanged,
             "skipped_duplicate": self.skipped_duplicate,
+            "skipped_existing": self.skipped_existing,
             "errors": [
-                {"path": error.path, "reason": error.reason}
-                for error in self.errors
+                {"path": error.path, "reason": error.reason} for error in self.errors
             ],
         }
 
@@ -71,6 +73,7 @@ class ImageAssetImportService:
         paths: list[str],
         recursive: bool,
         reindex_changed_only: bool,
+        update_existing_files: bool = True,
     ) -> ImageAssetsImportSummary:
         """Import image assets from one or more roots.
 
@@ -78,7 +81,14 @@ class ImageAssetImportService:
             paths: Root directories selected by user.
             recursive: If True, walk subdirectories; otherwise scan direct children only.
             reindex_changed_only: If True, keep unchanged records as-is.
+            update_existing_files: If True, replace matching existing rows with
+                metadata read from the import directories.
         """
+        options = ImageDirectoryImportOptions(
+            recursive=recursive,
+            reindex_changed_only=reindex_changed_only,
+            update_existing_files=update_existing_files,
+        )
         normalized_roots = self._normalize_roots(paths)
         existing_items = self.repository.list_all()
         existing_by_path = {
@@ -94,6 +104,7 @@ class ImageAssetImportService:
         updated = 0
         skipped_unchanged = 0
         skipped_duplicate = 0
+        skipped_existing = 0
         errors: list[AssetImportError] = []
 
         seen_keys: set[str] = {
@@ -108,7 +119,9 @@ class ImageAssetImportService:
                 roots_missing.append(str(root_path))
                 continue
 
-            for file_path in self._iter_image_files(root_path, recursive=recursive):
+            for file_path in self._iter_image_files(
+                root_path, recursive=options.recursive
+            ):
                 scanned_files += 1
                 discovered_candidates += 1
 
@@ -119,12 +132,20 @@ class ImageAssetImportService:
                     file_size = file_path.stat().st_size
                     content_hash = self._compute_sha256(file_path)
                 except OSError as exc:
-                    errors.append(AssetImportError(path=abs_path, reason=f"stat/hash failed: {exc}"))
+                    errors.append(
+                        AssetImportError(
+                            path=abs_path, reason=f"stat/hash failed: {exc}"
+                        )
+                    )
                     continue
 
                 dedupe_key = self._compose_dedupe_key(content_hash, file_size)
                 if existing is None and dedupe_key in seen_keys:
                     skipped_duplicate += 1
+                    continue
+
+                if existing is not None and not options.update_existing_files:
+                    skipped_existing += 1
                     continue
 
                 unchanged = bool(
@@ -133,7 +154,7 @@ class ImageAssetImportService:
                     and int(existing.get("FileSizeBytes") or 0) == file_size
                 )
 
-                if unchanged and reindex_changed_only:
+                if unchanged and options.reindex_changed_only:
                     skipped_unchanged += 1
                     continue
 
@@ -143,20 +164,32 @@ class ImageAssetImportService:
                     try:
                         width, height = self._read_dimensions(file_path)
                     except (OSError, UnidentifiedImageError) as exc:
-                        errors.append(AssetImportError(path=abs_path, reason=f"metadata read failed: {exc}"))
+                        errors.append(
+                            AssetImportError(
+                                path=abs_path, reason=f"metadata read failed: {exc}"
+                            )
+                        )
                         continue
                 else:
-                    width = self._as_optional_int(existing.get("Width") if existing else None)
-                    height = self._as_optional_int(existing.get("Height") if existing else None)
+                    width = self._as_optional_int(
+                        existing.get("Width") if existing else None
+                    )
+                    height = self._as_optional_int(
+                        existing.get("Height") if existing else None
+                    )
 
                 stem = file_path.stem
                 tags: list[str] = []
                 name_normalized = normalize_filename(stem)
-                search_tokens = build_search_tokens(name_normalized=name_normalized, tags=tags)
+                search_tokens = build_search_tokens(
+                    name_normalized=name_normalized, tags=tags
+                )
                 searchable_blob = build_searchable_blob(
                     name=stem,
                     path=abs_path,
-                    relative_path=self._compute_relative(file_path=file_path, root_path=root_path),
+                    relative_path=self._compute_relative(
+                        file_path=file_path, root_path=root_path
+                    ),
                     source_root=str(root_path.resolve()),
                     extension=file_path.suffix.lower().lstrip("."),
                     tags=tags,
@@ -168,7 +201,9 @@ class ImageAssetImportService:
                 payload = {
                     "Name": stem,
                     "Path": abs_path,
-                    "RelativePath": self._compute_relative(file_path=file_path, root_path=root_path),
+                    "RelativePath": self._compute_relative(
+                        file_path=file_path, root_path=root_path
+                    ),
                     "SourceRoot": str(root_path.resolve()),
                     "SourceFolderName": file_path.parent.name,
                     "Extension": file_path.suffix.lower().lstrip("."),
@@ -182,7 +217,11 @@ class ImageAssetImportService:
                     "SearchableBlob": searchable_blob,
                 }
 
-                saved = self.repository.upsert_by_hash_or_path(payload)
+                saved = (
+                    self.repository.replace_by_path(payload)
+                    if existing
+                    else self.repository.upsert_by_hash_or_path(payload)
+                )
                 existing_by_path[abs_path] = saved
                 seen_keys.add(dedupe_key)
 
@@ -200,6 +239,7 @@ class ImageAssetImportService:
             updated=updated,
             skipped_unchanged=skipped_unchanged,
             skipped_duplicate=skipped_duplicate,
+            skipped_existing=skipped_existing,
             errors=errors,
         )
 

--- a/modules/ui/image_library/dialogs/import_directories_dialog.py
+++ b/modules/ui/image_library/dialogs/import_directories_dialog.py
@@ -39,6 +39,7 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
 
         self.recursive_var = ctk.BooleanVar(value=True)
         self.reindex_changed_var = ctk.BooleanVar(value=True)
+        self.update_existing_files_var = ctk.BooleanVar(value=True)
 
         self._build_ui()
         self._refresh_roots()
@@ -57,9 +58,9 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
         top.grid(row=0, column=0, sticky="ew", padx=12, pady=(12, 8))
         top.grid_columnconfigure(1, weight=1)
 
-        ctk.CTkLabel(top, text="Source directories", font=ctk.CTkFont(size=16, weight="bold")).grid(
-            row=0, column=0, sticky="w"
-        )
+        ctk.CTkLabel(
+            top, text="Source directories", font=ctk.CTkFont(size=16, weight="bold")
+        ).grid(row=0, column=0, sticky="w")
         ctk.CTkLabel(
             top,
             text="Choose one or more folders to index images into the shared library.",
@@ -76,28 +77,43 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
         side = ctk.CTkFrame(list_frame)
         side.grid(row=0, column=1, sticky="ns", padx=8, pady=8)
 
-        ctk.CTkButton(side, text="Add directory...", command=self._add_directory).pack(fill="x", pady=(0, 6))
-        ctk.CTkButton(side, text="Bulk add...", command=self._bulk_add_directories).pack(fill="x", pady=6)
-        ctk.CTkButton(side, text="Remove selected", command=self._remove_selected).pack(fill="x", pady=6)
+        ctk.CTkButton(side, text="Add directory...", command=self._add_directory).pack(
+            fill="x", pady=(0, 6)
+        )
+        ctk.CTkButton(
+            side, text="Bulk add...", command=self._bulk_add_directories
+        ).pack(fill="x", pady=6)
+        ctk.CTkButton(side, text="Remove selected", command=self._remove_selected).pack(
+            fill="x", pady=6
+        )
         ctk.CTkButton(side, text="Clear", command=self._clear).pack(fill="x", pady=6)
 
         options = ctk.CTkFrame(self)
         options.grid(row=2, column=0, sticky="ew", padx=12, pady=(0, 8))
-        ctk.CTkCheckBox(options, text="Scan subdirectories recursively", variable=self.recursive_var).pack(
-            anchor="w", padx=8, pady=(8, 4)
-        )
+        ctk.CTkCheckBox(
+            options, text="Scan subdirectories recursively", variable=self.recursive_var
+        ).pack(anchor="w", padx=8, pady=(8, 4))
         ctk.CTkCheckBox(
             options,
             text="Skip unchanged files (faster incremental import)",
             variable=self.reindex_changed_var,
+        ).pack(anchor="w", padx=8, pady=(0, 4))
+        ctk.CTkCheckBox(
+            options,
+            text="Update existing files",
+            variable=self.update_existing_files_var,
         ).pack(anchor="w", padx=8, pady=(0, 8))
 
         actions = ctk.CTkFrame(self)
         actions.grid(row=3, column=0, sticky="ew", padx=12, pady=(0, 12))
         actions.grid_columnconfigure(0, weight=1)
 
-        ctk.CTkButton(actions, text="Cancel", command=self.destroy).grid(row=0, column=1, padx=(8, 4), pady=8)
-        ctk.CTkButton(actions, text="Import", command=self._run_import).grid(row=0, column=2, padx=(4, 8), pady=8)
+        ctk.CTkButton(actions, text="Cancel", command=self.destroy).grid(
+            row=0, column=1, padx=(8, 4), pady=8
+        )
+        ctk.CTkButton(actions, text="Import", command=self._run_import).grid(
+            row=0, column=2, padx=(4, 8), pady=8
+        )
 
     def _add_directory(self) -> None:
         """Prompt and append one directory."""
@@ -108,7 +124,9 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
         """Repeatedly prompt the user to add multiple directories in one flow."""
         selected_roots: list[str] = []
         while True:
-            selected = filedialog.askdirectory(parent=self, title="Select image directory")
+            selected = filedialog.askdirectory(
+                parent=self, title="Select image directory"
+            )
             if not selected:
                 break
             selected_roots.append(selected)
@@ -136,7 +154,11 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
         if not selection:
             return
         selected_indexes = set(selection)
-        self._roots = [value for idx, value in enumerate(self._roots) if idx not in selected_indexes]
+        self._roots = [
+            value
+            for idx, value in enumerate(self._roots)
+            if idx not in selected_indexes
+        ]
         self._refresh_roots()
 
     def _clear(self) -> None:
@@ -155,7 +177,11 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
         validation = validate_roots(self._roots)
         existing_roots = validation.existing_roots
         if not existing_roots:
-            messagebox.showwarning("No directory", "Add at least one valid directory to import.", parent=self)
+            messagebox.showwarning(
+                "No directory",
+                "Add at least one valid directory to import.",
+                parent=self,
+            )
             return
 
         if validation.missing_roots:
@@ -171,9 +197,12 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
             paths=existing_roots,
             recursive=bool(self.recursive_var.get()),
             reindex_changed_only=bool(self.reindex_changed_var.get()),
+            update_existing_files=bool(self.update_existing_files_var.get()),
         )
         self._recent_roots_store.save(existing_roots)
-        messagebox.showinfo("Import complete", self._format_summary(summary), parent=self)
+        messagebox.showinfo(
+            "Import complete", self._format_summary(summary), parent=self
+        )
 
     def _enable_drag_and_drop_if_available(self) -> None:
         """Enable folder drag-and-drop when supported by the current Tk stack."""
@@ -194,7 +223,9 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
             return "break"
 
         try:
-            candidates = [str(value).strip("{}") for value in self.tk.splitlist(raw_data)]
+            candidates = [
+                str(value).strip("{}") for value in self.tk.splitlist(raw_data)
+            ]
         except tk.TclError:
             candidates = [raw_data.strip("{}")]
 
@@ -224,6 +255,7 @@ class ImageDirectoryImportDialog(ctk.CTkToplevel):
             f"Updated: {summary.updated}",
             f"Skipped unchanged: {summary.skipped_unchanged}",
             f"Skipped duplicates: {summary.skipped_duplicate}",
+            f"Skipped existing: {summary.skipped_existing}",
         ]
         if summary.roots_missing:
             lines.append(f"Missing roots: {len(summary.roots_missing)}")

--- a/tests/image_assets/test_import_dedupe.py
+++ b/tests/image_assets/test_import_dedupe.py
@@ -27,8 +27,13 @@ class _FakeRepository:
         existing.update(payload)
         return dict(existing)
 
+    def replace_by_path(self, payload: dict) -> dict:
+        return self.upsert_by_hash_or_path(payload)
 
-def test_import_directories_skips_duplicate_content(tmp_path: Path, monkeypatch) -> None:
+
+def test_import_directories_skips_duplicate_content(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Importer should dedupe by content hash+size across distinct paths."""
     root = tmp_path / "assets"
     root.mkdir()
@@ -53,7 +58,9 @@ def test_import_directories_skips_duplicate_content(tmp_path: Path, monkeypatch)
     assert summary.scanned_files == 2
 
 
-def test_import_directories_stores_source_folder_name(tmp_path: Path, monkeypatch) -> None:
+def test_import_directories_stores_source_folder_name(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Importer should capture the parent directory leaf as SourceFolderName."""
     root = tmp_path / "assets"
     nested = root / "portraits"
@@ -73,3 +80,90 @@ def test_import_directories_stores_source_folder_name(tmp_path: Path, monkeypatc
 
     assert summary.imported_new == 1
     assert repository.items[0]["SourceFolderName"] == "portraits"
+
+
+def test_import_directories_updates_existing_path_by_default(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Importer should replace matching existing path records by default."""
+    root = tmp_path / "assets"
+    root.mkdir()
+    image = root / "hero.png"
+    image.write_bytes(b"new-image-payload")
+
+    abs_path = str(image.resolve())
+    repository = _FakeRepository()
+    repository.items.append(
+        {
+            "Name": "Old Hero",
+            "Path": abs_path,
+            "Hash": "old-hash",
+            "FileSizeBytes": 1,
+            "Width": 32,
+            "Height": 32,
+            "Tags": ["custom"],
+        }
+    )
+    service = ImageAssetImportService(repository=repository)
+    monkeypatch.setattr(service, "_read_dimensions", lambda _path: (512, 256))
+
+    summary = service.import_directories(
+        paths=[str(root)],
+        recursive=False,
+        reindex_changed_only=True,
+    )
+
+    assert summary.imported_new == 0
+    assert summary.updated == 1
+    assert repository.items[0]["Name"] == "hero"
+    assert repository.items[0]["Width"] == 512
+    assert repository.items[0]["Height"] == 256
+    assert repository.items[0]["Tags"] == []
+    assert repository.items[0]["Hash"] != "old-hash"
+
+
+def test_import_directories_can_leave_existing_paths_unchanged(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Importer should preserve matching rows when existing updates are disabled."""
+    root = tmp_path / "assets"
+    root.mkdir()
+    image = root / "hero.png"
+    image.write_bytes(b"new-image-payload")
+
+    abs_path = str(image.resolve())
+    repository = _FakeRepository()
+    repository.items.append(
+        {
+            "Name": "Old Hero",
+            "Path": abs_path,
+            "Hash": "old-hash",
+            "FileSizeBytes": 1,
+            "Width": 32,
+            "Height": 32,
+            "Tags": ["custom"],
+        }
+    )
+    service = ImageAssetImportService(repository=repository)
+    monkeypatch.setattr(
+        service,
+        "_read_dimensions",
+        lambda _path: (_ for _ in ()).throw(
+            AssertionError("should skip metadata read")
+        ),
+    )
+
+    summary = service.import_directories(
+        paths=[str(root)],
+        recursive=False,
+        reindex_changed_only=True,
+        update_existing_files=False,
+    )
+
+    assert summary.imported_new == 0
+    assert summary.updated == 0
+    assert summary.skipped_duplicate == 0
+    assert summary.skipped_existing == 1
+    assert repository.items[0]["Name"] == "Old Hero"
+    assert repository.items[0]["Hash"] == "old-hash"
+    assert repository.items[0]["Tags"] == ["custom"]

--- a/tests/test_image_assets_repository.py
+++ b/tests/test_image_assets_repository.py
@@ -68,9 +68,24 @@ def test_delete_stale_files_keeps_only_active_paths():
 def test_list_paginated_supports_search_and_paging():
     wrapper = _FakeWrapper()
     wrapper.items = [
-        {"AssetId": "1", "Name": "Forest", "Path": "/images/forest.png", "UpdatedAt": "2026-04-03T00:00:00+00:00"},
-        {"AssetId": "2", "Name": "Castle", "Path": "/images/castle.png", "UpdatedAt": "2026-04-04T00:00:00+00:00"},
-        {"AssetId": "3", "Name": "Dungeon", "Path": "/images/dungeon.jpg", "UpdatedAt": "2026-04-05T00:00:00+00:00"},
+        {
+            "AssetId": "1",
+            "Name": "Forest",
+            "Path": "/images/forest.png",
+            "UpdatedAt": "2026-04-03T00:00:00+00:00",
+        },
+        {
+            "AssetId": "2",
+            "Name": "Castle",
+            "Path": "/images/castle.png",
+            "UpdatedAt": "2026-04-04T00:00:00+00:00",
+        },
+        {
+            "AssetId": "3",
+            "Name": "Dungeon",
+            "Path": "/images/dungeon.jpg",
+            "UpdatedAt": "2026-04-05T00:00:00+00:00",
+        },
     ]
     repository = ImageAssetsRepository(wrapper=wrapper)
 
@@ -78,3 +93,35 @@ def test_list_paginated_supports_search_and_paging():
 
     assert total == 2
     assert [item["AssetId"] for item in page] == ["2", "1"]
+
+
+def test_replace_by_path_updates_path_match_without_hash_collision():
+    wrapper = _FakeWrapper()
+    wrapper.items = [
+        {
+            "AssetId": "same-hash",
+            "Path": "/tmp/original.png",
+            "Hash": "abc",
+            "Name": "Original",
+        },
+        {
+            "AssetId": "target",
+            "Path": "/tmp/target.png",
+            "Hash": "old",
+            "Name": "Target",
+        },
+    ]
+    repository = ImageAssetsRepository(wrapper=wrapper)
+
+    updated = repository.replace_by_path(
+        {
+            "Path": "/tmp/target.png",
+            "Hash": "abc",
+            "Name": "Target Replacement",
+        }
+    )
+
+    assert updated["AssetId"] == "target"
+    assert len(wrapper.items) == 2
+    assert wrapper.items[0]["Name"] == "Original"
+    assert wrapper.items[1]["Name"] == "Target Replacement"


### PR DESCRIPTION
### Motivation
- Provide users control over whether importing directories should overwrite existing image-library records when files match by path. 
- Make incremental imports safer by allowing the default behavior (update enabled) while offering an opt-out to preserve existing DB entries.

### Description
- Added an `Update existing files` checkbox (checked by default) to the image directory import dialog and passed its value into the import call (`modules/ui/image_library/dialogs/import_directories_dialog.py`).
- Introduced an `ImageDirectoryImportOptions` dataclass to group import flags and threaded the `update_existing_files` option through the import workflow (`modules/image_assets/services/import_options.py`, `modules/image_assets/services/import_service.py`).
- When updates are enabled, the importer replaces matching path records using a new repository method `replace_by_path`; when disabled, matching existing-path rows are skipped and counted separately (`modules/image_assets/repository.py`, `modules/image_assets/services/import_service.py`).
- Propagated the new option through the public service facade (`modules/image_assets/service.py`) and extended import summaries and the dialog results to report skipped-existing counts.

### Testing
- Ran `pytest tests/image_assets/test_import_dedupe.py tests/test_image_assets_repository.py` and all tests passed (`8 passed`).
- Performed byte-compile sanity check with `python -m compileall` over the modified modules and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2e94f120832b8544389792667b41)