### PR TITLE
Handle missing tkhtmlview gracefully

### DIFF
--- a/modules/objects/object_shelf_canvas_view.py
+++ b/modules/objects/object_shelf_canvas_view.py
@@ -35,10 +35,7 @@ from modules.helpers.theme_manager import (
     THEME_SF,
 )
 from modules.helpers.text_helpers import rtf_to_html, format_multiline_text
-try:
-    from tkhtmlview import HTMLLabel  # type: ignore
-except Exception:
-    HTMLLabel = None  # fallback to plain textbox
+from modules.ui.html import HTMLLabel
 
 
 @dataclass

--- a/modules/scenarios/scenario_graph_editor.py
+++ b/modules/scenarios/scenario_graph_editor.py
@@ -1,4 +1,4 @@
-﻿"""Editor helpers for scenario graph."""
+"""Editor helpers for scenario graph."""
 
 import json
 import math
@@ -18,10 +18,7 @@ import textwrap
 import html
 from collections.abc import Mapping
 
-try:  # Optional rich-text renderer for detail panel content
-    from tkhtmlview import HTMLLabel  # type: ignore
-except Exception:  # pragma: no cover - fallback when library is absent
-    HTMLLabel = None
+from modules.ui.html import HTMLLabel
 
 from modules.helpers.template_loader import load_template
 from modules.generic.generic_model_wrapper import GenericModelWrapper

--- a/modules/ui/html/__init__.py
+++ b/modules/ui/html/__init__.py
@@ -1,0 +1,5 @@
+"""HTML rendering helpers for Tk-based UI widgets."""
+
+from .optional_html_label import HTMLLabel, is_html_label_available
+
+__all__ = ["HTMLLabel", "is_html_label_available"]

--- a/modules/ui/html/optional_html_label.py
+++ b/modules/ui/html/optional_html_label.py
@@ -1,0 +1,24 @@
+"""Optional access to :mod:`tkhtmlview` without hard dependency failures.
+
+Some screens can render richer descriptions with ``tkhtmlview`` when the
+package is installed.  The application must still start when that optional
+package is missing, so this module probes for it before loading it and exposes
+``None`` when unavailable.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module, util
+from typing import Any
+
+
+_TKHTMLVIEW_SPEC = util.find_spec("tkhtmlview")
+HTMLLabel: type[Any] | None = (
+    getattr(import_module("tkhtmlview"), "HTMLLabel") if _TKHTMLVIEW_SPEC is not None else None
+)
+
+
+def is_html_label_available() -> bool:
+    """Return whether the optional rich HTML label widget can be used."""
+
+    return HTMLLabel is not None


### PR DESCRIPTION
### Motivation
- Prevent application startup failures when the optional `tkhtmlview` package is not installed by making rich-text rendering optional and non-fatal.

### Description
- Added a small shared helper package `modules/ui/html` with `optional_html_label.py` that probes for `tkhtmlview` using `importlib.util.find_spec()` and exposes `HTMLLabel` as `None` when unavailable.
- Exported the helper via `modules/ui/html/__init__.py` which exposes `HTMLLabel` and `is_html_label_available` for callers.
- Replaced fragile direct `tkhtmlview` imports in `modules/scenarios/scenario_graph_editor.py` and `modules/objects/object_shelf_canvas_view.py` with imports from the new shared helper so both modules gracefully fall back when the optional widget is absent.

### Testing
- Ran `python -m py_compile modules/ui/html/__init__.py modules/ui/html/optional_html_label.py modules/scenarios/scenario_graph_editor.py modules/objects/object_shelf_canvas_view.py` which succeeded without syntax errors.
- Executed a small runtime probe `from modules.ui.html import HTMLLabel, is_html_label_available` and validated `HTMLLabel is None` and `is_html_label_available()` returned `False` in this environment.
- Attempted to import the full `modules.scenarios.scenario_graph_editor` module, but that runtime check was not completed here due to a missing GUI dependency (`customtkinter`) in the test container, so that integration import was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0093e47154832b99ff492e81cf77a1)