### PR TITLE
Add WorldMap floating drawing palette and split floating toolbar builders

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -25,7 +25,7 @@ from modules.maps.views.toolbar_view import (
     _update_fog_button_states,
 )
 from modules.maps.views.canvas_view import _build_canvas, _on_delete_key
-from modules.maps.views.floating_drawing_toolbar import _build_floating_drawing_toolbar
+from modules.maps.views.floating_drawing_toolbar import build_maptool_floating_drawing_toolbar
 from modules.maps.services.fog_manager import (
     _set_fog,
     clear_fog,
@@ -6377,7 +6377,7 @@ class DisplayMapController:
     # Method assignments (some will be replaced by generic item handlers)
     _build_canvas = _build_canvas
     _build_toolbar = _build_toolbar
-    _build_floating_drawing_toolbar = _build_floating_drawing_toolbar
+    _build_floating_drawing_toolbar = build_maptool_floating_drawing_toolbar
     _change_brush = _change_brush # For fog brush
     _change_token_border_color = _change_token_border_color # Specific to tokens via old menu
     

--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -1,12 +1,12 @@
-"""Floating drawing and fog palette for map canvas."""
+"""Floating drawing and fog palettes for map canvases."""
 
 import tkinter as tk
 import customtkinter as ctk
 
 from modules.helpers.logging_helper import log_module_import
-from modules.ui.icon_dropdown import IconDropdown
-from modules.maps.views.floating_toolbar.slim_option_menu import create_slim_option_menu
-from modules.maps.views.floating_toolbar.shape_selector import add_shape_icon_selector
+from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
+from modules.maps.measurement.templates import MEASUREMENT_TEMPLATE_LABELS
+from modules.maps.utils.icon_loader import load_icon
 from modules.maps.views.floating_toolbar.layout import (
     BORDER,
     PALETTE_BG,
@@ -16,24 +16,27 @@ from modules.maps.views.floating_toolbar.layout import (
     create_row,
     create_section,
 )
+from modules.maps.views.floating_toolbar.shape_selector import add_shape_icon_selector
+from modules.maps.views.floating_toolbar.slim_option_menu import create_slim_option_menu
+from modules.ui.icon_dropdown import IconDropdown
 
 log_module_import(__name__)
 
-def _build_floating_drawing_toolbar(self):
-    """Build a compact floating palette for fog and drawing controls."""
-    host = getattr(self, "parent", None)
-    canvas = getattr(self, "canvas", None)
-    if host is None or canvas is None:
-        return None
 
-    existing = getattr(self, "floating_drawing_toolbar", None)
+def _destroy_existing_palette(owner):
+    """Destroy the currently attached floating palette, if any."""
+    existing = getattr(owner, "floating_drawing_toolbar", None)
     if existing is not None:
         try:
             existing.destroy()
         except tk.TclError:
             pass
 
-    slider_width = SLIDER_WIDTH
+
+def _create_floating_palette(owner, host, *, x=8, y=84, title="☰"):
+    """Create a draggable floating palette attached to *host*."""
+    _destroy_existing_palette(owner)
+
     palette = ctk.CTkFrame(
         host,
         fg_color=PALETTE_BG,
@@ -41,16 +44,16 @@ def _build_floating_drawing_toolbar(self):
         border_color=BORDER,
         corner_radius=12,
     )
-    self.floating_drawing_toolbar = palette
+    owner.floating_drawing_toolbar = palette
 
     header = ctk.CTkFrame(palette, fg_color="#242424", corner_radius=10)
     header.pack(side="top", fill="x", padx=4, pady=(4, 2))
-    handle = ctk.CTkLabel(header, text="☰", text_color=TEXT_MUTED, cursor="fleur")
+    handle = ctk.CTkLabel(header, text=title, text_color=TEXT_MUTED, cursor="fleur")
     handle.pack(side="left", padx=(6, 4), pady=3)
 
     content = ctk.CTkFrame(palette, fg_color="transparent")
     content.pack(side="top", fill="both", expand=True, padx=4, pady=(0, 4))
-    self.floating_drawing_toolbar_content = content
+    owner.floating_drawing_toolbar_content = content
 
     collapsed = tk.BooleanVar(value=False)
 
@@ -98,226 +101,346 @@ def _build_floating_drawing_toolbar(self):
         draggable.bind("<ButtonPress-1>", _drag_start)
         draggable.bind("<B1-Motion>", _drag_motion)
 
-    def _section(title):
-        return create_section(content, title)
-
-    def _row(parent):
-        return create_row(parent)
-
-    def _stacked_control(parent, label, widget, *, pady=(0, 4)):
-        return add_stacked_control(parent, label, widget, pady=pady)
-
-    icons = {
-        "add": self.load_icon("assets/icons/brush.png", (24, 24)),
-        "rem": self.load_icon("assets/icons/eraser.png", (24, 24)),
-        "clear": self.load_icon("assets/icons/empty.png", (24, 24)),
-        "reset": self.load_icon("assets/icons/full.png", (24, 24)),
-        "npc": self.load_icon("assets/icons/npc.png", (24, 24)),
-        "creat": self.load_icon("assets/icons/creature.png", (24, 24)),
-        "pc": self.load_icon("assets/icons/pc.png", (24, 24)),
-        "marker": self.load_icon("assets/icons/marker.png", (24, 24)),
-    }
-
-    self._fog_button_default_style = {
-        "fg_color": "#0077CC",
-        "hover_color": "#005fa3",
-        "border_color": "#005fa3",
-        "border_width": 1,
-    }
-    self._fog_button_active_style = {
-        "fg_color": "#004c80",
-        "hover_color": "#004c80",
-        "border_color": "#d7263d",
-        "border_width": 3,
-    }
-    self._fog_buttons = {}
-
-    fog_body = _section("Fog")
-    fog_actions = [
-        {"key": "add", "icon": icons["add"], "tooltip": "Add Fog", "command": lambda: self._set_fog("add")},
-        {"key": "rem", "icon": icons["rem"], "tooltip": "Remove Fog", "command": lambda: self._set_fog("rem")},
-        {"key": "add_rect", "icon": icons["add"], "tooltip": "Add Fog Rectangle", "command": lambda: self._set_fog("add_rect")},
-        {"key": "rem_rect", "icon": icons["rem"], "tooltip": "Remove Fog Rectangle", "command": lambda: self._set_fog("rem_rect")},
-        {"key": "clear", "icon": icons["clear"], "tooltip": "Clear Fog", "command": self.clear_fog},
-        {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": self.reset_fog},
-    ]
-    fog_row = _row(fog_body)
-    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add", button_size=(24, 24), show_arrow=False)
-    fog_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
-    self._fog_buttons.update(fog_dropdown.option_buttons)
-    self._fog_dropdown = fog_dropdown
-
-    self.shape_menu = add_shape_icon_selector(fog_body, self._on_brush_shape_change)
-
-    brush_size_options = list(getattr(self, "brush_size_options", list(range(4, 129, 4))))
-    current_brush_size = int(getattr(self, "brush_size", brush_size_options[0] if brush_size_options else 32))
-    if current_brush_size not in brush_size_options:
-        brush_size_options.append(current_brush_size)
-        brush_size_options = sorted(set(brush_size_options))
-    self.brush_size_options = list(brush_size_options)
-    self.brush_size_menu = create_slim_option_menu(
-        fog_body,
-        values=[str(size) for size in self.brush_size_options],
-        command=self._on_brush_size_change,
-    )
-    self.brush_size_menu.set(str(current_brush_size))
-    _stacked_control(fog_body, "Size", self.brush_size_menu)
-
-    tools_body = _section("Tools")
-    drawing_tools = ["Token", "Rectangle", "Oval", "Text", "Whiteboard", "Eraser"]
-    self.drawing_tool_menu = create_slim_option_menu(
-        tools_body,
-        values=drawing_tools,
-        command=self._on_drawing_tool_change,
-    )
-    current_tool = self.drawing_mode.capitalize() if hasattr(self, "drawing_mode") else "Token"
-    self.drawing_tool_menu.set(current_tool if current_tool in drawing_tools else "Token")
-    _stacked_control(tools_body, "Tool", self.drawing_tool_menu)
-
-    whiteboard_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
-    self.whiteboard_controls_frame = whiteboard_controls
-
-    self.whiteboard_color_button = ctk.CTkButton(
-        whiteboard_controls,
-        text="Ink Color",
-        width=70,
-        command=self._on_pick_whiteboard_color,
-    )
-    try:
-        self.whiteboard_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
-    except tk.TclError:
-        pass
-    self.whiteboard_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
-
-    width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
-    width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
-    ctk.CTkLabel(width_container, text="Width", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
-    self.whiteboard_width_slider = ctk.CTkSlider(
-        width_container,
-        from_=1,
-        to=20,
-        number_of_steps=19,
-        command=self._on_whiteboard_width_change,
-        width=slider_width,
-    )
-    current_width = float(getattr(self, "whiteboard_width", 4))
-    self.whiteboard_width_slider.set(current_width)
-    self.whiteboard_width_slider.pack(side="top", fill="x", padx=0)
-    self.whiteboard_width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)), text_color=TEXT_MUTED)
-    self.whiteboard_width_value_label.pack(side="top", fill="x", padx=0)
-
-    text_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
-    self.text_controls_frame = text_controls
-    ctk.CTkLabel(text_controls, text="Text Size", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
-    text_sizes = getattr(self, "text_size_options", [16, 20, 24, 32, 40])
-    current_text_size = int(getattr(self, "text_size", text_sizes[0] if text_sizes else 24))
-    if current_text_size not in text_sizes:
-        text_sizes = sorted(set(list(text_sizes) + [current_text_size]))
-    self.text_size_options = list(text_sizes)
-    self.text_size_menu = create_slim_option_menu(
-        text_controls,
-        values=[str(size) for size in self.text_size_options],
-        command=getattr(self, "_on_text_size_change", None) or (lambda _v: None),
-    )
-    self.text_size_menu.set(str(current_text_size))
-    self.text_size_menu.pack(side="top", anchor="center", padx=0, pady=(0, 4))
-
-    self.text_color_button = ctk.CTkButton(
-        text_controls,
-        text="Text Color",
-        width=76,
-        command=self._on_pick_whiteboard_color,
-    )
-    try:
-        self.text_color_button.configure(fg_color=getattr(self, "whiteboard_color", "#FF0000"))
-    except tk.TclError:
-        pass
-    self.text_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
-
-    eraser_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
-    self.eraser_controls_frame = eraser_controls
-    eraser_width_container = ctk.CTkFrame(eraser_controls, fg_color="transparent")
-    eraser_width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
-    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
-    self.whiteboard_eraser_slider = ctk.CTkSlider(
-        eraser_width_container,
-        from_=2,
-        to=40,
-        number_of_steps=38,
-        command=getattr(self, "_on_eraser_radius_change", None) or (lambda _v: None),
-        width=slider_width,
-    )
-    current_eraser_radius = float(getattr(self, "whiteboard_eraser_radius", 8))
-    self.whiteboard_eraser_slider.set(current_eraser_radius)
-    self.whiteboard_eraser_slider.pack(side="top", fill="x", padx=0)
-    self.eraser_radius_value_label = ctk.CTkLabel(
-        eraser_width_container,
-        text=str(int(round(current_eraser_radius))),
-        text_color=TEXT_MUTED,
-    )
-    self.eraser_radius_value_label.pack(side="top", fill="x", padx=0)
-
-    tokens_body = _section("Tokens")
-    token_actions = [
-        {"key": "creature", "icon": icons["creat"], "tooltip": "Add Creature", "command": lambda: self.open_entity_picker("Creature")},
-        {"key": "npc", "icon": icons["npc"], "tooltip": "Add NPC", "command": lambda: self.open_entity_picker("NPC")},
-        {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: self.open_entity_picker("PC")},
-        {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": self.add_marker},
-    ]
-    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc", button_size=(24, 24), show_arrow=False)
-    token_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
-
-    token_size_options = list(getattr(self, "token_size_options", list(range(16, 129, 8))))
-    current_token_size = int(getattr(self, "token_size", token_size_options[0] if token_size_options else 48))
-    if current_token_size not in token_size_options:
-        token_size_options.append(current_token_size)
-        token_size_options = sorted(set(token_size_options))
-    self.token_size_options = list(token_size_options)
-    self.token_size_menu = create_slim_option_menu(
-        tokens_body,
-        values=[str(size) for size in self.token_size_options],
-        command=self._on_token_size_change,
-    )
-    self.token_size_menu.set(str(current_token_size))
-    _stacked_control(tokens_body, "Size", self.token_size_menu)
-
-    shape_controls_row = ctk.CTkFrame(tools_body, fg_color="transparent")
-    self.shape_controls_row = shape_controls_row
-    self.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill", text_color=TEXT_MUTED)
-    self.shape_fill_mode_menu = create_slim_option_menu(
-        shape_controls_row,
-        values=["Filled", "Border Only"],
-        command=self._on_shape_fill_mode_change,
-    )
-    self.shape_fill_mode_menu.set("Filled" if hasattr(self, "shape_is_filled") and self.shape_is_filled else "Border Only")
-    self.shape_fill_color_button = ctk.CTkButton(
-        shape_controls_row,
-        text="Fill Color",
-        width=70,
-        command=self._on_pick_shape_fill_color,
-    )
-    self.shape_border_color_button = ctk.CTkButton(
-        shape_controls_row,
-        text="Border Color",
-        width=88,
-        command=self._on_pick_shape_border_color,
-    )
-
-    try:
-        toolbar_height = int(getattr(self, "_toolbar_container", host).winfo_height())
-    except Exception:
-        toolbar_height = 0
-    if toolbar_height <= 1:
-        toolbar_height = 72
-    palette.place(relx=0, x=8, y=toolbar_height + 12, anchor="nw")
+    palette.place(relx=0, x=x, y=y, anchor="nw")
     try:
         palette.lift()
     except tk.TclError:
         pass
 
-    if hasattr(self, "_update_shape_controls_visibility"):
-        self._update_shape_controls_visibility()
-    if hasattr(self, "_update_fog_button_states"):
-        self._update_fog_button_states()
+    return palette, content
+
+
+def _load_icon(owner, path, size):
+    """Load an icon for either the MapTool controller or the WorldMap panel."""
+    loader = getattr(owner, "load_icon", None)
+    if callable(loader):
+        return loader(path, size)
+    return load_icon(owner, path, size)
+
+
+def _build_fog_controls(owner, parent, icons, *, include_global_actions):
+    """Add fog brush controls to the floating palette."""
+    owner._fog_button_default_style = {
+        "fg_color": "#0077CC",
+        "hover_color": "#005fa3",
+        "border_color": "#005fa3",
+        "border_width": 1,
+    }
+    owner._fog_button_active_style = {
+        "fg_color": "#004c80",
+        "hover_color": "#004c80",
+        "border_color": "#d7263d",
+        "border_width": 3,
+    }
+    owner._fog_buttons = {}
+
+    fog_body = create_section(parent, "Fog")
+    fog_actions = [
+        {"key": "add", "icon": icons["add"], "tooltip": "Add Fog", "command": lambda: owner._set_fog("add")},
+        {"key": "rem", "icon": icons["rem"], "tooltip": "Remove Fog", "command": lambda: owner._set_fog("rem")},
+        {"key": "add_rect", "icon": icons["add"], "tooltip": "Add Fog Rectangle", "command": lambda: owner._set_fog("add_rect")},
+        {"key": "rem_rect", "icon": icons["rem"], "tooltip": "Remove Fog Rectangle", "command": lambda: owner._set_fog("rem_rect")},
+    ]
+    if include_global_actions:
+        fog_actions.extend(
+            [
+                {"key": "clear", "icon": icons["clear"], "tooltip": "Clear Fog", "command": owner.clear_fog},
+                {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": owner.reset_fog},
+            ]
+        )
+
+    fog_row = create_row(fog_body)
+    fog_dropdown = IconDropdown(fog_row, fog_actions, default_key="add", button_size=(24, 24), show_arrow=False)
+    fog_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
+    owner._fog_buttons.update(fog_dropdown.option_buttons)
+    owner._fog_dropdown = fog_dropdown
+
+    owner.shape_menu = add_shape_icon_selector(fog_body, owner._on_brush_shape_change)
+
+    brush_size_options = list(getattr(owner, "brush_size_options", list(range(4, 129, 4))))
+    current_brush_size = int(getattr(owner, "brush_size", brush_size_options[0] if brush_size_options else 32))
+    if current_brush_size not in brush_size_options:
+        brush_size_options.append(current_brush_size)
+        brush_size_options = sorted(set(brush_size_options))
+    owner.brush_size_options = list(brush_size_options)
+    owner.brush_size_menu = create_slim_option_menu(
+        fog_body,
+        values=[str(size) for size in owner.brush_size_options],
+        command=owner._on_brush_size_change,
+    )
+    owner.brush_size_menu.set(str(current_brush_size))
+    add_stacked_control(fog_body, "Size", owner.brush_size_menu)
+
+
+def _build_measurement_controls(panel, parent):
+    """Add WorldMap measurement controls to the floating palette."""
+    measure_body = create_section(parent, "Measure")
+    panel.measure_template_menu = create_slim_option_menu(
+        measure_body,
+        values=MEASUREMENT_TEMPLATE_LABELS,
+        command=getattr(panel, "_on_measure_template_change", None) or (lambda _v: None),
+    )
+    panel.measure_template_menu.set(getattr(panel, "measure_template_label", "Line"))
+    add_stacked_control(measure_body, "Template", panel.measure_template_menu)
+
+    panel.measure_button = ctk.CTkButton(
+        measure_body,
+        text="Measure",
+        width=76,
+        command=getattr(panel, "_toggle_measure_mode", None) or (lambda: None),
+    )
+    panel.measure_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+
+    panel.measure_cell_entry = ctk.CTkEntry(measure_body, width=76, justify="center")
+    panel.measure_cell_entry.insert(0, str(int(getattr(panel, "measure_grid_cell_pixels", 50))))
+    add_stacked_control(measure_body, "Cell px", panel.measure_cell_entry)
+
+    panel.measure_scale_entry = ctk.CTkEntry(measure_body, width=76, justify="center")
+    panel.measure_scale_entry.insert(0, str(int(getattr(panel, "measure_grid_scale", 5))))
+    add_stacked_control(measure_body, "Scale", panel.measure_scale_entry)
+
+    panel.measure_unit_label = ctk.CTkLabel(measure_body, text=getattr(panel, "measure_unit", "m") + "/cell", text_color=TEXT_MUTED)
+    panel.measure_unit_label.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+
+    panel.clear_measurements_button = ctk.CTkButton(
+        measure_body,
+        text="Clear",
+        width=76,
+        command=getattr(panel, "clear_measurements", None) or (lambda: None),
+    )
+    panel.clear_measurements_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+
+
+def build_maptool_floating_drawing_toolbar(controller):
+    """Build the map-tool floating drawing palette."""
+    host = getattr(controller, "parent", None)
+    canvas = getattr(controller, "canvas", None)
+    if host is None or canvas is None:
+        return None
+
+    try:
+        toolbar_height = int(getattr(controller, "_toolbar_container", host).winfo_height())
+    except Exception:
+        toolbar_height = 0
+    if toolbar_height <= 1:
+        toolbar_height = 72
+
+    palette, content = _create_floating_palette(controller, host, y=toolbar_height + 12)
+    slider_width = SLIDER_WIDTH
+
+    icons = {
+        "add": _load_icon(controller, "assets/icons/brush.png", (24, 24)),
+        "rem": _load_icon(controller, "assets/icons/eraser.png", (24, 24)),
+        "clear": _load_icon(controller, "assets/icons/empty.png", (24, 24)),
+        "reset": _load_icon(controller, "assets/icons/full.png", (24, 24)),
+        "npc": _load_icon(controller, "assets/icons/npc.png", (24, 24)),
+        "creat": _load_icon(controller, "assets/icons/creature.png", (24, 24)),
+        "pc": _load_icon(controller, "assets/icons/pc.png", (24, 24)),
+        "marker": _load_icon(controller, "assets/icons/marker.png", (24, 24)),
+    }
+
+    _build_fog_controls(controller, content, icons, include_global_actions=True)
+
+    tools_body = create_section(content, "Tools")
+    drawing_tools = ["Token", "Rectangle", "Oval", "Text", "Whiteboard", "Eraser"]
+    controller.drawing_tool_menu = create_slim_option_menu(
+        tools_body,
+        values=drawing_tools,
+        command=controller._on_drawing_tool_change,
+    )
+    current_tool = controller.drawing_mode.capitalize() if hasattr(controller, "drawing_mode") else "Token"
+    controller.drawing_tool_menu.set(current_tool if current_tool in drawing_tools else "Token")
+    add_stacked_control(tools_body, "Tool", controller.drawing_tool_menu)
+
+    whiteboard_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
+    controller.whiteboard_controls_frame = whiteboard_controls
+
+    controller.whiteboard_color_button = ctk.CTkButton(
+        whiteboard_controls,
+        text="Ink Color",
+        width=70,
+        command=controller._on_pick_whiteboard_color,
+    )
+    try:
+        controller.whiteboard_color_button.configure(fg_color=getattr(controller, "whiteboard_color", "#FF0000"))
+    except tk.TclError:
+        pass
+    controller.whiteboard_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+
+    width_container = ctk.CTkFrame(whiteboard_controls, fg_color="transparent")
+    width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    ctk.CTkLabel(width_container, text="Width", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
+    controller.whiteboard_width_slider = ctk.CTkSlider(
+        width_container,
+        from_=1,
+        to=20,
+        number_of_steps=19,
+        command=controller._on_whiteboard_width_change,
+        width=slider_width,
+    )
+    current_width = float(getattr(controller, "whiteboard_width", 4))
+    controller.whiteboard_width_slider.set(current_width)
+    controller.whiteboard_width_slider.pack(side="top", fill="x", padx=0)
+    controller.whiteboard_width_value_label = ctk.CTkLabel(width_container, text=str(int(current_width)), text_color=TEXT_MUTED)
+    controller.whiteboard_width_value_label.pack(side="top", fill="x", padx=0)
+
+    text_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
+    controller.text_controls_frame = text_controls
+    ctk.CTkLabel(text_controls, text="Text Size", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
+    text_sizes = getattr(controller, "text_size_options", [16, 20, 24, 32, 40])
+    current_text_size = int(getattr(controller, "text_size", text_sizes[0] if text_sizes else 24))
+    if current_text_size not in text_sizes:
+        text_sizes = sorted(set(list(text_sizes) + [current_text_size]))
+    controller.text_size_options = list(text_sizes)
+    controller.text_size_menu = create_slim_option_menu(
+        text_controls,
+        values=[str(size) for size in controller.text_size_options],
+        command=getattr(controller, "_on_text_size_change", None) or (lambda _v: None),
+    )
+    controller.text_size_menu.set(str(current_text_size))
+    controller.text_size_menu.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+
+    controller.text_color_button = ctk.CTkButton(
+        text_controls,
+        text="Text Color",
+        width=76,
+        command=controller._on_pick_whiteboard_color,
+    )
+    try:
+        controller.text_color_button.configure(fg_color=getattr(controller, "whiteboard_color", "#FF0000"))
+    except tk.TclError:
+        pass
+    controller.text_color_button.pack(side="top", anchor="center", padx=0, pady=(0, 4))
+
+    eraser_controls = ctk.CTkFrame(tools_body, fg_color="transparent")
+    controller.eraser_controls_frame = eraser_controls
+    eraser_width_container = ctk.CTkFrame(eraser_controls, fg_color="transparent")
+    eraser_width_container.pack(side="top", fill="x", padx=0, pady=(0, 4))
+    ctk.CTkLabel(eraser_width_container, text="Radius", text_color=TEXT_MUTED).pack(side="top", fill="x", padx=0, pady=(0, 2))
+    controller.whiteboard_eraser_slider = ctk.CTkSlider(
+        eraser_width_container,
+        from_=2,
+        to=40,
+        number_of_steps=38,
+        command=getattr(controller, "_on_eraser_radius_change", None) or (lambda _v: None),
+        width=slider_width,
+    )
+    current_eraser_radius = float(getattr(controller, "whiteboard_eraser_radius", 8))
+    controller.whiteboard_eraser_slider.set(current_eraser_radius)
+    controller.whiteboard_eraser_slider.pack(side="top", fill="x", padx=0)
+    controller.eraser_radius_value_label = ctk.CTkLabel(
+        eraser_width_container,
+        text=str(int(round(current_eraser_radius))),
+        text_color=TEXT_MUTED,
+    )
+    controller.eraser_radius_value_label.pack(side="top", fill="x", padx=0)
+
+    tokens_body = create_section(content, "Tokens")
+    token_actions = [
+        {"key": "creature", "icon": icons["creat"], "tooltip": "Add Creature", "command": lambda: controller.open_entity_picker("Creature")},
+        {"key": "npc", "icon": icons["npc"], "tooltip": "Add NPC", "command": lambda: controller.open_entity_picker("NPC")},
+        {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: controller.open_entity_picker("PC")},
+        {"key": "marker", "icon": icons["marker"], "tooltip": "Add Marker", "command": controller.add_marker},
+    ]
+    token_dropdown = IconDropdown(tokens_body, token_actions, default_key="npc", button_size=(24, 24), show_arrow=False)
+    token_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
+
+    token_size_options = list(getattr(controller, "token_size_options", list(range(16, 129, 8))))
+    current_token_size = int(getattr(controller, "token_size", token_size_options[0] if token_size_options else 48))
+    if current_token_size not in token_size_options:
+        token_size_options.append(current_token_size)
+        token_size_options = sorted(set(token_size_options))
+    controller.token_size_options = list(token_size_options)
+    controller.token_size_menu = create_slim_option_menu(
+        tokens_body,
+        values=[str(size) for size in controller.token_size_options],
+        command=controller._on_token_size_change,
+    )
+    controller.token_size_menu.set(str(current_token_size))
+    add_stacked_control(tokens_body, "Size", controller.token_size_menu)
+
+    shape_controls_row = ctk.CTkFrame(tools_body, fg_color="transparent")
+    controller.shape_controls_row = shape_controls_row
+    controller.shape_fill_label = ctk.CTkLabel(shape_controls_row, text="Shape Fill", text_color=TEXT_MUTED)
+    controller.shape_fill_mode_menu = create_slim_option_menu(
+        shape_controls_row,
+        values=["Filled", "Border Only"],
+        command=controller._on_shape_fill_mode_change,
+    )
+    controller.shape_fill_mode_menu.set("Filled" if hasattr(controller, "shape_is_filled") and controller.shape_is_filled else "Border Only")
+    controller.shape_fill_color_button = ctk.CTkButton(
+        shape_controls_row,
+        text="Fill Color",
+        width=70,
+        command=controller._on_pick_shape_fill_color,
+    )
+    controller.shape_border_color_button = ctk.CTkButton(
+        shape_controls_row,
+        text="Border Color",
+        width=88,
+        command=controller._on_pick_shape_border_color,
+    )
+
+    if hasattr(controller, "_update_shape_controls_visibility"):
+        controller._update_shape_controls_visibility()
+    if hasattr(controller, "_update_fog_button_states"):
+        controller._update_fog_button_states()
 
     return palette
+
+
+def build_world_map_floating_tools(panel):
+    """Build the WorldMap floating tools attached to the canvas surface."""
+    host = getattr(panel, "canvas_container", None)
+    canvas = getattr(panel, "canvas", None)
+    if host is None or canvas is None:
+        return None
+
+    palette, content = _create_floating_palette(panel, host, x=20, y=20)
+    icons = {
+        "add": _load_icon(panel, "assets/icons/brush.png", (24, 24)),
+        "rem": _load_icon(panel, "assets/icons/eraser.png", (24, 24)),
+        "clear": _load_icon(panel, "assets/icons/empty.png", (24, 24)),
+        "reset": _load_icon(panel, "assets/icons/full.png", (24, 24)),
+        "npc": _load_icon(panel, "assets/icons/npc.png", (24, 24)),
+        "creat": _load_icon(panel, "assets/icons/creature.png", (24, 24)),
+        "pc": _load_icon(panel, "assets/icons/pc.png", (24, 24)),
+        "marker": _load_icon(panel, "assets/icons/marker.png", (24, 24)),
+    }
+
+    _build_fog_controls(panel, content, icons, include_global_actions=False)
+    _build_measurement_controls(panel, content)
+
+    entities_body = create_section(content, "Entities")
+    entity_actions = [
+        {"key": "npc", "icon": icons["npc"], "tooltip": "Add NPC", "command": lambda: panel._open_picker("NPC")},
+        {"key": "pc", "icon": icons["pc"], "tooltip": "Add PC", "command": lambda: panel._open_picker("PC")},
+        {"key": "creature", "icon": icons["creat"], "tooltip": "Add Creature", "command": lambda: panel._open_picker("Creature")},
+        {"key": "base", "icon": icons["marker"], "tooltip": "Add Base", "command": lambda: panel._open_picker("Base")},
+        {"key": "place", "icon": icons["marker"], "tooltip": "Add Place", "command": lambda: panel._open_picker("Place")},
+        {"key": "map", "icon": icons["marker"], "tooltip": "Add Map", "command": lambda: panel._open_picker("Map")},
+    ]
+    entity_dropdown = IconDropdown(entities_body, entity_actions, default_key="npc", button_size=(24, 24), show_arrow=False)
+    entity_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
+
+    panel.marker_type_filter_menu = create_slim_option_menu(
+        entities_body,
+        values=MARKER_TYPE_FILTER_LABELS,
+        command=panel._on_marker_type_filter_change,
+    )
+    panel.marker_type_filter_menu.set(getattr(panel, "marker_type_filter", "All Types") or "All Types")
+    add_stacked_control(entities_body, "Marker", panel.marker_type_filter_menu)
+
+    root = panel.winfo_toplevel()
+    root.bind("[", lambda e: panel._change_brush(-4), add="+")
+    root.bind("]", lambda e: panel._change_brush(+4), add="+")
+
+    if hasattr(panel, "_update_fog_button_states"):
+        panel._update_fog_button_states()
+
+    return palette
+
+
+def _build_floating_drawing_toolbar(self):
+    """Build a compact floating palette for fog and drawing controls."""
+    return build_maptool_floating_drawing_toolbar(self)

--- a/modules/maps/views/world_map_toolbar_view.py
+++ b/modules/maps/views/world_map_toolbar_view.py
@@ -5,8 +5,6 @@ import customtkinter as ctk
 from modules.helpers.logging_helper import log_module_import
 from modules.maps.utils.icon_loader import load_icon
 from modules.ui.icon_dropdown import IconDropdown
-from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
-from modules.maps.measurement.templates import MEASUREMENT_TEMPLATE_LABELS
 
 log_module_import(__name__)
 
@@ -83,8 +81,6 @@ def build_world_map_toolbar(panel) -> None:
     toolbar.pack(fill="x", expand=True)
 
     icons = {
-        "add": load_icon(panel, "assets/icons/brush.png", (32, 32)),
-        "rem": load_icon(panel, "assets/icons/eraser.png", (32, 32)),
         "clear": load_icon(panel, "assets/icons/empty.png", (32, 32)),
         "reset": load_icon(panel, "assets/icons/full.png", (32, 32)),
     }
@@ -117,138 +113,13 @@ def build_world_map_toolbar(panel) -> None:
     _pack_control(panel.back_button, trailing=6)
 
     fog_section = _create_collapsible_section(toolbar, "Fog")
-    panel._fog_button_default_style = {
-        "fg_color": "#0077CC",
-        "hover_color": "#005fa3",
-        "border_color": "#005fa3",
-        "border_width": 1,
-    }
-    panel._fog_button_active_style = {
-        "fg_color": "#004c80",
-        "hover_color": "#004c80",
-        "border_color": "#d7263d",
-        "border_width": 3,
-    }
-    panel._fog_buttons = {}
-
     fog_actions = [
-        {"key": "add", "icon": icons["add"], "tooltip": "Add Fog", "command": lambda: panel._set_fog("add")},
-        {"key": "rem", "icon": icons["rem"], "tooltip": "Remove Fog", "command": lambda: panel._set_fog("rem")},
-        {"key": "add_rect", "icon": icons["add"], "tooltip": "Add Fog Rectangle", "command": lambda: panel._set_fog("add_rect")},
-        {"key": "rem_rect", "icon": icons["rem"], "tooltip": "Remove Fog Rectangle", "command": lambda: panel._set_fog("rem_rect")},
         {"key": "clear", "icon": icons["clear"], "tooltip": "Clear Fog", "command": panel.clear_fog},
         {"key": "reset", "icon": icons["reset"], "tooltip": "Reset Fog", "command": panel.reset_fog},
     ]
-
-    fog_dropdown = IconDropdown(fog_section, fog_actions, default_key="add")
+    fog_dropdown = IconDropdown(fog_section, fog_actions, default_key="clear")
     _pack_control(fog_dropdown, trailing=4)
-    panel._fog_buttons.update(fog_dropdown.option_buttons)
-    panel._fog_dropdown = fog_dropdown
-
-    shape_label = ctk.CTkLabel(fog_section, text="Fog Shape:")
-    _pack_control(shape_label, leading=8, trailing=4)
-    panel.shape_menu = ctk.CTkOptionMenu(
-        fog_section,
-        values=["Rectangle", "Circle"],
-        command=panel._on_brush_shape_change,
-        width=110,
-    )
-    panel.shape_menu.set("Rectangle")
-    _pack_control(panel.shape_menu, trailing=4)
-
-    size_label = ctk.CTkLabel(fog_section, text="Brush Size")
-    _pack_control(size_label, leading=4, trailing=4)
-    brush_size_options = list(getattr(panel, "brush_size_options", list(range(4, 129, 4))))
-    current_brush_size = int(getattr(panel, "brush_size", brush_size_options[0] if brush_size_options else 32))
-    if current_brush_size not in brush_size_options:
-        brush_size_options.append(current_brush_size)
-        brush_size_options = sorted(set(brush_size_options))
-    panel.brush_size_options = list(brush_size_options)
-    brush_size_values = [str(size) for size in panel.brush_size_options]
-    panel.brush_size_menu = ctk.CTkOptionMenu(
-        fog_section,
-        values=brush_size_values,
-        command=panel._on_brush_size_change,
-        width=90,
-    )
-    panel.brush_size_menu.set(str(current_brush_size))
-    _pack_control(panel.brush_size_menu, leading=0, trailing=4, pady=6)
-
-    root = panel.winfo_toplevel()
-    root.bind("[", lambda e: panel._change_brush(-4), add="+")
-    root.bind("]", lambda e: panel._change_brush(+4), add="+")
-
-    measure_section = _create_collapsible_section(toolbar, "Measure")
-    ctk.CTkLabel(measure_section, text="Template").pack(side="left", padx=(8, 4), pady=6)
-    panel.measure_template_menu = ctk.CTkOptionMenu(
-        measure_section,
-        values=MEASUREMENT_TEMPLATE_LABELS,
-        command=getattr(panel, "_on_measure_template_change", None) or (lambda _v: None),
-        width=110,
-    )
-    panel.measure_template_menu.set(getattr(panel, "measure_template_label", "Line"))
-    _pack_control(panel.measure_template_menu, trailing=4, pady=6)
-
-    panel.measure_button = ctk.CTkButton(
-        measure_section,
-        text="Measure",
-        width=100,
-        command=getattr(panel, "_toggle_measure_mode", None) or (lambda: None),
-    )
-    _pack_control(panel.measure_button, trailing=4)
-
-    ctk.CTkLabel(measure_section, text="Cell px").pack(side="left", padx=(8, 4), pady=6)
-    panel.measure_cell_entry = ctk.CTkEntry(measure_section, width=62)
-    panel.measure_cell_entry.insert(0, str(int(getattr(panel, "measure_grid_cell_pixels", 50))))
-    _pack_control(panel.measure_cell_entry, trailing=4, pady=6)
-
-    ctk.CTkLabel(measure_section, text="Scale").pack(side="left", padx=(4, 4), pady=6)
-    panel.measure_scale_entry = ctk.CTkEntry(measure_section, width=62)
-    panel.measure_scale_entry.insert(0, str(int(getattr(panel, "measure_grid_scale", 5))))
-    _pack_control(panel.measure_scale_entry, trailing=2, pady=6)
-    panel.measure_unit_label = ctk.CTkLabel(measure_section, text=getattr(panel, "measure_unit", "m") + "/cell")
-    _pack_control(panel.measure_unit_label, trailing=6, pady=6)
-
-    panel.clear_measurements_button = ctk.CTkButton(
-        measure_section,
-        text="Clear",
-        width=80,
-        command=getattr(panel, "clear_measurements", None) or (lambda: None),
-    )
-    _pack_control(panel.clear_measurements_button, trailing=6)
-
-    entity_section = _create_collapsible_section(toolbar, "Entities")
-    panel.add_npc_button = ctk.CTkButton(entity_section, text="Add NPC", command=lambda: panel._open_picker("NPC"))
-    panel.add_pc_button = ctk.CTkButton(entity_section, text="Add PC", command=lambda: panel._open_picker("PC"))
-    panel.add_creature_button = ctk.CTkButton(
-        entity_section,
-        text="Add Creature",
-        command=lambda: panel._open_picker("Creature"),
-    )
-    panel.add_base_button = ctk.CTkButton(entity_section, text="Add Base", command=lambda: panel._open_picker("Base"))
-    panel.add_place_button = ctk.CTkButton(entity_section, text="Add Place", command=lambda: panel._open_picker("Place"))
-    panel.add_map_button = ctk.CTkButton(entity_section, text="Add Map", command=lambda: panel._open_picker("Map"))
-
-    for button in (
-        panel.add_npc_button,
-        panel.add_pc_button,
-        panel.add_creature_button,
-        panel.add_base_button,
-        panel.add_place_button,
-        panel.add_map_button,
-    ):
-        _pack_control(button, trailing=6)
-
-    filter_label = ctk.CTkLabel(entity_section, text="Marker Type")
-    _pack_control(filter_label, leading=8, trailing=4)
-    panel.marker_type_filter_menu = ctk.CTkOptionMenu(
-        entity_section,
-        values=MARKER_TYPE_FILTER_LABELS,
-        command=panel._on_marker_type_filter_change,
-        width=130,
-    )
-    panel.marker_type_filter_menu.set(getattr(panel, "marker_type_filter", "All Types") or "All Types")
-    _pack_control(panel.marker_type_filter_menu, trailing=6)
+    panel._global_fog_dropdown = fog_dropdown
 
     action_section = _create_collapsible_section(toolbar, "Actions")
     panel.save_button = ctk.CTkButton(action_section, text="Save", width=120, command=panel._persist_tokens)
@@ -274,5 +145,3 @@ def build_world_map_toolbar(panel) -> None:
 
     panel.chatbot_button = ctk.CTkButton(action_section, text="Chatbot", width=140, command=panel.open_chatbot)
     _pack_control(panel.chatbot_button, trailing=6)
-
-    panel._update_fog_button_states()

--- a/modules/maps/world_map_view.py
+++ b/modules/maps/world_map_view.py
@@ -24,6 +24,7 @@ from modules.ui.chatbot_dialog import (
     open_chatbot_dialog,
     _DEFAULT_NAME_FIELD_OVERRIDES as CHATBOT_NAME_OVERRIDES,
 )
+from modules.maps.views.floating_drawing_toolbar import build_world_map_floating_tools
 from modules.maps.views.world_map_toolbar_view import build_world_map_toolbar
 from modules.maps.measurement.templates import (
     DEFAULT_DISTANCE_UNIT,
@@ -268,6 +269,8 @@ class WorldMapPanel(ctk.CTkFrame):
         self.canvas.bind("<ButtonPress-1>", self._on_canvas_press, add="+")
         self.canvas.bind("<B1-Motion>", self._on_canvas_drag, add="+")
         self.canvas.bind("<ButtonRelease-1>", self._on_canvas_release, add="+")
+        build_world_map_floating_tools(self)
+
         root = self.winfo_toplevel()
         root.bind_all("<Control-z>", lambda e: self.undo_fog(e), add="+")
         root.bind_all("<Control-Z>", lambda e: self.undo_fog(e), add="+")

--- a/tests/maps/test_floating_toolbar_compact_controls.py
+++ b/tests/maps/test_floating_toolbar_compact_controls.py
@@ -41,17 +41,36 @@ def test_shape_selector_stacks_shape_buttons_vertically():
     assert 'button.pack(side="left"' not in source
 
 
-def test_marker_type_filter_moved_from_floating_palette_to_top_toolbar():
+def test_maptool_marker_type_filter_stays_in_top_toolbar():
     import inspect
 
     from modules.maps.views import floating_drawing_toolbar, toolbar_view
 
-    floating_source = inspect.getsource(floating_drawing_toolbar._build_floating_drawing_toolbar)
+    floating_source = inspect.getsource(floating_drawing_toolbar.build_maptool_floating_drawing_toolbar)
     toolbar_source = inspect.getsource(toolbar_view._build_toolbar)
 
     assert 'Marker Type' not in floating_source
     assert 'MARKER_TYPE_FILTER_LABELS' in toolbar_source
     assert 'token_section = _create_collapsible_section(toolbar, "Tokens")' in toolbar_source
+
+
+def test_world_map_canvas_tools_moved_to_floating_palette():
+    import inspect
+
+    from modules.maps.views import floating_drawing_toolbar, world_map_toolbar_view
+
+    floating_source = inspect.getsource(floating_drawing_toolbar.build_world_map_floating_tools)
+    measurement_source = inspect.getsource(floating_drawing_toolbar._build_measurement_controls)
+    toolbar_source = inspect.getsource(world_map_toolbar_view.build_world_map_toolbar)
+
+    assert 'panel._open_picker("NPC")' in floating_source
+    assert 'panel._on_marker_type_filter_change' in floating_source
+    assert 'panel.measure_button' in measurement_source
+    assert 'include_global_actions=False' in floating_source
+    assert 'panel._open_picker("NPC")' not in toolbar_source
+    assert 'panel.measure_button' not in toolbar_source
+    assert 'panel.clear_fog' in toolbar_source
+    assert 'panel.reset_fog' in toolbar_source
 
 
 def test_floating_toolbar_layout_helpers_center_content():


### PR DESCRIPTION
### Motivation
- Provide a reusable floating palette implementation and move canvas-focused controls off the fixed WorldMap toolbar so the brush/measurement/token tools float above the map surface. 
- Keep destructive/global fog actions (`clear_fog`, `reset_fog`) in the persistent top toolbar while housing per-canvas brush tools in a detachable palette. 
- Make the same floating palette reusable for both the Map Tool controller and WorldMap panel to simplify UI code and avoid duplication.

### Description
- Introduce a single reusable floating-palette module with builders `build_maptool_floating_drawing_toolbar(controller)` and `build_world_map_floating_tools(panel)` in `modules/maps/views/floating_drawing_toolbar.py`, plus helpers (`_create_floating_palette`, `_build_fog_controls`, `_build_measurement_controls`, `_load_icon`, `_destroy_existing_palette`).
- Move WorldMap canvas-interaction controls (token pickers: `panel._open_picker("NPC")`, `panel._open_picker("PC")`, `panel._open_picker("Creature")`, `panel._open_picker("Base")`, `panel._open_picker("Place")`, `panel._open_picker("Map")`, marker filter handler `panel._on_marker_type_filter_change`, fog brush actions `add/rem/add_rect/rem_rect`, fog `shape_menu` and `brush_size_menu`, and measurement controls `measure_template_menu`, `measure_button`, `measure_cell_entry`, `measure_scale_entry`, `measure_unit_label`, `clear_measurements_button`) into the WorldMap floating builder and attach the palette to `self.canvas_container` so it visually floats above the map surface.
- Keep global/destructive fog actions in the fixed top toolbar and expose them via a simplified dropdown (`panel._global_fog_dropdown`) in `modules/maps/views/world_map_toolbar_view.py`.
- Integrate the floating WorldMap palette after `WorldMapPanel._build_layout` creates `self.canvas_container` and `self.canvas` by calling `build_world_map_floating_tools(self)` from `modules/maps/world_map_view.py` and wire the MapTool controller to `build_maptool_floating_drawing_toolbar` in `modules/maps/controllers/display_map_controller.py`.
- Update unit tests in `tests/maps/test_floating_toolbar_compact_controls.py` to validate the split between MapTool top-toolbar controls and WorldMap canvas floating tools.

### Testing
- Ran Python compile checks with `python -m py_compile modules/maps/views/floating_drawing_toolbar.py modules/maps/views/world_map_toolbar_view.py modules/maps/world_map_view.py modules/maps/controllers/display_map_controller.py tests/maps/test_floating_toolbar_compact_controls.py` and it succeeded. 
- Ran focused unit tests with `pytest tests/maps/test_floating_toolbar_compact_controls.py` and all tests passed (`9 passed`). 
- Ran `git diff --check` to ensure no whitespace/git-check issues and found no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcec8fc9a4832bb6fece0af456faa8)