### PR TITLE
Add missing-reference remap target selector

### DIFF
--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -32,7 +32,12 @@ from src.ui.validation.dialogs.campaign_selector_dialog import (
 )
 from src.ui.validation.dialogs.missing_reference_dialog import (
     MissingReferenceDialogConfig,
+    RemapTargetProvider,
     open_missing_reference_dialog,
+)
+from src.ui.validation.dialogs.remap_target_selector_dialog import (
+    RemapTargetOption,
+    open_remap_target_selector_dialog,
 )
 from src.ui.validation.dialogs.invalid_hierarchy_dialog import (
     InvalidHierarchyDialogConfig,
@@ -68,9 +73,11 @@ from src.ui.validation.validation_wizard_controller import (
 from src.validation import (
     IssueType,
     ReferenceValidationResult,
+    ValidationIssue,
     normalize_validator_reference_fields,
     validate_reference_graph,
 )
+from src.validation.reference_validator import EntityRecord
 
 CampaignSelector = Callable[
     [Any, Sequence[CampaignSelectorOption]],
@@ -273,7 +280,11 @@ class CampaignHierarchyValidationLauncher:
                 step,
                 reference=resolve_reference_for_issue(step.issue, run.graph.references),
                 config=MissingReferenceDialogConfig(
-                    on_step=lambda next_step: self._handle_step(run, next_step)
+                    remap_target_provider=build_missing_reference_remap_target_provider(
+                        self.app,
+                        run.graph,
+                    ),
+                    on_step=lambda next_step: self._handle_step(run, next_step),
                 ),
             )
             return
@@ -325,6 +336,48 @@ class CampaignHierarchyValidationLauncher:
             HIERARCHY_CONSISTENCY_TITLE,
             safe_display_text(step.message, max_chars=LONGFORM_DISPLAY_LIMIT),
         )
+
+
+def build_missing_reference_remap_target_provider(
+    master: Any,
+    graph: ReferenceValidationResult,
+    *,
+    selector: Callable[
+        [Any, Sequence[RemapTargetOption]],
+        EntityRecord | None,
+    ] = open_remap_target_selector_dialog,
+) -> RemapTargetProvider:
+    """Build a provider that lets users choose a compatible existing entity."""
+
+    def provide_remap_target(issue: ValidationIssue) -> EntityRecord | None:
+        targets = remap_target_options_for_issue(issue, graph.entities)
+        return selector(master, targets)
+
+    return provide_remap_target
+
+
+def remap_target_options_for_issue(
+    issue: ValidationIssue,
+    entities: Sequence[EntityRecord],
+) -> tuple[RemapTargetOption, ...]:
+    """Return existing entities compatible with a missing-reference issue."""
+
+    if issue.issue_type != IssueType.MISSING_REFERENCE:
+        return ()
+
+    expected_type = _normalize_entity_type(issue.payload.expected_type)
+    if not expected_type:
+        return ()
+
+    return tuple(
+        RemapTargetOption(entity)
+        for entity in entities
+        if _normalize_entity_type(entity.entity_type) == expected_type
+    )
+
+
+def _normalize_entity_type(entity_type: str | None) -> str:
+    return str(entity_type or "").strip().lower().replace(" ", "_")
 
 
 def load_campaign_options(

--- a/src/ui/validation/dialogs/__init__.py
+++ b/src/ui/validation/dialogs/__init__.py
@@ -19,6 +19,11 @@ from .campaign_selector_dialog import (
     CampaignSelectorOption,
     open_campaign_selector_dialog,
 )
+from .remap_target_selector_dialog import (
+    RemapTargetOption,
+    RemapTargetSelectorDialog,
+    open_remap_target_selector_dialog,
+)
 from .missing_reference_dialog import (
     MissingReferenceDialog,
     MissingReferenceDialogConfig,
@@ -48,6 +53,8 @@ __all__ = [
     "InvalidHierarchyDialogConfig",
     "MissingReferenceDialog",
     "MissingReferenceDialogConfig",
+    "RemapTargetOption",
+    "RemapTargetSelectorDialog",
     "ValidationSummaryCounts",
     "ValidationSummaryDialog",
     "build_prefilled_entity",
@@ -57,5 +64,6 @@ __all__ = [
     "open_campaign_selector_dialog",
     "open_invalid_hierarchy_dialog",
     "open_missing_reference_dialog",
+    "open_remap_target_selector_dialog",
     "open_validation_summary_dialog",
 ]

--- a/src/ui/validation/dialogs/missing_reference_dialog.py
+++ b/src/ui/validation/dialogs/missing_reference_dialog.py
@@ -128,23 +128,20 @@ class MissingReferenceDialog:
 
         actions = ctk.CTkFrame(window)
         actions.grid(row=2, column=0, sticky="ew", padx=20, pady=8)
-        for index in range(4):
-            actions.grid_columnconfigure(index, weight=1)
+        action_buttons: list[tuple[str, Callable[[], Any]]] = [
+            (CREATE_LABEL, self.create_via_generic_editor),
+            (REMOVE_LABEL, self.remove_reference),
+            (IGNORE_LABEL, self.ignore),
+        ]
+        if self.config.remap_target_provider is not None:
+            action_buttons.insert(1, (REMAP_LABEL, self.remap))
 
-        ctk.CTkButton(
-            actions, text=CREATE_LABEL, command=self.create_via_generic_editor
-        ).grid(
-            row=0, column=0, sticky="ew", padx=4, pady=4
-        )
-        ctk.CTkButton(actions, text=REMAP_LABEL, command=self.remap).grid(
-            row=0, column=1, sticky="ew", padx=4, pady=4
-        )
-        ctk.CTkButton(actions, text=REMOVE_LABEL, command=self.remove_reference).grid(
-            row=0, column=2, sticky="ew", padx=4, pady=4
-        )
-        ctk.CTkButton(actions, text=IGNORE_LABEL, command=self.ignore).grid(
-            row=0, column=3, sticky="ew", padx=4, pady=4
-        )
+        for index in range(len(action_buttons)):
+            actions.grid_columnconfigure(index, weight=1)
+        for index, (label, command) in enumerate(action_buttons):
+            ctk.CTkButton(actions, text=label, command=command).grid(
+                row=0, column=index, sticky="ew", padx=4, pady=4
+            )
         return self
 
     def create_via_generic_editor(self) -> ValidationWizardStep | None:

--- a/src/ui/validation/dialogs/remap_target_selector_dialog.py
+++ b/src/ui/validation/dialogs/remap_target_selector_dialog.py
@@ -1,0 +1,174 @@
+"""Selector dialog for choosing a missing-reference remap target."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from modules.helpers.tk_text_safety import (
+    LABEL_DISPLAY_LIMIT,
+    LONGFORM_DISPLAY_LIMIT,
+    safe_display_text,
+)
+from src.ui.validation.labels import (
+    CANCEL_LABEL,
+    CHOOSE_REMAP_TARGET_MESSAGE,
+    CHOOSE_REMAP_TARGET_TITLE,
+    NO_REMAP_TARGETS_MESSAGE,
+    REMAP_LABEL,
+)
+from src.validation.reference_validator import EntityRecord
+
+
+@dataclass(frozen=True)
+class RemapTargetOption:
+    """One compatible entity that can replace a missing reference."""
+
+    entity: EntityRecord
+
+    @property
+    def display_text(self) -> str:
+        """Return a stable user-facing label for dropdowns and lists."""
+
+        label = safe_display_text(self.entity.label, max_chars=LABEL_DISPLAY_LIMIT)
+        identifier = safe_display_text(
+            self.entity.identifier,
+            max_chars=LABEL_DISPLAY_LIMIT,
+        )
+        path = " > ".join(self.entity.path)
+        path_text = safe_display_text(path, max_chars=LONGFORM_DISPLAY_LIMIT)
+        if label == identifier:
+            main_text = label
+        else:
+            main_text = f"{label} ({identifier})"
+        if path_text:
+            return safe_display_text(
+                f"{main_text} — {path_text}",
+                max_chars=LONGFORM_DISPLAY_LIMIT,
+            )
+        return safe_display_text(main_text, max_chars=LONGFORM_DISPLAY_LIMIT)
+
+
+class RemapTargetSelectorDialog:
+    """Blocking CustomTkinter dialog that returns the selected remap target."""
+
+    def __init__(self, master: Any, targets: Sequence[RemapTargetOption]) -> None:
+        self.master = master
+        self.targets = tuple(targets)
+        self.selected_target: EntityRecord | None = None
+        self.window: Any | None = None
+        self._selected_text: Any | None = None
+        self._remap_button: Any | None = None
+        self._display_to_target = _display_index(self.targets)
+
+    def show(self) -> EntityRecord | None:
+        """Open the modal selector and return the chosen target, or ``None``."""
+
+        import customtkinter as ctk
+
+        window = ctk.CTkToplevel(self.master)
+        self.window = window
+        window.title(CHOOSE_REMAP_TARGET_TITLE)
+        window.transient(self.master)
+        window.grab_set()
+        window.geometry("560x280")
+        window.grid_columnconfigure(0, weight=1)
+        window.protocol("WM_DELETE_WINDOW", self.cancel)
+
+        ctk.CTkLabel(
+            window,
+            text=CHOOSE_REMAP_TARGET_TITLE,
+            font=ctk.CTkFont(size=18, weight="bold"),
+        ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 8))
+
+        if self.targets:
+            ctk.CTkLabel(
+                window,
+                text=CHOOSE_REMAP_TARGET_MESSAGE,
+                wraplength=500,
+                justify="left",
+            ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
+            self._selected_text = ctk.StringVar(value="")
+            dropdown = ctk.CTkOptionMenu(
+                window,
+                values=tuple(self._display_to_target),
+                variable=self._selected_text,
+                command=self._on_selection_changed,
+            )
+            dropdown.grid(row=2, column=0, sticky="ew", padx=20, pady=4)
+        else:
+            ctk.CTkLabel(
+                window,
+                text=NO_REMAP_TARGETS_MESSAGE,
+                wraplength=500,
+                justify="left",
+            ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
+
+        actions = ctk.CTkFrame(window)
+        actions.grid(row=3, column=0, sticky="e", padx=20, pady=(22, 20))
+        self._remap_button = ctk.CTkButton(
+            actions,
+            text=REMAP_LABEL,
+            command=self.remap,
+            state="disabled",
+        )
+        self._remap_button.grid(row=0, column=0, padx=(0, 8))
+        ctk.CTkButton(actions, text=CANCEL_LABEL, command=self.cancel).grid(
+            row=0,
+            column=1,
+        )
+
+        window.wait_window()
+        return self.selected_target
+
+    def _on_selection_changed(self, selected_text: str) -> None:
+        if self._remap_button is not None:
+            state = "normal" if selected_text in self._display_to_target else "disabled"
+            self._remap_button.configure(state=state)
+
+    def remap(self) -> None:
+        """Accept the current selection and close the dialog."""
+
+        selected_text = (
+            self._selected_text.get() if self._selected_text is not None else ""
+        )
+        selected_target = self._display_to_target.get(selected_text)
+        if selected_target is None:
+            return
+        self.selected_target = selected_target.entity
+        self._close()
+
+    def cancel(self) -> None:
+        """Abort remapping without choosing a target."""
+
+        self.selected_target = None
+        self._close()
+
+    def _close(self) -> None:
+        if self.window is not None:
+            self.window.destroy()
+            self.window = None
+
+
+def open_remap_target_selector_dialog(
+    master: Any,
+    targets: Sequence[RemapTargetOption],
+) -> EntityRecord | None:
+    """Open the dedicated remap target selector dialog."""
+
+    return RemapTargetSelectorDialog(master, targets).show()
+
+
+def _display_index(
+    targets: Sequence[RemapTargetOption],
+) -> dict[str, RemapTargetOption]:
+    display_to_target: dict[str, RemapTargetOption] = {}
+    for index, target in enumerate(targets, start=1):
+        display_text = target.display_text
+        if display_text in display_to_target:
+            display_text = safe_display_text(
+                f"{display_text} #{index}",
+                max_chars=LONGFORM_DISPLAY_LIMIT,
+            )
+        display_to_target[display_text] = target
+    return display_to_target

--- a/src/ui/validation/labels.py
+++ b/src/ui/validation/labels.py
@@ -87,6 +87,11 @@ REMAP_LABEL = "Remap"
 REMOVE_LABEL = "Remove"
 NO_REMAP_TARGET_SELECTOR_MESSAGE = "No target selector is configured for remapping."
 REMAPPING_UNAVAILABLE_TITLE = "Remapping unavailable"
+CHOOSE_REMAP_TARGET_TITLE = "Choose remap target"
+CHOOSE_REMAP_TARGET_MESSAGE = (
+    "Select an existing compatible entity to replace this missing reference."
+)
+NO_REMAP_TARGETS_MESSAGE = "No compatible existing entities are available for remapping."
 
 CHOOSE_CAMPAIGN_TITLE = "Choose a campaign"
 CHOOSE_CAMPAIGN_MESSAGE = (

--- a/tests/ui/validation/test_missing_reference_dialog.py
+++ b/tests/ui/validation/test_missing_reference_dialog.py
@@ -1,5 +1,8 @@
 """Regression tests for missing-reference validation dialog helpers."""
 
+import sys
+import types
+
 from src.ui.validation import (
     ValidationWizardController,
     ValidationWizardIssue,
@@ -14,6 +17,11 @@ from src.ui.validation.dialogs import (
     creation_request_from_issue,
     entity_slug_for_expected_type,
 )
+from src.ui.validation.campaign_validation_launcher import (
+    build_missing_reference_remap_target_provider,
+    remap_target_options_for_issue,
+)
+from src.ui.validation.labels import REMAP_LABEL
 from src.validation import validate_reference_graph
 
 
@@ -185,3 +193,121 @@ def test_dialog_actions_delegate_remap_remove_and_ignore_to_controller():
     assert dialog.ignore().status == ValidationWizardStatus.COMPLETED
     assert controller.summary.skipped_session == 1
     assert ignore_hierarchy["arc_refs"] == ["Missing Arc"]
+
+
+def test_remap_target_options_only_include_expected_entity_type():
+    hierarchy = {
+        "type": "arc",
+        "id": "A1",
+        "scenario_refs": ["Missing Scenario"],
+        "scenarios": [
+            {"type": "scenario", "id": "S1", "name": "Existing Scenario"},
+        ],
+    }
+    graph = validate_reference_graph(hierarchy, campaign={"id": "sample"})
+
+    options = remap_target_options_for_issue(graph.issues[0], graph.entities)
+
+    assert [option.entity.identifier for option in options] == ["S1"]
+    assert options[0].display_text.startswith("Existing Scenario (S1)")
+
+
+def test_remap_target_provider_returns_selector_choice():
+    hierarchy = {
+        "type": "arc",
+        "id": "A1",
+        "scenario_refs": ["Missing Scenario"],
+        "scenarios": [
+            {"type": "scenario", "id": "S1", "name": "Existing Scenario"},
+        ],
+    }
+    graph = validate_reference_graph(hierarchy, campaign={"id": "sample"})
+    observed_targets = []
+
+    def selector(master, targets):
+        observed_targets.extend(targets)
+        return targets[0].entity
+
+    provider = build_missing_reference_remap_target_provider(
+        object(),
+        graph,
+        selector=selector,
+    )
+
+    assert provider(graph.issues[0]).identifier == "S1"
+    assert [target.entity.identifier for target in observed_targets] == ["S1"]
+
+
+def test_dialog_show_hides_remap_button_without_provider(monkeypatch):
+    graph, reference, controller = _wizard_for(
+        {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    )
+    fake_ctk = _install_fake_customtkinter(monkeypatch)
+    dialog = MissingReferenceDialog(None, controller, graph.issues[0], reference=reference)
+
+    dialog.show()
+
+    assert REMAP_LABEL not in fake_ctk.button_texts
+    assert fake_ctk.column_indexes[-3:] == [0, 1, 2]
+
+
+def test_dialog_show_includes_remap_button_with_provider(monkeypatch):
+    graph, reference, controller = _wizard_for(
+        {"type": "campaign", "id": "C1", "arc_refs": ["Missing Arc"]}
+    )
+    fake_ctk = _install_fake_customtkinter(monkeypatch)
+    dialog = MissingReferenceDialog(
+        None,
+        controller,
+        graph.issues[0],
+        reference=reference,
+        config=MissingReferenceDialogConfig(remap_target_provider=lambda issue: "A1"),
+    )
+
+    dialog.show()
+
+    assert REMAP_LABEL in fake_ctk.button_texts
+    assert fake_ctk.column_indexes[-4:] == [0, 1, 2, 3]
+
+
+def _install_fake_customtkinter(monkeypatch):
+    fake_ctk = types.SimpleNamespace(button_texts=[], column_indexes=[])
+
+    class _Widget:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def grid(self, *args, **kwargs):
+            return None
+
+        def grid_columnconfigure(self, index, **kwargs):
+            fake_ctk.column_indexes.append(index)
+
+        def title(self, *args, **kwargs):
+            return None
+
+        def transient(self, *args, **kwargs):
+            return None
+
+        def grab_set(self, *args, **kwargs):
+            return None
+
+        def geometry(self, *args, **kwargs):
+            return None
+
+        def destroy(self):
+            return None
+
+    class _Button(_Widget):
+        def __init__(self, *args, text="", command=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            fake_ctk.button_texts.append(text)
+            self.command = command
+
+    fake_ctk.CTkToplevel = _Widget
+    fake_ctk.CTkFrame = _Widget
+    fake_ctk.CTkLabel = _Widget
+    fake_ctk.CTkButton = _Button
+    fake_ctk.CTkFont = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "customtkinter", fake_ctk)
+    return fake_ctk


### PR DESCRIPTION
### Motivation
- Provide a UI flow to remap missing-reference issues to compatible existing entities from the current validation run instead of always showing an unavailable remap action.  
- Ensure the missing-reference dialog shows the Remap action only when a provider is available so the user experience is consistent and non-breaking.  

### Description
- Added a selector dialog `RemapTargetSelectorDialog` and `RemapTargetOption` in `src/ui/validation/dialogs/remap_target_selector_dialog.py` to present compatible existing entities and return the chosen `EntityRecord`.  
- Wired a provider via `build_missing_reference_remap_target_provider` and helper `remap_target_options_for_issue` in `src/ui/validation/campaign_validation_launcher.py` to filter `run.graph.entities` by the issue `expected_type` and call the selector.  
- Updated `MissingReferenceDialog` so action buttons are built dynamically and the `Remap` button is only inserted when `MissingReferenceDialogConfig.remap_target_provider` is provided in `src/ui/validation/dialogs/missing_reference_dialog.py`.  
- Added new labels/messages for the selector in `src/ui/validation/labels.py` and exported the selector utilities from `src/ui/validation/dialogs/__init__.py`.  
- Added regression tests in `tests/ui/validation/test_missing_reference_dialog.py` covering target filtering, provider delegation, and Remap button visibility/behavior.  

### Testing
- Ran `pytest -q tests/ui/validation/test_missing_reference_dialog.py` and observed all tests pass (`9 passed`).  
- Ran `python -m compileall -q src/ui/validation tests/ui/validation/test_missing_reference_dialog.py` to check for syntax/bytecode issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c1573cb4832bb939e826bc977d23)