### PR TITLE
Slim map floating toolbar controls

### DIFF
--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -6,6 +6,7 @@ import customtkinter as ctk
 from modules.helpers.logging_helper import log_module_import
 from modules.ui.icon_dropdown import IconDropdown
 from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
+from modules.maps.views.floating_toolbar.slim_option_menu import create_slim_option_menu
 from modules.maps.views.floating_toolbar.layout import (
     BORDER,
     DROPDOWN_WIDTH,
@@ -143,12 +144,12 @@ def _build_floating_drawing_toolbar(self):
         {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": self.reset_fog},
     ]
     fog_row = _row(fog_body)
-    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add", button_size=(24, 24))
+    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add", button_size=(24, 24), show_arrow=False)
     fog_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
     self._fog_buttons.update(fog_dropdown.option_buttons)
     self._fog_dropdown = fog_dropdown
 
-    self.shape_menu = ctk.CTkOptionMenu(
+    self.shape_menu = create_slim_option_menu(
         fog_body,
         values=["Rectangle", "Circle"],
         command=self._on_brush_shape_change,
@@ -163,7 +164,7 @@ def _build_floating_drawing_toolbar(self):
         brush_size_options.append(current_brush_size)
         brush_size_options = sorted(set(brush_size_options))
     self.brush_size_options = list(brush_size_options)
-    self.brush_size_menu = ctk.CTkOptionMenu(
+    self.brush_size_menu = create_slim_option_menu(
         fog_body,
         values=[str(size) for size in self.brush_size_options],
         command=self._on_brush_size_change,
@@ -174,7 +175,7 @@ def _build_floating_drawing_toolbar(self):
 
     tools_body = _section("Tools")
     drawing_tools = ["Token", "Rectangle", "Oval", "Text", "Whiteboard", "Eraser"]
-    self.drawing_tool_menu = ctk.CTkOptionMenu(
+    self.drawing_tool_menu = create_slim_option_menu(
         tools_body,
         values=drawing_tools,
         command=self._on_drawing_tool_change,
@@ -224,7 +225,7 @@ def _build_floating_drawing_toolbar(self):
     if current_text_size not in text_sizes:
         text_sizes = sorted(set(list(text_sizes) + [current_text_size]))
     self.text_size_options = list(text_sizes)
-    self.text_size_menu = ctk.CTkOptionMenu(
+    self.text_size_menu = create_slim_option_menu(
         text_controls,
         values=[str(size) for size in self.text_size_options],
         command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
@@ -275,7 +276,7 @@ def _build_floating_drawing_toolbar(self):
         {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: self.open_entity_picker("PC")},
         {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": self.add_marker},
     ]
-    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc", button_size=(24, 24))
+    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc", button_size=(24, 24), show_arrow=False)
     token_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
 
     token_size_options = list(getattr(self, "token_size_options", list(range(16, 129, 8))))
@@ -284,7 +285,7 @@ def _build_floating_drawing_toolbar(self):
         token_size_options.append(current_token_size)
         token_size_options = sorted(set(token_size_options))
     self.token_size_options = list(token_size_options)
-    self.token_size_menu = ctk.CTkOptionMenu(
+    self.token_size_menu = create_slim_option_menu(
         tokens_body,
         values=[str(size) for size in self.token_size_options],
         command=self._on_token_size_change,
@@ -293,7 +294,7 @@ def _build_floating_drawing_toolbar(self):
     self.token_size_menu.set(str(current_token_size))
     _stacked_control(tokens_body, "Size", self.token_size_menu)
 
-    self.marker_type_filter_menu = ctk.CTkOptionMenu(
+    self.marker_type_filter_menu = create_slim_option_menu(
         tokens_body,
         values=MARKER_TYPE_FILTER_LABELS,
         command=getattr(self, "_on_marker_type_filter_change", None) or (lambda _v: None),
@@ -305,7 +306,7 @@ def _build_floating_drawing_toolbar(self):
     shape_controls_row = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.shape_controls_row = shape_controls_row
     self.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill", text_color=TEXT_MUTED)
-    self.shape_fill_mode_menu = ctk.CTkOptionMenu(
+    self.shape_fill_mode_menu = create_slim_option_menu(
         shape_controls_row,
         values=["Filled", "Border Only"],
         command=self._on_shape_fill_mode_change,
@@ -331,7 +332,7 @@ def _build_floating_drawing_toolbar(self):
         toolbar_height = 0
     if toolbar_height <= 1:
         toolbar_height = 72
-    palette.place(relx=0.5, y=toolbar_height + 12, anchor="n")
+    palette.place(relx=0, x=8, y=toolbar_height + 12, anchor="nw")
     try:
         palette.lift()
     except tk.TclError:

--- a/modules/maps/views/floating_toolbar/layout.py
+++ b/modules/maps/views/floating_toolbar/layout.py
@@ -6,8 +6,9 @@ PALETTE_BG = "#151515"
 SECTION_BG = "#1f1f1f"
 BORDER = "#3f3f3f"
 TEXT_MUTED = "#cfcfcf"
-DROPDOWN_WIDTH = 88
-SLIDER_WIDTH = 88
+DROPDOWN_WIDTH = 76
+SLIDER_WIDTH = 76
+CONTROL_FONT_SIZE = 11
 
 
 def create_section(parent, title):

--- a/modules/maps/views/floating_toolbar/slim_option_menu.py
+++ b/modules/maps/views/floating_toolbar/slim_option_menu.py
@@ -1,0 +1,68 @@
+"""Slim option-menu helpers for narrow floating map palettes."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Any
+
+import customtkinter as ctk
+
+from modules.maps.views.floating_toolbar.layout import CONTROL_FONT_SIZE
+
+
+def create_slim_option_menu(parent: tk.Misc, **kwargs: Any) -> ctk.CTkOptionMenu:
+    """Create a compact option menu with its arrow area visually removed."""
+    font = kwargs.pop("font", ctk.CTkFont(size=CONTROL_FONT_SIZE))
+    dropdown_font = kwargs.pop("dropdown_font", ctk.CTkFont(size=CONTROL_FONT_SIZE))
+    menu = ctk.CTkOptionMenu(parent, font=font, dropdown_font=dropdown_font, **kwargs)
+    hide_option_menu_arrow(menu)
+    return menu
+
+
+def hide_option_menu_arrow(menu: ctk.CTkOptionMenu) -> None:
+    """
+    Make a CTkOptionMenu use the whole control width for text.
+
+    CustomTkinter draws the dropdown arrow and right-side button on the menu's
+    internal canvas. Keeping the menu itself clickable but removing that visual
+    split makes narrow toolbar controls read more like compact pills.
+    """
+    try:
+        fg_color = menu.cget("fg_color")
+        hover_color = menu.cget("fg_color")
+        menu.configure(
+            anchor="w",
+            button_color=fg_color,
+            button_hover_color=hover_color,
+            dropdown_font=ctk.CTkFont(size=CONTROL_FONT_SIZE),
+            font=ctk.CTkFont(size=CONTROL_FONT_SIZE),
+        )
+    except (tk.TclError, ValueError):
+        return
+
+    _expand_text_label(menu)
+    _erase_arrow(menu)
+    menu.after_idle(lambda: (_expand_text_label(menu), _erase_arrow(menu)))
+
+
+def _expand_text_label(menu: ctk.CTkOptionMenu) -> None:
+    """Let the internal text label span the area normally reserved for the arrow."""
+    label = getattr(menu, "_text_label", None)
+    if label is None:
+        return
+    try:
+        label.grid_configure(column=0, columnspan=2, sticky="ew", padx=(6, 6))
+        label.configure(anchor="w")
+    except tk.TclError:
+        return
+
+
+def _erase_arrow(menu: ctk.CTkOptionMenu) -> None:
+    """Remove the canvas arrow tag when supported by the CustomTkinter version."""
+    canvas = getattr(menu, "_canvas", None)
+    if canvas is None:
+        return
+    try:
+        canvas.delete("dropdown_arrow")
+    except tk.TclError:
+        return

--- a/modules/ui/icon_dropdown.py
+++ b/modules/ui/icon_dropdown.py
@@ -19,8 +19,16 @@ class IconDropdown(ctk.CTkFrame):
     buttons for state updates.
     """
 
-    def __init__(self, parent, items, default_key=None, button_size=(32, 32)):
-        """Initialize the IconDropdown instance."""
+    def __init__(self, parent, items, default_key=None, button_size=(32, 32), show_arrow=True):
+        """Initialize the IconDropdown instance.
+
+        Args:
+            parent: Parent widget.
+            items: Dropdown actions with key, icon, tooltip, and command entries.
+            default_key: Initially selected action key.
+            button_size: Base icon button size.
+            show_arrow: Whether the collapsed button reserves space for a down arrow.
+        """
         super().__init__(parent, fg_color="transparent")
 
         if not items:
@@ -32,6 +40,7 @@ class IconDropdown(ctk.CTkFrame):
         self._button_size = button_size
         self._default_key = default_key or self._order[0]
         self._selected_key = self._default_key
+        self._show_arrow = show_arrow
 
         self._menu = tk.Toplevel(self)
         self._menu.withdraw()
@@ -46,10 +55,10 @@ class IconDropdown(ctk.CTkFrame):
         initial = self._items[self._selected_key]
         self._display_button = ctk.CTkButton(
             self,
-            text="▼",
+            text="▼" if self._show_arrow else "",
             image=initial["icon"],
-            compound="right",
-            width=self._button_size[0] + 18,
+            compound="right" if self._show_arrow else "left",
+            width=self._button_size[0] + (18 if self._show_arrow else 10),
             height=self._button_size[1] + 10,
             corner_radius=12,
             fg_color=self._tokens.get("button_fg"),


### PR DESCRIPTION
### Motivation
- The floating map toolbar was too wide because dropdowns reserved space for a right-side arrow and the palette was centered; the goal is to reclaim horizontal space by removing the arrow area from dropdowns and place the palette at the left edge.

### Description
- Add a reusable helper `modules/maps/views/floating_toolbar/slim_option_menu.py` with `create_slim_option_menu` that shrinks font and hides the internal arrow area for `CTkOptionMenu` controls.
- Reduce the floating palette control widths and introduce `CONTROL_FONT_SIZE` in `modules/maps/views/floating_toolbar/layout.py` (`DROPDOWN_WIDTH`/`SLIDER_WIDTH` from `88` to `76`).
- Add a `show_arrow` flag to `modules/ui/icon_dropdown.py` and disable the arrow for icon triggers used in the floating palette (keeps default behavior unchanged elsewhere).
- Apply the slim option menu and hide arrows in `modules/maps/views/floating_drawing_toolbar.py` for Fog, Shape, Size, Tool, Token Size, Marker Type, and Shape Fill controls, and move the palette initial placement from centered to left (`palette.place(relx=0, x=8, ... )`).

### Testing
- Compiled modified modules with `python -m compileall modules/maps/views/floating_drawing_toolbar.py modules/maps/views/floating_toolbar/layout.py modules/maps/views/floating_toolbar/slim_option_menu.py modules/ui/icon_dropdown.py` and it succeeded. 
- Ran `git diff --check` to ensure no trailing whitespace or obvious diff issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdf4f2ef8832bbd21a90770361bb5)