### PR TITLE
Make circle measurements outline-only

### DIFF
--- a/modules/maps/measurement/templates.py
+++ b/modules/maps/measurement/templates.py
@@ -262,16 +262,18 @@ def render_measurement_on_canvas(
             )
             label_anchor = ((sx + ex_square) / 2.0, (sy + ey_square) / 2.0)
         else:
+            fill = "" if template_type == "circle" else style.fill
+            stipple = "" if template_type == "circle" else style.stipple
             ids.append(
                 canvas.create_oval(
                     sx - radius,
                     sy - radius,
                     sx + radius,
                     sy + radius,
-                    fill=style.fill,
+                    fill=fill,
                     outline=style.outline,
                     width=style.width,
-                    stipple=style.stipple,
+                    stipple=stipple,
                     tags=common_tags,
                 )
             )

--- a/tests/maps/test_measurement_templates.py
+++ b/tests/maps/test_measurement_templates.py
@@ -1,0 +1,53 @@
+from modules.maps.measurement.templates import build_measurement_item, render_measurement_on_canvas
+
+
+class FakeCanvas:
+    def __init__(self):
+        self.ovals = []
+        self._next_id = 1
+
+    def _id(self):
+        canvas_id = self._next_id
+        self._next_id += 1
+        return canvas_id
+
+    def create_oval(self, *coords, **kwargs):
+        self.ovals.append({"coords": coords, "kwargs": kwargs})
+        return self._id()
+
+    def create_text(self, *args, **kwargs):
+        return self._id()
+
+    def bbox(self, _text_id):
+        return (0, 0, 40, 20)
+
+    def create_rectangle(self, *args, **kwargs):
+        return self._id()
+
+    def tag_lower(self, *_args, **_kwargs):
+        return None
+
+
+def _identity_world_to_screen(x, y):
+    return x, y
+
+
+def test_circle_measurement_renders_outline_without_fill():
+    canvas = FakeCanvas()
+    item = build_measurement_item("circle", (100, 100), (150, 100))
+
+    render_measurement_on_canvas(canvas, item, _identity_world_to_screen)
+
+    assert canvas.ovals[0]["kwargs"]["fill"] == ""
+    assert canvas.ovals[0]["kwargs"]["stipple"] == ""
+    assert canvas.ovals[0]["kwargs"]["outline"] == "#45B7FF"
+
+
+def test_aura_measurement_keeps_translucent_fill():
+    canvas = FakeCanvas()
+    item = build_measurement_item("aura", (100, 100), (150, 100))
+
+    render_measurement_on_canvas(canvas, item, _identity_world_to_screen)
+
+    assert canvas.ovals[0]["kwargs"]["fill"] == "#45B7FF"
+    assert canvas.ovals[0]["kwargs"]["stipple"] == "gray25"


### PR DESCRIPTION
### Motivation

- Circle measurement templates currently draw a translucent fill that can obscure map details inside the radius, so make circle measurements outline-only to preserve map visibility.
- Keep existing translucent fills for other oval-like templates (e.g., `aura`) so their intended visual semantics remain.

### Description

- Update `render_measurement_on_canvas` in `modules/maps/measurement/templates.py` to use an empty `fill` and empty `stipple` when `template_type == "circle"`, leaving `outline` and other template types unchanged.
- Add regression tests in `tests/maps/test_measurement_templates.py` that assert a `circle` renders with no fill/stipple and an `aura` still uses the translucent fill and stipple.
- Change is limited to measurement rendering behavior; square, cone, path, and line templates are unaffected.

### Testing

- Ran `pytest -q tests/maps/test_measurement_templates.py` and received `2 passed` for the new tests.
- Ran `python -m compileall -q modules/maps/measurement/templates.py tests/maps/test_measurement_templates.py` and compilation succeeded.
- Attempted `pytest -q tests/maps` but collection was blocked by the environment `PIL` import state with `ImportError: cannot import name 'ImageFont' from 'PIL'`, so broader map test suite was not fully executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcbc6feec0832ba1ae7385848284ef)