### PR TITLE
Add context-aware GM Table middle-drag handling

### DIFF
--- a/modules/scenarios/gm_table/drag_controller.py
+++ b/modules/scenarios/gm_table/drag_controller.py
@@ -1,0 +1,19 @@
+"""Drag coordination for the virtual GM Table workspace."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from modules.scenarios.gm_table.window_hit_testing import pointer_screen_position
+
+
+class GMTableDragController:
+    """Context-aware gatekeeper for GM Table drag gestures."""
+
+    def __init__(self, *, should_block_middle_drag: Callable[[int, int], bool]) -> None:
+        self._should_block_middle_drag = should_block_middle_drag
+
+    def allows_middle_drag_start(self, event) -> bool:
+        """Return whether a middle-button drag should start for the GM Table."""
+        screen_x, screen_y = pointer_screen_position(event)
+        return not self._should_block_middle_drag(screen_x, screen_y)

--- a/modules/scenarios/gm_table/window_hit_testing.py
+++ b/modules/scenarios/gm_table/window_hit_testing.py
@@ -1,0 +1,114 @@
+"""Screen-space hit testing for GM Table hosted windows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import tkinter as tk
+
+
+@dataclass(frozen=True, slots=True)
+class ScreenBounds:
+    """A widget's bounds in screen coordinates."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        """Return the exclusive right edge."""
+        return self.x + self.width
+
+    @property
+    def bottom(self) -> int:
+        """Return the exclusive bottom edge."""
+        return self.y + self.height
+
+    def contains(self, screen_x: int, screen_y: int) -> bool:
+        """Return whether the point is inside these screen bounds."""
+        return self.x <= screen_x < self.right and self.y <= screen_y < self.bottom
+
+
+def pointer_screen_position(event) -> tuple[int, int]:
+    """Return the current pointer position in screen coordinates."""
+    widget = getattr(event, "widget", None)
+    if isinstance(widget, tk.Widget):
+        try:
+            pointer_x, pointer_y = widget.winfo_pointerxy()
+            return int(pointer_x), int(pointer_y)
+        except Exception:
+            pass
+    return int(getattr(event, "x_root", 0) or 0), int(getattr(event, "y_root", 0) or 0)
+
+
+def widget_screen_bounds(widget) -> ScreenBounds | None:
+    """Return mapped widget bounds in screen coordinates, or None if unavailable."""
+    if not isinstance(widget, tk.Widget):
+        return None
+    try:
+        if not widget.winfo_exists() or not widget.winfo_ismapped():
+            return None
+        widget.update_idletasks()
+        width = int(widget.winfo_width())
+        height = int(widget.winfo_height())
+        if width <= 1 or height <= 1:
+            return None
+        return ScreenBounds(
+            x=int(widget.winfo_rootx()),
+            y=int(widget.winfo_rooty()),
+            width=width,
+            height=height,
+        )
+    except Exception:
+        return None
+
+
+def point_in_any_bounds(screen_x: int, screen_y: int, bounds: Iterable[ScreenBounds]) -> bool:
+    """Return whether a screen point is contained by any supplied bounds."""
+    return any(bound.contains(screen_x, screen_y) for bound in bounds)
+
+
+def map_tool_screen_bounds(
+    panel_records: Iterable[dict[str, object]],
+    *,
+    map_tool_window=None,
+) -> list[ScreenBounds]:
+    """Return screen bounds for open MapTool windows hosted by the app."""
+    bounds: list[ScreenBounds] = []
+    if map_tool_window is not None:
+        external_bound = widget_screen_bounds(map_tool_window)
+        if external_bound is not None:
+            bounds.append(external_bound)
+    for record in panel_records:
+        if record.get("layout_mode") == "minimized":
+            continue
+        definition = record.get("definition")
+        kind = getattr(definition, "kind", "")
+        if kind != "map_tool":
+            continue
+        bound = widget_screen_bounds(record.get("panel"))
+        if bound is not None:
+            bounds.append(bound)
+    return bounds
+
+
+def point_inside_map_tool(
+    screen_x: int,
+    screen_y: int,
+    panel_records: Iterable[dict[str, object]],
+    *,
+    map_tool_window=None,
+) -> bool:
+    """Return whether a pointer is inside an open MapTool panel.
+
+    If MapTool is closed, minimized, unmapped, or unavailable, this returns False so
+    callers can fall back to their normal GM Table behavior.
+    """
+    return point_in_any_bounds(
+        screen_x,
+        screen_y,
+        map_tool_screen_bounds(panel_records, map_tool_window=map_tool_window),
+    )

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -10,6 +10,8 @@ from typing import Callable
 import customtkinter as ctk
 from modules.helpers import theme_manager
 from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
+from modules.scenarios.gm_table.drag_controller import GMTableDragController
+from modules.scenarios.gm_table.window_hit_testing import point_inside_map_tool
 from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
 
 
@@ -1059,10 +1061,12 @@ class GMTableWorkspace(ctk.CTkFrame):
         *,
         on_panel_build: Callable[[ctk.CTkFrame, PanelDefinition], object],
         on_layout_changed: Callable[[], None] | None = None,
+        map_tool_window_provider: Callable[[], object | None] | None = None,
     ) -> None:
         super().__init__(master, fg_color=TABLE_PALETTE["table_bg"], corner_radius=28)
         self._build_panel = on_panel_build
         self._layout_changed_callback = on_layout_changed
+        self._map_tool_window_provider = map_tool_window_provider
         self._panels: dict[str, GMTablePanel] = {}
         self._definitions: dict[str, PanelDefinition] = {}
         self._panel_payloads: dict[str, object] = {}
@@ -1079,6 +1083,9 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._minimap_projection: dict[str, float] | None = None
         self._surface_pan_binding_target = None
         self._surface_pan_binding_ids: dict[str, str] = {}
+        self._drag_controller = GMTableDragController(
+            should_block_middle_drag=self._pointer_is_inside_map_tool
+        )
 
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
@@ -1317,6 +1324,21 @@ class GMTableWorkspace(ctk.CTkFrame):
                 binding_ids[sequence] = binding_id
         self._surface_pan_binding_target = target
         self._surface_pan_binding_ids = binding_ids
+
+    def _pointer_is_inside_map_tool(self, screen_x: int, screen_y: int) -> bool:
+        """Return whether the screen pointer is inside an open MapTool panel."""
+        map_tool_window = None
+        if self._map_tool_window_provider is not None:
+            try:
+                map_tool_window = self._map_tool_window_provider()
+            except Exception:
+                map_tool_window = None
+        return point_inside_map_tool(
+            screen_x,
+            screen_y,
+            self.list_panels(include_minimized=False),
+            map_tool_window=map_tool_window,
+        )
 
     def _unbind_workspace_middle_pan(self) -> None:
         """Remove any middle-button pan bindings registered on the window."""
@@ -1570,6 +1592,9 @@ class GMTableWorkspace(ctk.CTkFrame):
             if not is_middle_button or not self._widget_is_in_surface_subtree(widget):
                 return
         if is_middle_button:
+            if not self._drag_controller.allows_middle_drag_start(event):
+                self._pan_origin = None
+                return "break"
             self._pin_snapped_panels_to_world()
         self.surface.focus_set()
         self._pan_origin = (

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -149,10 +149,18 @@ class GMTableView(ctk.CTkFrame):
             self,
             on_panel_build=self._mount_panel_content,
             on_layout_changed=self._persist_layout,
+            map_tool_window_provider=self._get_map_tool_window,
         )
         self.workspace.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 18))
 
         self.after_idle(self._restore_or_seed_layout)
+
+    def _get_map_tool_window(self):
+        """Return the standalone MapTool window if the root app has one open."""
+        root_app = self._root_app
+        if root_app is None:
+            return None
+        return getattr(root_app, "_map_tool_window", None)
 
     def _build_toolbar(self) -> None:
         """Build top controls."""

--- a/tests/scenarios/test_gm_table_middle_drag_hit_testing.py
+++ b/tests/scenarios/test_gm_table_middle_drag_hit_testing.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+from modules.scenarios.gm_table.drag_controller import GMTableDragController
+from modules.scenarios.gm_table import window_hit_testing as hit_testing
+from modules.scenarios.gm_table.window_hit_testing import ScreenBounds
+
+
+def test_screen_bounds_uses_exclusive_edges():
+    bounds = ScreenBounds(x=100, y=200, width=50, height=25)
+
+    assert bounds.contains(100, 200)
+    assert bounds.contains(149, 224)
+    assert not bounds.contains(150, 224)
+    assert not bounds.contains(149, 225)
+
+
+def test_map_tool_hit_testing_ignores_closed_or_minimized_maptool(monkeypatch):
+    monkeypatch.setattr(
+        hit_testing,
+        "widget_screen_bounds",
+        lambda widget: ScreenBounds(10, 20, 100, 80),
+    )
+    records = [
+        {
+            "definition": SimpleNamespace(kind="map_tool"),
+            "panel": object(),
+            "layout_mode": "minimized",
+        },
+        {
+            "definition": SimpleNamespace(kind="note"),
+            "panel": object(),
+            "layout_mode": "floating",
+        },
+    ]
+
+    assert not hit_testing.point_inside_map_tool(25, 30, records)
+
+
+def test_map_tool_hit_testing_matches_visible_maptool(monkeypatch):
+    monkeypatch.setattr(
+        hit_testing,
+        "widget_screen_bounds",
+        lambda widget: ScreenBounds(10, 20, 100, 80),
+    )
+    records = [
+        {
+            "definition": SimpleNamespace(kind="map_tool"),
+            "panel": object(),
+            "layout_mode": "floating",
+        }
+    ]
+
+    assert hit_testing.point_inside_map_tool(25, 30, records)
+    assert not hit_testing.point_inside_map_tool(125, 30, records)
+
+
+def test_drag_controller_blocks_middle_drag_inside_maptool(monkeypatch):
+    monkeypatch.setattr(
+        "modules.scenarios.gm_table.drag_controller.pointer_screen_position",
+        lambda event: (42, 84),
+    )
+    controller = GMTableDragController(
+        should_block_middle_drag=lambda screen_x, screen_y: (screen_x, screen_y) == (42, 84)
+    )
+
+    assert not controller.allows_middle_drag_start(SimpleNamespace())
+
+
+def test_drag_controller_allows_middle_drag_when_maptool_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        "modules.scenarios.gm_table.drag_controller.pointer_screen_position",
+        lambda event: (42, 84),
+    )
+    controller = GMTableDragController(should_block_middle_drag=lambda _x, _y: False)
+
+    assert controller.allows_middle_drag_start(SimpleNamespace())
+
+
+def test_map_tool_hit_testing_matches_standalone_maptool_window(monkeypatch):
+    map_tool_window = object()
+
+    def _bounds(widget):
+        if widget is map_tool_window:
+            return ScreenBounds(20, 30, 60, 40)
+        return None
+
+    monkeypatch.setattr(hit_testing, "widget_screen_bounds", _bounds)
+
+    assert hit_testing.point_inside_map_tool(25, 35, [], map_tool_window=map_tool_window)
+    assert not hit_testing.point_inside_map_tool(5, 35, [], map_tool_window=map_tool_window)


### PR DESCRIPTION
### Motivation
- Avoid starting GM Table middle-button camera drags when the pointer is over an open MapTool instance while preserving normal behavior when MapTool is closed, minimized, or unavailable.

### Description
- Add `modules/scenarios/gm_table/window_hit_testing.py` with `ScreenBounds`, `pointer_screen_position`, `widget_screen_bounds`, and `point_inside_map_tool` helpers for screen-space hit testing.
- Add `modules/scenarios/gm_table/drag_controller.py` implementing `GMTableDragController` that gates middle-drag starts using screen coordinates.
- Wire the workspace to use the new controller and hit-testing by adding a `map_tool_window_provider` injection and calling the controller before beginning a middle-button pan in `GMTableWorkspace` (`_start_surface_pan`).
- Pass a `map_tool_window_provider` from `GMTableView` via a new `_get_map_tool_window` helper so MapTool-specific checks are not scattered through UI code.
- Add unit tests `tests/scenarios/test_gm_table_middle_drag_hit_testing.py` covering bounds logic, embedded and standalone MapTool detection, and drag-controller gating.

### Testing
- Ran `pytest -q tests/scenarios/test_gm_table_middle_drag_hit_testing.py` and all tests passed (`6 passed`).
- Compiled changed modules with `python3 -m compileall` and compilation succeeded for the new/modified files.
- Attempted broader GM Table integration tests (`tests/scenarios/gm_table/test_gm_table_view.py` and `tests/test_gm_screen_map_tool_deferred_open.py`), but collection was blocked by an environment import error (`ImportError: cannot import name 'ImageFont' from 'PIL'`) unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9a213714832b9e49386be023fac4)