### PR TITLE
Make map floating toolbar single-column and move token tools into it

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -6245,10 +6245,10 @@ class DisplayMapController:
                     shape_controls_row.pack(side="top", fill="x", anchor="w", padx=(6, 2), pady=4)
 
                 # Repack in desired order without 'before'
-                if shape_fill_label: shape_fill_label.pack(side="left", padx=(10,2), pady=8)
-                if shape_fill_mode_menu: shape_fill_mode_menu.pack(side="left", padx=5, pady=8)
-                if shape_fill_color_button: shape_fill_color_button.pack(side="left", padx=(10,2), pady=8)
-                if shape_border_color_button: shape_border_color_button.pack(side="left", padx=2, pady=8)
+                if shape_fill_label: shape_fill_label.pack(side="top", anchor="w", padx=0, pady=(2, 1))
+                if shape_fill_mode_menu: shape_fill_mode_menu.pack(side="top", fill="x", padx=0, pady=(0, 4))
+                if shape_fill_color_button: shape_fill_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
+                if shape_border_color_button: shape_border_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
             elif whiteboard_active:
                 # Continue with this path when whiteboard active is set.
                 shape_controls_row = getattr(self, "shape_controls_row", None)
@@ -6267,10 +6267,10 @@ class DisplayMapController:
                         pass
                 if whiteboard_controls_frame:
                     whiteboard_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
-                if whiteboard_color_button: whiteboard_color_button.pack(side="left", padx=(0, 6), pady=6)
+                if whiteboard_color_button: whiteboard_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
                 if whiteboard_width_slider:
                     try:
-                        whiteboard_width_slider.master.pack(side="left", padx=(0, 6), pady=6)
+                        whiteboard_width_slider.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
                     except Exception:
                         pass
                 if eraser_slider:
@@ -6308,7 +6308,7 @@ class DisplayMapController:
                     eraser_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
                 if eraser_slider:
                     try:
-                        eraser_slider.master.pack(side="left", padx=(0, 6), pady=6)
+                        eraser_slider.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
                     except Exception:
                         pass
             elif text_active:
@@ -6333,12 +6333,12 @@ class DisplayMapController:
                     text_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
                 if text_size_menu:
                     try:
-                        text_size_menu.master.pack(side="left", padx=(0, 6), pady=6)
+                        text_size_menu.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
                     except Exception:
                         pass
                 if text_color_button:
                     try:
-                        text_color_button.pack(side="left", padx=(0, 6), pady=6)
+                        text_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
                     except tk.TclError:
                         pass
             else:

--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -5,14 +5,19 @@ import customtkinter as ctk
 
 from modules.helpers.logging_helper import log_module_import
 from modules.ui.icon_dropdown import IconDropdown
+from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
+from modules.maps.views.floating_toolbar.layout import (
+    BORDER,
+    DROPDOWN_WIDTH,
+    PALETTE_BG,
+    SLIDER_WIDTH,
+    TEXT_MUTED,
+    add_stacked_control,
+    create_row,
+    create_section,
+)
 
 log_module_import(__name__)
-
-_PALETTE_BG = "#151515"
-_SECTION_BG = "#1f1f1f"
-_BORDER = "#3f3f3f"
-_TEXT_MUTED = "#cfcfcf"
-
 
 def _build_floating_drawing_toolbar(self):
     """Build a compact floating palette for fog and drawing controls."""
@@ -28,19 +33,20 @@ def _build_floating_drawing_toolbar(self):
         except tk.TclError:
             pass
 
-    dropdown_width = 112
+    dropdown_width = DROPDOWN_WIDTH
+    slider_width = SLIDER_WIDTH
     palette = ctk.CTkFrame(
         host,
-        fg_color=_PALETTE_BG,
+        fg_color=PALETTE_BG,
         border_width=1,
-        border_color=_BORDER,
+        border_color=BORDER,
         corner_radius=12,
     )
     self.floating_drawing_toolbar = palette
 
     header = ctk.CTkFrame(palette, fg_color="#242424", corner_radius=10)
     header.pack(side="top", fill="x", padx=6, pady=(6, 3))
