### PR TITLE
Add search field to remap target selector

### DIFF
--- a/src/ui/validation/dialogs/remap_target_filter.py
+++ b/src/ui/validation/dialogs/remap_target_filter.py
@@ -1,0 +1,27 @@
+"""Filtering helpers for remap target selector dialogs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def filter_remap_target_display_values(
+    display_values: Iterable[str],
+    query: str,
+) -> tuple[str, ...]:
+    """Return display values matching all case-insensitive search terms."""
+
+    values = tuple(display_values)
+    normalized_query = str(query or "").strip().casefold()
+    if not normalized_query:
+        return values
+
+    terms = tuple(term for term in normalized_query.split() if term)
+    if not terms:
+        return values
+
+    return tuple(
+        value
+        for value in values
+        if all(term in value.casefold() for term in terms)
+    )

--- a/src/ui/validation/dialogs/remap_target_selector_dialog.py
+++ b/src/ui/validation/dialogs/remap_target_selector_dialog.py
@@ -15,9 +15,14 @@ from src.ui.validation.labels import (
     CHOOSE_REMAP_TARGET_MESSAGE,
     CHOOSE_REMAP_TARGET_TITLE,
     NO_REMAP_TARGETS_MESSAGE,
+    NO_REMAP_TARGET_SEARCH_RESULTS_MESSAGE,
     REMAP_LABEL,
+    REMAP_TARGET_SEARCH_LABEL,
+    REMAP_TARGET_SEARCH_PLACEHOLDER,
 )
 from src.validation.reference_validator import EntityRecord
+
+from .remap_target_filter import filter_remap_target_display_values
 
 
 @dataclass(frozen=True)
@@ -58,8 +63,12 @@ class RemapTargetSelectorDialog:
         self.selected_target: EntityRecord | None = None
         self.window: Any | None = None
         self._selected_text: Any | None = None
+        self._search_text: Any | None = None
+        self._target_dropdown: Any | None = None
+        self._search_status_label: Any | None = None
         self._remap_button: Any | None = None
         self._display_to_target = _display_index(self.targets)
+        self._filtered_display_to_target = dict(self._display_to_target)
 
     def show(self) -> EntityRecord | None:
         """Open the modal selector and return the chosen target, or ``None``."""
@@ -71,7 +80,7 @@ class RemapTargetSelectorDialog:
         window.title(CHOOSE_REMAP_TARGET_TITLE)
         window.transient(self.master)
         window.grab_set()
-        window.geometry("560x280")
+        window.geometry("560x340")
         window.grid_columnconfigure(0, weight=1)
         window.protocol("WM_DELETE_WINDOW", self.cancel)
 
@@ -88,14 +97,40 @@ class RemapTargetSelectorDialog:
                 wraplength=500,
                 justify="left",
             ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
-            self._selected_text = ctk.StringVar(value="")
-            dropdown = ctk.CTkOptionMenu(
+            self._search_text = ctk.StringVar(value="")
+            self._search_text.trace_add("write", self._on_search_changed)
+            ctk.CTkLabel(
                 window,
-                values=tuple(self._display_to_target),
+                text=REMAP_TARGET_SEARCH_LABEL,
+                anchor="w",
+            ).grid(row=2, column=0, sticky="ew", padx=20, pady=(0, 4))
+            search_entry = ctk.CTkEntry(
+                window,
+                textvariable=self._search_text,
+                placeholder_text=REMAP_TARGET_SEARCH_PLACEHOLDER,
+            )
+            search_entry.grid(row=3, column=0, sticky="ew", padx=20, pady=(0, 8))
+
+            self._selected_text = ctk.StringVar(value="")
+            self._target_dropdown = ctk.CTkOptionMenu(
+                window,
+                values=tuple(self._filtered_display_to_target),
                 variable=self._selected_text,
                 command=self._on_selection_changed,
             )
-            dropdown.grid(row=2, column=0, sticky="ew", padx=20, pady=4)
+            self._target_dropdown.grid(row=4, column=0, sticky="ew", padx=20, pady=4)
+            self._search_status_label = ctk.CTkLabel(
+                window,
+                text="",
+                anchor="w",
+            )
+            self._search_status_label.grid(
+                row=5,
+                column=0,
+                sticky="ew",
+                padx=20,
+                pady=(4, 0),
+            )
         else:
             ctk.CTkLabel(
                 window,
@@ -105,7 +140,7 @@ class RemapTargetSelectorDialog:
             ).grid(row=1, column=0, sticky="ew", padx=20, pady=(0, 14))
 
         actions = ctk.CTkFrame(window)
-        actions.grid(row=3, column=0, sticky="e", padx=20, pady=(22, 20))
+        actions.grid(row=6, column=0, sticky="e", padx=20, pady=(22, 20))
         self._remap_button = ctk.CTkButton(
             actions,
             text=REMAP_LABEL,
@@ -121,9 +156,40 @@ class RemapTargetSelectorDialog:
         window.wait_window()
         return self.selected_target
 
+    def _on_search_changed(self, *_args: Any) -> None:
+        query = self._search_text.get() if self._search_text is not None else ""
+        display_values = filter_remap_target_display_values(
+            self._display_to_target,
+            query,
+        )
+        self._filtered_display_to_target = {
+            value: self._display_to_target[value] for value in display_values
+        }
+        if self._target_dropdown is not None:
+            self._target_dropdown.configure(values=display_values)
+        selected_text = (
+            self._selected_text.get() if self._selected_text is not None else ""
+        )
+        if selected_text not in self._filtered_display_to_target:
+            selected_text = ""
+            if self._selected_text is not None:
+                self._selected_text.set("")
+        if self._search_status_label is not None:
+            status_text = (
+                ""
+                if display_values
+                else NO_REMAP_TARGET_SEARCH_RESULTS_MESSAGE
+            )
+            self._search_status_label.configure(text=status_text)
+        self._on_selection_changed(selected_text)
+
     def _on_selection_changed(self, selected_text: str) -> None:
         if self._remap_button is not None:
-            state = "normal" if selected_text in self._display_to_target else "disabled"
+            state = (
+                "normal"
+                if selected_text in self._filtered_display_to_target
+                else "disabled"
+            )
             self._remap_button.configure(state=state)
 
     def remap(self) -> None:
@@ -132,7 +198,7 @@ class RemapTargetSelectorDialog:
         selected_text = (
             self._selected_text.get() if self._selected_text is not None else ""
         )
-        selected_target = self._display_to_target.get(selected_text)
+        selected_target = self._filtered_display_to_target.get(selected_text)
         if selected_target is None:
             return
         self.selected_target = selected_target.entity

--- a/src/ui/validation/labels.py
+++ b/src/ui/validation/labels.py
@@ -92,6 +92,9 @@ CHOOSE_REMAP_TARGET_MESSAGE = (
     "Select an existing compatible entity to replace this missing reference."
 )
 NO_REMAP_TARGETS_MESSAGE = "No compatible existing entities are available for remapping."
+REMAP_TARGET_SEARCH_LABEL = "Search targets"
+REMAP_TARGET_SEARCH_PLACEHOLDER = "Type a name, id, or path..."
+NO_REMAP_TARGET_SEARCH_RESULTS_MESSAGE = "No targets match your search."
 
 CHOOSE_CAMPAIGN_TITLE = "Choose a campaign"
 CHOOSE_CAMPAIGN_MESSAGE = (

--- a/tests/ui/validation/test_remap_target_selector_dialog.py
+++ b/tests/ui/validation/test_remap_target_selector_dialog.py
@@ -1,0 +1,102 @@
+"""Tests for remap target selector search behavior."""
+
+from src.ui.validation.dialogs.remap_target_filter import (
+    filter_remap_target_display_values,
+)
+from src.ui.validation.dialogs.remap_target_selector_dialog import (
+    RemapTargetOption,
+    RemapTargetSelectorDialog,
+)
+from src.validation.reference_validator import EntityRecord
+
+
+class _FakeVariable:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+class _FakeWidget:
+    def __init__(self):
+        self.config = {}
+
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+
+def _entity(identifier, label, path=()):
+    return EntityRecord(
+        entity_type="scenario",
+        identifier=identifier,
+        label=label,
+        node={},
+        path=tuple(path),
+        parent_path=(),
+        parent_type=None,
+        parent_identifier=None,
+        order=0,
+    )
+
+
+def test_filter_remap_target_display_values_matches_name_id_and_path_terms():
+    values = (
+        "Open the Vault (S1) — Campaign > Arc One",
+        "Talk to the Bishop (S2) — Campaign > Cathedral",
+        "Ambush at Docks (S3) — Campaign > Harbor",
+    )
+
+    assert filter_remap_target_display_values(values, "bishop") == (values[1],)
+    assert filter_remap_target_display_values(values, "s3 harbor") == (values[2],)
+    assert filter_remap_target_display_values(values, "  ") == values
+    assert filter_remap_target_display_values(values, "missing") == ()
+
+
+def test_dialog_search_updates_options_status_and_selected_target():
+    first = RemapTargetOption(_entity("S1", "Open the Vault", ("Arc One",)))
+    second = RemapTargetOption(_entity("S2", "Talk to the Bishop", ("Cathedral",)))
+    dialog = RemapTargetSelectorDialog(None, (first, second))
+    dropdown = _FakeWidget()
+    status_label = _FakeWidget()
+    remap_button = _FakeWidget()
+    dialog._target_dropdown = dropdown
+    dialog._search_status_label = status_label
+    dialog._remap_button = remap_button
+    dialog._selected_text = _FakeVariable(first.display_text)
+    dialog._search_text = _FakeVariable("bishop")
+
+    dialog._on_search_changed()
+
+    assert dropdown.config["values"] == (second.display_text,)
+    assert dialog._selected_text.get() == ""
+    assert status_label.config["text"] == ""
+    assert remap_button.config["state"] == "disabled"
+
+    dialog._selected_text.set(second.display_text)
+    dialog._on_selection_changed(second.display_text)
+    dialog.remap()
+
+    assert dialog.selected_target == second.entity
+
+
+def test_dialog_search_reports_no_results():
+    target = RemapTargetOption(_entity("S1", "Open the Vault"))
+    dialog = RemapTargetSelectorDialog(None, (target,))
+    dropdown = _FakeWidget()
+    status_label = _FakeWidget()
+    remap_button = _FakeWidget()
+    dialog._target_dropdown = dropdown
+    dialog._search_status_label = status_label
+    dialog._remap_button = remap_button
+    dialog._selected_text = _FakeVariable(target.display_text)
+    dialog._search_text = _FakeVariable("zzzz")
+
+    dialog._on_search_changed()
+
+    assert dropdown.config["values"] == ()
+    assert status_label.config["text"] == "No targets match your search."
+    assert remap_button.config["state"] == "disabled"


### PR DESCRIPTION
### Motivation
- Users need a quick way to find a compatible remap target from potentially long lists by name, id, or path.
- Keep UI logic testable and avoid cluttering the dialog with filtering logic by moving matching to a helper.

### Description
- Add a search field and UI wiring to the remap dialog so the dropdown is filtered live, stale selections are cleared, and the `Remap` button is enabled only for visible valid choices (file: `src/ui/validation/dialogs/remap_target_selector_dialog.py`).
- Introduce a small, focused filtering helper `filter_remap_target_display_values` that matches all space-separated search terms case-insensitively (file: `src/ui/validation/dialogs/remap_target_filter.py`).
- Add labels/placeholders and a no-results message used by the search UI (file: `src/ui/validation/labels.py`).
- Add regression tests for filtering behavior, no-result messaging, and remap selection after filtering (file: `tests/ui/validation/test_remap_target_selector_dialog.py`).

### Testing
- Ran `python -m pytest tests/ui/validation/test_remap_target_selector_dialog.py tests/ui/validation/test_missing_reference_dialog.py -q` and the suite completed successfully with `12 passed`.
- Ensured module files compile and the new tests exercise the dialog filtering and selection logic via unit tests for the helper and dialog wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c500b2ec832b9d99c86c95d6214e)