### PR TITLE
Slim down map floating toolbar

### DIFF
--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -45,19 +45,19 @@ def _build_floating_drawing_toolbar(self):
     self.floating_drawing_toolbar = palette
 
     header = ctk.CTkFrame(palette, fg_color="#242424", corner_radius=10)
-    header.pack(side="top", fill="x", padx=6, pady=(6, 3))
-    handle = ctk.CTkLabel(header, text="☰ Draw", text_color=TEXT_MUTED, cursor="fleur")
-    handle.pack(side="left", padx=(8, 6), pady=4)
+    header.pack(side="top", fill="x", padx=4, pady=(4, 2))
+    handle = ctk.CTkLabel(header, text="☰", text_color=TEXT_MUTED, cursor="fleur")
+    handle.pack(side="left", padx=(6, 4), pady=3)
 
     content = ctk.CTkFrame(palette, fg_color="transparent")
-    content.pack(side="top", fill="both", expand=True, padx=6, pady=(0, 6))
+    content.pack(side="top", fill="both", expand=True, padx=4, pady=(0, 4))
     self.floating_drawing_toolbar_content = content
 
     collapsed = tk.BooleanVar(value=False)
 
     def _toggle_palette():
         if collapsed.get():
-            content.pack(side="top", fill="both", expand=True, padx=6, pady=(0, 6))
+            content.pack(side="top", fill="both", expand=True, padx=4, pady=(0, 4))
             collapse_button.configure(text="−")
             collapsed.set(False)
         else:
@@ -69,8 +69,8 @@ def _build_floating_drawing_toolbar(self):
         except tk.TclError:
             pass
 
-    collapse_button = ctk.CTkButton(header, text="−", width=28, height=24, command=_toggle_palette)
-    collapse_button.pack(side="right", padx=(2, 6), pady=4)
+    collapse_button = ctk.CTkButton(header, text="−", width=24, height=22, command=_toggle_palette)
+    collapse_button.pack(side="right", padx=(1, 4), pady=3)
 
     drag_state = {"x": 0, "y": 0}
 
@@ -109,14 +109,14 @@ def _build_floating_drawing_toolbar(self):
         return add_stacked_control(parent, label, widget, pady=pady)
 
     icons = {
-        "add": self.load_icon("assets/icons/brush.png", (32, 32)),
-        "rem": self.load_icon("assets/icons/eraser.png", (32, 32)),
-        "clear": self.load_icon("assets/icons/empty.png", (32, 32)),
-        "reset": self.load_icon("assets/icons/full.png", (32, 32)),
-        "npc": self.load_icon("assets/icons/npc.png", (32, 32)),
-        "creat": self.load_icon("assets/icons/creature.png", (32, 32)),
-        "pc": self.load_icon("assets/icons/pc.png", (32, 32)),
-        "marker": self.load_icon("assets/icons/marker.png", (32, 32)),
+        "add": self.load_icon("assets/icons/brush.png", (24, 24)),
+        "rem": self.load_icon("assets/icons/eraser.png", (24, 24)),
+        "clear": self.load_icon("assets/icons/empty.png", (24, 24)),
+        "reset": self.load_icon("assets/icons/full.png", (24, 24)),
+        "npc": self.load_icon("assets/icons/npc.png", (24, 24)),
+        "creat": self.load_icon("assets/icons/creature.png", (24, 24)),
+        "pc": self.load_icon("assets/icons/pc.png", (24, 24)),
+        "marker": self.load_icon("assets/icons/marker.png", (24, 24)),
     }
 
     self._fog_button_default_style = {
@@ -143,7 +143,7 @@ def _build_floating_drawing_toolbar(self):
         {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": self.reset_fog},
     ]
     fog_row = _row(fog_body)
-    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add")
+    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add", button_size=(24, 24))
     fog_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
     self._fog_buttons.update(fog_dropdown.option_buttons)
     self._fog_dropdown = fog_dropdown
@@ -190,7 +190,7 @@ def _build_floating_drawing_toolbar(self):
     self.whiteboard_color_button = ctk.CTkButton(
         whiteboard_controls,
         text="Ink Color",
-        width=84,
+        width=dropdown_width,
         command=self._on_pick_whiteboard_color,
     )
     try:
@@ -228,7 +228,7 @@ def _build_floating_drawing_toolbar(self):
         text_controls,
         values=[str(size) for size in self.text_size_options],
         command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
-        width=76,
+        width=dropdown_width,
     )
     self.text_size_menu.set(str(current_text_size))
     self.text_size_menu.pack(side="top", fill="x", padx=0, pady=(0, 4))
@@ -236,7 +236,7 @@ def _build_floating_drawing_toolbar(self):
     self.text_color_button = ctk.CTkButton(
         text_controls,
         text="Text Color",
-        width=90,
+        width=dropdown_width,
         command=self._on_pick_whiteboard_color,
     )
     try:
