### PR TITLE
Harden generic JSON candidate parsing

### DIFF
--- a/modules/generic/deserialization/json_candidates.py
+++ b/modules/generic/deserialization/json_candidates.py
@@ -1,0 +1,32 @@
+"""Helpers that identify strings worth attempting to decode as JSON."""
+
+from __future__ import annotations
+
+_JSON_STRING_PREFIX = '"'
+_JSON_CONTAINER_PAIRS = {
+    "{": "}",
+    "[": "]",
+}
+
+
+def looks_like_json_candidate(value: str) -> bool:
+    """Return whether ``value`` is plausible serialized JSON.
+
+    User-authored notes sometimes start with JSON delimiter characters (for
+    example ``[draft]`` or ``{idea``).  The generic loader should not ask the
+    JSON decoder to parse obviously incomplete text because those parse errors
+    are expected plain-text content, not corrupt database rows.
+    """
+
+    stripped_value = value.strip()
+    if not stripped_value:
+        return False
+
+    if stripped_value.startswith(_JSON_STRING_PREFIX):
+        return True
+
+    expected_suffix = _JSON_CONTAINER_PAIRS.get(stripped_value[0])
+    if expected_suffix is None:
+        return False
+
+    return stripped_value.endswith(expected_suffix)

--- a/modules/generic/deserialization/json_value_parser.py
+++ b/modules/generic/deserialization/json_value_parser.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
-_JSON_PREFIXES = ("{", "[", "\"")
+from modules.generic.deserialization.json_candidates import looks_like_json_candidate
+
 _RECOVERABLE_JSON_PARSE_ERRORS = (
     json.JSONDecodeError,
     TypeError,
@@ -13,12 +14,6 @@ _RECOVERABLE_JSON_PARSE_ERRORS = (
     StopIteration,
     RecursionError,
 )
-
-
-def _is_recoverable_parse_error(error: Exception) -> bool:
-    """Return whether a JSON parse failure should keep the raw DB value."""
-
-    return isinstance(error, _RECOVERABLE_JSON_PARSE_ERRORS)
 
 
 def deserialize_possible_json(value: Any) -> Any:
@@ -33,12 +28,10 @@ def deserialize_possible_json(value: Any) -> Any:
         return value
 
     stripped_value = value.strip()
-    if not stripped_value.startswith(_JSON_PREFIXES):
+    if not looks_like_json_candidate(stripped_value):
         return value
 
     try:
         return json.loads(stripped_value)
-    except Exception as error:
-        if _is_recoverable_parse_error(error):
-            return value
-        raise
+    except _RECOVERABLE_JSON_PARSE_ERRORS:
+        return value

--- a/tests/test_generic_model_wrapper_key_field.py
+++ b/tests/test_generic_model_wrapper_key_field.py
@@ -79,7 +79,7 @@ def test_load_items_keeps_json_decoder_stop_iteration_as_text(tmp_path, monkeypa
         conn.execute("CREATE TABLE events (Name TEXT PRIMARY KEY, Notes TEXT)")
         conn.execute(
             "INSERT INTO events (Name, Notes) VALUES (?, ?)",
-            ("Session", "[draft note"),
+            ("Session", "[draft note]"),
         )
         conn.commit()
     finally:
@@ -89,7 +89,7 @@ def test_load_items_keeps_json_decoder_stop_iteration_as_text(tmp_path, monkeypa
 
     wrapper = GenericModelWrapper("events", db_path=str(db_path))
 
-    assert wrapper.load_items() == [{"Name": "Session", "Notes": "[draft note"}]
+    assert wrapper.load_items() == [{"Name": "Session", "Notes": "[draft note]"}]
 
 
 def test_deserialize_possible_json_keeps_direct_malformed_json_text():
@@ -98,3 +98,30 @@ def test_deserialize_possible_json_keeps_direct_malformed_json_text():
 
     assert deserialize_possible_json(" [calendar note") == " [calendar note"
     assert deserialize_possible_json("{not really json") == "{not really json"
+
+
+def test_incomplete_json_like_text_is_not_sent_to_decoder(monkeypatch):
+    """Verify incomplete note text is kept without invoking JSON decoding."""
+    from modules.generic.deserialization import json_value_parser
+
+    def fail_if_called(_value):
+        raise AssertionError("json.loads should not be called for incomplete text")
+
+    monkeypatch.setattr(json_value_parser.json, "loads", fail_if_called)
+
+    assert (
+        json_value_parser.deserialize_possible_json("[calendar note")
+        == "[calendar note"
+    )
+    assert (
+        json_value_parser.deserialize_possible_json(" {calendar note")
+        == " {calendar note"
+    )
+
+
+def test_complete_invalid_json_like_text_still_loads_as_plain_text():
+    """Verify invalid-but-balanced note text remains plain text."""
+    from modules.generic.deserialization.json_value_parser import deserialize_possible_json
+
+    assert deserialize_possible_json("[calendar note]") == "[calendar note]"
+    assert deserialize_possible_json("{not really json}") == "{not really json}"


### PR DESCRIPTION
### Motivation
- Prevent the JSON decoder from being invoked on user-authored text that merely starts with JSON delimiter characters but is not real JSON, so generic table loading remains robust and does not raise recoverable decoder errors.

### Description
- Added `modules/generic/deserialization/json_candidates.py` with `looks_like_json_candidate()` to quickly identify plausible JSON strings before attempting decoding.
- Updated `modules/generic/deserialization/json_value_parser.py` to use the new candidate filter and to only swallow known recoverable decoder exceptions instead of re-raising, simplifying the logic and avoiding unnecessary decoder calls.
- Added regression tests and small test-data fixes in `tests/test_generic_model_wrapper_key_field.py` to cover decoder `StopIteration`, incomplete JSON-like text, and balanced-but-invalid JSON-like text.

### Testing
- Ran `pytest -q tests/test_generic_model_wrapper_key_field.py` and the targeted suite passed (`6 passed`).
- Ran `python -m compileall -q modules/generic/deserialization tests/test_generic_model_wrapper_key_field.py` which succeeded.
- Attempting a broader test run that included `tests/test_calendar_dock_lifecycle.py` failed during collection due to an environment `PIL` import error (`ImportError: cannot import name 'ImageEnhance' from 'PIL'`), which is unrelated to this JSON parsing change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0091d77360832b9123f16ddfd7b8be)