### PR TITLE
Slim down map floating toolbar controls

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -6246,9 +6246,9 @@ class DisplayMapController:
 
                 # Repack in desired order without 'before'
                 if shape_fill_label: shape_fill_label.pack(side="top", anchor="w", padx=0, pady=(2, 1))
-                if shape_fill_mode_menu: shape_fill_mode_menu.pack(side="top", fill="x", padx=0, pady=(0, 4))
-                if shape_fill_color_button: shape_fill_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
-                if shape_border_color_button: shape_border_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
+                if shape_fill_mode_menu: shape_fill_mode_menu.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+                if shape_fill_color_button: shape_fill_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+                if shape_border_color_button: shape_border_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
             elif whiteboard_active:
                 # Continue with this path when whiteboard active is set.
                 shape_controls_row = getattr(self, "shape_controls_row", None)
@@ -6267,7 +6267,7 @@ class DisplayMapController:
                         pass
                 if whiteboard_controls_frame:
                     whiteboard_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
-                if whiteboard_color_button: whiteboard_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
+                if whiteboard_color_button: whiteboard_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
                 if whiteboard_width_slider:
                     try:
                         whiteboard_width_slider.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
@@ -6333,12 +6333,12 @@ class DisplayMapController:
                     text_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
                 if text_size_menu:
                     try:
-                        text_size_menu.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
+                        text_size_menu.master.pack(side="top", anchor="w", padx=0, pady=(0, 4))
                     except Exception:
                         pass
                 if text_color_button:
                     try:
-                        text_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
+                        text_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
                     except tk.TclError:
                         pass
             else:

--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -7,9 +7,9 @@ from modules.helpers.logging_helper import log_module_import
 from modules.ui.icon_dropdown import IconDropdown
 from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
 from modules.maps.views.floating_toolbar.slim_option_menu import create_slim_option_menu
+from modules.maps.views.floating_toolbar.shape_selector import add_shape_icon_selector
 from modules.maps.views.floating_toolbar.layout import (
     BORDER,
-    DROPDOWN_WIDTH,
     PALETTE_BG,
     SLIDER_WIDTH,
     TEXT_MUTED,
@@ -34,7 +34,6 @@ def _build_floating_drawing_toolbar(self):
         except tk.TclError:
             pass
 
-    dropdown_width = DROPDOWN_WIDTH
     slider_width = SLIDER_WIDTH
     palette = ctk.CTkFrame(
         host,
@@ -149,14 +148,7 @@ def _build_floating_drawing_toolbar(self):
     self._fog_buttons.update(fog_dropdown.option_buttons)
     self._fog_dropdown = fog_dropdown
 
-    self.shape_menu = create_slim_option_menu(
-        fog_body,
-        values=["Rectangle", "Circle"],
-        command=self._on_brush_shape_change,
-        width=dropdown_width,
-    )
-    self.shape_menu.set("Rectangle")
-    _stacked_control(fog_body, "Shape", self.shape_menu)
+    self.shape_menu = add_shape_icon_selector(fog_body, self._on_brush_shape_change)
 
     brush_size_options = list(getattr(self, "brush_size_options", list(range(4, 129, 4))))
     current_brush_size = int(getattr(self, "brush_size", brush_size_options[0] if brush_size_options else 32))
@@ -168,7 +160,6 @@ def _build_floating_drawing_toolbar(self):
         fog_body,
         values=[str(size) for size in self.brush_size_options],
         command=self._on_brush_size_change,
-        width=dropdown_width,
     )
     self.brush_size_menu.set(str(current_brush_size))
     _stacked_control(fog_body, "Size", self.brush_size_menu)
@@ -179,7 +170,6 @@ def _build_floating_drawing_toolbar(self):
         tools_body,
         values=drawing_tools,
         command=self._on_drawing_tool_change,
-        width=dropdown_width,
     )
     current_tool = self.drawing_mode.capitalize() if hasattr(self, "drawing_mode") else "Token"
     self.drawing_tool_menu.set(current_tool if current_tool in drawing_tools else "Token")
@@ -191,14 +181,14 @@ def _build_floating_drawing_toolbar(self):
     self.whiteboard_color_button = ctk.CTkButton(
         whiteboard_controls,
         text="Ink Color",
-        width=dropdown_width,
+        width=70,
         command=self._on_pick_whiteboard_color,
     )
     try:
         self.whiteboard_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
     except tk.TclError:
         pass
-    self.whiteboard_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    self.whiteboard_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
 
     width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
     width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