@@ -275,7 +275,7 @@ def _build_floating_drawing_toolbar(self):
         {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: self.open_entity_picker("PC")},
         {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": self.add_marker},
     ]
-    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc")
+    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc", button_size=(24, 24))
     token_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
 
     token_size_options = list(getattr(self, "token_size_options", list(range(16, 129, 8))))
@@ -315,13 +315,13 @@ def _build_floating_drawing_toolbar(self):
     self.shape_fill_color_button = ctk.CTkButton(
         shape_controls_row,
         text="Fill Color",
-        width=84,
+        width=dropdown_width,
         command=self._on_pick_shape_fill_color,
     )
     self.shape_border_color_button = ctk.CTkButton(
         shape_controls_row,
         text="Border Color",
-        width=96,
+        width=dropdown_width,
         command=self._on_pick_shape_border_color,
     )
 

--- a/modules/maps/views/floating_toolbar/layout.py
+++ b/modules/maps/views/floating_toolbar/layout.py
@@ -6,32 +6,32 @@ PALETTE_BG = "#151515"
 SECTION_BG = "#1f1f1f"
 BORDER = "#3f3f3f"
 TEXT_MUTED = "#cfcfcf"
-DROPDOWN_WIDTH = 112
-SLIDER_WIDTH = 112
+DROPDOWN_WIDTH = 88
+SLIDER_WIDTH = 88
 
 
 def create_section(parent, title):
     """Create a titled toolbar section that stacks controls vertically."""
     section = ctk.CTkFrame(parent, fg_color=SECTION_BG, border_width=1, border_color="#303030", corner_radius=9)
-    section.pack(side="top", fill="x", padx=0, pady=(4, 0))
+    section.pack(side="top", fill="x", padx=0, pady=(3, 0))
     ctk.CTkLabel(section, text=title, text_color=TEXT_MUTED, font=ctk.CTkFont(size=11, weight="bold")).pack(
-        side="top", anchor="w", padx=8, pady=(5, 0)
+        side="top", anchor="w", padx=5, pady=(4, 0)
     )
     body = ctk.CTkFrame(section, fg_color="transparent")
-    body.pack(side="top", fill="x", padx=6, pady=(2, 6))
+    body.pack(side="top", fill="x", padx=4, pady=(1, 5))
     return body
 
 
 def create_row(parent):
     """Create a full-width row in the toolbar's single column."""
     row = ctk.CTkFrame(parent, fg_color="transparent")
-    row.pack(side="top", fill="x", anchor="w", pady=2)
+    row.pack(side="top", fill="x", anchor="w", pady=1)
     return row
 
 
 def add_small_label(parent, text):
     """Add a muted label above a control."""
-    ctk.CTkLabel(parent, text=text, text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(3, 1))
+    ctk.CTkLabel(parent, text=text, text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(2, 0))
 
 
 def add_stacked_control(parent, label, widget, *, pady=(0, 4)):


### PR DESCRIPTION
### Motivation
- The floating map tool palette was too wide and visually heavy; the goal is to make it as slim as possible while keeping controls usable.
- Keep layout changes localized to the floating toolbar so other UI areas are unaffected.

### Description
- Reduced shared control widths by changing `DROPDOWN_WIDTH` and `SLIDER_WIDTH` from `112` to `88` in `modules/maps/views/floating_toolbar/layout.py` and tightened section/label/row paddings. 
- Slimmed the floating drawing palette in `modules/maps/views/floating_drawing_toolbar.py` by shortening the header to an icon-only drag handle, reducing header/content paddings, and using a smaller collapse button. 
- Reduced icon/button sizes used by the palette from `32x32` → `24x24` and passed `button_size=(24, 24)` to `IconDropdown` instances for fog and token menus. 
- Replaced several fixed control widths with the slimmer `dropdown_width` so fog, tools, token, text, eraser, and shape controls adopt the compact sizing.

### Testing
- Ran static checks and assertions: `python -m compileall -q modules/maps/views/floating_toolbar/layout.py modules/maps/views/floating_drawing_toolbar.py` and a small Python assertion script to confirm `DROPDOWN_WIDTH == 88`, `SLIDER_WIDTH == 88`, header text change, and `button_size=(24, 24)` presence — these succeeded. 
- Ran `git diff --check` to ensure no whitespace/merge issues — passed. 
- Attempted targeted pytest run (`tests/maps/test_marker_types.py tests/maps/test_measurement_templates.py tests/maps/test_token_facing.py`) but collection failed due to an environment dependency: `ImportError: cannot import name 'ImageFont' from 'PIL'`, so UI-related runtime tests were blocked by the missing Pillow component.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdbdebaa0832ba34ece23a5e1df71)