### PR TITLE
Add token facing_angle with rotate handles, context menu and web API

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -9,7 +9,7 @@ import webbrowser
 import threading
 import io
 from pathlib import Path
-from tkinter import colorchooser, filedialog, messagebox
+from tkinter import colorchooser, filedialog, messagebox, simpledialog
 import tkinter as tk
 from tkinter import font as tkfont
 from types import SimpleNamespace
@@ -57,6 +57,11 @@ from modules.maps.services.entity_picker_service import (
     on_entities_selected,
 )
 from modules.maps.utils.icon_loader import load_icon
+from modules.maps.utils.token_facing import (
+    facing_angle_from_points,
+    facing_arrow_points,
+    normalize_facing_angle,
+)
 from PIL import Image, ImageTk, ImageDraw
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.template_loader import load_template
@@ -862,6 +867,8 @@ class DisplayMapController:
                 extra.extend([cid for cid in item["hp_canvas_ids"] if cid])
             if item.get("defense_canvas_ids"):
                 extra.extend([cid for cid in item["defense_canvas_ids"] if cid])
+            if item.get("facing_canvas_ids"):
+                extra.extend([cid for cid in item["facing_canvas_ids"] if cid])
             if item.get("name_id"):
                 extra.append(item.get("name_id"))
             preferred_ids.extend(extra)
@@ -3066,6 +3073,10 @@ class DisplayMapController:
                         for def_cid in item["defense_canvas_ids"]:
                             if def_cid:
                                 self.canvas.move(def_cid, dx, dy)
+                    if item.get("facing_canvas_ids"):
+                        for facing_cid in item["facing_canvas_ids"]:
+                            if facing_cid:
+                                self.canvas.move(facing_cid, dx, dy)
                     if item.get("hover_bbox"):
                         x1, y1, x2, y2 = item["hover_bbox"]
                         item["hover_bbox"] = (x1 + dx, y1 + dy, x2 + dx, y2 + dy)
@@ -3838,6 +3849,7 @@ class DisplayMapController:
                         item.pop("defense_canvas_ids", None)
                     name_id = item.get('name_id')
                     if name_id: tx = sx + nw/2; ty = sy + nh + 2; self.canvas.coords(name_id, tx, ty); self.canvas.itemconfig(name_id, text=item.get('entity_id', ''))
+                    self._draw_token_facing_arrow(item, sx, sy, nw)
                     item['hover_bbox'] = (sx - 3, sy - 3, sx + nw + 3, sy + nh + 3)
                     self._refresh_token_hover_popup(item)
                     if item.get("hover_visible"):
@@ -3892,6 +3904,7 @@ class DisplayMapController:
                         item.pop("defense_canvas_ids", None)
                     item.update({'canvas_ids': (b_id, i_id), 'name_id': name_id})
                     self._bind_item_events(item)
+                    self._draw_token_facing_arrow(item, sx, sy, nw)
                     item['hover_bbox'] = (sx - 3, sy - 3, sx + nw + 3, sy + nh + 3)
                     self._refresh_token_hover_popup(item)
                 if debug_entry is not None:
@@ -4415,6 +4428,161 @@ class DisplayMapController:
         if getattr(self, '_web_server_thread', None):
             self._update_web_display_map()
 