-    handle = ctk.CTkLabel(header, text="☰ Draw", text_color=_TEXT_MUTED, cursor="fleur")
+    handle = ctk.CTkLabel(header, text="☰ Draw", text_color=TEXT_MUTED, cursor="fleur")
     handle.pack(side="left", padx=(8, 6), pady=4)
 
     content = ctk.CTkFrame(palette, fg_color="transparent")
@@ -94,28 +100,23 @@ def _build_floating_drawing_toolbar(self):
         draggable.bind("<B1-Motion>", _drag_motion)
 
     def _section(title):
-        section = ctk.CTkFrame(content, fg_color=_SECTION_BG, border_width=1, border_color="#303030", corner_radius=9)
-        section.pack(side="top", fill="x", padx=0, pady=(4, 0))
-        ctk.CTkLabel(section, text=title, text_color=_TEXT_MUTED, font=ctk.CTkFont(size=11, weight="bold")).pack(
-            side="top", anchor="w", padx=8, pady=(5, 0)
-        )
-        body = ctk.CTkFrame(section, fg_color="transparent")
-        body.pack(side="top", fill="x", padx=6, pady=(2, 6))
-        return body
+        return create_section(content, title)
 
     def _row(parent):
-        row = ctk.CTkFrame(parent, fg_color="transparent")
-        row.pack(side="top", fill="x", anchor="w", pady=2)
-        return row
+        return create_row(parent)
 
-    def _small_label(parent, text):
-        ctk.CTkLabel(parent, text=text, text_color=_TEXT_MUTED).pack(side="left", padx=(0, 4), pady=3)
+    def _stacked_control(parent, label, widget, *, pady=(0, 4)):
+        return add_stacked_control(parent, label, widget, pady=pady)
 
     icons = {
         "add": self.load_icon("assets/icons/brush.png", (32, 32)),
         "rem": self.load_icon("assets/icons/eraser.png", (32, 32)),
         "clear": self.load_icon("assets/icons/empty.png", (32, 32)),
         "reset": self.load_icon("assets/icons/full.png", (32, 32)),
+        "npc": self.load_icon("assets/icons/npc.png", (32, 32)),
+        "creat": self.load_icon("assets/icons/creature.png", (32, 32)),
+        "pc": self.load_icon("assets/icons/pc.png", (32, 32)),
+        "marker": self.load_icon("assets/icons/marker.png", (32, 32)),
     }
 
     self._fog_button_default_style = {
@@ -143,22 +144,19 @@ def _build_floating_drawing_toolbar(self):
     ]
     fog_row = _row(fog_body)
     fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add")
-    fog_dropdown.pack(side="left", padx=(0, 6), pady=3)
+    fog_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
     self._fog_buttons.update(fog_dropdown.option_buttons)
     self._fog_dropdown = fog_dropdown
 
-    fog_shape_row = _row(fog_body)
-    _small_label(fog_shape_row, "Shape")
     self.shape_menu = ctk.CTkOptionMenu(
-        fog_shape_row,
+        fog_body,
         values=["Rectangle", "Circle"],
         command=self._on_brush_shape_change,
         width=dropdown_width,
     )
     self.shape_menu.set("Rectangle")
-    self.shape_menu.pack(side="left", padx=(0, 6), pady=3)
+    _stacked_control(fog_body, "Shape", self.shape_menu)
 
-    _small_label(fog_shape_row, "Size")
     brush_size_options = list(getattr(self, "brush_size_options", list(range(4, 129, 4))))
     current_brush_size = int(getattr(self, "brush_size", brush_size_options[0] if brush_size_options else 32))
     if current_brush_size not in brush_size_options:
@@ -166,27 +164,25 @@ def _build_floating_drawing_toolbar(self):
         brush_size_options = sorted(set(brush_size_options))
     self.brush_size_options = list(brush_size_options)
     self.brush_size_menu = ctk.CTkOptionMenu(
-        fog_shape_row,
+        fog_body,
         values=[str(size) for size in self.brush_size_options],
         command=self._on_brush_size_change,
-        width=74,
+        width=dropdown_width,
     )
     self.brush_size_menu.set(str(current_brush_size))
-    self.brush_size_menu.pack(side="left", padx=(0, 2), pady=3)
+    _stacked_control(fog_body, "Size", self.brush_size_menu)
 
     tools_body = _section("Tools")
-    tool_row = _row(tools_body)
-    _small_label(tool_row, "Tool")
     drawing_tools = ["Token", "Rectangle", "Oval", "Text", "Whiteboard", "Eraser"]
     self.drawing_tool_menu = ctk.CTkOptionMenu(
-        tool_row,
+        tools_body,
         values=drawing_tools,
         command=self._on_drawing_tool_change,
         width=dropdown_width,
     )
     current_tool = self.drawing_mode.capitalize() if hasattr(self, "drawing_mode") else "Token"
     self.drawing_tool_menu.set(current_tool if current_tool in drawing_tools else "Token")
-    self.drawing_tool_menu.pack(side="left", padx=(0, 4), pady=3)
+    _stacked_control(tools_body, "Tool", self.drawing_tool_menu)
 
     whiteboard_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.whiteboard_controls_frame = whiteboard_controls
@@ -201,28 +197,28 @@ def _build_floating_drawing_toolbar(self):
         self.whiteboard_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
     except tk.TclError:
         pass
-    self.whiteboard_color_button.pack(side="left", padx=(0, 6), pady=4)
+    self.whiteboard_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
 
     width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
-    width_container.pack(side="left", padx=(0, 4), pady=4)
-    ctk.CTkLabel(width_container, text="Width", text_color=_TEXT_MUTED).pack(side="left", padx=(0, 2))
+    width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    ctk.CTkLabel(width_container, text="Width", text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(0, 2))
     self.whiteboard_width_slider = ctk.CTkSlider(
         width_container,
         from_=1,
         to=20,
         number_of_steps=19,
         command=self._on_whiteboard_width_change,
-        width=105,
+        width=slider_width,
     )
     current_width = float(getattr(self, "whiteboard_width", 4))
     self.whiteboard_width_slider.set(current_width)
-    self.whiteboard_width_slider.pack(side="left", padx=(0, 4))
-    self.whiteboard_width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)), text_color=_TEXT_MUTED)
-    self.whiteboard_width_value_label.pack(side="left", padx=(2, 0))
+    self.whiteboard_width_slider.pack(side="top", fill="x", padx=0)
+    self.whiteboard_width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)), text_color=TEXT_MUTED)
+    self.whiteboard_width_value_label.pack(side="top", anchor="e", padx=0)
 
     text_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.text_controls_frame = text_controls
-    ctk.CTkLabel(text_controls, text="Text Size", text_color=_TEXT_MUTED).pack(side="left", padx=(0, 4), pady=4)
+    ctk.CTkLabel(text_controls, text="Text Size", text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(0, 2))
     text_sizes = getattr(self, "text_size_options", [16, 20, 24, 32, 40])
     current_text_size = int(getattr(self, "text_size", text_sizes[0] if text_sizes else 24))
     if current_text_size not in text_sizes:
@@ -235,7 +231,7 @@ def _build_floating_drawing_toolbar(self):
         width=76,
     )
     self.text_size_menu.set(str(current_text_size))
