### PR TITLE
Move map drawing controls to floating palette

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -25,6 +25,7 @@ from modules.maps.views.toolbar_view import (
     _update_fog_button_states,
 )
 from modules.maps.views.canvas_view import _build_canvas, _on_delete_key
+from modules.maps.views.floating_drawing_toolbar import _build_floating_drawing_toolbar
 from modules.maps.services.fog_manager import (
     _set_fog,
     clear_fog,
@@ -6204,6 +6205,7 @@ class DisplayMapController:
             shape_border_color_button = getattr(self, 'shape_border_color_button', None)
             whiteboard_color_button = getattr(self, "whiteboard_color_button", None)
             whiteboard_width_slider = getattr(self, "whiteboard_width_slider", None)
+            text_color_button = getattr(self, "text_color_button", None)
             whiteboard_controls_frame = getattr(self, "whiteboard_controls_frame", None)
             eraser_controls_frame = getattr(self, "eraser_controls_frame", None)
             eraser_slider = getattr(self, "whiteboard_eraser_slider", None)
@@ -6334,8 +6336,11 @@ class DisplayMapController:
                         text_size_menu.master.pack(side="left", padx=(0, 6), pady=6)
                     except Exception:
                         pass
-                if whiteboard_color_button:
-                    whiteboard_color_button.pack(side="left", padx=(0, 6), pady=6)
+                if text_color_button:
+                    try:
+                        text_color_button.pack(side="left", padx=(0, 6), pady=6)
+                    except tk.TclError:
+                        pass
             else:
                 shape_controls_row = getattr(self, "shape_controls_row", None)
                 if shape_controls_row:
@@ -6372,6 +6377,7 @@ class DisplayMapController:
     # Method assignments (some will be replaced by generic item handlers)
     _build_canvas = _build_canvas
     _build_toolbar = _build_toolbar
+    _build_floating_drawing_toolbar = _build_floating_drawing_toolbar
     _change_brush = _change_brush # For fog brush
     _change_token_border_color = _change_token_border_color # Specific to tokens via old menu
     

--- a/modules/maps/views/canvas_view.py
+++ b/modules/maps/views/canvas_view.py
@@ -79,6 +79,10 @@ def _build_canvas(self):
     except Exception:
         pass
 
+
+    if hasattr(self, "_build_floating_drawing_toolbar"):
+        self._build_floating_drawing_toolbar()
+
     if hasattr(self, "_on_canvas_focus_out"):
         self.canvas.bind("<FocusOut>", self._on_canvas_focus_out)
 

--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -1,0 +1,315 @@
+"""Floating drawing and fog palette for map canvas."""
+
+import tkinter as tk
+import customtkinter as ctk
+
+from modules.helpers.logging_helper import log_module_import
+from modules.ui.icon_dropdown import IconDropdown
+
+log_module_import(__name__)
+
+_PALETTE_BG = "#151515"
+_SECTION_BG = "#1f1f1f"
+_BORDER = "#3f3f3f"
+_TEXT_MUTED = "#cfcfcf"
+
+
+def _build_floating_drawing_toolbar(self):
+    """Build a compact floating palette for fog and drawing controls."""
+    host = getattr(self, "parent", None)
+    canvas = getattr(self, "canvas", None)
+    if host is None or canvas is None:
+        return None
+
+    existing = getattr(self, "floating_drawing_toolbar", None)
+    if existing is not None:
+        try:
+            existing.destroy()
+        except tk.TclError:
+            pass
+
+    dropdown_width = 112
+    palette = ctk.CTkFrame(
+        host,
+        fg_color=_PALETTE_BG,
+        border_width=1,
+        border_color=_BORDER,
+        corner_radius=12,
+    )
+    self.floating_drawing_toolbar = palette
+
+    header = ctk.CTkFrame(palette, fg_color="#242424", corner_radius=10)
+    header.pack(side="top", fill="x", padx=6, pady=(6, 3))
+    handle = ctk.CTkLabel(header, text="☰ Draw", text_color=_TEXT_MUTED, cursor="fleur")
+    handle.pack(side="left", padx=(8, 6), pady=4)
+
+    content = ctk.CTkFrame(palette, fg_color="transparent")
+    content.pack(side="top", fill="both", expand=True, padx=6, pady=(0, 6))
+    self.floating_drawing_toolbar_content = content
+
+    collapsed = tk.BooleanVar(value=False)
+
+    def _toggle_palette():
+        if collapsed.get():
+            content.pack(side="top", fill="both", expand=True, padx=6, pady=(0, 6))
+            collapse_button.configure(text="−")
+            collapsed.set(False)
+        else:
+            content.pack_forget()
+            collapse_button.configure(text="+")
+            collapsed.set(True)
+        try:
+            palette.lift()
+        except tk.TclError:
+            pass
+
+    collapse_button = ctk.CTkButton(header, text="−", width=28, height=24, command=_toggle_palette)
+    collapse_button.pack(side="right", padx=(2, 6), pady=4)
+
+    drag_state = {"x": 0, "y": 0}
+
+    def _drag_start(event):
+        drag_state["x"] = event.x_root
+        drag_state["y"] = event.y_root
+        try:
+            palette.lift()
+        except tk.TclError:
+            pass
+
+    def _drag_motion(event):
+        try:
+            info = palette.place_info()
+            current_x = int(float(info.get("x", 0)))
+            current_y = int(float(info.get("y", 0)))
+        except (tk.TclError, TypeError, ValueError):
+            return
+        dx = event.x_root - drag_state["x"]
+        dy = event.y_root - drag_state["y"]
+        drag_state["x"] = event.x_root
+        drag_state["y"] = event.y_root
+        palette.place_configure(relx=0, x=max(8, current_x + dx), y=max(8, current_y + dy), anchor="nw")
+
+    for draggable in (header, handle):
+        draggable.bind("<ButtonPress-1>", _drag_start)
+        draggable.bind("<B1-Motion>", _drag_motion)
+
+    def _section(title):
+        section = ctk.CTkFrame(content, fg_color=_SECTION_BG, border_width=1, border_color="#303030", corner_radius=9)
+        section.pack(side="top", fill="x", padx=0, pady=(4, 0))
+        ctk.CTkLabel(section, text=title, text_color=_TEXT_MUTED, font=ctk.CTkFont(size=11, weight="bold")).pack(
+            side="top", anchor="w", padx=8, pady=(5, 0)
+        )
+        body = ctk.CTkFrame(section, fg_color="transparent")
+        body.pack(side="top", fill="x", padx=6, pady=(2, 6))
+        return body
+
+    def _row(parent):
+        row = ctk.CTkFrame(parent, fg_color="transparent")
+        row.pack(side="top", fill="x", anchor="w", pady=2)
+        return row
+
+    def _small_label(parent, text):
+        ctk.CTkLabel(parent, text=text, text_color=_TEXT_MUTED).pack(side="left", padx=(0, 4), pady=3)
+
+    icons = {
+        "add": self.load_icon("assets/icons/brush.png", (32, 32)),
+        "rem": self.load_icon("assets/icons/eraser.png", (32, 32)),
+        "clear": self.load_icon("assets/icons/empty.png", (32, 32)),
+        "reset": self.load_icon("assets/icons/full.png", (32, 32)),
+    }
+
+    self._fog_button_default_style = {
+        "fg_color": "#0077CC",
+        "hover_color": "#005fa3",
+        "border_color": "#005fa3",
+        "border_width": 1,
+    }
+    self._fog_button_active_style = {
+        "fg_color": "#004c80",
+        "hover_color": "#004c80",
+        "border_color": "#d7263d",
+        "border_width": 3,
+    }
+    self._fog_buttons = {}
+
+    fog_body = _section("Fog")
+    fog_actions = [
+        {"key": "add", "icon": icons["add"], "tooltip": "Add Fog", "command": lambda: self._set_fog("add")},
+        {"key": "rem", "icon": icons["rem"], "tooltip": "Remove Fog", "command": lambda: self._set_fog("rem")},
+        {"key": "add_rect", "icon": icons["add"], "tooltip": "Add Fog Rectangle", "command": lambda: self._set_fog("add_rect")},
+        {"key": "rem_rect", "icon": icons["rem"], "tooltip": "Remove Fog Rectangle", "command": lambda: self._set_fog("rem_rect")},
+        {"key": "clear", "icon": icons["clear"], "tooltip": "Clear Fog", "command": self.clear_fog},
+        {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": self.reset_fog},
+    ]
+    fog_row = _row(fog_body)
+    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add")
+    fog_dropdown.pack(side="left", padx=(0, 6), pady=3)
+    self._fog_buttons.update(fog_dropdown.option_buttons)
+    self._fog_dropdown = fog_dropdown
+
+    fog_shape_row = _row(fog_body)
+    _small_label(fog_shape_row, "Shape")
+    self.shape_menu = ctk.CTkOptionMenu(
+        fog_shape_row,
+        values=["Rectangle", "Circle"],
+        command=self._on_brush_shape_change,
+        width=dropdown_width,
+    )
+    self.shape_menu.set("Rectangle")
+    self.shape_menu.pack(side="left", padx=(0, 6), pady=3)
+
+    _small_label(fog_shape_row, "Size")
+    brush_size_options = list(getattr(self, "brush_size_options", list(range(4, 129, 4))))
+    current_brush_size = int(getattr(self, "brush_size", brush_size_options[0] if brush_size_options else 32))
+    if current_brush_size not in brush_size_options:
+        brush_size_options.append(current_brush_size)
+        brush_size_options = sorted(set(brush_size_options))
+    self.brush_size_options = list(brush_size_options)
+    self.brush_size_menu = ctk.CTkOptionMenu(
+        fog_shape_row,
+        values=[str(size) for size in self.brush_size_options],
+        command=self._on_brush_size_change,
+        width=74,
+    )
+    self.brush_size_menu.set(str(current_brush_size))
+    self.brush_size_menu.pack(side="left", padx=(0, 2), pady=3)
+
+    tools_body = _section("Tools")
+    tool_row = _row(tools_body)
+    _small_label(tool_row, "Tool")
+    drawing_tools = ["Token", "Rectangle", "Oval", "Text", "Whiteboard", "Eraser"]
+    self.drawing_tool_menu = ctk.CTkOptionMenu(
+        tool_row,
+        values=drawing_tools,
+        command=self._on_drawing_tool_change,
+        width=dropdown_width,
+    )
+    current_tool = self.drawing_mode.capitalize() if hasattr(self, "drawing_mode") else "Token"
+    self.drawing_tool_menu.set(current_tool if current_tool in drawing_tools else "Token")
+    self.drawing_tool_menu.pack(side="left", padx=(0, 4), pady=3)
+
+    whiteboard_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
+    self.whiteboard_controls_frame = whiteboard_controls
+
+    self.whiteboard_color_button = ctk.CTkButton(
+        whiteboard_controls,
+        text="Ink Color",
+        width=84,
+        command=self._on_pick_whiteboard_color,
+    )
+    try:
+        self.whiteboard_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
+    except tk.TclError:
+        pass
+    self.whiteboard_color_button.pack(side="left", padx=(0, 6), pady=4)
+
+    width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
+    width_container.pack(side="left", padx=(0, 4), pady=4)
+    ctk.CTkLabel(width_container, text="Width", text_color=_TEXT_MUTED).pack(side="left", padx=(0, 2))
+    self.whiteboard_width_slider = ctk.CTkSlider(
+        width_container,
+        from_=1,
+        to=20,
+        number_of_steps=19,
+        command=self._on_whiteboard_width_change,
+        width=105,
+    )
+    current_width = float(getattr(self, "whiteboard_width", 4))
+    self.whiteboard_width_slider.set(current_width)
+    self.whiteboard_width_slider.pack(side="left", padx=(0, 4))
+    self.whiteboard_width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)), text_color=_TEXT_MUTED)
+    self.whiteboard_width_value_label.pack(side="left", padx=(2, 0))
+
+    text_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
+    self.text_controls_frame = text_controls
+    ctk.CTkLabel(text_controls, text="Text Size", text_color=_TEXT_MUTED).pack(side="left", padx=(0, 4), pady=4)
+    text_sizes = getattr(self, "text_size_options", [16, 20, 24, 32, 40])
+    current_text_size = int(getattr(self, "text_size", text_sizes[0] if text_sizes else 24))
+    if current_text_size not in text_sizes:
+        text_sizes = sorted(set(list(text_sizes) + [current_text_size]))
+    self.text_size_options = list(text_sizes)
+    self.text_size_menu = ctk.CTkOptionMenu(
+        text_controls,
+        values=[str(size) for size in self.text_size_options],
+        command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
+        width=76,
+    )
+    self.text_size_menu.set(str(current_text_size))
+    self.text_size_menu.pack(side="left", padx=(0, 6), pady=4)
+
+    self.text_color_button = ctk.CTkButton(
+        text_controls,
+        text="Text Color",
+        width=90,
+        command=self._on_pick_whiteboard_color,
+    )
+    try:
+        self.text_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
+    except tk.TclError:
+        pass
+    self.text_color_button.pack(side="left", padx=(0, 4), pady=4)
+
+    eraser_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
+    self.eraser_controls_frame = eraser_controls
+    eraser_width_container = ctk.CTkFrame(eraser_controls, fg_color="transparent")
+    eraser_width_container.pack(side="left", padx=(0, 6), pady=4)
+    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=_TEXT_MUTED).pack(side="left", padx=(0, 4))
+    self.whiteboard_eraser_slider = ctk.CTkSlider(
+        eraser_width_container,
+        from_=2,
+        to=40,
+        number_of_steps=38,
+        command=getattr(self, "_on_eraser_radius_change", None) or (lambda _v: None),
+        width=116,
+    )
+    current_eraser_radius = float(getattr(self, "whiteboard_eraser_radius", 8))
+    self.whiteboard_eraser_slider.set(current_eraser_radius)
+    self.whiteboard_eraser_slider.pack(side="left", padx=(0, 4))
+    self.eraser_radius_value_label = ctk.CTkLabel(
+        eraser_width_container,
+        text=str(int(round(current_eraser_radius))),
+        text_color=_TEXT_MUTED,
+    )
+    self.eraser_radius_value_label.pack(side="left", padx=(2, 0))
+
+    shape_controls_row = ctk.CTkFrame(tools_body, fg_color="transparent")
+    self.shape_controls_row = shape_controls_row
+    self.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill", text_color=_TEXT_MUTED)
+    self.shape_fill_mode_menu = ctk.CTkOptionMenu(
+        shape_controls_row,
+        values=["Filled", "Border Only"],
+        command=self._on_shape_fill_mode_change,
+        width=dropdown_width,
+    )
+    self.shape_fill_mode_menu.set("Filled" if hasattr(self, "shape_is_filled") and self.shape_is_filled else "Border Only")
+    self.shape_fill_color_button = ctk.CTkButton(
+        shape_controls_row,
+        text="Fill Color",
+        width=84,
+        command=self._on_pick_shape_fill_color,
+    )
+    self.shape_border_color_button = ctk.CTkButton(
+        shape_controls_row,
+        text="Border Color",
+        width=96,
+        command=self._on_pick_shape_border_color,
+    )
+
+    try:
+        toolbar_height = int(getattr(self, "_toolbar_container", host).winfo_height())
+    except Exception:
+        toolbar_height = 0
+    if toolbar_height <= 1:
+        toolbar_height = 72
+    palette.place(relx=0.5, y=toolbar_height + 12, anchor="n")
+    try:
+        palette.lift()
+    except tk.TclError:
+        pass
+
+    if hasattr(self, "_update_shape_controls_visibility"):
+        self._update_shape_controls_visibility()
+    if hasattr(self, "_update_fog_button_states"):
+        self._update_fog_button_states()
+
+    return palette

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -86,10 +86,6 @@ def _build_toolbar(self):
 
     # Load icons
     icons = {
-        "add":   self.load_icon("assets/icons/brush.png",    (48,48)),
-        "rem":   self.load_icon("assets/icons/eraser.png",   (48,48)),
-        "clear": self.load_icon("assets/icons/empty.png",    (48,48)),
-        "reset": self.load_icon("assets/icons/full.png",     (48,48)),
         "save":  self.load_icon("assets/icons/save.png",     (48,48)),
         "fs":    self.load_icon("assets/icons/expand.png",   (48,48)),
         "rotate":    self.load_icon("assets/icons/turn_background_icon.png",   (48,48)),
@@ -103,66 +99,7 @@ def _build_toolbar(self):
 
     dropdown_width = 0
 
-    # Fog controls
-    fog_section = _create_collapsible_section(toolbar, "Fog")
-    self._fog_button_default_style = {
-        "fg_color": "#0077CC",
-        "hover_color": "#005fa3",
-        "border_color": "#005fa3",
-        "border_width": 1,
-    }
-    self._fog_button_active_style = {
-        "fg_color": "#004c80",
-        "hover_color": "#004c80",
-        "border_color": "#d7263d",
-        "border_width": 3,
-    }
-    self._fog_buttons = {}
-
-    fog_actions = [
-        {"key": "add", "icon": icons["add"], "tooltip": "Add Fog", "command": lambda: self._set_fog("add")},
-        {"key": "rem", "icon": icons["rem"], "tooltip": "Remove Fog", "command": lambda: self._set_fog("rem")},
-        {"key": "add_rect", "icon": icons["add"], "tooltip": "Add Fog Rectangle", "command": lambda: self._set_fog("add_rect")},
-        {"key": "rem_rect", "icon": icons["rem"], "tooltip": "Remove Fog Rectangle", "command": lambda: self._set_fog("rem_rect")},
-        {"key": "clear", "icon": icons["clear"], "tooltip": "Clear Fog", "command": self.clear_fog},
-        {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": self.reset_fog},
-    ]
-
-    fog_dropdown = IconDropdown(fog_section, fog_actions, default_key="add")
-    _pack_control(fog_dropdown, trailing=4)
-    self._fog_buttons.update(fog_dropdown.option_buttons)
-    self._fog_dropdown = fog_dropdown
-
-    shape_label = ctk.CTkLabel(fog_section, text="Fog Shape:") # Clarified label
-    _pack_control(shape_label, leading=8, trailing=4)
-
-    self.shape_menu = ctk.CTkOptionMenu(
-        fog_section,
-        values=["Rectangle", "Circle"],
-        command=self._on_brush_shape_change, # This is for fog brush shape
-        width=dropdown_width,
-    )
-    self.shape_menu.set("Rectangle") # Default fog brush shape
-    _pack_control(self.shape_menu, trailing=4)
-
-    size_label = ctk.CTkLabel(fog_section, text="Brush Size") # Clarified label
-    _pack_control(size_label, leading=4, trailing=4)
-
-    brush_size_options = list(getattr(self, "brush_size_options", list(range(4, 129, 4))))
-    current_brush_size = int(getattr(self, "brush_size", brush_size_options[0] if brush_size_options else 32))
-    if current_brush_size not in brush_size_options:
-        brush_size_options.append(current_brush_size)
-        brush_size_options = sorted(set(brush_size_options))
-    self.brush_size_options = list(brush_size_options)
-    brush_size_values = [str(size) for size in self.brush_size_options]
-    self.brush_size_menu = ctk.CTkOptionMenu(
-        fog_section,
-        values=brush_size_values,
-        command=self._on_brush_size_change, # This is for fog brush size
-        width=dropdown_width,
-    )
-    self.brush_size_menu.set(str(current_brush_size))
-    _pack_control(self.brush_size_menu, leading=0, trailing=4, pady=6)
+    # Fog and drawing controls are hosted by the floating canvas palette.
 
     # Key bindings for bracket adjustments (for fog brush)
     self.parent.bind("[", lambda e: self._change_brush(-4))
@@ -248,141 +185,7 @@ def _build_toolbar(self):
     )
     _pack_control(self.clear_measurements_button, trailing=6)
 
-    drawing_section = _create_collapsible_section(toolbar, "Drawings")
-
-    drawing_container = ctk.CTkScrollableFrame(
-        drawing_section,
-        fg_color="transparent",
-        orientation="vertical",
-    )
-    drawing_container.pack(side="left", fill="both", expand=True, padx=(0, 4), pady=(2, 2))
-
-    def _pack_drawing_row(row, *, pady=(4, 2)):
-        """Pack drawing row."""
-        row.pack(side="top", fill="x", anchor="w", padx=(6, 2), pady=pady)
-
-    drawing_tool_row = ctk.CTkFrame(drawing_container, fg_color="transparent")
-    _pack_drawing_row(drawing_tool_row)
-
-    # --- Drawing Tool Selector ---
-    tool_label = ctk.CTkLabel(drawing_tool_row, text="Tool")
-    _pack_control(tool_label, leading=8, trailing=4)
-    drawing_tools = ["Token", "Rectangle", "Oval", "Text", "Whiteboard", "Eraser"]
-    self.drawing_tool_menu = ctk.CTkOptionMenu(
-        drawing_tool_row,
-        values=drawing_tools,
-        command=self._on_drawing_tool_change, # To be created in DisplayMapController
-        width=dropdown_width,
-    )
-    # Ensure self.drawing_mode is initialized in DisplayMapController before this
-    self.drawing_tool_menu.set(self.drawing_mode.capitalize() if hasattr(self, 'drawing_mode') else "Token")
-    _pack_control(self.drawing_tool_menu, trailing=4)
-
-    whiteboard_controls = ctk.CTkFrame(drawing_container, fg_color="transparent")
-    _pack_drawing_row(whiteboard_controls)
-    self.whiteboard_controls_frame = whiteboard_controls
-
-    self.whiteboard_color_button = ctk.CTkButton(
-        whiteboard_controls,
-        text="Ink Color",
-        width=0,
-        command=self._on_pick_whiteboard_color,
-    )
-    try:
-        self.whiteboard_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
-    except tk.TclError:
-        pass
-    _pack_control(self.whiteboard_color_button, leading=0, trailing=4, pady=4)
-
-    width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
-    width_container.pack(side="left", padx=(0, 4), pady=4)
-    width_label = ctk.CTkLabel(width_container, text="Width")
-    width_label.pack(side="left", padx=(0, 2))
-    self.whiteboard_width_slider = ctk.CTkSlider(
-        width_container,
-        from_=1,
-        to=20,
-        number_of_steps=19,
-        command=self._on_whiteboard_width_change,
-        width=110,
-    )
-    current_width = float(getattr(self, "whiteboard_width", 4))
-    self.whiteboard_width_slider.set(current_width)
-    width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)))
-    width_value_label.pack(side="left", padx=(4, 0))
-    self.whiteboard_width_value_label = width_value_label
-
-    text_controls = ctk.CTkFrame(drawing_container, fg_color="transparent")
-    _pack_drawing_row(text_controls)
-    self.text_controls_frame = text_controls
-    text_size_label = ctk.CTkLabel(text_controls, text="Text Size")
-    text_size_label.pack(side="left", padx=(0, 2))
-    text_sizes = getattr(self, "text_size_options", [16, 20, 24, 32, 40])
-    current_text_size = int(getattr(self, "text_size", text_sizes[0] if text_sizes else 24))
-    if current_text_size not in text_sizes:
-        text_sizes = sorted(set(list(text_sizes) + [current_text_size]))
-    self.text_size_options = list(text_sizes)
-    self.text_size_menu = ctk.CTkOptionMenu(
-        text_controls,
-        values=[str(size) for size in self.text_size_options],
-        command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
-        width=dropdown_width,
-    )
-    self.text_size_menu.set(str(current_text_size))
-    self.text_size_menu.pack(side="left", padx=(0, 4), pady=4)
-
-    self.text_color_button = ctk.CTkButton(
-        text_controls,
-        text="Text Color",
-        width=0,
-        command=self._on_pick_whiteboard_color,
-    )
-    try:
-        self.text_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
-    except tk.TclError:
-        pass
-    self.text_color_button.pack(side="left", padx=(0, 4), pady=4)
-
-    eraser_controls = ctk.CTkFrame(drawing_container, fg_color="transparent")
-    self.eraser_controls_frame = eraser_controls
-
-    eraser_width_container = ctk.CTkFrame(eraser_controls, fg_color="transparent")
-    eraser_width_container.pack(side="left", padx=(0, 6), pady=6)
-    eraser_width = float(8)
-    
-
-    # --- Shape Fill Mode Selector (conditionally visible) ---
-    shape_controls_row = ctk.CTkFrame(drawing_container, fg_color="transparent")
-    self.shape_controls_row = shape_controls_row
-
-    self.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill:")
-    # Packed by _update_shape_controls_visibility
-    self.shape_fill_mode_menu = ctk.CTkOptionMenu(
-        shape_controls_row,
-        values=["Filled", "Border Only"],
-        command=self._on_shape_fill_mode_change, # To be created in DisplayMapController
-        width=dropdown_width,
-    )
-    # Ensure self.shape_is_filled is initialized
-    self.shape_fill_mode_menu.set("Filled" if hasattr(self, 'shape_is_filled') and self.shape_is_filled else "Border Only")
-    # Packed by _update_shape_controls_visibility
-
-    # --- Shape Color Pickers (conditionally visible) ---
-    self.shape_fill_color_button = ctk.CTkButton(
-        shape_controls_row,
-        text="Fill Color",
-        width=80,
-        command=self._on_pick_shape_fill_color # To be created in DisplayMapController
-    )
-    # Packed by _update_shape_controls_visibility
-
-    self.shape_border_color_button = ctk.CTkButton(
-        shape_controls_row,
-        text="Border Color",
-        width=100,
-        command=self._on_pick_shape_border_color # To be created in DisplayMapController
-    )
-    # Packed by _update_shape_controls_visibility
+    # Drawing-specific controls live in the floating drawing palette.
 
     display_section = _create_collapsible_section(toolbar, "Display")
     display_actions = [


### PR DESCRIPTION
### Motivation
- Reduce clutter in the fixed top toolbar by moving fog/drawing controls into a compact overlay that sits above the map canvas.
- Provide a reusable floating palette with a compact dark style, grouped controls, and basic collapse/drag behavior so drawing tools are closer to the canvas.
- Preserve existing controller widget identifiers so existing visibility and behavior logic continues to work without large controller changes.

### Description
- Added a new reusable floating palette `modules/maps/views/floating_drawing_toolbar.py` which builds a compact `ctk.CTkFrame` placed over the canvas and containing grouped `Fog` and `Tools` sections with collapse and drag-handle support.
- Removed the Fog and Drawings block from the fixed toolbar in `modules/maps/views/toolbar_view.py` and left token insertion, measurement, display, hover/fit, and plot-twist controls in the top toolbar.
- Initialize the floating palette after the canvas exists by calling the builder from `modules/maps/views/canvas_view.py` after canvas creation, and wired the builder into `DisplayMapController` via `modules/maps/controllers/display_map_controller.py`.
- Kept controller widget attribute names intact (e.g. `drawing_tool_menu`, `whiteboard_color_button`, `whiteboard_width_slider`, `whiteboard_width_value_label`, `whiteboard_controls_frame`, `text_size_menu`, `text_color_button`, `text_controls_frame`, `shape_fill_mode_menu`, `shape_fill_color_button`, `shape_border_color_button`, `shape_controls_row`, `eraser_controls_frame`, `whiteboard_eraser_slider`, `eraser_radius_value_label`, `_fog_buttons`, etc.) so `DisplayMapController._update_shape_controls_visibility` continues to operate against the same attributes.

### Testing
- Compiled modified modules with `python -m compileall -q modules/maps/views/floating_drawing_toolbar.py modules/maps/views/toolbar_view.py modules/maps/views/canvas_view.py modules/maps/controllers/display_map_controller.py` and compilation succeeded.
- Ran targeted tests with `pytest tests/maps/test_token_facing.py tests/maps/test_measurement_templates.py` and they passed (`7 passed` across those files).
- Attempted a broader test run including `tests/maps/test_marker_types.py` and `tests/test_gm_screen_map_tool_deferred_open.py`, but collection was blocked by an environment PIL import issue (`ImportError: cannot import name 'ImageFont' from 'PIL'`), so those tests did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccdc305c8832b8fab31a5ef93c03e)