### PR TITLE
Move Marker Type filter to top toolbar and stack shape selector vertically

### DIFF
--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -5,7 +5,6 @@ import customtkinter as ctk
 
 from modules.helpers.logging_helper import log_module_import
 from modules.ui.icon_dropdown import IconDropdown
-from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
 from modules.maps.views.floating_toolbar.slim_option_menu import create_slim_option_menu
 from modules.maps.views.floating_toolbar.shape_selector import add_shape_icon_selector
 from modules.maps.views.floating_toolbar.layout import (
@@ -281,14 +280,6 @@ def _build_floating_drawing_toolbar(self):
     )
     self.token_size_menu.set(str(current_token_size))
     _stacked_control(tokens_body, "Size", self.token_size_menu)
-
-    self.marker_type_filter_menu = create_slim_option_menu(
-        tokens_body,
-        values=MARKER_TYPE_FILTER_LABELS,
-        command=getattr(self, "_on_marker_type_filter_change", None) or (lambda _v: None),
-    )
-    self.marker_type_filter_menu.set(getattr(self, "marker_type_filter", "All Types") or "All Types")
-    _stacked_control(tokens_body, "Marker Type", self.marker_type_filter_menu)
 
     shape_controls_row = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.shape_controls_row = shape_controls_row

--- a/modules/maps/views/floating_toolbar/shape_selector.py
+++ b/modules/maps/views/floating_toolbar/shape_selector.py
@@ -51,7 +51,7 @@ class ShapeIconSelector(ctk.CTkFrame):
                 command=lambda selected=value: self.set(selected),
                 **self._DEFAULT_STYLE,
             )
-            button.pack(side="left", padx=(0, 3), pady=(0, 4))
+            button.pack(side="top", anchor="w", padx=0, pady=(0, 3))
             self._buttons[value] = button
             ToolTip(button, tooltip)
 

--- a/modules/maps/views/toolbar_view.py
+++ b/modules/maps/views/toolbar_view.py
@@ -6,6 +6,7 @@ from modules.ui.icon_dropdown import IconDropdown
 from modules.helpers.logging_helper import log_module_import
 from modules.scenarios.plot_twist_panel import PlotTwistPanel
 from modules.maps.measurement.templates import MEASUREMENT_TEMPLATE_LABELS
+from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
 
 log_module_import(__name__)
 
@@ -100,7 +101,19 @@ def _build_toolbar(self):
     self.parent.bind("[", lambda e: self._change_brush(-4))
     self.parent.bind("]", lambda e: self._change_brush(+4))
 
-    # Token controls live in the one-column floating drawing palette.
+    # Token creation controls live in the one-column floating drawing palette.
+    # Marker filtering belongs to the persistent top toolbar so it stays visible.
+
+    token_section = _create_collapsible_section(toolbar, "Tokens")
+    ctk.CTkLabel(token_section, text="Marker Type").pack(side="left", padx=(8, 4), pady=6)
+    self.marker_type_filter_menu = ctk.CTkOptionMenu(
+        token_section,
+        values=MARKER_TYPE_FILTER_LABELS,
+        command=getattr(self, "_on_marker_type_filter_change", None) or (lambda _v: None),
+        width=110,
+    )
+    self.marker_type_filter_menu.set(getattr(self, "marker_type_filter", "All Types") or "All Types")
+    _pack_control(self.marker_type_filter_menu, trailing=6, pady=6)
 
     measure_section = _create_collapsible_section(toolbar, "Measure")
     ctk.CTkLabel(measure_section, text="Template").pack(side="left", padx=(8, 4), pady=6)

--- a/tests/maps/test_floating_toolbar_compact_controls.py
+++ b/tests/maps/test_floating_toolbar_compact_controls.py
@@ -28,3 +28,27 @@ def test_brush_shape_handler_accepts_oval_label():
     _on_brush_shape_change(panel, "Oval")
 
     assert panel.brush_shape == "circle"
+
+
+def test_shape_selector_stacks_shape_buttons_vertically():
+    import inspect
+
+    from modules.maps.views.floating_toolbar.shape_selector import ShapeIconSelector
+
+    source = inspect.getsource(ShapeIconSelector._build_buttons)
+
+    assert 'button.pack(side="top"' in source
+    assert 'button.pack(side="left"' not in source
+
+
+def test_marker_type_filter_moved_from_floating_palette_to_top_toolbar():
+    import inspect
+
+    from modules.maps.views import floating_drawing_toolbar, toolbar_view
+
+    floating_source = inspect.getsource(floating_drawing_toolbar._build_floating_drawing_toolbar)
+    toolbar_source = inspect.getsource(toolbar_view._build_toolbar)
+
+    assert 'Marker Type' not in floating_source
+    assert 'MARKER_TYPE_FILTER_LABELS' in toolbar_source
+    assert 'token_section = _create_collapsible_section(toolbar, "Tokens")' in toolbar_source


### PR DESCRIPTION
### Motivation
- Improve map tool UX by making the Rectangle/Oval shape selector vertical to better match the floating palette layout and to free space in the floating Tokens section. 
- Keep the `Marker Type` filter persistent and always visible by moving it from the floating palette into the main Map Tool top toolbar.

### Description
- Stacked the shape selector buttons vertically by changing the button packing in `modules/maps/views/floating_toolbar/shape_selector.py` from `side="left"` to `side="top", anchor="w"` so shape toggle is top/down instead of left/right. 
- Removed the `Marker Type` filter widgets from the floating palette in `modules/maps/views/floating_drawing_toolbar.py`. 
- Added a persistent `Tokens` section with the `Marker Type` `CTkOptionMenu` (using `MARKER_TYPE_FILTER_LABELS`) to the top toolbar in `modules/maps/views/toolbar_view.py` and added the required import. 
- Added regression tests in `tests/maps/test_floating_toolbar_compact_controls.py` to assert the vertical packing and the relocation of the marker filter.

### Testing
- Ran `python -m pytest tests/maps/test_floating_toolbar_compact_controls.py -q` and the test file passed (`5 passed`).
- Ran `python -m compileall -q modules/maps/views tests/maps/test_floating_toolbar_compact_controls.py` which succeeded with no syntax errors. 
- Ran `git diff --check` and no whitespace or diff errors were reported. 
- Running the entire `tests/maps` with `python -m pytest tests/maps -q` failed during collection due to a missing environment dependency (`PIL.ImageFont` unavailable), which is unrelated to these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce72c6bf0832b8810d61837d97f8e)