### PR TITLE
Harden generic JSON value parsing

### DIFF
--- a/modules/generic/deserialization/json_value_parser.py
+++ b/modules/generic/deserialization/json_value_parser.py
@@ -6,7 +6,19 @@ import json
 from typing import Any
 
 _JSON_PREFIXES = ("{", "[", "\"")
-_JSON_PARSE_EXCEPTIONS = (json.JSONDecodeError, TypeError, ValueError, StopIteration)
+_RECOVERABLE_JSON_PARSE_ERRORS = (
+    json.JSONDecodeError,
+    TypeError,
+    ValueError,
+    StopIteration,
+    RecursionError,
+)
+
+
+def _is_recoverable_parse_error(error: Exception) -> bool:
+    """Return whether a JSON parse failure should keep the raw DB value."""
+
+    return isinstance(error, _RECOVERABLE_JSON_PARSE_ERRORS)
 
 
 def deserialize_possible_json(value: Any) -> Any:
@@ -26,5 +38,7 @@ def deserialize_possible_json(value: Any) -> Any:
 
     try:
         return json.loads(stripped_value)
-    except _JSON_PARSE_EXCEPTIONS:
-        return value
+    except Exception as error:
+        if _is_recoverable_parse_error(error):
+            return value
+        raise

--- a/tests/test_generic_model_wrapper_key_field.py
+++ b/tests/test_generic_model_wrapper_key_field.py
@@ -90,3 +90,11 @@ def test_load_items_keeps_json_decoder_stop_iteration_as_text(tmp_path, monkeypa
     wrapper = GenericModelWrapper("events", db_path=str(db_path))
 
     assert wrapper.load_items() == [{"Name": "Session", "Notes": "[draft note"}]
+
+
+def test_deserialize_possible_json_keeps_direct_malformed_json_text():
+    """Verify direct parser calls preserve malformed JSON-looking notes."""
+    from modules.generic.deserialization.json_value_parser import deserialize_possible_json
+
+    assert deserialize_possible_json(" [calendar note") == " [calendar note"
+    assert deserialize_possible_json("{not really json") == "{not really json"


### PR DESCRIPTION
### Motivation

- Generic tables persist structured payloads as JSON text but some user-authored strings start with JSON punctuation yet are not valid JSON, which must not break row loading. 
- The code previously caught a fixed set of exceptions but some parser failures (e.g. unusual decoder errors) could still surface and interrupt loading. 

### Description

- Introduce `_RECOVERABLE_JSON_PARSE_ERRORS` and helper `_is_recoverable_parse_error` to centralize which parse failures should fall back to raw text. 
- Change `deserialize_possible_json` to catch all `Exception` and return the original string for recoverable parse errors while re-raising unexpected exceptions. 
- Add a regression test `test_deserialize_possible_json_keeps_direct_malformed_json_text` in `tests/test_generic_model_wrapper_key_field.py` to ensure malformed JSON-like notes (e.g. `" [calendar note"`, `"{not really json"`) are preserved as plain text. 

### Testing

- Verified the parser compiles with `python -m py_compile modules/generic/deserialization/json_value_parser.py` and the step succeeded. 
- Ran the focused test file with `python -m pytest tests/test_generic_model_wrapper_key_field.py -q` and it passed (`4 passed`). 
- Attempted a broader run including calendar tests with `python -m pytest tests/test_generic_model_wrapper_key_field.py tests/test_calendar_event_links.py tests/test_calendar_dock_lifecycle.py -q`, which was blocked during test collection by an environment `ImportError: cannot import name 'ImageEnhance' from 'PIL'` unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0090c5c2ac832b8d00a26e2dbd8bdf)