### PR TITLE
Guard PC banner text rendering (prevent OverflowError)

### DIFF
--- a/modules/campaigns/ui/graphical_display/text_safety.py
+++ b/modules/campaigns/ui/graphical_display/text_safety.py
@@ -1,61 +1,26 @@
 """Display text guards for the campaign graphical overview."""
 from __future__ import annotations
 
-from typing import Any
+from modules.helpers.tk_text_safety import (
+    DEFAULT_DISPLAY_LIMIT,
+    ELLIPSIS,
+    LABEL_DISPLAY_LIMIT,
+    LIST_ITEM_DISPLAY_LIMIT,
+    LONGFORM_DISPLAY_LIMIT,
+    MAX_LIST_ITEMS,
+    safe_display_list,
+    safe_display_text,
+    truncate_display_text,
+)
 
-from modules.helpers.text_helpers import coerce_text
-
-ELLIPSIS = "…"
-DEFAULT_DISPLAY_LIMIT = 8_000
-LABEL_DISPLAY_LIMIT = 240
-LONGFORM_DISPLAY_LIMIT = 6_000
-LIST_ITEM_DISPLAY_LIMIT = 240
-MAX_LIST_ITEMS = 200
-
-
-def safe_display_text(value: Any, *, max_chars: int = DEFAULT_DISPLAY_LIMIT) -> str:
-    """Return plain text bounded to a size Tk can safely render.
-
-    Imported campaign data can contain accidentally huge blobs (for example a
-    pasted PDF, serialized rich-text payload, or binary-ish field). Passing those
-    values directly into Tk label/button/menu text can surface later from
-    ``mainloop`` as ``OverflowError: string is too long``. This helper keeps the
-    overview readable while preserving enough content to identify the record.
-    """
-
-    text = coerce_text(value).strip()
-    return truncate_display_text(text, max_chars=max_chars)
-
-
-def truncate_display_text(value: Any, *, max_chars: int = DEFAULT_DISPLAY_LIMIT) -> str:
-    """Truncate ``value`` to ``max_chars`` with a visible ellipsis marker."""
-
-    text = str(value or "")
-    if max_chars < 1:
-        return ""
-    if len(text) <= max_chars:
-        return text
-    suffix = f" {ELLIPSIS}"
-    keep = max(max_chars - len(suffix), 0)
-    return text[:keep].rstrip() + suffix
-
-
-def safe_display_list(
-    value: Any,
-    *,
-    max_items: int = MAX_LIST_ITEMS,
-    item_max_chars: int = LIST_ITEM_DISPLAY_LIMIT,
-) -> list[str]:
-    """Return a de-duplicated, bounded list of safe display strings."""
-
-    if not isinstance(value, list):
-        return []
-
-    result: list[str] = []
-    for entry in value:
-        text = safe_display_text(entry, max_chars=item_max_chars)
-        if text and text not in result:
-            result.append(text)
-        if len(result) >= max_items:
-            break
-    return result
+__all__ = [
+    "DEFAULT_DISPLAY_LIMIT",
+    "ELLIPSIS",
+    "LABEL_DISPLAY_LIMIT",
+    "LIST_ITEM_DISPLAY_LIMIT",
+    "LONGFORM_DISPLAY_LIMIT",
+    "MAX_LIST_ITEMS",
+    "safe_display_list",
+    "safe_display_text",
+    "truncate_display_text",
+]

