### PR TITLE
Ignore non-application GitHub release tags in updater

### DIFF
--- a/modules/helpers/update_helper.py
+++ b/modules/helpers/update_helper.py
@@ -1,4 +1,4 @@
-﻿"""Utilities for update helper."""
+"""Utilities for update helper."""
 
 from __future__ import annotations
 
@@ -359,13 +359,32 @@ def _emit_progress(callback: Optional[ProgressCallback], message: str, fraction:
 
 
 def _normalize_tag(tag: str) -> Version:
-    """Normalize tag."""
+    """Normalize a release tag into an application version.
+
+    GitHub releases are also used by the online asset gallery, whose tags are
+    named like ``bundle-fallout-20260509-091119``. Those tags are not
+    application versions and must be ignored by the updater instead of letting
+    ``packaging`` raise an ``InvalidVersion`` that can bubble up to the UI.
+    """
     candidate = tag.strip()
     if not candidate:
         raise RuntimeError("Release tag is empty")
+
+    candidates = [candidate]
     if candidate.lower().startswith("v") and len(candidate) > 1:
-        candidate = candidate[1:]
-    return Version(candidate)
+        candidates.append(candidate[1:])
+
+    embedded_version = _extract_version_string(candidate)
+    if embedded_version:
+        candidates.append(embedded_version)
+
+    for value in candidates:
+        try:
+            return Version(value)
+        except InvalidVersion:
+            continue
+
+    raise RuntimeError(f"Release tag does not contain a valid application version: {tag}")
 
 
 def _select_asset(assets: Sequence[dict], preferred_asset: Optional[str]) -> Optional[dict]:

--- a/tests/test_update_helper_launch.py
+++ b/tests/test_update_helper_launch.py
@@ -6,6 +6,7 @@ import types
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 if "requests" not in sys.modules:
     requests_stub = types.ModuleType("requests")
@@ -112,3 +113,73 @@ def test_launch_installer_copies_helper_when_frozen(
     assert cleanup_indices, "expected cleanup root to be provided"
     for index in cleanup_indices:
         assert Path(captured["args"][index + 1]) in temp_dirs
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        """Initialize the fake response."""
+        self._payload = payload
+
+    def raise_for_status(self):
+        """Simulate a successful response status."""
+        return None
+
+    def json(self):
+        """Return the fake JSON payload."""
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, payload):
+        """Initialize the fake session."""
+        self.headers = {}
+        self._payload = payload
+
+    def get(self, *_args, **_kwargs):
+        """Return a fake releases response."""
+        return _FakeResponse(self._payload)
+
+
+def test_check_for_update_skips_gallery_bundle_release_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify gallery bundle releases do not crash the application updater."""
+    monkeypatch.setattr(update_helper, "read_installed_version", lambda: Version("1.0.0"))
+    session = _FakeSession(
+        [
+            {
+                "draft": False,
+                "prerelease": False,
+                "tag_name": "bundle-fallout-20260509-091119",
+                "assets": [
+                    {
+                        "name": "fallout-bundle.zip",
+                        "browser_download_url": "https://example.invalid/fallout-bundle.zip",
+                        "size": 123,
+                    }
+                ],
+            },
+            {
+                "draft": False,
+                "prerelease": False,
+                "tag_name": "v1.0.1",
+                "assets": [
+                    {
+                        "name": "GMCampaignDesigner.zip",
+                        "browser_download_url": "https://example.invalid/GMCampaignDesigner.zip",
+                        "size": 456,
+                    }
+                ],
+            },
+        ]
+    )
+
+    _current, candidate = update_helper.check_for_update(session=session)
+
+    assert candidate is not None
+    assert candidate.tag == "v1.0.1"
+    assert candidate.version == Version("1.0.1")
+
+
+def test_normalize_tag_rejects_non_application_bundle_tags() -> None:
+    """Verify non-application release tags are rejected with a controlled error."""
+    with pytest.raises(RuntimeError, match="valid application version"):
+        update_helper._normalize_tag("bundle-fallout-20260509-091119")


### PR DESCRIPTION
### Motivation
- The updater attempted to parse arbitrary GitHub release tags with `packaging.version.Version`, which raised `InvalidVersion` for gallery bundle tags like `bundle-fallout-20260509-091119` and could bubble up to the UI. 
- The updater should skip non-application release tags and continue to the next valid application release instead of failing.

### Description
- Change `_normalize_tag` in `modules/helpers/update_helper.py` to try multiple candidate forms (the raw tag, tag without a leading `v`, and an extracted embedded dotted version) and return the first successfully parsed `Version`, otherwise raise a clear `RuntimeError` indicating no application version was found. 
- Add regression tests to `tests/test_update_helper_launch.py` that fake a GitHub releases response to verify a gallery bundle tag is skipped and a subsequent valid `v1.0.1` release is selected. 
- Add a test ensuring `_normalize_tag` rejects purely non-application bundle tags with a controlled error, and adjust test imports to use `packaging.version.Version` where needed.

### Testing
- Ran `python -m compileall modules/helpers/update_helper.py tests/test_update_helper_launch.py` successfully. 
- Ran `pytest tests/test_update_helper_launch.py -q` and observed `4 passed`. 
- Ran `pytest tests/test_main_window_update.py tests/test_update_helper_launch.py -q` which failed during collection due to the local `PIL` package/stub missing `ImageEnhance`, an environment issue unrelated to the updater changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00963923ec832b8ff59f17b57794c6)