-    self.text_size_menu.pack(side="left", padx=(0, 6), pady=4)
+    self.text_size_menu.pack(side="top", fill="x", padx=0, pady=(0, 4))
 
     self.text_color_button = ctk.CTkButton(
         text_controls,
@@ -247,34 +243,68 @@ def _build_floating_drawing_toolbar(self):
         self.text_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
     except tk.TclError:
         pass
-    self.text_color_button.pack(side="left", padx=(0, 4), pady=4)
+    self.text_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
 
     eraser_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.eraser_controls_frame = eraser_controls
     eraser_width_container = ctk.CTkFrame(eraser_controls, fg_color="transparent")
-    eraser_width_container.pack(side="left", padx=(0, 6), pady=4)
-    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=_TEXT_MUTED).pack(side="left", padx=(0, 4))
+    eraser_width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(0, 2))
     self.whiteboard_eraser_slider = ctk.CTkSlider(
         eraser_width_container,
         from_=2,
         to=40,
         number_of_steps=38,
         command=getattr(self, "_on_eraser_radius_change", None) or (lambda _v: None),
-        width=116,
+        width=slider_width,
     )
     current_eraser_radius = float(getattr(self, "whiteboard_eraser_radius", 8))
     self.whiteboard_eraser_slider.set(current_eraser_radius)
-    self.whiteboard_eraser_slider.pack(side="left", padx=(0, 4))
+    self.whiteboard_eraser_slider.pack(side="top", fill="x", padx=0)
     self.eraser_radius_value_label = ctk.CTkLabel(
         eraser_width_container,
         text=str(int(round(current_eraser_radius))),
-        text_color=_TEXT_MUTED,
+        text_color=TEXT_MUTED,
     )
