### PR TITLE
Avoid JSON parsing for bracketed prose

### DIFF
--- a/modules/generic/deserialization/json_candidates.py
+++ b/modules/generic/deserialization/json_candidates.py
@@ -7,6 +7,8 @@ _JSON_CONTAINER_PAIRS = {
     "{": "}",
     "[": "]",
 }
+_JSON_ARRAY_VALUE_PREFIXES = frozenset('{["-0123456789tfn]')
+_JSON_OBJECT_VALUE_PREFIXES = frozenset('"}')
 
 
 def looks_like_json_candidate(value: str) -> bool:
@@ -14,7 +16,7 @@ def looks_like_json_candidate(value: str) -> bool:
 
     User-authored notes sometimes start with JSON delimiter characters (for
     example ``[draft]`` or ``{idea``).  The generic loader should not ask the
-    JSON decoder to parse obviously incomplete text because those parse errors
+    JSON decoder to parse obviously incomplete prose because those parse errors
     are expected plain-text content, not corrupt database rows.
     """
 
@@ -26,7 +28,28 @@ def looks_like_json_candidate(value: str) -> bool:
         return True
 
     expected_suffix = _JSON_CONTAINER_PAIRS.get(stripped_value[0])
-    if expected_suffix is None:
+    if expected_suffix is None or not stripped_value.endswith(expected_suffix):
         return False
 
-    return stripped_value.endswith(expected_suffix)
+    return _has_plausible_container_content(stripped_value)
+
+
+def _has_plausible_container_content(value: str) -> bool:
+    """Return whether a bracketed value starts like JSON, not plain prose."""
+
+    if value[0] == "[":
+        return _first_inner_character(value) in _JSON_ARRAY_VALUE_PREFIXES
+
+    if value[0] == "{":
+        return _first_inner_character(value) in _JSON_OBJECT_VALUE_PREFIXES
+
+    return False
+
+
+def _first_inner_character(value: str) -> str:
+    """Return the first non-whitespace character after the opening delimiter."""
+
+    for character in value[1:]:
+        if not character.isspace():
+            return character
+    return ""

--- a/tests/test_generic_model_wrapper_key_field.py
+++ b/tests/test_generic_model_wrapper_key_field.py
@@ -125,3 +125,32 @@ def test_complete_invalid_json_like_text_still_loads_as_plain_text():
 
     assert deserialize_possible_json("[calendar note]") == "[calendar note]"
     assert deserialize_possible_json("{not really json}") == "{not really json}"
+
+
+def test_balanced_prose_is_not_sent_to_decoder(monkeypatch):
+    """Verify bracketed prose avoids noisy JSON decoder exceptions."""
+    from modules.generic.deserialization import json_value_parser
+
+    def fail_if_called(_value):
+        raise AssertionError("json.loads should not be called for bracketed prose")
+
+    monkeypatch.setattr(json_value_parser.json, "loads", fail_if_called)
+
+    assert (
+        json_value_parser.deserialize_possible_json("[calendar note]")
+        == "[calendar note]"
+    )
+    assert (
+        json_value_parser.deserialize_possible_json("{not really json}")
+        == "{not really json}"
+    )
+
+
+def test_valid_json_containers_are_still_decoded():
+    """Verify stricter candidate detection still accepts real JSON payloads."""
+    from modules.generic.deserialization.json_value_parser import deserialize_possible_json
+
+    assert deserialize_possible_json('["calendar note"]') == ["calendar note"]
+    assert deserialize_possible_json('{"title": "calendar note"}') == {
+        "title": "calendar note"
+    }


### PR DESCRIPTION
### Motivation
- Prevent noisy JSON decoder exceptions and JSONDecodeError regressions when user-authored notes start with balanced brackets or braces that are prose (e.g. `[calendar note]` or `{not really json}`), so these values are preserved as plain text during model loading.
- Maintain backwards-compatible behavior where actual JSON arrays/objects continue to be deserialized by `deserialize_possible_json` when they are plausible JSON.

### Description
- Tighten JSON-candidate detection in `modules/generic/deserialization/json_candidates.py` by adding `_has_plausible_container_content` and `_first_inner_character` helpers and by checking the first non-whitespace inner character against `_JSON_ARRAY_VALUE_PREFIXES` and `_JSON_OBJECT_VALUE_PREFIXES` before sending a value to the decoder.
- Keep `modules/generic/deserialization/json_value_parser.py` behavior unchanged to still catch recoverable decoder failures while avoiding unnecessary `json.loads` calls for bracketed prose.
- Add regression tests in `tests/test_generic_model_wrapper_key_field.py` that assert bracketed prose is not sent to the decoder and that valid JSON containers are still decoded.

### Testing
- Ran `python -m pytest tests/test_generic_model_wrapper_key_field.py` which succeeded with all tests passing (`8 passed`).
- Ran `python -m py_compile modules/generic/deserialization/json_candidates.py modules/generic/deserialization/json_value_parser.py modules/generic/generic_model_wrapper.py` which succeeded with no syntax errors.
- Attempting `python -m pytest tests/test_generic_model_wrapper_key_field.py tests/test_calendar_dock_lifecycle.py` surfaced an unrelated test collection failure due to a local PIL environment import error (`cannot import name 'ImageEnhance' from 'PIL'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0092ff21f4832ba2cbc9fe003fbdfa)