+    def _draw_token_facing_arrow(self, token, sx, sy, size_px):
+        """Draw or update the GM-facing arrow and draggable rotation handle."""
+        if not token or token.get("type") != "token":
+            return
+        try:
+            angle = normalize_facing_angle(token.get("facing_angle", 0.0))
+            token["facing_angle"] = angle
+            size_world = float(token.get("size", self.token_size))
+            start_x, start_y, end_x, end_y = facing_arrow_points(
+                token.get("position", (0.0, 0.0)),
+                size_world,
+                angle,
+                zoom=float(self.zoom),
+                pan_x=float(self.pan_x),
+                pan_y=float(self.pan_y),
+            )
+        except Exception:
+            return
+
+        line_width = max(2, int(float(size_px) * 0.06))
+        handle_radius = max(5, int(float(size_px) * 0.10))
+        arrow_color = token.get("border_color", "#38bdf8") or "#38bdf8"
+        ids = token.get("facing_canvas_ids") or ()
+        if ids and len(ids) == 2:
+            arrow_id, handle_id = ids
+            try:
+                self.canvas.coords(arrow_id, start_x, start_y, end_x, end_y)
+                self.canvas.itemconfig(arrow_id, fill=arrow_color, width=line_width, arrow=tk.LAST)
+                self.canvas.coords(
+                    handle_id,
+                    end_x - handle_radius,
+                    end_y - handle_radius,
+                    end_x + handle_radius,
+                    end_y + handle_radius,
+                )
+                self.canvas.itemconfig(handle_id, fill=arrow_color)
+            except tk.TclError:
+                token.pop("facing_canvas_ids", None)
+                self._draw_token_facing_arrow(token, sx, sy, size_px)
+            return
+
+        try:
+            arrow_id = self.canvas.create_line(
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                fill=arrow_color,
+                width=line_width,
+                arrow=tk.LAST,
+                arrowshape=(12, 14, 5),
+                tags=("token_facing",),
+            )
+            handle_id = self.canvas.create_oval(
+                end_x - handle_radius,
+                end_y - handle_radius,
+                end_x + handle_radius,
+                end_y + handle_radius,
+                fill=arrow_color,
+                outline="white",
+                width=2,
+                tags=("token_facing_handle",),
+            )
+        except tk.TclError:
+            return
+        token["facing_canvas_ids"] = (arrow_id, handle_id)
+        for canvas_id in (arrow_id, handle_id):
+            self.canvas.tag_bind(canvas_id, "<ButtonPress-1>", lambda e, t=token: self._on_token_facing_press(e, t))
+            self.canvas.tag_bind(canvas_id, "<B1-Motion>", lambda e, t=token: self._on_token_facing_drag(e, t))
+            self.canvas.tag_bind(canvas_id, "<ButtonRelease-1>", lambda e, t=token: self._on_token_facing_release(e, t))
+            self.canvas.tag_bind(canvas_id, "<Button-3>", lambda e, t=token: self._show_token_menu(e, [t]))
+
+    def _on_token_facing_press(self, event, token):
+        """Start dragging a token facing handle."""
+        self.selected_token = token
+        self.selected_items = [token]
+        token["facing_drag_active"] = True
+        self._update_token_facing_from_event(token, event)
+        return "break"
+
+    def _on_token_facing_drag(self, event, token):
+        """Rotate token facing while the handle is dragged."""
+        if not token.get("facing_drag_active"):
+            return "break"
+        self._update_token_facing_from_event(token, event)
+        return "break"
+
+    def _on_token_facing_release(self, event, token):
+        """Finish dragging a token facing handle and persist the new angle."""
+        token.pop("facing_drag_active", None)
+        self._update_token_facing_from_event(token, event)
+        self._persist_tokens()
+        if getattr(self, "fs_canvas", None) and self.fs_canvas.winfo_exists():
+            self._update_fullscreen_map()
+        if getattr(self, "_web_server_thread", None):
+            self._update_web_display_map()
+        return "break"
+
+    def _update_token_facing_from_event(self, token, event):
+        """Set token facing from a canvas event point."""
+        try:
+            xw, yw = token.get("position", (0.0, 0.0))
+            size_world = float(token.get("size", self.token_size))
+            center_x = (float(xw) + size_world / 2.0) * self.zoom + self.pan_x
+            center_y = (float(yw) + size_world / 2.0) * self.zoom + self.pan_y
+            token["facing_angle"] = facing_angle_from_points(center_x, center_y, event.x, event.y)
+        except Exception:
+            return
+        self._update_canvas_images(resample=self._fast_resample)
+
+    def _set_tokens_facing_angle(self, tokens, angle):
+        """Set facing angle for one or more tokens."""
+        changed = False
+        normalized = normalize_facing_angle(angle)
+        for token in tokens:
+            if isinstance(token, dict) and token.get("type") == "token":
+                token["facing_angle"] = normalized
+                changed = True
+        if changed:
+            self._update_canvas_images()
+            if getattr(self, "fs_canvas", None) and self.fs_canvas.winfo_exists():
+                self._update_fullscreen_map()
+            if getattr(self, "_web_server_thread", None):
+                self._update_web_display_map()
+            self._persist_tokens()
+
+    def _rotate_tokens_facing(self, tokens, delta):
+        """Rotate token facing by a relative delta in degrees."""
+        changed = False
+        for token in tokens:
+            if isinstance(token, dict) and token.get("type") == "token":
+                token["facing_angle"] = normalize_facing_angle(token.get("facing_angle", 0.0) + delta)
+                changed = True
+        if changed:
+            self._update_canvas_images()
+            if getattr(self, "fs_canvas", None) and self.fs_canvas.winfo_exists():
+                self._update_fullscreen_map()
+            if getattr(self, "_web_server_thread", None):
+                self._update_web_display_map()
+            self._persist_tokens()
+
+    def _prompt_tokens_facing_angle(self, tokens):
+        """Prompt for an absolute token facing angle."""
+        current = normalize_facing_angle(tokens[0].get("facing_angle", 0.0)) if tokens else 0.0
+        angle = simpledialog.askfloat(
+            "Token Facing",
+            "Facing angle in degrees (0° right, 90° down, 180° left, 270° up):",
+            initialvalue=current,
+            minvalue=0.0,
+            maxvalue=359.99,
+            parent=self.canvas,
+        )
+        if angle is not None:
+            self._set_tokens_facing_angle(tokens, angle)
+
     def _bind_item_events(self, item):
         """Bind item events."""
         if item.get("type") == "whiteboard":
@@ -4557,6 +4725,14 @@ class DisplayMapController:
                         continue
                     try:
                         self.canvas.move(def_cid, dx, dy)
+                    except tk.TclError:
+                        continue
+            if item.get("facing_canvas_ids"):
+                for facing_cid in item["facing_canvas_ids"]:
+                    if not facing_cid:
+                        continue
+                    try:
+                        self.canvas.move(facing_cid, dx, dy)
                     except tk.TclError:
                         continue
             main_id = item.get("canvas_ids", (None,))[0]
@@ -4906,6 +5082,16 @@ class DisplayMapController:
             command=lambda: self._toggle_tokens_player_visibility(valid_tokens),
         )
 
