### PR TITLE
Replace token facing point with arrowhead

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -60,6 +60,7 @@ from modules.maps.utils.icon_loader import load_icon
 from modules.maps.utils.token_facing import (
     facing_angle_from_points,
     facing_arrow_points,
+    facing_arrowhead_points,
     normalize_facing_angle,
 )
 from PIL import Image, ImageTk, ImageDraw
@@ -4448,23 +4449,27 @@ class DisplayMapController:
             return
 
         line_width = max(2, int(float(size_px) * 0.06))
-        handle_radius = max(5, int(float(size_px) * 0.10))
+        head_length = max(10, int(float(size_px) * 0.24))
+        head_width = max(8, int(float(size_px) * 0.18))
+        head_points = facing_arrowhead_points(
+            end_x, end_y, angle, length=head_length, width=head_width
+        )
         arrow_color = token.get("border_color", "#38bdf8") or "#38bdf8"
         ids = token.get("facing_canvas_ids") or ()
         if ids and len(ids) == 2:
             arrow_id, handle_id = ids
             try:
                 self.canvas.coords(arrow_id, start_x, start_y, end_x, end_y)
-                self.canvas.itemconfig(arrow_id, fill=arrow_color, width=line_width, arrow=tk.LAST)
-                self.canvas.coords(
-                    handle_id,
-                    end_x - handle_radius,
-                    end_y - handle_radius,
-                    end_x + handle_radius,
-                    end_y + handle_radius,
-                )
-                self.canvas.itemconfig(handle_id, fill=arrow_color)
+                self.canvas.itemconfig(arrow_id, fill=arrow_color, width=line_width, arrow=tk.NONE)
+                if self.canvas.type(handle_id) != "polygon":
+                    self.canvas.delete(handle_id)
+                    raise tk.TclError("legacy facing handle")
+                self.canvas.coords(handle_id, *head_points)
+                self.canvas.itemconfig(handle_id, fill=arrow_color, outline="white", width=2)
             except tk.TclError:
+                for facing_id in (arrow_id, handle_id):
+                    if facing_id:
+                        self.canvas.delete(facing_id)
                 token.pop("facing_canvas_ids", None)
                 self._draw_token_facing_arrow(token, sx, sy, size_px)
             return
@@ -4477,15 +4482,11 @@ class DisplayMapController:
                 end_y,
                 fill=arrow_color,
                 width=line_width,
-                arrow=tk.LAST,
-                arrowshape=(12, 14, 5),
+                arrow=tk.NONE,
                 tags=("token_facing",),
             )
-            handle_id = self.canvas.create_oval(
-                end_x - handle_radius,
-                end_y - handle_radius,
-                end_x + handle_radius,
-                end_y + handle_radius,
+            handle_id = self.canvas.create_polygon(
+                *head_points,
                 fill=arrow_color,
                 outline="white",
                 width=2,

--- a/modules/maps/utils/token_facing.py
+++ b/modules/maps/utils/token_facing.py
@@ -63,3 +63,30 @@ def facing_arrow_points(
         end_world_x * zoom + pan_x - offset_x,
         end_world_y * zoom + pan_y - offset_y,
     )
+
+
+def facing_arrowhead_points(
+    tip_x: float,
+    tip_y: float,
+    angle: Any,
+    *,
+    length: float,
+    width: float | None = None,
+) -> tuple[float, float, float, float, float, float]:
+    """Return triangle polygon points for an arrowhead whose tip follows *angle*."""
+    head_length = max(1.0, float(length))
+    head_width = max(1.0, float(width if width is not None else head_length * 0.72))
+    vec_x, vec_y = facing_vector(angle)
+    base_x = float(tip_x) - vec_x * head_length
+    base_y = float(tip_y) - vec_y * head_length
+    perp_x = -vec_y
+    perp_y = vec_x
+    half_width = head_width / 2.0
+    return (
+        float(tip_x),
+        float(tip_y),
+        base_x + perp_x * half_width,
+        base_y + perp_y * half_width,
+        base_x - perp_x * half_width,
+        base_y - perp_y * half_width,
+    )

--- a/modules/maps/views/fullscreen_view.py
+++ b/modules/maps/views/fullscreen_view.py
@@ -2,7 +2,11 @@
 
 import tkinter as tk
 from PIL import ImageTk, Image
-from modules.maps.utils.token_facing import facing_arrow_points, normalize_facing_angle
+from modules.maps.utils.token_facing import (
+    facing_arrow_points,
+    facing_arrowhead_points,
+    normalize_facing_angle,
+)
 from screeninfo import get_monitors
 from modules.helpers.logging_helper import log_module_import
 from modules.maps.utils.text_items import TextFontCache
@@ -151,11 +155,27 @@ def _update_fullscreen_map(self):
                 self.fs_canvas.itemconfig(t_id, text=item.get('entity_id', ''))
                 arrow = facing_arrow_points(item.get('position', (0, 0)), size_px, facing_angle, zoom=float(self.zoom), pan_x=float(self.pan_x), pan_y=float(self.pan_y))
                 self.fs_canvas.coords(f_id, *arrow)
-                self.fs_canvas.itemconfig(f_id, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)), arrow='last')
+                self.fs_canvas.itemconfig(f_id, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)), arrow='none')
                 end_x, end_y = arrow[2], arrow[3]