--- a/modules/helpers/tk_text_safety.py
+++ b/modules/helpers/tk_text_safety.py
@@ -1,0 +1,61 @@
+"""Shared guards for text rendered by Tk widgets."""
+from __future__ import annotations
+
+from typing import Any
+
+from modules.helpers.text_helpers import coerce_text
+
+ELLIPSIS = "…"
+DEFAULT_DISPLAY_LIMIT = 8_000
+LABEL_DISPLAY_LIMIT = 240
+LONGFORM_DISPLAY_LIMIT = 6_000
+LIST_ITEM_DISPLAY_LIMIT = 240
+MAX_LIST_ITEMS = 200
+
+
+def safe_display_text(value: Any, *, max_chars: int = DEFAULT_DISPLAY_LIMIT) -> str:
+    """Return plain text bounded to a size Tk can safely render.
+
+    Imported campaign data can contain accidentally huge blobs (for example a
+    pasted PDF, serialized rich-text payload, or binary-ish field). Passing those
+    values directly into Tk label/button/menu text can surface later from
+    ``mainloop`` as ``OverflowError: string is too long``. This helper keeps UI
+    labels readable while preserving enough content to identify the record.
+    """
+
+    text = coerce_text(value).strip()
+    return truncate_display_text(text, max_chars=max_chars)
+
+
+def truncate_display_text(value: Any, *, max_chars: int = DEFAULT_DISPLAY_LIMIT) -> str:
+    """Truncate ``value`` to ``max_chars`` with a visible ellipsis marker."""
+
+    text = str(value or "")
+    if max_chars < 1:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    suffix = f" {ELLIPSIS}"
+    keep = max(max_chars - len(suffix), 0)
+    return text[:keep].rstrip() + suffix
+
+
+def safe_display_list(
+    value: Any,
+    *,
+    max_items: int = MAX_LIST_ITEMS,
+    item_max_chars: int = LIST_ITEM_DISPLAY_LIMIT,
+) -> list[str]:
+    """Return a de-duplicated, bounded list of safe display strings."""
+
+    if not isinstance(value, list):
+        return []
+
+    result: list[str] = []
+    for entry in value:
+        text = safe_display_text(entry, max_chars=item_max_chars)
+        if text and text not in result:
+            result.append(text)
+        if len(result) >= max_items:
+            break
+    return result

--- a/modules/pcs/display_pcs.py
+++ b/modules/pcs/display_pcs.py
@@ -3,6 +3,11 @@
 import customtkinter as ctk
 from modules.helpers import theme_manager
 from modules.helpers.text_helpers import format_multiline_text
