### PR TITLE
Center floating map toolbar icons and labels

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -6242,13 +6242,13 @@ class DisplayMapController:
 
                 shape_controls_row = getattr(self, "shape_controls_row", None)
                 if shape_controls_row:
-                    shape_controls_row.pack(side="top", fill="x", anchor="w", padx=(6, 2), pady=4)
+                    shape_controls_row.pack(side="top", fill="x", padx=(6, 2), pady=4)
 
                 # Repack in desired order without 'before'
-                if shape_fill_label: shape_fill_label.pack(side="top", anchor="w", padx=0, pady=(2, 1))
-                if shape_fill_mode_menu: shape_fill_mode_menu.pack(side="top", anchor="w", padx=0, pady=(0, 4))
-                if shape_fill_color_button: shape_fill_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
-                if shape_border_color_button: shape_border_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+                if shape_fill_label: shape_fill_label.pack(side="top", fill="x", padx=0, pady=(2, 1))
+                if shape_fill_mode_menu: shape_fill_mode_menu.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+                if shape_fill_color_button: shape_fill_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+                if shape_border_color_button: shape_border_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
             elif whiteboard_active:
                 # Continue with this path when whiteboard active is set.
                 shape_controls_row = getattr(self, "shape_controls_row", None)
@@ -6266,8 +6266,8 @@ class DisplayMapController:
                     except Exception:
                         pass
                 if whiteboard_controls_frame:
-                    whiteboard_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
-                if whiteboard_color_button: whiteboard_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+                    whiteboard_controls_frame.pack(side="top", fill="x", padx=(8, 2), pady=4)
+                if whiteboard_color_button: whiteboard_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
                 if whiteboard_width_slider:
                     try:
                         whiteboard_width_slider.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
@@ -6305,7 +6305,7 @@ class DisplayMapController:
                 if text_controls_frame:
                     text_controls_frame.pack_forget()
                 if eraser_controls_frame:
-                    eraser_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
+                    eraser_controls_frame.pack(side="top", fill="x", padx=(8, 2), pady=4)
                 if eraser_slider:
                     try:
                         eraser_slider.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
@@ -6330,15 +6330,15 @@ class DisplayMapController:
                 if eraser_controls_frame:
                     eraser_controls_frame.pack_forget()
                 if text_controls_frame:
-                    text_controls_frame.pack(side="top", fill="x", anchor="w", padx=(8, 2), pady=4)
+                    text_controls_frame.pack(side="top", fill="x", padx=(8, 2), pady=4)
                 if text_size_menu:
                     try:
-                        text_size_menu.master.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+                        text_size_menu.master.pack(side="top", fill="x", padx=0, pady=(0, 4))
                     except Exception:
                         pass
                 if text_color_button:
                     try:
-                        text_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+                        text_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
                     except tk.TclError:
                         pass
             else:

--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -143,7 +143,7 @@ def _build_floating_drawing_toolbar(self):
     ]
     fog_row = _row(fog_body)
     fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add", button_size=(24, 24), show_arrow=False)
-    fog_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
+    fog_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
     self._fog_buttons.update(fog_dropdown.option_buttons)
     self._fog_dropdown = fog_dropdown
 
@@ -187,11 +187,11 @@ def _build_floating_drawing_toolbar(self):
         self.whiteboard_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
     except tk.TclError:
         pass
-    self.whiteboard_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+    self.whiteboard_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
 
     width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
     width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
-    ctk.CTkLabel(width_container, text="Width", text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(0, 2))
+    ctk.CTkLabel(width_container, text="Width", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
     self.whiteboard_width_slider = ctk.CTkSlider(
         width_container,
         from_=1,
@@ -204,11 +204,11 @@ def _build_floating_drawing_toolbar(self):
     self.whiteboard_width_slider.set(current_width)
     self.whiteboard_width_slider.pack(side="top", fill="x", padx=0)
     self.whiteboard_width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)), text_color=TEXT_MUTED)
-    self.whiteboard_width_value_label.pack(side="top", anchor="e", padx=0)
+    self.whiteboard_width_value_label.pack(side="top", fill="x", padx=0)
 
     text_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.text_controls_frame = text_controls
-    ctk.CTkLabel(text_controls, text="Text Size", text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(0, 2))
+    ctk.CTkLabel(text_controls, text="Text Size", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
     text_sizes = getattr(self, "text_size_options", [16, 20, 24, 32, 40])
     current_text_size = int(getattr(self, "text_size", text_sizes[0] if text_sizes else 24))
     if current_text_size not in text_sizes:
@@ -220,7 +220,7 @@ def _build_floating_drawing_toolbar(self):
         command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
     )
     self.text_size_menu.set(str(current_text_size))