-    self.eraser_radius_value_label.pack(side="left", padx=(2, 0))
+    self.eraser_radius_value_label.pack(side="top", anchor="e", padx=0)
+
+    tokens_body = _section("Tokens")
+    token_actions = [
+        {"key": "creature", "icon": icons["creat"], "tooltip": "Add Creature", "command": lambda: self.open_entity_picker("Creature")},
+        {"key": "npc", "icon": icons["npc"], "tooltip": "Add NPC", "command": lambda: self.open_entity_picker("NPC")},
+        {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: self.open_entity_picker("PC")},
+        {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": self.add_marker},
+    ]
+    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc")
+    token_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
+
+    token_size_options = list(getattr(self, "token_size_options", list(range(16, 129, 8))))
+    current_token_size = int(getattr(self, "token_size", token_size_options[0] if token_size_options else 48))
+    if current_token_size not in token_size_options:
+        token_size_options.append(current_token_size)
+        token_size_options = sorted(set(token_size_options))
+    self.token_size_options = list(token_size_options)
+    self.token_size_menu = ctk.CTkOptionMenu(
+        tokens_body,
+        values=[str(size) for size in self.token_size_options],
+        command=self._on_token_size_change,
+        width=dropdown_width,
+    )
+    self.token_size_menu.set(str(current_token_size))
+    _stacked_control(tokens_body, "Size", self.token_size_menu)
+
+    self.marker_type_filter_menu = ctk.CTkOptionMenu(
+        tokens_body,
+        values=MARKER_TYPE_FILTER_LABELS,
+        command=getattr(self, "_on_marker_type_filter_change", None) or (lambda _v: None),
+        width=dropdown_width,
+    )
+    self.marker_type_filter_menu.set(getattr(self, "marker_type_filter", "All Types") or "All Types")
+    _stacked_control(tokens_body, "Marker Type", self.marker_type_filter_menu)
 
     shape_controls_row = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.shape_controls_row = shape_controls_row
-    self.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill", text_color=_TEXT_MUTED)
+    self.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill", text_color=TEXT_MUTED)
     self.shape_fill_mode_menu = ctk.CTkOptionMenu(
         shape_controls_row,
         values=["Filled", "Border Only"],

--- a/modules/maps/views/floating_toolbar/__init__.py
+++ b/modules/maps/views/floating_toolbar/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable widgets and layout helpers for the map floating toolbar."""

--- a/modules/maps/views/floating_toolbar/layout.py
+++ b/modules/maps/views/floating_toolbar/layout.py
@@ -1,0 +1,42 @@
+"""One-column layout helpers for the map floating toolbar."""
+
+import customtkinter as ctk
+
+PALETTE_BG = "#151515"
+SECTION_BG = "#1f1f1f"
+BORDER = "#3f3f3f"
+TEXT_MUTED = "#cfcfcf"
+DROPDOWN_WIDTH = 112
+SLIDER_WIDTH = 112
+
+
+def create_section(parent, title):
+    """Create a titled toolbar section that stacks controls vertically."""
+    section = ctk.CTkFrame(parent, fg_color=SECTION_BG, border_width=1, border_color="#303030", corner_radius=9)
+    section.pack(side="top", fill="x", padx=0, pady=(4, 0))
+    ctk.CTkLabel(section, text=title, text_color=TEXT_MUTED, font=ctk.CTkFont(size=11, weight="bold")).pack(
+        side="top", anchor="w", padx=8, pady=(5, 0)
+    )
+    body = ctk.CTkFrame(section, fg_color="transparent")
+    body.pack(side="top", fill="x", padx=6, pady=(2, 6))
+    return body
+
+
+def create_row(parent):
+    """Create a full-width row in the toolbar's single column."""
+    row = ctk.CTkFrame(parent, fg_color="transparent")
+    row.pack(side="top", fill="x", anchor="w", pady=2)
+    return row
+
+
+def add_small_label(parent, text):
+    """Add a muted label above a control."""
+    ctk.CTkLabel(parent, text=text, text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(3, 1))
+
+
+def add_stacked_control(parent, label, widget, *, pady=(0, 4)):
+    """Place a label and a widget in the toolbar's single column."""
+    row = create_row(parent)
+    add_small_label(row, label)
+    widget.pack(side="top", fill="x", padx=0, pady=pady)
+    return row

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -5,7 +5,6 @@ import customtkinter as ctk
 from modules.ui.icon_dropdown import IconDropdown
 from modules.helpers.logging_helper import log_module_import
 from modules.scenarios.plot_twist_panel import PlotTwistPanel
-from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
 from modules.maps.measurement.templates import MEASUREMENT_TEMPLATE_LABELS
 
 log_module_import(__name__)
@@ -89,10 +88,6 @@ def _build_toolbar(self):
         "save":  self.load_icon("assets/icons/save.png",     (48,48)),
         "fs":    self.load_icon("assets/icons/expand.png",   (48,48)),
         "rotate":    self.load_icon("assets/icons/turn_background_icon.png",   (48,48)),
-        "npc":   self.load_icon("assets/icons/npc.png",      (48,48)),
-        "creat": self.load_icon("assets/icons/creature.png", (48,48)),
-        "pc":    self.load_icon("assets/icons/pc.png",       (48,48)),
-        "marker":    self.load_icon("assets/icons/marker.png",       (48,48)),
         "chatbot":    self.load_icon("assets/icons/chatbot.png",       (48,48)),
 
     }
@@ -105,46 +100,7 @@ def _build_toolbar(self):
     self.parent.bind("[", lambda e: self._change_brush(-4))
     self.parent.bind("]", lambda e: self._change_brush(+4))
 
-    # Token controls and fullscreen before the brush size
-    token_section = _create_collapsible_section(toolbar, "Tokens")
-    token_actions = [
-        {"key": "creature", "icon": icons["creat"], "tooltip": "Add Creature", "command": lambda: self.open_entity_picker("Creature")},
-        {"key": "npc", "icon": icons["npc"], "tooltip": "Add NPC", "command": lambda: self.open_entity_picker("NPC")},
-        {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: self.open_entity_picker("PC")},
-        {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": self.add_marker},
-    ]
-    token_dropdown = IconDropdown(token_section, token_actions, default_key="npc")
-    _pack_control(token_dropdown, trailing=4)
-
-    token_size_label = ctk.CTkLabel(token_section, text="Size") # Renamed label variable
-    _pack_control(token_size_label, leading=8, trailing=4)
-
-    token_size_options = list(getattr(self, "token_size_options", list(range(16, 129, 8))))
-    current_token_size = int(getattr(self, "token_size", token_size_options[0] if token_size_options else 48))
-    if current_token_size not in token_size_options:
-        token_size_options.append(current_token_size)
-        token_size_options = sorted(set(token_size_options))
-    self.token_size_options = list(token_size_options)
-    token_size_values = [str(size) for size in self.token_size_options]
-    self.token_size_menu = ctk.CTkOptionMenu(
-        token_section,
-        values=token_size_values,
-        command=self._on_token_size_change,
-        width=dropdown_width,
-    )
-    self.token_size_menu.set(str(current_token_size))
-    _pack_control(self.token_size_menu, trailing=4)
-
-    marker_filter_label = ctk.CTkLabel(token_section, text="Marker Type")
-    _pack_control(marker_filter_label, leading=8, trailing=4)
-    self.marker_type_filter_menu = ctk.CTkOptionMenu(
-        token_section,
-        values=MARKER_TYPE_FILTER_LABELS,
-        command=getattr(self, "_on_marker_type_filter_change", None) or (lambda _v: None),
-        width=120,
-    )
-    self.marker_type_filter_menu.set(getattr(self, "marker_type_filter", "All Types") or "All Types")
-    _pack_control(self.marker_type_filter_menu, trailing=4)
+    # Token controls live in the one-column floating drawing palette.
 
     measure_section = _create_collapsible_section(toolbar, "Measure")
     ctk.CTkLabel(measure_section, text="Template").pack(side="left", padx=(8, 4), pady=6)


### PR DESCRIPTION
### Motivation
- Reduce horizontal footprint of the floating map toolbar by forcing a slim, single-column layout so the palette stays compact and readable.
- Ensure every drawing/token control presented in the floating toolbar uses a single stacked column rather than multiple side-by-side columns.
- Consolidate token-related controls into the floating palette to avoid duplicated token controls in the horizontal toolbar.

### Description
- Added a reusable one-column layout module at `modules/maps/views/floating_toolbar/layout.py` with helpers `create_section`, `create_row`, and `add_stacked_control` and shared sizing tokens.
- Reworked the floating drawing palette in `modules/maps/views/floating_drawing_toolbar.py` to use the new one-column helpers and changed a number of widgets (fog, brush shape/size, drawing tool, whiteboard, text, eraser) to stack vertically; token tools (creature/NPC/PC/marker), token size and marker type were added to the floating palette and follow the one-column rule.
- Removed the token section from the horizontal toolbar in `modules/maps/views/toolbar_view.py` so token controls are no longer duplicated there and instead live in the floating palette.
- Updated dynamic visibility/packing logic in `modules/maps/controllers/display_map_controller.py` so tool-specific controls (shape, whiteboard, eraser, text) are shown/hidden using vertical packing to remain consistent with the single-column layout.

### Testing
- Ran syntax/compile checks with `python -m py_compile modules/maps/views/floating_drawing_toolbar.py modules/maps/views/floating_toolbar/layout.py modules/maps/views/toolbar_view.py modules/maps/controllers/display_map_controller.py`, which succeeded.
- Ran `pytest tests/maps/test_measurement_templates.py`, which passed (`2 passed`).
- Performed a static verification script (`python - <<'PY' ...`) to assert no legacy `pack(side="left")` usages remain in the floating toolbar, and the check confirmed vertical packing is used.
- Attempted broader test run `pytest tests/maps/test_marker_types.py tests/maps/test_token_facing.py tests/maps/test_measurement_templates.py`, but collection failed due to an environment dependency: `ImportError: cannot import name 'ImageFont' from 'PIL'` (Pillow in the environment is missing a symbol), so those tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd908d7ac832ba41c9f107002f0ae)