+from modules.helpers.tk_text_safety import (
+    LABEL_DISPLAY_LIMIT,
+    LONGFORM_DISPLAY_LIMIT,
+    safe_display_text,
+)
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -135,7 +140,7 @@ def display_pcs_in_banner(banner_frame, pcs_items):
         header.pack(fill="x", padx=8, pady=(8, 4))
         label = ctk.CTkLabel(
             header,
-            text=name,
+            text=safe_display_text(name, max_chars=LABEL_DISPLAY_LIMIT),
             font=fonts["title"],
             text_color=colors["text"],
             anchor="w",
@@ -158,7 +163,7 @@ def display_pcs_in_banner(banner_frame, pcs_items):
         label_title.pack(fill="x")
         label_content = ctk.CTkLabel(
             frame,
-            text=content,
+            text=safe_display_text(content, max_chars=LONGFORM_DISPLAY_LIMIT),
             font=fonts["body"],
             text_color=colors["text"],
             anchor="w",
@@ -178,7 +183,7 @@ def display_pcs_in_banner(banner_frame, pcs_items):
         )
         pc_frame.grid(row=0, column=col_idx, sticky="nsew", padx=8, pady=(0, 8))
 
-        display_name = pc_data.get("Name") or pc_name
+        display_name = safe_display_text(pc_data.get("Name") or pc_name, max_chars=LABEL_DISPLAY_LIMIT)
         add_header(pc_frame, display_name)
 
         add_section(pc_frame, "Traits", format_multiline_text(pc_data.get("Traits", "")))

--- a/tests/test_pc_banner_text_safety.py
+++ b/tests/test_pc_banner_text_safety.py
@@ -1,0 +1,60 @@
+"""Regression tests for PC banner text safety."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+SOURCE_PATH = Path("modules/pcs/display_pcs.py")
+MODULE_AST = ast.parse(SOURCE_PATH.read_text(encoding="utf-8"))
+
+
+def test_pc_banner_imports_shared_tk_text_safety() -> None:
+    """The PC banner should use shared bounded text helpers before rendering labels."""
+
+    imports = [node for node in MODULE_AST.body if isinstance(node, ast.ImportFrom)]
+
+    assert any(
+        node.module == "modules.helpers.tk_text_safety"
+        and {alias.name for alias in node.names}
+        >= {"LABEL_DISPLAY_LIMIT", "LONGFORM_DISPLAY_LIMIT", "safe_display_text"}
+        for node in imports
+    )
+
+
+def test_pc_banner_sanitizes_label_text_before_ctk_label_creation() -> None:
+    """Header and body labels should not receive raw database text."""
+
+    calls = [node for node in ast.walk(MODULE_AST) if isinstance(node, ast.Call)]
+    ctk_label_calls = [
+        call
+        for call in calls
+        if isinstance(call.func, ast.Attribute) and call.func.attr == "CTkLabel"
+    ]
+    text_keywords = [keyword.value for call in ctk_label_calls for keyword in call.keywords if keyword.arg == "text"]
+
+    safe_text_calls = [
+        value
+        for value in text_keywords
+        if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "safe_display_text"
+    ]
+
+    assert len(safe_text_calls) >= 2
+    assert any(
+        any(
+            keyword.arg == "max_chars"
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == "LABEL_DISPLAY_LIMIT"
+            for keyword in call.keywords
+        )
+        for call in safe_text_calls
+    )
+    assert any(
+        any(
+            keyword.arg == "max_chars"
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == "LONGFORM_DISPLAY_LIMIT"
+            for keyword in call.keywords
+        )
+        for call in safe_text_calls
+    )

--- a/tests/test_tk_text_safety.py
+++ b/tests/test_tk_text_safety.py
@@ -1,0 +1,21 @@
+"""Regression tests for shared Tk display text guards."""
+from __future__ import annotations
+
+from modules.helpers.tk_text_safety import ELLIPSIS, safe_display_list, safe_display_text
+
+
+def test_safe_display_text_truncates_huge_values_for_tk_labels() -> None:
+    """Huge imported blobs should be visibly truncated before reaching Tk."""
+
+    result = safe_display_text("x" * 100, max_chars=12)
+
+    assert len(result) == 12
+    assert result.endswith(ELLIPSIS)
+
+
+def test_safe_display_list_bounds_items_and_item_length() -> None:
+    """Lists rendered in menus/selectors should be capped in size and length."""
+
+    result = safe_display_list(["a" * 20, "b" * 20, "c" * 20], max_items=2, item_max_chars=8)
+
+    assert result == [f"aaaaaa {ELLIPSIS}", f"bbbbbb {ELLIPSIS}"]


### PR DESCRIPTION
### Motivation
- The app could raise `OverflowError: string is too long` in `mainloop()` when very large imported text reached Tk labels (notably in the campaign overview / PC banner). 
- Introduce a small, shared guard so long/blobby fields are truncated before being passed to Tk widgets to keep the UI stable.

### Description
- Added a shared helper `modules/helpers/tk_text_safety.py` with `safe_display_text`, `truncate_display_text`, `safe_display_list` and constants like `LABEL_DISPLAY_LIMIT` and `LONGFORM_DISPLAY_LIMIT` to centralize truncation rules.  
- Kept backward compatibility by re-exporting the same API from `modules/campaigns/ui/graphical_display/text_safety.py` so existing imports continue to work.  
- Applied the guard to the PC banner in `modules/pcs/display_pcs.py`, ensuring PC names and long Traits/Background/Secret text are truncated via `safe_display_text` before creating `CTkLabel` widgets.  
- Added regression tests `tests/test_tk_text_safety.py` and `tests/test_pc_banner_text_safety.py` which verify truncation behavior and that the PC banner uses the shared helper.

### Testing
- Ran targeted unit tests with `python -m pytest tests/test_tk_text_safety.py tests/test_pc_banner_text_safety.py tests/test_campaign_overview_launch_layout.py` and all tests passed (`7 passed`).
- Verified modules compile with `python -m py_compile modules/helpers/tk_text_safety.py modules/campaigns/ui/graphical_display/text_safety.py modules/pcs/display_pcs.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b9649f98832bb392a3486051dd12)