-    self.text_size_menu.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+    self.text_size_menu.pack(side="top", anchor="center", padx=0, pady=(0, 4))
 
     self.text_color_button = ctk.CTkButton(
         text_controls,
@@ -232,13 +232,13 @@ def _build_floating_drawing_toolbar(self):
         self.text_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
     except tk.TclError:
         pass
-    self.text_color_button.pack(side="top", anchor="w", padx=0, pady=(0, 4))
+    self.text_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
 
     eraser_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
     self.eraser_controls_frame = eraser_controls
     eraser_width_container = ctk.CTkFrame(eraser_controls, fg_color="transparent")
     eraser_width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
-    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(0, 2))
+    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
     self.whiteboard_eraser_slider = ctk.CTkSlider(
         eraser_width_container,
         from_=2,
@@ -255,7 +255,7 @@ def _build_floating_drawing_toolbar(self):
         text=str(int(round(current_eraser_radius))),
         text_color=TEXT_MUTED,
     )
-    self.eraser_radius_value_label.pack(side="top", anchor="e", padx=0)
+    self.eraser_radius_value_label.pack(side="top", fill="x", padx=0)
 
     tokens_body = _section("Tokens")
     token_actions = [
@@ -265,7 +265,7 @@ def _build_floating_drawing_toolbar(self):
         {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": self.add_marker},
     ]
     token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc", button_size=(24, 24), show_arrow=False)
-    token_dropdown.pack(side="top", anchor="w", padx=0, pady=3)
+    token_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
 
     token_size_options = list(getattr(self, "token_size_options", list(range(16, 129, 8))))
     current_token_size = int(getattr(self, "token_size", token_size_options[0] if token_size_options else 48))

--- a/modules/maps/views/floating_toolbar/layout.py
+++ b/modules/maps/views/floating_toolbar/layout.py
@@ -15,7 +15,7 @@ def create_section(parent, title):
     section = ctk.CTkFrame(parent, fg_color=SECTION_BG, border_width=1, border_color="#303030", corner_radius=9)
     section.pack(side="top", fill="x", padx=0, pady=(3, 0))
     ctk.CTkLabel(section, text=title, text_color=TEXT_MUTED, font=ctk.CTkFont(size=11, weight="bold")).pack(
-        side="top", anchor="w", padx=5, pady=(4, 0)
+        side="top", fill="x", padx=5, pady=(4, 0)
     )
     body = ctk.CTkFrame(section, fg_color="transparent")
     body.pack(side="top", fill="x", padx=4, pady=(1, 5))
@@ -25,18 +25,18 @@ def create_section(parent, title):
 def create_row(parent):
     """Create a full-width row in the toolbar's single column."""
     row = ctk.CTkFrame(parent, fg_color="transparent")
-    row.pack(side="top", fill="x", anchor="w", pady=1)
+    row.pack(side="top", fill="x", pady=1)
     return row
 
 
 def add_small_label(parent, text):
     """Add a muted label above a control."""
-    ctk.CTkLabel(parent, text=text, text_color=TEXT_MUTED).pack(side="top", anchor="w", padx=0, pady=(2, 0))
+    ctk.CTkLabel(parent, text=text, text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(2, 0))
 
 
 def add_stacked_control(parent, label, widget, *, pady=(0, 4)):
     """Place a label and a naturally-sized widget in the toolbar column."""
     row = create_row(parent)
     add_small_label(row, label)
-    widget.pack(side="top", anchor="w", padx=0, pady=pady)
+    widget.pack(side="top", anchor="center", padx=0, pady=pady)
     return row

--- a/modules/maps/views/floating_toolbar/shape_selector.py
+++ b/modules/maps/views/floating_toolbar/shape_selector.py
@@ -51,7 +51,7 @@ class ShapeIconSelector(ctk.CTkFrame):
                 command=lambda selected=value: self.set(selected),
                 **self._DEFAULT_STYLE,
             )
-            button.pack(side="top", anchor="w", padx=0, pady=(0, 3))
+            button.pack(side="top", anchor="center", padx=0, pady=(0, 3))
             self._buttons[value] = button
             ToolTip(button, tooltip)
 
@@ -78,5 +78,5 @@ def add_shape_icon_selector(parent: tk.Misc, command: Callable[[str], None]) -> 
     row = create_row(parent)
     add_small_label(row, "Shape")
     selector = ShapeIconSelector(row, command)
