### PR TITLE
Fix campaign graph services lazy import

### DIFF
--- a/modules/campaigns/ui/graphical_display/__init__.py
+++ b/modules/campaigns/ui/graphical_display/__init__.py
@@ -3,7 +3,9 @@
 Use lazy exports so importing the package does not immediately import UI windows.
 """
 
-__all__ = ["CampaignGraphWindow", "CampaignGraphPanel"]
+from importlib import import_module
+
+__all__ = ["CampaignGraphWindow", "CampaignGraphPanel", "services"]
 
 
 def __getattr__(name: str):
@@ -16,4 +18,6 @@ def __getattr__(name: str):
         from .panel import CampaignGraphPanel
 
         return CampaignGraphPanel
+    if name == "services":
+        return import_module(f"{__name__}.services")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/modules/campaigns/ui/graphical_display/panel.py
+++ b/modules/campaigns/ui/graphical_display/panel.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
-import customtkinter as ctk
+import importlib
 import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox
+
+import customtkinter as ctk
 
 from modules.generic.entity_detail_factory import open_entity_tab
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.scenarios.gm_screen.dashboard.styles.dashboard_theme import DASHBOARD_THEME
 from modules.helpers import theme_manager
 from modules.campaigns.services.poster_export import build_poster_theme_from_tokens, render_campaign_poster
+from modules.scenarios.gm_layout_manager import GMScreenLayoutManager
+from modules.scenarios.gm_screen_view import GMScreenView
+
 from .components import (
     CampaignOverviewHero,
     ArcSelectorStrip,
@@ -22,9 +27,9 @@ from .components import (
     ScenarioSelectorStrip,
 )
 from .data import CampaignGraphArc, CampaignGraphPayload, CampaignGraphScenario, build_campaign_graph_payload, build_campaign_option_index
-from modules.scenarios.gm_screen_view import GMScreenView
-from modules.scenarios.gm_layout_manager import GMScreenLayoutManager
-from . import services as _graph_services
+
+# Import the services submodule directly to avoid the package lazy __getattr__ hook.
+_graph_services = importlib.import_module(f"{__package__}.services")
 
 
 class CampaignOverviewSelectionStore(getattr(_graph_services, "CampaignOverviewSelectionStore", object)):

--- a/tests/campaigns/ui/test_campaign_graph_panel.py
+++ b/tests/campaigns/ui/test_campaign_graph_panel.py
@@ -6,6 +6,19 @@ import types
 from pathlib import Path
 
 
+def _make_services_stub():
+    """Create a services package stub that still allows submodule imports."""
+    services_stub = types.ModuleType("modules.campaigns.ui.graphical_display.services")
+    services_stub.__path__ = [str(Path("modules/campaigns/ui/graphical_display/services"))]
+    services_stub.open_scenario_in_embedded_gm_screen = (
+        lambda widget, scenario_name, fallback: widget.winfo_toplevel().open_gm_screen(
+            show_empty_message=True,
+            scenario_name=scenario_name,
+        )
+    )
+    return services_stub
+
+
 class _DummyWidget:
     def __init__(self, *args, **kwargs):
         """Initialize the _DummyWidget instance."""
@@ -159,9 +172,7 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault(
     "modules.campaigns.ui.graphical_display.services",
-    types.SimpleNamespace(
-        open_scenario_in_embedded_gm_screen=lambda widget, scenario_name, fallback: widget.winfo_toplevel().open_gm_screen(show_empty_message=True, scenario_name=scenario_name)
-    ),
+    _make_services_stub(),
 )
 
 MODULE_PATH = Path("modules/campaigns/ui/graphical_display/panel.py")


### PR DESCRIPTION
### Motivation
- Importing `modules.campaigns.ui.graphical_display.panel` could trigger the package lazy `__getattr__` and raise `AttributeError` for the `services` submodule when code expects `modules.campaigns.ui.graphical_display.services` to be importable.
- Tests that import the panel and service submodules in the same pytest process were failing due to the package-level lazy export behavior.

### Description
- Expose the `services` submodule via the package lazy attribute hook by adding `services` to `__all__` and returning `import_module(f"{__name__}.services")` in `modules/campaigns/ui/graphical_display/__init__.py`.
- Update `modules/campaigns/ui/graphical_display/panel.py` to import the services submodule directly with `importlib.import_module` into `_graph_services`, avoiding the package `__getattr__` trap during panel loading.
- Adjust `tests/campaigns/ui/test_campaign_graph_panel.py` to install a services stub that behaves like a package (sets `__path__`) so service submodule imports work inside the same pytest process.

### Testing
- Ran `pytest` for `tests/campaigns/ui/test_campaign_graph_panel.py`, `tests/campaigns/ui/test_campaign_graph_selection_state.py`, and `tests/campaigns/ui/test_gm_screen_router.py`, and all tests passed (`12 passed`).
- Ran `python -m compileall` on the modified modules and test file to verify syntax correctness, and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b71b8d14832b9b3d3dae7ed8fee5)