### PR TITLE
Fix calendar state null numeric values

### DIFF
--- a/modules/events/services/calendar_state_store.py
+++ b/modules/events/services/calendar_state_store.py
@@ -122,7 +122,10 @@ class CalendarStateStore:
 
     @staticmethod
     def _int_or_none(value):
-        """Internal helper for int or none."""
+        """Return an integer for valid numeric values, otherwise None."""
+        if value is None:
+            return None
+
         try:
             return int(value)
         except (TypeError, ValueError):

--- a/tests/test_campaign_date_service.py
+++ b/tests/test_campaign_date_service.py
@@ -52,6 +52,19 @@ def test_calendar_runtime_state_defaults_to_campaign_today(campaign_db):
     assert runtime["active_date"] == date(2030, 1, 2)
 
 
+def test_calendar_state_store_ignores_null_numeric_values(campaign_db):
+    """Verify that nullable stored dimensions do not crash state restoration."""
+    stored_state = {
+        "filters": {"agenda_window_days": None},
+        "panel_widths": {"left_sidebar": None, "center_grid": None},
+    }
+
+    runtime = CalendarStateStore.to_runtime_state(stored_state)
+
+    assert runtime["filters"]["agenda_window_days"] == 7
+    assert runtime["panel_widths"] == {"left_sidebar": None, "center_grid": None}
+
+
 def test_campaign_date_service_rejects_invalid_values(campaign_db):
     """Verify that campaign date service rejects invalid values."""
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Motivation
- Prevent a startup `TypeError` caused by calling `int()` on `None` when persisted calendar UI state contains `null` for numeric fields like panel widths or `agenda_window_days`.

### Description
- Add an early `None` check in `CalendarStateStore._int_or_none` so `None` returns `None` instead of being passed to `int()`, and add a regression test `test_calendar_state_store_ignores_null_numeric_values` to verify runtime restoration handles `null` values; modified `modules/events/services/calendar_state_store.py` and `tests/test_campaign_date_service.py`.

### Testing
- Executed `pytest tests/test_campaign_date_service.py` and received `4 passed`; also ran `python -m compileall modules/events/services/calendar_state_store.py tests/test_campaign_date_service.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0087501018832bafc427692287b313)