-    selector.pack(side="top", anchor="w", padx=0, pady=(0, 1))
+    selector.pack(side="top", anchor="center", padx=0, pady=(0, 1))
     return selector

--- a/modules/maps/views/floating_toolbar/slim_option_menu.py
+++ b/modules/maps/views/floating_toolbar/slim_option_menu.py
@@ -52,7 +52,7 @@ def hide_option_menu_arrow(menu: ctk.CTkOptionMenu) -> None:
         fg_color = menu.cget("fg_color")
         hover_color = menu.cget("fg_color")
         menu.configure(
-            anchor="w",
+            anchor="center",
             button_color=fg_color,
             button_hover_color=hover_color,
             dropdown_font=ctk.CTkFont(size=CONTROL_FONT_SIZE),
@@ -73,7 +73,7 @@ def _expand_text_label(menu: ctk.CTkOptionMenu) -> None:
         return
     try:
         label.grid_configure(column=0, columnspan=2, sticky="ew", padx=(6, 6))
-        label.configure(anchor="w")
+        label.configure(anchor="center")
     except tk.TclError:
         return
 

--- a/tests/maps/test_floating_toolbar_compact_controls.py
+++ b/tests/maps/test_floating_toolbar_compact_controls.py
@@ -52,3 +52,39 @@ def test_marker_type_filter_moved_from_floating_palette_to_top_toolbar():
     assert 'Marker Type' not in floating_source
     assert 'MARKER_TYPE_FILTER_LABELS' in toolbar_source
     assert 'token_section = _create_collapsible_section(toolbar, "Tokens")' in toolbar_source
+
+
+def test_floating_toolbar_layout_helpers_center_content():
+    import inspect
+
+    from modules.maps.views.floating_toolbar import layout
+
+    layout_source = inspect.getsource(layout)
+
+    assert 'anchor="center"' in layout_source
+    assert 'anchor="w"' not in layout_source
+    assert 'fill="x", padx=5' in layout_source
+
+
+def test_slim_option_menu_centers_display_text():
+    import inspect
+
+    from modules.maps.views.floating_toolbar import slim_option_menu
+
+    source = inspect.getsource(slim_option_menu.hide_option_menu_arrow)
+    label_source = inspect.getsource(slim_option_menu._expand_text_label)
+
+    assert 'anchor="center"' in source
+    assert 'label.configure(anchor="center")' in label_source
+
+
+def test_floating_toolbar_dynamic_controls_repack_centered():
+    from pathlib import Path
+
+    source = Path("modules/maps/controllers/display_map_controller.py").read_text()
+    visibility_source = source.split("def _update_shape_controls_visibility", 1)[1].split(
+        "# Method assignments", 1
+    )[0]
+
+    assert 'anchor="center"' in visibility_source
+    assert 'anchor="w"' not in visibility_source


### PR DESCRIPTION
### Motivation
- Ensure the float-bar UI for the MapTool reads clearly by centering icons, compact option text and stacked labels so controls look visually balanced in narrow floating palettes.
- Keep dynamic control repacking (shape / whiteboard / eraser / text) consistent so they remain centered when the active drawing tool changes.

### Description
- Center-aligned layout primitives in `modules/maps/views/floating_toolbar/layout.py` so section titles and small labels fill the width and stacked widgets are packed centered instead of left-aligned.
- Centered shape selector buttons and its container in `modules/maps/views/floating_toolbar/shape_selector.py` by changing the `pack(..., anchor=...)` calls to use `anchor="center"`.
- Adjusted compact option-menu handling in `modules/maps/views/floating_toolbar/slim_option_menu.py` to use `anchor="center"` and set the internal text label anchor to center so displayed text occupies the full control area.
- Centered several floating toolbar controls in `modules/maps/views/floating_drawing_toolbar.py` (fog/token `IconDropdown` collapsed button, whiteboard/text controls and value labels, eraser labels/value) to align icons/labels in the float bar.
- Updated dynamic repacking in `modules/maps/controllers/display_map_controller.py` (`_update_shape_controls_visibility`) to remove left anchors and use `fill="x"` / `anchor="center"` where appropriate so controls stay centered when visibility changes.
- Added regression tests to `tests/maps/test_floating_toolbar_compact_controls.py` that assert the new centered packing/configuration for layout helpers, slim option menu internals, and the dynamic repacking code.

### Testing
- Ran `pytest tests/maps/test_floating_toolbar_compact_controls.py`, which reported `8 passed`.
- Verified syntax/bytecode with `python -m py_compile` on the modified modules and the updated test file, which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce8a21ba8832bbcf82ea772b18fea)