-                handle_radius = max(5, int(nw * 0.10))
-                self.fs_canvas.coords(fh_id, end_x - handle_radius, end_y - handle_radius, end_x + handle_radius, end_y + handle_radius)
-                self.fs_canvas.itemconfig(fh_id, fill=item.get('border_color', '#38bdf8'))
+                head_points = facing_arrowhead_points(
+                    end_x,
+                    end_y,
+                    facing_angle,
+                    length=max(10, int(nw * 0.24)),
+                    width=max(8, int(nw * 0.18)),
+                )
+                if self.fs_canvas.type(fh_id) != 'polygon':
+                    self.fs_canvas.delete(fh_id)
+                    fh_id = self.fs_canvas.create_polygon(
+                        *head_points,
+                        fill=item.get('border_color', '#38bdf8'),
+                        outline='white',
+                        width=2,
+                    )
+                    item['fs_canvas_ids'] = (b_id, i_id, t_id, f_id, fh_id)
+                else:
+                    self.fs_canvas.coords(fh_id, *head_points)
+                    self.fs_canvas.itemconfig(fh_id, fill=item.get('border_color', '#38bdf8'), outline='white', width=2)
             else:
                 b_id = self.fs_canvas.create_rectangle(sx - 3, sy - 3, sx + nw + 3, sy + nh + 3,
                                                        outline=item.get('border_color', '#0000ff'), width=3)
@@ -163,10 +183,21 @@ def _update_fullscreen_map(self):
                 t_id = self.fs_canvas.create_text(sx + nw // 2, sy + nh + 2, text=item.get('entity_id', ''),
                                                   fill='white', anchor='n')
                 arrow = facing_arrow_points(item.get('position', (0, 0)), size_px, facing_angle, zoom=float(self.zoom), pan_x=float(self.pan_x), pan_y=float(self.pan_y))
-                f_id = self.fs_canvas.create_line(*arrow, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)), arrow='last')
+                f_id = self.fs_canvas.create_line(*arrow, fill=item.get('border_color', '#38bdf8'), width=max(2, int(nw * 0.06)), arrow='none')
                 end_x, end_y = arrow[2], arrow[3]
-                handle_radius = max(5, int(nw * 0.10))
-                fh_id = self.fs_canvas.create_oval(end_x - handle_radius, end_y - handle_radius, end_x + handle_radius, end_y + handle_radius, fill=item.get('border_color', '#38bdf8'), outline='white', width=2)
+                head_points = facing_arrowhead_points(
+                    end_x,
+                    end_y,
+                    facing_angle,
+                    length=max(10, int(nw * 0.24)),
+                    width=max(8, int(nw * 0.18)),
+                )
+                fh_id = self.fs_canvas.create_polygon(
+                    *head_points,
+                    fill=item.get('border_color', '#38bdf8'),
+                    outline='white',
+                    width=2,
+                )
                 item['fs_canvas_ids'] = (b_id, i_id, t_id, f_id, fh_id)
 
             # HP-related cross for dead tokens

--- a/tests/maps/test_token_facing.py
+++ b/tests/maps/test_token_facing.py
@@ -5,6 +5,7 @@ import math
 from modules.maps.utils.token_facing import (
     facing_angle_from_points,
     facing_arrow_points,
+    facing_arrowhead_points,
     facing_vector,
     normalize_facing_angle,
     token_center,
@@ -50,3 +51,14 @@ def test_facing_arrow_points_include_pan_zoom_and_offset() -> None:
     assert (start_x, start_y) == (68, 83)
     assert math.isclose(end_x, 114.8)
     assert end_y == 83
+
+
+def test_facing_arrowhead_points_orient_triangle_tip() -> None:
+    """The facing handle is a triangle with its tip in the facing direction."""
+    right = facing_arrowhead_points(100, 50, 0, length=20, width=10)
+    assert right == (100.0, 50.0, 80.0, 55.0, 80.0, 45.0)
+
+    down = facing_arrowhead_points(100, 50, 90, length=20, width=10)
+    assert down[0:2] == (100.0, 50.0)
+    assert math.isclose(down[3], 30.0, abs_tol=1e-9)
+    assert math.isclose(down[5], 30.0, abs_tol=1e-9)


### PR DESCRIPTION
### Motivation
- Improve token facing visualization by replacing the small draggable dot with a directional arrowhead that clearly indicates facing direction. 
- Share facing geometry between GM canvas and fullscreen/player map so both render the same arrow shape. 
- Keep existing interaction (drag-to-rotate, menu actions) while smoothly migrating legacy oval handles.

### Description
- Add `facing_arrowhead_points` to `modules/maps/utils/token_facing.py` to compute an oriented triangle polygon for arrowheads. 
- Replace the oval facing handle with a polygon arrowhead in `DisplayMapController._draw_token_facing_arrow` and use `create_polygon` for the handle while preserving the facing line and drag bindings. 
- Update `modules/maps/views/fullscreen_view.py` to use the same arrowhead geometry and convert/migrate legacy oval handles to the polygon when present. 
- Add unit test coverage for arrowhead geometry in `tests/maps/test_token_facing.py` and keep facing endpoints tests intact.

### Testing
- Compiled the changed modules with `python -m compileall modules/maps/utils/token_facing.py modules/maps/controllers/display_map_controller.py modules/maps/views/fullscreen_view.py tests/maps/test_token_facing.py` which completed without syntax errors. 
- Ran the unit tests `python -m pytest tests/maps/test_token_facing.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb61f75cc832b8f35e583c21c782f)