### PR TITLE
Handle Python-style portrait list values

### DIFF
--- a/modules/helpers/portrait_helper.py
+++ b/modules/helpers/portrait_helper.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 from pathlib import Path
 from typing import Iterable, List, Optional
 
 from modules.helpers.config_helper import ConfigHelper
+
+
+def _parse_sequence_text(stripped: str):
+    """Return a decoded list-like value from JSON or Python literal text."""
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(stripped)
+        except (ValueError, SyntaxError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, (list, tuple, set)):
+            return parsed
+    return None
 
 
 def _extract_dict_value(value: dict) -> str:
@@ -43,11 +56,8 @@ def parse_portrait_value(value) -> List[str]:
         if not stripped:
             return []
         if stripped.startswith("[") and stripped.endswith("]"):
-            # Handle the branch where stripped.startswith('[') and stripped.endswith(']').
-            try:
-                parsed = json.loads(stripped)
-            except json.JSONDecodeError:
-                parsed = None
+            # Support JSON arrays and Python-style list literals saved by older data.
+            parsed = _parse_sequence_text(stripped)
             if parsed is not None:
                 return _flatten_portrait_values(parsed)
         lines = [line.strip() for line in stripped.splitlines() if line.strip()]

--- a/tests/helpers/test_portrait_helper.py
+++ b/tests/helpers/test_portrait_helper.py
@@ -1,0 +1,16 @@
+from modules.helpers.portrait_helper import parse_portrait_value
+
+
+def test_parse_portrait_value_accepts_python_style_list_literal():
+    assert parse_portrait_value("['No Image']") == ["No Image"]
+
+
+def test_parse_portrait_value_accepts_json_list():
+    assert parse_portrait_value('["portrait.png", "token.png"]') == [
+        "portrait.png",
+        "token.png",
+    ]
+
+
+def test_parse_portrait_value_keeps_invalid_list_like_text_as_single_value():
+    assert parse_portrait_value("[not valid]") == ["[not valid]"]


### PR DESCRIPTION
### Motivation
- Fix parsing of portrait-like string values saved as Python-style list literals (for example `['No Image']` from the screenshot) so they decode to usable entries instead of being left as literal bracketed text or causing JSON decode failures.

### Description
- Add `ast` import and a helper `_parse_sequence_text` that tries `json.loads` then `ast.literal_eval` to decode bracketed list-like text, and use it in `parse_portrait_value` to support both JSON arrays and Python-style list literals.
- Add unit tests in `tests/helpers/test_portrait_helper.py` covering a Python-style list literal, a JSON list, and malformed list-like text fallback.

### Testing
- Ran `python -m pytest tests/helpers/test_portrait_helper.py -q` which returned `3 passed`.
- Ran `python -m pytest tests/scenarios/gm_table/test_gm_table_handouts_service.py tests/helpers/test_portrait_helper.py -q` which completed successfully (combined tests passed locally).
- Ran `python -m py_compile modules/helpers/portrait_helper.py` which succeeded.
- A full `python -m pytest -q` run fails during collection due to unrelated environment/test-stub issues (duplicate test module basename and incomplete GUI/PIL test stubs), not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f2830eb0832b88a1dcb7c91ea073)