+        facing_menu = tk.Menu(menu, tearoff=0)
+        facing_menu.add_command(label="Set Angle…", command=lambda: self._prompt_tokens_facing_angle(valid_tokens))
+        facing_menu.add_command(label="Rotate Clockwise 45°", command=lambda: self._rotate_tokens_facing(valid_tokens, 45))
+        facing_menu.add_command(label="Rotate Counterclockwise 45°", command=lambda: self._rotate_tokens_facing(valid_tokens, -45))
+        facing_menu.add_command(label="Face Right (0°)", command=lambda: self._set_tokens_facing_angle(valid_tokens, 0))
+        facing_menu.add_command(label="Face Down (90°)", command=lambda: self._set_tokens_facing_angle(valid_tokens, 90))
+        facing_menu.add_command(label="Face Left (180°)", command=lambda: self._set_tokens_facing_angle(valid_tokens, 180))
+        facing_menu.add_command(label="Face Up (270°)", command=lambda: self._set_tokens_facing_angle(valid_tokens, 270))
+        menu.add_cascade(label=f"Facing{plural}", menu=facing_menu)
+
         menu.add_separator()
         menu.add_command(
             label=f"Copy Token{plural}",
@@ -5225,6 +5411,8 @@ class DisplayMapController:
             "canvas_ids",
             "hp_canvas_ids",
             "defense_canvas_ids",
+            "facing_canvas_ids",
+            "facing_drag_active",
             "name_id",
             "hp_entry_widget",
             "hp_entry_widget_id",
@@ -5397,6 +5585,9 @@ class DisplayMapController:
             if item_to_delete.get("defense_canvas_ids"):
                 for def_cid in item_to_delete["defense_canvas_ids"]:
                     if def_cid: self.canvas.delete(def_cid)
+            if item_to_delete.get("facing_canvas_ids"):
+                for facing_cid in item_to_delete["facing_canvas_ids"]:
+                    if facing_cid: self.canvas.delete(facing_cid)
             popup = item_to_delete.get("hover_popup")
             if popup and popup.winfo_exists():
                 popup.destroy()
@@ -5472,6 +5663,9 @@ class DisplayMapController:
                 if item.get('defense_canvas_ids'):
                     for def_cid_lift in item['defense_canvas_ids']:
                         if def_cid_lift: self.canvas.lift(def_cid_lift)
+                if item.get('facing_canvas_ids'):
+                    for facing_cid_lift in item['facing_canvas_ids']:
+                        if facing_cid_lift: self.canvas.lift(facing_cid_lift)
             elif item.get("type") == "marker":
                 # Keep the marker popup above the canvas after the z-order change.
                 popup = item.get("description_popup")
@@ -6230,6 +6424,34 @@ class DisplayMapController:
             raise ValueError("token_id does not reference a PC token")
 
         matched["position"] = (x, y)
+        self._remote_checkpoint()
+        try:
+            self._update_canvas_images()
+        except Exception:
+            pass
+        _update_web_display_map(self)
+        try:
+            self._persist_tokens()
+        except Exception:
+            pass
+
+    def handle_remote_token_facing(self, token_id: str, facing_angle):
+        """Handle remote token facing rotation."""
+        try:
+            angle = normalize_facing_angle(facing_angle)
+        except Exception:
+            raise ValueError("facing_angle must be numeric")
+
+        matched = None
+        for token in self._iter_pc_tokens():
+            remote_id = token.get("remote_id") or token.get("entity_id")
+            if remote_id and str(remote_id) == str(token_id):
+                matched = token
+                break
+        if matched is None:
+            raise ValueError("token_id does not reference a PC token")
+
+        matched["facing_angle"] = angle
         self._remote_checkpoint()
         try:
             self._update_canvas_images()

--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -9,6 +9,7 @@ import os
 import copy
 from modules.helpers.config_helper import ConfigHelper
 from modules.maps.marker_types import DEFAULT_MARKER_TYPE, normalize_marker_type
+from modules.maps.utils.token_facing import normalize_facing_angle
 from modules.ui.image_viewer import show_portrait
 import tkinter.simpledialog as sd
 import tkinter as tk
@@ -364,6 +365,7 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
         "hover_visible": False,
         "hover_bbox": None,
         "player_visible": True,
+        "facing_angle": 0.0,
     }
 
     self.tokens.append(token)
@@ -388,6 +390,10 @@ def _on_token_move(self, event, token):
     b_id, i_id = token["canvas_ids"]
     self.canvas.move(b_id, dx, dy)
     self.canvas.move(i_id, dx, dy)
+    if token.get("facing_canvas_ids"):
+        for facing_cid in token["facing_canvas_ids"]:
+            if facing_cid:
+                self.canvas.move(facing_cid, dx, dy)
     # move the name label too, if it exists
     name_id = token.get("name_id")
     if name_id:
@@ -463,6 +469,7 @@ def _copy_token(self, event=None):
         "defense_label": t.get("defense_label", ""),
         "entity_record": copy.deepcopy(t.get("entity_record")) if t.get("entity_record") else None,
         "player_visible": bool(t.get("player_visible", True)),