@@ -229,22 +219,21 @@ def _build_floating_drawing_toolbar(self):
         text_controls,
         values=[str(size) for size in self.text_size_options],
         command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
-        width=dropdown_width,
     )
     self.text_size_menu.set(str(current_text_size))
-    self.text_size_menu.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    self.text_size_menu.pack(side="top", anchor="w", padx=0, pady=(0, 4))
 
     self.text_color_button = ctk.CTkButton(
         text_controls,
         text="Text Color",
-        width=dropdown_width,
+        width=76,
         command=self._on_pick_whiteboard_color,
     )
     try:
         self.text_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
     except tk.TclError:
         pass
-    self.text_color_button.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    self.text_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
 
     eraser_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.eraser_controls_frame = eraser_controls
@@ -289,7 +278,6 @@ def _build_floating_drawing_toolbar(self):
         tokens_body,
         values=[str(size) for size in self.token_size_options],
         command=self._on_token_size_change,
-        width=dropdown_width,
     )
     self.token_size_menu.set(str(current_token_size))
     _stacked_control(tokens_body, "Size", self.token_size_menu)
@@ -298,7 +286,6 @@ def _build_floating_drawing_toolbar(self):
         tokens_body,
         values=MARKER_TYPE_FILTER_LABELS,
         command=getattr(self, "_on_marker_type_filter_change", None) or (lambda _v: None),
-        width=dropdown_width,
     )
     self.marker_type_filter_menu.set(getattr(self, "marker_type_filter", "All Types") or "All Types")
     _stacked_control(tokens_body, "Marker Type", self.marker_type_filter_menu)
@@ -310,19 +297,18 @@ def _build_floating_drawing_toolbar(self):
         shape_controls_row,
         values=["Filled", "Border Only"],
         command=self._on_shape_fill_mode_change,
-        width=dropdown_width,
     )
     self.shape_fill_mode_menu.set("Filled" if hasattr(self, "shape_is_filled") and self.shape_is_filled else "Border Only")
     self.shape_fill_color_button = ctk.CTkButton(
         shape_controls_row,
         text="Fill Color",
-        width=dropdown_width,
+        width=70,
         command=self._on_pick_shape_fill_color,
     )
     self.shape_border_color_button = ctk.CTkButton(
         shape_controls_row,
         text="Border Color",
-        width=dropdown_width,
+        width=88,
         command=self._on_pick_shape_border_color,
     )
 

--- a/modules/maps/views/floating_toolbar/compact_widths.py
+++ b/modules/maps/views/floating_toolbar/compact_widths.py
@@ -1,0 +1,13 @@
+"""Width helpers for compact floating toolbar controls."""
+
+from __future__ import annotations
+
+CONTROL_TEXT_PIXEL_WIDTH = 7
+CONTROL_HORIZONTAL_PADDING = 18
+CONTROL_MIN_WIDTH = 34
+
+
+def width_for_display_text(text: object) -> int:
+    """Return a compact control width sized to the currently displayed text."""
+    display_text = str(text or "")
+    return max(CONTROL_MIN_WIDTH, len(display_text) * CONTROL_TEXT_PIXEL_WIDTH + CONTROL_HORIZONTAL_PADDING)

--- a/modules/maps/views/floating_toolbar/layout.py
+++ b/modules/maps/views/floating_toolbar/layout.py
@@ -6,7 +6,6 @@ PALETTE_BG = "#151515"
 SECTION_BG = "#1f1f1f"
 BORDER = "#3f3f3f"
 TEXT_MUTED = "#cfcfcf"
-DROPDOWN_WIDTH = 76
 SLIDER_WIDTH = 76
 CONTROL_FONT_SIZE = 11
 
@@ -36,8 +35,8 @@ def add_small_label(parent, text):
 
 
 def add_stacked_control(parent, label, widget, *, pady=(0, 4)):
-    """Place a label and a widget in the toolbar's single column."""
+    """Place a label and a naturally-sized widget in the toolbar column."""
     row = create_row(parent)
     add_small_label(row, label)
-    widget.pack(side="top", fill="x", padx=0, pady=pady)
+    widget.pack(side="top", anchor="w", padx=0, pady=pady)
     return row

