### PR TITLE
Reposition world map marker controls

### DIFF
--- a/modules/maps/views/floating_drawing_toolbar.py
+++ b/modules/maps/views/floating_drawing_toolbar.py
@@ -4,7 +4,6 @@ import tkinter as tk
 import customtkinter as ctk
 
 from modules.helpers.logging_helper import log_module_import
-from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
 from modules.maps.measurement.templates import MEASUREMENT_TEMPLATE_LABELS
 from modules.maps.utils.icon_loader import load_icon
 from modules.maps.views.floating_toolbar.layout import (
@@ -408,9 +407,6 @@ def build_world_map_floating_tools(panel):
         "marker": _load_icon(panel, "assets/icons/marker.png", (24, 24)),
     }
 
-    _build_fog_controls(panel, content, icons, include_global_actions=False)
-    _build_measurement_controls(panel, content)
-
     entities_body = create_section(content, "Entities")
     entity_actions = [
         {"key": "npc", "icon": icons["npc"], "tooltip": "Add NPC", "command": lambda: panel._open_picker("NPC")},
@@ -423,13 +419,8 @@ def build_world_map_floating_tools(panel):
     entity_dropdown = IconDropdown(entities_body, entity_actions, default_key="npc", button_size=(24, 24), show_arrow=False)
     entity_dropdown.pack(side="top", anchor="center", padx=0, pady=3)
 
-    panel.marker_type_filter_menu = create_slim_option_menu(
-        entities_body,
-        values=MARKER_TYPE_FILTER_LABELS,
-        command=panel._on_marker_type_filter_change,
-    )
-    panel.marker_type_filter_menu.set(getattr(panel, "marker_type_filter", "All Types") or "All Types")
-    add_stacked_control(entities_body, "Marker", panel.marker_type_filter_menu)
+    _build_fog_controls(panel, content, icons, include_global_actions=False)
+    _build_measurement_controls(panel, content)
 
     root = panel.winfo_toplevel()
     root.bind("[", lambda e: panel._change_brush(-4), add="+")

--- a/modules/maps/views/world_map_toolbar_view.py
+++ b/modules/maps/views/world_map_toolbar_view.py
@@ -3,6 +3,7 @@
 import tkinter as tk
 import customtkinter as ctk
 from modules.helpers.logging_helper import log_module_import
+from modules.maps.marker_types import MARKER_TYPE_FILTER_LABELS
 from modules.maps.utils.icon_loader import load_icon
 from modules.ui.icon_dropdown import IconDropdown
 
@@ -111,6 +112,19 @@ def build_world_map_toolbar(panel) -> None:
         state=ctk.DISABLED,
     )
     _pack_control(panel.back_button, trailing=6)
+
+    marker_section = _create_collapsible_section(toolbar, "Marker")
+    ctk.CTkLabel(marker_section, text="Type:", font=("Segoe UI", 14, "bold")).pack(
+        side="left", padx=(8, 6), pady=6
+    )
+    panel.marker_type_filter_menu = ctk.CTkOptionMenu(
+        marker_section,
+        values=MARKER_TYPE_FILTER_LABELS,
+        command=panel._on_marker_type_filter_change,
+        width=130,
+    )
+    panel.marker_type_filter_menu.set(getattr(panel, "marker_type_filter", "All Types") or "All Types")
+    _pack_control(panel.marker_type_filter_menu, trailing=6, pady=6)
 
     fog_section = _create_collapsible_section(toolbar, "Fog")
     fog_actions = [


### PR DESCRIPTION
### Motivation
- Improve the world map UI so the Entities dropdown has room to show its lower options and the marker filter is easier to discover and use.

### Description
- Moved the floating World Map palette `Entities` section to the top of the floating palette so the entity `IconDropdown` opens from a higher position (`modules/maps/views/floating_drawing_toolbar.py`).
- Removed the marker type filter controls from the floating palette and restored fog/measurement controls below the entity picker (`modules/maps/views/floating_drawing_toolbar.py`).
- Added a dedicated `Marker` collapsible section to the persistent top toolbar and created the persistent `marker_type_filter_menu` there using `MARKER_TYPE_FILTER_LABELS` (`modules/maps/views/world_map_toolbar_view.py`).

### Testing
- Ran `python3 -m compileall modules/maps/views/floating_drawing_toolbar.py modules/maps/views/world_map_toolbar_view.py` which completed successfully.
- Ran `pytest -q` which failed during test collection due to unrelated test-environment issues (duplicate test module basenames and incomplete `customtkinter`/`PIL` test stubs), so UI behavior was verified by code inspection and compilation rather than full test-suite execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf11b0610832b9ce0191573758bd4)