+        "facing_angle": normalize_facing_angle(t.get("facing_angle", 0.0)),
     }
 
 def _paste_token(self, event=None):
@@ -508,6 +515,7 @@ def _paste_token(self, event=None):
         "defense_label": defense_label,
         "entity_record": entity_record,
         "player_visible": bool(c.get("player_visible", True)),
+        "facing_angle": normalize_facing_angle(c.get("facing_angle", 0.0)),
     }
 
     # Add it to your tokens list, then persist & re-draw everything
@@ -599,6 +607,11 @@ def _delete_token(self, token):
         for cid in token["defense_canvas_ids"]:
             self.canvas.delete(cid)
         del token["defense_canvas_ids"]
+
+    if "facing_canvas_ids" in token:
+        for cid in token["facing_canvas_ids"]:
+            self.canvas.delete(cid)
+        del token["facing_canvas_ids"]
 
     # 4) Any inline HP edit entry
     if "hp_entry_widget_id" in token:
@@ -715,6 +728,7 @@ def _persist_tokens(self):
                     "defense_label": t.get("defense_label", ""),
                     "border_color":   t.get("border_color", "#0000ff"),
                     "player_visible": bool(t.get("player_visible", True)),
+                    "facing_angle": normalize_facing_angle(t.get("facing_angle", 0.0)),
                 })
             elif item_type in ["rectangle", "oval"]:
                 item_data.update({

--- a/modules/maps/utils/token_facing.py
+++ b/modules/maps/utils/token_facing.py
@@ -1,0 +1,65 @@
+"""Helpers for token facing angles and arrow geometry."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+DEFAULT_FACING_ANGLE = 0.0
+
+
+def normalize_facing_angle(value: Any, default: float = DEFAULT_FACING_ANGLE) -> float:
+    """Return *value* as a clockwise canvas angle in degrees, normalized to [0, 360)."""
+    try:
+        angle = float(value)
+    except (TypeError, ValueError):
+        angle = float(default)
+    if not math.isfinite(angle):
+        angle = float(default)
+    return angle % 360.0
+
+
+def token_center(position: tuple[float, float] | list[float], size: float) -> tuple[float, float]:
+    """Return the world-space center for a top-left token position and token size."""
+    x, y = position
+    half = float(size) / 2.0
+    return float(x) + half, float(y) + half
+
+
+def facing_vector(angle: Any) -> tuple[float, float]:
+    """Return a unit vector for a clockwise canvas angle where 0° points right."""
+    radians = math.radians(normalize_facing_angle(angle))
+    return math.cos(radians), math.sin(radians)
+
+
+def facing_angle_from_points(center_x: float, center_y: float, point_x: float, point_y: float) -> float:
+    """Return the clockwise canvas angle from a center point to a target point."""
+    return normalize_facing_angle(math.degrees(math.atan2(point_y - center_y, point_x - center_x)))
+
+
+def facing_arrow_points(
+    position: tuple[float, float] | list[float],
+    size: float,
+    angle: Any,
+    *,
+    zoom: float = 1.0,
+    pan_x: float = 0.0,
+    pan_y: float = 0.0,
+    offset_x: float = 0.0,
+    offset_y: float = 0.0,
+    extension: float = 0.32,
+) -> tuple[float, float, float, float]:
+    """Return screen-space start/end coordinates for a token facing arrow."""
+    center_x, center_y = token_center(position, size)
+    vec_x, vec_y = facing_vector(angle)
+    radius = float(size) / 2.0
+    start_world_x = center_x + vec_x * radius * 0.15
+    start_world_y = center_y + vec_y * radius * 0.15
+    end_world_x = center_x + vec_x * radius * (1.0 + extension)
+    end_world_y = center_y + vec_y * radius * (1.0 + extension)
+    return (
+        start_world_x * zoom + pan_x - offset_x,
+        start_world_y * zoom + pan_y - offset_y,
+        end_world_x * zoom + pan_x - offset_x,
+        end_world_y * zoom + pan_y - offset_y,
+    )

--- a/modules/maps/views/fullscreen_view.py
+++ b/modules/maps/views/fullscreen_view.py
@@ -2,6 +2,7 @@
 
 import tkinter as tk
 from PIL import ImageTk, Image
+from modules.maps.utils.token_facing import facing_arrow_points, normalize_facing_angle
 from screeninfo import get_monitors
 from modules.helpers.logging_helper import log_module_import
 from modules.maps.utils.text_items import TextFontCache
@@ -137,23 +138,36 @@ def _update_fullscreen_map(self):
             item['fs_tk'] = fsimg # Store the PhotoImage to prevent garbage collection
 
             # Token border, image, and name
+            facing_angle = normalize_facing_angle(item.get('facing_angle', 0.0))
             fs_canvas_ids = item.get('fs_canvas_ids')
-            if fs_canvas_ids and len(fs_canvas_ids) == 3: # Expecting (border_id, image_id, text_id)
+            if fs_canvas_ids and len(fs_canvas_ids) == 5: # Expecting (border_id, image_id, text_id, facing_line_id, facing_handle_id)
                 # Handle the branch where fs canvas ids is set and len(fs_canvas_ids) == 3.
-                b_id, i_id, t_id = fs_canvas_ids
+                b_id, i_id, t_id, f_id, fh_id = fs_canvas_ids
                 self.fs_canvas.coords(b_id, sx - 3, sy - 3, sx + nw + 3, sy + nh + 3)
                 self.fs_canvas.itemconfig(b_id, outline=item.get('border_color', '#0000ff'))
                 self.fs_canvas.coords(i_id, sx, sy)
                 self.fs_canvas.itemconfig(i_id, image=fsimg)
                 self.fs_canvas.coords(t_id, sx + nw // 2, sy + nh + 2)
                 self.fs_canvas.itemconfig(t_id, text=item.get('entity_id', ''))
+                arrow = facing_arrow_points(item.get('position', (0, 0)), size_px, facing_angle, zoom=float(self.zoom), pan_x=float(self.pan_x), pan_y=float(self.pan_y))
+                self.fs_canvas.coords(f_id, *arrow)
+                self.fs_canvas.itemconfig(f_id, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)), arrow='last')
+                end_x, end_y = arrow[2], arrow[3]
+                handle_radius = max(5, int(nw * 0.10))
+                self.fs_canvas.coords(fh_id, end_x - handle_radius, end_y - handle_radius, end_x + handle_radius, end_y + handle_radius)
+                self.fs_canvas.itemconfig(fh_id, fill=item.get('border_color', '#38bdf8'))
             else:
                 b_id = self.fs_canvas.create_rectangle(sx - 3, sy - 3, sx + nw + 3, sy + nh + 3,
                                                        outline=item.get('border_color', '#0000ff'), width=3)
                 i_id = self.fs_canvas.create_image(sx, sy, image=fsimg, anchor='nw')
                 t_id = self.fs_canvas.create_text(sx + nw // 2, sy + nh + 2, text=item.get('entity_id', ''),
                                                   fill='white', anchor='n')
-                item['fs_canvas_ids'] = (b_id, i_id, t_id)
+                arrow = facing_arrow_points(item.get('position', (0, 0)), size_px, facing_angle, zoom=float(self.zoom), pan_x=float(self.pan_x), pan_y=float(self.pan_y))
+                f_id = self.fs_canvas.create_line(*arrow, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)), arrow='last')
+                end_x, end_y = arrow[2], arrow[3]
+                handle_radius = max(5, int(nw * 0.10))
+                fh_id = self.fs_canvas.create_oval(end_x - handle_radius, end_y - handle_radius, end_x + handle_radius, end_y + handle_radius, fill=item.get('border_color', '#38bdf8'), outline='white', width=2)
+                item['fs_canvas_ids'] = (b_id, i_id, t_id, f_id, fh_id)
 
             # HP-related cross for dead tokens
             hp = item.get("hp", 0)

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -16,6 +16,7 @@ from modules.helpers.template_loader import load_template
 from modules.generic.generic_list_selection_view import GenericListSelectionView
 from modules.helpers.logging_helper import log_module_import, log_debug, log_info, log_warning
 from modules.maps.marker_types import DEFAULT_MARKER_TYPE, normalize_marker_type
+from modules.maps.utils.token_facing import normalize_facing_angle
 
 log_module_import(__name__)
 
@@ -578,6 +579,7 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "hp_entry":     None,                        
                 "hp_entry_id":  None,
                 "player_visible": bool(rec.get("player_visible", True)),
+                "facing_angle": normalize_facing_angle(rec.get("facing_angle", 0.0)),
             })
         elif item_type_from_rec in ["rectangle", "oval"]:
             # Handle the branch where item type from rec is in ['rectangle', 'oval'].

--- a/modules/maps/views/web_display_view.py
+++ b/modules/maps/views/web_display_view.py
@@ -13,6 +13,7 @@ from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.logging_helper import log_module_import
 from modules.whiteboard.utils.remote_access_guard import RemoteAccessGuard
 from modules.maps.utils.text_items import TextFontCache
+from modules.maps.utils.token_facing import facing_arrow_points, normalize_facing_angle
 from modules.maps.views.web_map_api import register_map_api
 from modules.scenarios.plot_twist_panel import get_latest_plot_twist, roll_plot_twist
 
@@ -242,6 +243,12 @@ def open_web_display(self, port=None):
                     #plotTwistMeta { font-size: 12px; color: #94a3b8; margin-bottom: 10px; }
                     #plotTwistButton { background: #38bdf8; border: none; color: #0f172a; padding: 6px 12px; border-radius: 8px; font-weight: 700; cursor: pointer; }
                     #plotTwistButton:active { transform: translateY(1px); }
+                    .token .facingArrow { position: absolute; left: 50%; top: 50%; width: 64%; height: 6px; background: currentColor; transform-origin: left center; border-radius: 999px; pointer-events: none; filter: drop-shadow(0 2px 3px rgba(0,0,0,0.55)); }
+                    .token .facingArrow::after { content: ''; position: absolute; right: -8px; top: 50%; transform: translateY(-50%); border-left: 12px solid currentColor; border-top: 8px solid transparent; border-bottom: 8px solid transparent; }
+                    .token .facingHandle { position: absolute; left: 50%; top: 50%; width: 16px; height: 16px; margin-left: -8px; margin-top: -8px; border: 2px solid #fff; border-radius: 999px; background: currentColor; box-shadow: 0 2px 8px rgba(0,0,0,0.45); touch-action: none; }
+                    .tokenMenu { position: fixed; z-index: 300; display: none; min-width: 180px; padding: 6px; border-radius: 10px; background: rgba(15, 23, 42, 0.96); box-shadow: 0 16px 30px rgba(0,0,0,0.35); }
+                    .tokenMenu button { display: block; width: 100%; border: none; background: transparent; color: #e2e8f0; text-align: left; padding: 8px 10px; border-radius: 8px; font-weight: 700; cursor: pointer; }
+                    .tokenMenu button:hover { background: rgba(56, 189, 248, 0.18); }
                 </style>
             </head>
             <body>
@@ -256,6 +263,7 @@ def open_web_display(self, port=None):
                     <canvas id='drawLayer'></canvas>
                     <div id='tokenLayer'></div>
                     <div id='status'>Connecting…</div>
+                    <div id='tokenMenu' class='tokenMenu' role='menu' aria-hidden='true'></div>
                 </div>
                 <script>
                     window.MAP_REMOTE_TOKEN = {{ token|tojson }};
@@ -435,6 +443,7 @@ def _describe_remote_tokens(self, render_offset=None):
                 'size': size_px,
                 'screen_size': size_px * zoom,
                 'border_color': token.get('border_color', '#0ea5e9'),
+                'facing_angle': normalize_facing_angle(token.get('facing_angle', 0.0)),
             }
         )
     return tokens
@@ -502,6 +511,25 @@ def _render_map_image(self):
 
             img.paste(img_r, (sx, sy), img_r.convert('RGBA'))
             draw.rectangle([sx - 3, sy - 3, sx + nw + 3, sy + nh + 3], outline=item.get('border_color', '#0000ff'), width=3)
+            arrow = facing_arrow_points(
+                item.get('position', (0, 0)),
+                size_px,
+                item.get('facing_angle', 0.0),
+                zoom=float(self.zoom),
+                pan_x=float(self.pan_x),
+                pan_y=float(self.pan_y),
+                offset_x=float(min_x),
+                offset_y=float(min_y),
+            )
+            draw.line(arrow, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)))
+            end_x, end_y = arrow[2], arrow[3]
+            handle_radius = max(4, int(nw * 0.08))
+            draw.ellipse(
+                [end_x - handle_radius, end_y - handle_radius, end_x + handle_radius, end_y + handle_radius],
+                fill=item.get('border_color', '#38bdf8'),
+                outline='white',
+                width=2,
+            )
         elif item_type in ['rectangle', 'oval']:
             # Handle the branch where item type is in ['rectangle', 'oval'].
             shape_w = int(item.get('width', 50) * self.zoom)

--- a/modules/maps/views/web_map_api.py
+++ b/modules/maps/views/web_map_api.py
@@ -68,6 +68,27 @@ def register_map_api(app, controller, access_guard: RemoteAccessGuard | None):
             return jsonify({"message": f"Unable to move token: {exc}"}), 500
         return jsonify({"status": "ok"})
 
+    @blueprint.route("/api/tokens/facing", methods=["POST"])
+    def api_token_facing():
+        """Handle API token facing updates."""
+        unauthorized = _require_access()
+        if unauthorized:
+            return unauthorized
+        payload = request.get_json(silent=True) or {}
+        token_id = payload.get("token_id")
+        angle = payload.get("facing_angle")
+        if not token_id:
+            return jsonify({"message": "token_id is required"}), 400
+        if angle is None:
+            return jsonify({"message": "facing_angle is required"}), 400
+        try:
+            controller.handle_remote_token_facing(token_id=str(token_id), facing_angle=angle)
+        except ValueError as exc:
+            return jsonify({"message": str(exc)}), 400
+        except Exception as exc:  # noqa: BLE001
+            return jsonify({"message": f"Unable to rotate token: {exc}"}), 500
+        return jsonify({"status": "ok"})
+
     @blueprint.route("/api/strokes", methods=["POST"])
     def api_strokes():
         """Handle API strokes."""

--- a/static/maptool_web/player.js
+++ b/static/maptool_web/player.js
@@ -4,6 +4,7 @@
   const tokenLayer = document.getElementById('tokenLayer');
   const drawLayer = document.getElementById('drawLayer');
   const authToken = window.MAP_REMOTE_TOKEN || '';
+  const tokenMenu = document.getElementById('tokenMenu');
 
   let lastStatus = null;
   let drawCtx = null;
@@ -44,6 +45,48 @@
     drawCtx.lineJoin = 'round';
   }
 
+  function normalizeAngle(angle) {
+    const value = Number(angle);
+    return Number.isFinite(value) ? ((value % 360) + 360) % 360 : 0;
+  }
+
+  function hideTokenMenu() {
+    if (!tokenMenu) return;
+    tokenMenu.style.display = 'none';
+    tokenMenu.setAttribute('aria-hidden', 'true');
+    tokenMenu.innerHTML = '';
+  }
+
+  function showTokenMenu(ev, token) {
+    if (!lastStatus?.editing_enabled || !tokenMenu) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    const actions = [
+      ['Set Angle…', () => promptTokenFacing(token)],
+      ['Rotate Clockwise 45°', () => rotateTokenFacing(token, 45)],
+      ['Rotate Counterclockwise 45°', () => rotateTokenFacing(token, -45)],
+      ['Face Right (0°)', () => setTokenFacing(token, 0)],
+      ['Face Down (90°)', () => setTokenFacing(token, 90)],
+      ['Face Left (180°)', () => setTokenFacing(token, 180)],
+      ['Face Up (270°)', () => setTokenFacing(token, 270)],
+    ];
+    tokenMenu.innerHTML = '';
+    actions.forEach(([label, action]) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = label;
+      button.addEventListener('click', () => {
+        hideTokenMenu();
+        action();
+      });
+      tokenMenu.appendChild(button);
+    });
+    tokenMenu.style.left = `${Math.min(ev.clientX, window.innerWidth - 190)}px`;
+    tokenMenu.style.top = `${Math.min(ev.clientY, window.innerHeight - 240)}px`;
+    tokenMenu.style.display = 'block';
+    tokenMenu.setAttribute('aria-hidden', 'false');
+  }
+
   function renderTokens(status) {
     tokenLayer.innerHTML = '';
     if (!status || !Array.isArray(status.tokens)) return;
@@ -53,7 +96,12 @@
     status.tokens.forEach((token) => {
       const el = document.createElement('div');
       el.className = 'token';
-      el.textContent = token.label || 'PC';
+      const label = document.createElement('span');
+      label.textContent = token.label || 'PC';
+      label.style.color = '#0b1220';
+      label.style.position = 'relative';
+      label.style.zIndex = '2';
+      el.appendChild(label);
       el.draggable = false;
       const screenX = (token.screen_position?.[0] || 0) / scaleX;
       const screenY = (token.screen_position?.[1] || 0) / scaleY;
@@ -63,8 +111,23 @@
       el.style.height = `${size}px`;
       if (token.border_color) {
         el.style.borderColor = token.border_color;
+        el.style.color = token.border_color;
       }
-      el.addEventListener('pointerdown', (ev) => startDrag(ev, token));
+      const facingAngle = normalizeAngle(token.facing_angle);
+      const arrow = document.createElement('div');
+      arrow.className = 'facingArrow';
+      arrow.style.transform = `rotate(${facingAngle}deg)`;
+      el.appendChild(arrow);
+      const handle = document.createElement('div');
+      handle.className = 'facingHandle';
+      handle.style.transform = `rotate(${facingAngle}deg) translate(${size * 0.64}px, 0) rotate(${-facingAngle}deg)`;
+      handle.addEventListener('pointerdown', (ev) => startFacingDrag(ev, token, el));
+      el.appendChild(handle);
+      el.addEventListener('contextmenu', (ev) => showTokenMenu(ev, token));
+      el.addEventListener('pointerdown', (ev) => {
+        if (ev.target === handle) return;
+        startDrag(ev, token);
+      });
       tokenLayer.appendChild(el);
     });
   }
@@ -113,6 +176,65 @@
     window.addEventListener('pointermove', moveHandler);
     window.addEventListener('pointerup', upHandler);
     moveToken(token, start);
+  }
+
+  function tokenCenterScreen(token) {
+    const rect = mapImg.getBoundingClientRect();
+    const scaleX = lastStatus.render_size[0] ? lastStatus.render_size[0] / rect.width : 1;
+    const scaleY = lastStatus.render_size[1] ? lastStatus.render_size[1] / rect.height : 1;
+    const screenX = (token.screen_position?.[0] || 0) / scaleX;
+    const screenY = (token.screen_position?.[1] || 0) / scaleY;
+    const size = (token.screen_size || 48) / Math.max(scaleX, scaleY);
+    return { x: screenX + size / 2, y: screenY + size / 2 };
+  }
+
+  function angleFromScreenPoint(token, point) {
+    const center = tokenCenterScreen(token);
+    return normalizeAngle(Math.atan2(point.y - center.y, point.x - center.x) * 180 / Math.PI);
+  }
+
+  function startFacingDrag(ev, token) {
+    if (!lastStatus?.editing_enabled) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    hideTokenMenu();
+    const rect = mapImg.getBoundingClientRect();
+    const apply = (e) => {
+      const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      const angle = angleFromScreenPoint(token, point);
+      token.facing_angle = angle;
+      setTokenFacing(token, angle);
+    };
+    const upHandler = () => {
+      window.removeEventListener('pointermove', apply);
+      window.removeEventListener('pointerup', upHandler);
+    };
+    window.addEventListener('pointermove', apply);
+    window.addEventListener('pointerup', upHandler);
+    apply(ev);
+  }
+
+  function promptTokenFacing(token) {
+    const current = Math.round(normalizeAngle(token.facing_angle));
+    const value = prompt('Facing angle in degrees (0 right, 90 down, 180 left, 270 up)', `${current}`);
+    if (value === null) return;
+    const angle = Number(value);
+    if (!Number.isFinite(angle)) return;
+    setTokenFacing(token, angle);
+  }
+
+  function rotateTokenFacing(token, delta) {
+    setTokenFacing(token, normalizeAngle(token.facing_angle + delta));
+  }
+
+  function setTokenFacing(token, angle) {
+    const normalized = normalizeAngle(angle);
+    token.facing_angle = normalized;
+    fetch('/api/tokens/facing', {
+      method: 'POST',
+      headers: apiHeaders(),
+      body: JSON.stringify({ token_id: token.id, facing_angle: normalized }),
+    }).catch(() => {});
   }
 
   function moveToken(token, screenPoint) {
@@ -181,6 +303,8 @@
   window.addEventListener('resize', ensureCanvasSize);
   mapImg.addEventListener('dragstart', (ev) => ev.preventDefault());
   tokenLayer.addEventListener('dragstart', (ev) => ev.preventDefault());
+  window.addEventListener('click', hideTokenMenu);
+  window.addEventListener('keydown', (ev) => { if (ev.key === 'Escape') hideTokenMenu(); });
 
   drawLayer.addEventListener('pointerdown', (ev) => {
     if (ev.pointerType === 'pen' || ev.pointerType === 'touch') {

--- a/tests/maps/test_token_facing.py
+++ b/tests/maps/test_token_facing.py
@@ -1,0 +1,52 @@
+"""Tests for token facing geometry."""
+
+import math
+
+from modules.maps.utils.token_facing import (
+    facing_angle_from_points,
+    facing_arrow_points,
+    facing_vector,
+    normalize_facing_angle,
+    token_center,
+)
+
+
+def test_normalize_facing_angle_wraps_and_defaults() -> None:
+    """Facing angles are stored as finite degrees in [0, 360)."""
+    assert normalize_facing_angle(725) == 5
+    assert normalize_facing_angle(-90) == 270
+    assert normalize_facing_angle("bad", default=45) == 45
+
+
+def test_facing_angle_from_points_uses_canvas_orientation() -> None:
+    """Canvas coordinates grow downward, so 90 degrees points down."""
+    assert facing_angle_from_points(10, 10, 20, 10) == 0
+    assert facing_angle_from_points(10, 10, 10, 20) == 90
+    assert facing_angle_from_points(10, 10, 0, 10) == 180
+    assert facing_angle_from_points(10, 10, 10, 0) == 270
+
+
+def test_facing_vector_matches_cardinal_directions() -> None:
+    """Facing vectors should align with cardinal canvas directions."""
+    assert facing_vector(0) == (1.0, 0.0)
+    down_x, down_y = facing_vector(90)
+    assert math.isclose(down_x, 0.0, abs_tol=1e-9)
+    assert math.isclose(down_y, 1.0, abs_tol=1e-9)
+
+
+def test_facing_arrow_points_include_pan_zoom_and_offset() -> None:
+    """Arrow endpoints should be returned in screen/render coordinates."""
+    assert token_center((10, 20), 40) == (30, 40)
+    start_x, start_y, end_x, end_y = facing_arrow_points(
+        (10, 20),
+        40,
+        0,
+        zoom=2,
+        pan_x=5,
+        pan_y=7,
+        offset_x=3,
+        offset_y=4,
+    )
+    assert (start_x, start_y) == (68, 83)
+    assert math.isclose(end_x, 114.8)
+    assert end_y == 83


### PR DESCRIPTION
### Motivation
- Persist a token-facing orientation so GMs and players can see which way tokens face. 
- Provide intuitive controls (drag handles + context-menu) to rotate token facing from the GM canvas and remote web player. 
- Ensure facing is visible in all map render targets (GM canvas, fullscreen player, web player / exported PNGs) and accessible remotely via API.

### Description
- Added a small geometry utility `modules/maps/utils/token_facing.py` to normalize angles, compute facing vectors and return arrow endpoints for rendering. 
- Extended token model and persistence so tokens include `facing_angle` across creation, copy/paste, load and save flows (`modules/maps/services/token_manager.py`, `modules/maps/views/map_selector.py`).
- GM canvas: draw facing arrows and a draggable rotation handle, bind mouse handlers to start/drag/release rotation, and add per-token Facing submenu to the token context menu (`modules/maps/controllers/display_map_controller.py`).
- Player/web: render facing arrows/handles in the remote web player DOM and wire UI controls to call a new API; added server endpoint `/api/tokens/facing` and controller handler to accept remote facing updates (`static/maptool_web/player.js`, `modules/maps/views/web_map_api.py`, `modules/maps/views/web_display_view.py`).
- Fullscreen and PNG rendering now include facing arrows on the exported map image (`modules/maps/views/fullscreen_view.py`, `_render_map_image` in `web_display_view`).
- Added focused tests for facing helpers (`tests/maps/test_token_facing.py`).

### Testing
- Ran static checks and compilation: `python -m compileall modules/maps static/maptool_web` succeeded and `node --check static/maptool_web/player.js` reported no syntax errors. 
- Unit tests: `pytest tests/maps/test_token_facing.py tests/test_token_manager_hp.py -q` passed (10 tests total passed). 
- Attempted broader integration run including `tests/test_gm_screen_map_tool_deferred_open.py` but collection is blocked by the environment's PIL test stub missing `ImageFont` (pre-existing test-time stub), so that full suite run was not completed; focused unit tests above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb313d354832ba6b6719b28bb0319)