--- a/modules/maps/views/floating_toolbar/shape_selector.py
+++ b/modules/maps/views/floating_toolbar/shape_selector.py
@@ -1,0 +1,82 @@
+"""Icon-style shape selector for the floating map toolbar."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from collections.abc import Callable
+
+import customtkinter as ctk
+
+from modules.ui.tooltip import ToolTip
+from modules.maps.views.floating_toolbar.layout import TEXT_MUTED, create_row, add_small_label
+
+
+class ShapeIconSelector(ctk.CTkFrame):
+    """Two-button rectangle/oval selector that replaces a text dropdown."""
+
+    _DEFAULT_STYLE = {
+        "fg_color": "#2f2f2f",
+        "hover_color": "#3a3a3a",
+        "border_color": "#4a4a4a",
+        "border_width": 1,
+        "text_color": TEXT_MUTED,
+    }
+    _ACTIVE_STYLE = {
+        "fg_color": "#28a874",
+        "hover_color": "#239164",
+        "border_color": "#35c98c",
+        "border_width": 1,
+        "text_color": "#ffffff",
+    }
+
+    def __init__(self, parent: tk.Misc, command: Callable[[str], None]) -> None:
+        """Build a compact pair of shape buttons."""
+        super().__init__(parent, fg_color="transparent")
+        self._command = command
+        self._selected_value = "Rectangle"
+        self._buttons: dict[str, ctk.CTkButton] = {}
+        self._build_buttons()
+        self.set("Rectangle", invoke=False)
+
+    def _build_buttons(self) -> None:
+        items = (("Rectangle", "▭", "Rectangle brush"), ("Oval", "⬭", "Oval brush"))
+        for value, icon, tooltip in items:
+            button = ctk.CTkButton(
+                self,
+                text=icon,
+                width=28,
+                height=26,
+                corner_radius=8,
+                font=ctk.CTkFont(size=15, weight="bold"),
+                command=lambda selected=value: self.set(selected),
+                **self._DEFAULT_STYLE,
+            )
+            button.pack(side="left", padx=(0, 3), pady=(0, 4))
+            self._buttons[value] = button
+            ToolTip(button, tooltip)
+
+    def set(self, value: str, *, invoke: bool = True) -> None:
+        """Select a shape and optionally notify the controller."""
+        if value not in self._buttons:
+            value = "Rectangle"
+        self._selected_value = value
+        for button_value, button in self._buttons.items():
+            try:
+                button.configure(**(self._ACTIVE_STYLE if button_value == value else self._DEFAULT_STYLE))
+            except tk.TclError:
+                continue
+        if invoke:
+            self._command(value)
+
+    def get(self) -> str:
+        """Return the selected controller value."""
+        return self._selected_value
+
+
+def add_shape_icon_selector(parent: tk.Misc, command: Callable[[str], None]) -> ShapeIconSelector:
+    """Add a labeled rectangle/oval icon selector row."""
+    row = create_row(parent)
+    add_small_label(row, "Shape")
+    selector = ShapeIconSelector(row, command)
+    selector.pack(side="top", anchor="w", padx=0, pady=(0, 1))
+    return selector

--- a/modules/maps/views/floating_toolbar/slim_option_menu.py
+++ b/modules/maps/views/floating_toolbar/slim_option_menu.py
@@ -8,14 +8,35 @@ from typing import Any
 import customtkinter as ctk
 
 from modules.maps.views.floating_toolbar.layout import CONTROL_FONT_SIZE
+from modules.maps.views.floating_toolbar.compact_widths import width_for_display_text
 
 
 def create_slim_option_menu(parent: tk.Misc, **kwargs: Any) -> ctk.CTkOptionMenu:
     """Create a compact option menu with its arrow area visually removed."""
     font = kwargs.pop("font", ctk.CTkFont(size=CONTROL_FONT_SIZE))
     dropdown_font = kwargs.pop("dropdown_font", ctk.CTkFont(size=CONTROL_FONT_SIZE))
+    command = kwargs.get("command")
+    explicit_width = "width" in kwargs
+    initial_value = kwargs.pop("initial_value", None)
+    if not explicit_width:
+        values = kwargs.get("values") or []
+        initial_value = initial_value or (values[0] if values else "")
+        kwargs["width"] = width_for_display_text(initial_value)
+
+    def _compact_command(value: str) -> None:
+        set_menu_width_to_text(menu, value)
+        if callable(command):
+            command(value)
+
+    if command is not None:
+        kwargs["command"] = _compact_command
+
     menu = ctk.CTkOptionMenu(parent, font=font, dropdown_font=dropdown_font, **kwargs)
+    if not explicit_width:
+        _wrap_set_for_compact_width(menu)
     hide_option_menu_arrow(menu)
+    if not explicit_width:
+        set_menu_width_to_text(menu, initial_value)
     return menu
 
 
@@ -66,3 +87,27 @@ def _erase_arrow(menu: ctk.CTkOptionMenu) -> None:
         canvas.delete("dropdown_arrow")
     except tk.TclError:
         return
+
+
+def set_menu_width_to_text(menu: ctk.CTkOptionMenu, value: object | None = None) -> None:
+    """Resize an option menu to the text it currently displays."""
+    if value is None:
+        try:
+            value = menu.get()
+        except tk.TclError:
+            value = ""
+    try:
+        menu.configure(width=width_for_display_text(value))
+    except tk.TclError:
+        return
+
+
+def _wrap_set_for_compact_width(menu: ctk.CTkOptionMenu) -> None:
+    """Keep programmatic selections as compact as user-driven selections."""
+    original_set = menu.set
+
+    def _set_and_resize(value: str) -> None:
+        original_set(value)
+        set_menu_width_to_text(menu, value)
+
+    menu.set = _set_and_resize

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -231,8 +231,9 @@ def _on_brush_size_change(self, val): # This is for FOG brush
 
 def _on_brush_shape_change(self, val): # This is for FOG brush
     """Handle brush shape change."""
-    # normalize to lowercase for comparisons
-    self.brush_shape = val.lower()
+    # normalize to lowercase for comparisons; the compact floating toolbar labels
+    # the circular brush as Oval to match the drawing tool wording.
+    self.brush_shape = "circle" if str(val).lower() == "oval" else str(val).lower()
 
 def _change_brush(self, delta): # This is for FOG brush
     """Internal helper for change brush."""

--- a/tests/maps/test_floating_toolbar_compact_controls.py
+++ b/tests/maps/test_floating_toolbar_compact_controls.py
@@ -1,0 +1,30 @@
+"""Tests for compact floating map toolbar sizing helpers."""
+
+from modules.maps.views.floating_toolbar.compact_widths import (
+    CONTROL_MIN_WIDTH,
+    width_for_display_text,
+)
+
+
+def test_width_for_display_text_uses_minimum_for_empty_values():
+    assert width_for_display_text("") == CONTROL_MIN_WIDTH
+    assert width_for_display_text(None) == CONTROL_MIN_WIDTH
+
+
+def test_width_for_display_text_grows_with_displayed_text():
+    short_width = width_for_display_text("16")
+    medium_width = width_for_display_text("Token")
+    long_width = width_for_display_text("Border Only")
+
+    assert short_width == CONTROL_MIN_WIDTH
+    assert medium_width > short_width
+    assert long_width > medium_width
+
+
+def test_brush_shape_handler_accepts_oval_label():
+    from modules.maps.views.toolbar_view import _on_brush_shape_change
+
+    panel = type("Panel", (), {})()
+    _on_brush_shape_change(panel, "Oval")
+
+    assert panel.brush_shape == "circle"


### PR DESCRIPTION
### Motivation
- The floating MapTool palette was wider than necessary because several `CTkOptionMenu` controls reserved a fixed arrow/button area and used `fill="x"`, making the bar bulky.  
- Replace the text `Shape` dropdown with a compact rectangle/oval icon control and make other dropdowns only as wide as their displayed text so the floating bar is as slim as possible.

### Description
- Added `modules/maps/views/floating_toolbar/shape_selector.py` which implements a two-button icon selector (`ShapeIconSelector`) and `add_shape_icon_selector` to replace the text shape dropdown.  
- Added `modules/maps/views/floating_toolbar/compact_widths.py` and enhanced `slim_option_menu.py` so slim option menus auto-size to their displayed text and keep that compact width when selections change programmatically.  
- Updated the floating drawing toolbar to use `add_shape_icon_selector` instead of a `CTkOptionMenu` for shape selection and changed several controls to pack with `anchor="w"` (instead of `fill="x"`) so controls naturally size to content.  
- Kept behavior compatibility by normalizing the new `Oval` label to the existing circular brush mode in the brush handler (`_on_brush_shape_change`) and added a focused test for width logic and the Oval->circle normalization.

### Testing
- Ran the unit test `pytest tests/maps/test_floating_toolbar_compact_controls.py` which includes sizing assertions and the `Oval` label normalization, and it passed.  
- Performed a source compilation check with `python -m compileall` across modified modules to ensure syntax validity, and it succeeded.  
- Ran `git diff --check` locally to verify no whitespace/errors flagged by the repository checks (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce1953758832b952f64036f1984b7)