### PR TITLE
Harden generic JSON deserialization

### DIFF
--- a/modules/generic/deserialization/__init__.py
+++ b/modules/generic/deserialization/__init__.py
@@ -1,6 +1,4 @@
-"""Backward-compatible import location for generic JSON deserialization."""
-
-from __future__ import annotations
+"""Deserialization helpers for generic entity storage."""
 
 from modules.generic.deserialization.json_value_parser import deserialize_possible_json
 

--- a/modules/generic/deserialization/json_value_parser.py
+++ b/modules/generic/deserialization/json_value_parser.py
@@ -1,0 +1,30 @@
+"""Safe JSON value parsing for generic storage rows."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_JSON_PREFIXES = ("{", "[", "\"")
+_JSON_PARSE_EXCEPTIONS = (json.JSONDecodeError, TypeError, ValueError, StopIteration)
+
+
+def deserialize_possible_json(value: Any) -> Any:
+    """Decode JSON-looking strings while preserving plain text on failures.
+
+    Generic tables persist structured values (lists/dicts/RTF payloads) as JSON
+    text.  Some user-authored notes can still start with JSON prefix characters
+    such as ``[`` or ``{`` without being valid JSON.  In that case the value is
+    plain text and must not prevent the containing table from loading.
+    """
+    if not isinstance(value, str):
+        return value
+
+    stripped_value = value.strip()
+    if not stripped_value.startswith(_JSON_PREFIXES):
+        return value
+
+    try:
+        return json.loads(stripped_value)
+    except _JSON_PARSE_EXCEPTIONS:
+        return value

--- a/tests/test_generic_model_wrapper_key_field.py
+++ b/tests/test_generic_model_wrapper_key_field.py
@@ -64,3 +64,29 @@ def test_load_items_keeps_malformed_json_like_text(tmp_path):
     assert loaded == [
         {"Name": "Session", "Notes": "[draft note", "Tags": ["one", "two"]}
     ]
+
+
+def test_load_items_keeps_json_decoder_stop_iteration_as_text(tmp_path, monkeypatch):
+    """Verify odd decoder failures keep JSON-looking text loadable."""
+    from modules.generic.deserialization import json_value_parser
+
+    def broken_loads(_value):
+        raise StopIteration(1)
+
+    db_path = tmp_path / "calendar.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE events (Name TEXT PRIMARY KEY, Notes TEXT)")
+        conn.execute(
+            "INSERT INTO events (Name, Notes) VALUES (?, ?)",
+            ("Session", "[draft note"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(json_value_parser.json, "loads", broken_loads)
+
+    wrapper = GenericModelWrapper("events", db_path=str(db_path))
+
+    assert wrapper.load_items() == [{"Name": "Session", "Notes": "[draft note"}]


### PR DESCRIPTION
### Motivation
- Prevent application crashes when loading JSON-looking values from database rows, including odd decoder failures that raise `StopIteration` or similar exceptions.
- Ensure user-authored plain text that begins with JSON prefixes remains intact instead of breaking table loading.

### Description
- Introduced a dedicated deserialization helper at `modules/generic/deserialization/json_value_parser.py` that only attempts `json.loads` for JSON-looking strings and catches a broader set of parse exceptions (including `StopIteration`) to preserve the original text.
- Added a backward-compatible re-export at the previous import location `modules/generic/json_value_deserializer.py` so existing callers continue to work unchanged.
- Added `modules/generic/deserialization/__init__.py` to expose `deserialize_possible_json` from the new module.
- Added a regression test in `tests/test_generic_model_wrapper_key_field.py` that simulates a `StopIteration` raised by `json.loads` and verifies `GenericModelWrapper.load_items()` returns the original string rather than crashing.

### Testing
- Ran `pytest -q tests/test_generic_model_wrapper_key_field.py`, which succeeded with `3 passed`.
- Ran `python -m compileall -q modules/generic/json_value_deserializer.py modules/generic/deserialization tests/test_generic_model_wrapper_key_field.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008ddd7714832bbdd05a89fe6c7c31)