### PR TITLE
Persist campaign validation fixes immediately and make reference fixes resilient

### DIFF
--- a/src/services/reference_fix_service.py
+++ b/src/services/reference_fix_service.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Any, Mapping, MutableMapping, MutableSequence
 
 from src.validation.hierarchy_rules import ALLOWED_HIERARCHY_CHILDREN
+from src.validation.source_metadata import source_field_for, source_item_for
 from src.validation.reference_validator import EntityRecord, ReferenceRecord
 
 
@@ -164,7 +165,9 @@ class ReferenceFixService:
             return ReferenceActionResult.error(
                 "Cannot attach: target was not found in its current collection."
             )
+        _mirror_node_field(target.parent_node, target.collection_name, origin_collection)
         source_collection.append(target_node)
+        _mirror_node_field(source_node, collection_name, source_collection)
 
         return ReferenceActionResult.ok(
             f'Entity "{target.identifier}" attached under "{reference.source.identifier}".',
@@ -250,15 +253,16 @@ def _replace_reference_value(
         return False
 
     raw_value = source_node[reference.field_name]
-    index = _reference_index(reference)
+    index = _editable_reference_index(reference, raw_value)
     if _is_mutable_reference_collection(raw_value):
-        if index is None or not 0 <= index < len(raw_value):
+        if index is None:
             return False
         raw_value[index] = _updated_reference_object(
             raw_value[index],
             target_identifier,
             target_type,
         )
+        _mirror_reference_field(reference, raw_value)
         return True
 
     source_node[reference.field_name] = _updated_reference_object(
@@ -266,6 +270,7 @@ def _replace_reference_value(
         target_identifier,
         target_type,
     )
+    _mirror_reference_field(reference, source_node[reference.field_name])
     return True
 
 
@@ -275,15 +280,63 @@ def _remove_reference_value(reference: ReferenceRecord) -> bool:
         return False
 
     raw_value = source_node[reference.field_name]
-    index = _reference_index(reference)
+    index = _editable_reference_index(reference, raw_value)
     if _is_mutable_reference_collection(raw_value):
-        if index is None or not 0 <= index < len(raw_value):
+        if index is None:
             return False
         del raw_value[index]
+        _mirror_reference_field(reference, raw_value)
         return True
 
     del source_node[reference.field_name]
+    _remove_mirrored_reference_field(reference)
     return True
+
+
+def _editable_reference_index(reference: ReferenceRecord, raw_value: Any) -> int | None:
+    index = _reference_index(reference)
+    if (
+        index is not None
+        and _is_mutable_reference_collection(raw_value)
+        and 0 <= index < len(raw_value)
+        and _reference_value_matches(raw_value[index], reference.reference_value)
+    ):
+        return index
+    if not _is_mutable_reference_collection(raw_value):
+        return None
+    for fallback_index, candidate in enumerate(raw_value):
+        if _reference_value_matches(candidate, reference.reference_value):
+            return fallback_index
+    return None
+
+
+def _reference_value_matches(value: Any, expected: str) -> bool:
+    if isinstance(value, Mapping):
+        return _normalize(_first_present(value, _REFERENCE_KEYS)) == expected
+    return _normalize(value) == expected
+
+
+def _mirror_reference_field(reference: ReferenceRecord, value: Any) -> None:
+    _mirror_node_field(reference.source.node, reference.field_name, value)
+
+
+def _remove_mirrored_reference_field(reference: ReferenceRecord) -> None:
+    source_node = reference.source.node
+    if not isinstance(source_node, Mapping):
+        return
+    source_item = source_item_for(source_node)
+    if source_item is None:
+        return
+    source_item.pop(source_field_for(source_node, reference.field_name), None)
+
+
+def _mirror_node_field(node: Mapping[str, Any] | None, field_name: str, value: Any) -> None:
+    if not isinstance(node, Mapping):
+        return
+    source_item = source_item_for(node)
+    if source_item is None:
+        return
+    source_item[source_field_for(node, field_name)] = value
 
 
 def _is_mutable_reference_collection(value: Any) -> bool:
@@ -323,6 +376,7 @@ def _attach_child_entity(
         return ""
 
     collection.append(new_entity)
+    _mirror_node_field(source_node, collection_name, collection)
     return f"{collection_name}: entity added"
 
 

--- a/src/ui/validation/campaign_scenario_entity_hierarchy.py
+++ b/src/ui/validation/campaign_scenario_entity_hierarchy.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Mapping, MutableMapping, Sequence
 
 from modules.helpers.template_loader import load_entity_definitions, load_template
+from src.validation.source_metadata import SOURCE_ITEM_KEY
 from src.validation.field_normalization import (
     FIELD_NORMALIZATION_RULES,
     FieldNormalizationRule,
@@ -208,7 +209,7 @@ def attach_referenced_entities_to_scenarios(
                     identity = _identity_signature(rule.entity_slug, match)
                     if identity in local_identities:
                         continue
-                    child_collection.append(deepcopy(dict(match)))
+                    child_collection.append(_copy_attached_node(match))
                     local_identities.add(identity)
                     attached_signatures.add(signature)
 
@@ -220,6 +221,12 @@ def attach_referenced_entities_to_scenarios(
                 scenario.pop(rule.canonical_field, None)
 
     return frozenset(attached_signatures)
+
+
+def _copy_attached_node(node: Mapping[str, Any]) -> dict[str, Any]:
+    if SOURCE_ITEM_KEY in node:
+        return dict(node)
+    return deepcopy(dict(node))
 
 
 def entity_source_signature(

--- a/src/ui/validation/campaign_scenario_hierarchy.py
+++ b/src/ui/validation/campaign_scenario_hierarchy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Mapping, Sequence
 
+from src.validation.source_metadata import SOURCE_ITEM_KEY
+
 
 _SCENARIO_ID_KEYS = ("id", "uuid", "slug", "key", "Id", "ID", "Uuid", "Slug", "Key")
 _SCENARIO_NAME_KEYS = ("name", "Name", "title", "Title", "label", "Label")
@@ -56,7 +58,7 @@ def attach_referenced_scenarios_to_arcs(
                 signature = _scenario_signature(source_index, match)
                 if signature in attached_signatures:
                     continue
-                scenario_children.append(deepcopy(dict(match)))
+                scenario_children.append(_copy_attached_node(match))
                 attached_signatures.add(signature)
 
         if scenario_children:
@@ -64,6 +66,12 @@ def attach_referenced_scenarios_to_arcs(
         else:
             arc.pop("scenarios", None)
         arc["scenario_refs"] = unresolved_refs
+
+
+def _copy_attached_node(node: Mapping[str, Any]) -> dict[str, Any]:
+    if SOURCE_ITEM_KEY in node:
+        return dict(node)
+    return deepcopy(dict(node))
 
 
 def _scenario_lookup_keys(scenario: Mapping[str, Any]) -> tuple[str, ...]:

--- a/src/ui/validation/campaign_validation_launcher.py
+++ b/src/ui/validation/campaign_validation_launcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from time import monotonic
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
 
 from modules.helpers.tk_text_safety import LONGFORM_DISPLAY_LIMIT, safe_display_text
 from modules.helpers.logging_helper import log_exception, log_info
@@ -71,11 +71,17 @@ from src.ui.validation.validation_wizard_controller import (
     validation_setup_failed_step,
 )
 from src.validation import (
+    FieldNormalizationRule,
     IssueType,
     ReferenceValidationResult,
     ValidationIssue,
     normalize_validator_reference_fields,
     validate_reference_graph,
+)
+from src.validation.source_metadata import (
+    attach_source_metadata,
+    source_item_for,
+    source_wrapper_for,
 )
 from src.validation.reference_validator import EntityRecord
 
@@ -154,6 +160,7 @@ class CampaignHierarchyValidationLauncher:
                 selected_campaign,
                 progress=progress,
                 scenario_link_rules=scenario_link_rules,
+                include_source_metadata=True,
             )
             progress.set_phase("Checking references...")
             graph = validate_reference_graph(
@@ -172,6 +179,7 @@ class CampaignHierarchyValidationLauncher:
                     references_checked=len(graph.references),
                 ),
                 started_at=started_at,
+                on_successful_change=lambda _result: save_validation_sources(graph),
             )
             _log_validation_diagnostics(graph)
             first_step = controller.start()
@@ -409,6 +417,7 @@ def build_campaign_validation_hierarchy(
     *,
     progress: ValidationScanProgress | None = None,
     scenario_link_rules: Sequence[ScenarioLinkedEntityRule] | None = None,
+    include_source_metadata: bool = False,
 ) -> dict[str, Any]:
     """Build a validator-friendly hierarchy for one explicitly selected campaign."""
 
@@ -434,11 +443,21 @@ def build_campaign_validation_hierarchy(
     root["entity_type"] = "campaign"
     root["id"] = selected.campaign_id
     root["name"] = selected.label
+    if include_source_metadata and isinstance(selected.item, MutableMapping):
+        attach_source_metadata(
+            root,
+            source_item=selected.item,
+            wrapper=entity_wrappers.get("campaigns"),
+            field_aliases=_field_aliases_for("campaign", normalization_rules),
+        )
     root["arcs"] = build_campaign_arc_nodes(selected.item.get("Arcs"))
+    if include_source_metadata:
+        _attach_arc_source_metadata(root["arcs"], selected.item, entity_wrappers.get("campaigns"))
     scenario_nodes = _load_scenario_nodes(
         entity_wrappers,
         progress=progress,
         normalization_rules=normalization_rules,
+        include_source_metadata=include_source_metadata,
     )
     attach_referenced_scenarios_to_arcs(
         root["arcs"], build_scenario_reference_index(scenario_nodes)
@@ -447,6 +466,7 @@ def build_campaign_validation_hierarchy(
         entity_wrappers,
         progress=progress,
         normalization_rules=normalization_rules,
+        include_source_metadata=include_source_metadata,
     )
     attached_entity_signatures = attach_referenced_entities_to_scenarios(
         _iter_attached_scenario_nodes(root["arcs"]),
@@ -478,6 +498,7 @@ def _load_scenario_nodes(
     *,
     progress: ValidationScanProgress | None = None,
     normalization_rules: Sequence[Any] | None = None,
+    include_source_metadata: bool = False,
 ) -> tuple[dict[str, Any], ...]:
     """Load and normalize all scenarios for arc-local hierarchy attachment."""
 
@@ -492,6 +513,8 @@ def _load_scenario_nodes(
             item,
             index,
             normalization_rules=normalization_rules,
+            source_item=item if include_source_metadata and isinstance(item, MutableMapping) else None,
+            source_wrapper=wrapper if include_source_metadata else None,
         )
         for index, item in enumerate(_safe_load_items(wrapper))
         if isinstance(item, Mapping)
@@ -503,6 +526,7 @@ def _load_entity_nodes_by_slug(
     *,
     progress: ValidationScanProgress | None = None,
     normalization_rules: Sequence[Any] | None = None,
+    include_source_metadata: bool = False,
 ) -> dict[str, tuple[tuple[int, dict[str, Any]], ...]]:
     """Load non-campaign, non-scenario entities for flat or scenario placement."""
 
@@ -521,6 +545,8 @@ def _load_entity_nodes_by_slug(
                     item,
                     index,
                     normalization_rules=normalization_rules,
+                    source_item=item if include_source_metadata and isinstance(item, MutableMapping) else None,
+                    source_wrapper=wrapper if include_source_metadata else None,
                 ),
             )
             for index, item in enumerate(_safe_load_items(wrapper))
@@ -580,6 +606,60 @@ def _wizard_items(
     )
 
 
+def save_validation_sources(graph: ReferenceValidationResult) -> None:
+    """Persist every source item touched by a validation graph immediately."""
+
+    saved: set[int] = set()
+    for entity in graph.entities:
+        node = entity.node
+        if not isinstance(node, Mapping):
+            continue
+        source_item = source_item_for(node)
+        wrapper = source_wrapper_for(node)
+        if source_item is None or wrapper is None or id(source_item) in saved:
+            continue
+        save_item = getattr(wrapper, "save_item", None)
+        if not callable(save_item):
+            continue
+        save_item(source_item)
+        saved.add(id(source_item))
+
+
+def _field_aliases_for(
+    entity_type: str,
+    normalization_rules: Sequence[FieldNormalizationRule] | None,
+) -> dict[str, str]:
+    return {
+        rule.canonical_field: rule.source_field
+        for rule in tuple(normalization_rules or ())
+        if rule.entity_type == entity_type and rule.source_field != rule.canonical_field
+    }
+
+
+def _attach_arc_source_metadata(
+    arc_nodes: Sequence[MutableMapping[str, Any]],
+    campaign_item: Mapping[str, Any],
+    campaign_wrapper: Any,
+) -> None:
+    raw_arcs = campaign_item.get("Arcs")
+    if isinstance(raw_arcs, Mapping):
+        raw_arcs = raw_arcs.get("arcs")
+    if not isinstance(raw_arcs, Sequence) or isinstance(raw_arcs, (str, bytes, bytearray)):
+        return
+    for index, arc_node in enumerate(arc_nodes):
+        if index >= len(raw_arcs):
+            break
+        raw_arc = raw_arcs[index]
+        if not isinstance(raw_arc, MutableMapping):
+            continue
+        attach_source_metadata(
+            arc_node,
+            source_item=raw_arc,
+            wrapper=None,
+            field_aliases={"scenario_refs": "scenarios"},
+        )
+
+
 def _scan_phase_for_slug(slug: str) -> str:
     if slug == "arcs":
         return "Scanning arcs..."
@@ -611,6 +691,8 @@ def _normalize_entity_node(
     index: int,
     *,
     normalization_rules: Sequence[Any] | None = None,
+    source_item: MutableMapping[str, Any] | None = None,
+    source_wrapper: Any = None,
 ) -> dict[str, Any]:
     entity_type = _singular_entity_type(slug)
     node = normalize_validator_reference_fields(
@@ -623,6 +705,13 @@ def _normalize_entity_node(
     node.setdefault("entity_type", entity_type)
     node.setdefault("id", identifier)
     node.setdefault("name", _display_name_for(node, identifier))
+    if source_item is not None:
+        attach_source_metadata(
+            node,
+            source_item=source_item,
+            wrapper=source_wrapper,
+            field_aliases=_field_aliases_for(entity_type, normalization_rules),
+        )
     return node
 
 

--- a/src/ui/validation/validation_wizard_controller.py
+++ b/src/ui/validation/validation_wizard_controller.py
@@ -187,6 +187,7 @@ class ValidationWizardController:
         presenter: ValidationWizardPresenter | None = None,
         metrics: ValidationWizardMetrics | None = None,
         started_at: float | None = None,
+        on_successful_change: Callable[[ReferenceActionResult], None] | None = None,
     ) -> None:
         self._items = tuple(_coerce_issue_item(issue) for issue in issues)
         self._campaign = dict(campaign)
@@ -194,6 +195,7 @@ class ValidationWizardController:
         self._ignore_store = ignore_store or SessionIgnoreStore()
         self._reference_resolver = reference_resolver
         self._presenter = presenter
+        self._on_successful_change = on_successful_change
         self._started_at = started_at if started_at is not None else monotonic()
         self._cursor = -1
         self._summary = ValidationWizardSummary(
@@ -420,6 +422,14 @@ class ValidationWizardController:
     def _handle_action_result(self, result: ReferenceActionResult) -> ValidationWizardStep:
         if not result.success:
             return self._action_failed(result.ui_message, result)
+        if self._on_successful_change is not None and result.changes_applied:
+            try:
+                self._on_successful_change(result)
+            except Exception as exc:
+                return self._action_failed(
+                    f"Changes were applied but could not be saved: {exc}",
+                    result,
+                )
         self._summary = _summary_with_result(self._summary, result)
         return self._advance_to_next_issue()
 

--- a/src/validation/source_metadata.py
+++ b/src/validation/source_metadata.py
@@ -1,0 +1,56 @@
+"""Optional source metadata for validation hierarchy projections.
+
+Campaign validation often works on normalized copies of persisted entities.  These
+helpers let UI launchers remember which persisted item and field a projected node
+came from without changing the public validator models.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping
+
+SOURCE_ITEM_KEY = "__validation_source_item__"
+SOURCE_WRAPPER_KEY = "__validation_source_wrapper__"
+FIELD_ALIASES_KEY = "__validation_field_aliases__"
+
+
+def attach_source_metadata(
+    node: MutableMapping[str, Any],
+    *,
+    source_item: MutableMapping[str, Any] | None,
+    wrapper: Any = None,
+    field_aliases: Mapping[str, str] | None = None,
+) -> None:
+    """Attach persistence metadata to a normalized validation node in-place."""
+
+    if source_item is not None:
+        node[SOURCE_ITEM_KEY] = source_item
+    if wrapper is not None:
+        node[SOURCE_WRAPPER_KEY] = wrapper
+    aliases = {key: value for key, value in (field_aliases or {}).items() if key and value}
+    if aliases:
+        node[FIELD_ALIASES_KEY] = aliases
+
+
+def source_item_for(node: Mapping[str, Any]) -> MutableMapping[str, Any] | None:
+    """Return the persisted item behind ``node``, when metadata is present."""
+
+    source_item = node.get(SOURCE_ITEM_KEY)
+    return source_item if isinstance(source_item, MutableMapping) else None
+
+
+def source_wrapper_for(node: Mapping[str, Any]) -> Any:
+    """Return the persistence wrapper behind ``node``, when metadata is present."""
+
+    return node.get(SOURCE_WRAPPER_KEY)
+
+
+def source_field_for(node: Mapping[str, Any], field_name: str) -> str:
+    """Return the persisted field mirrored by a normalized reference field."""
+
+    aliases = node.get(FIELD_ALIASES_KEY)
+    if isinstance(aliases, Mapping):
+        alias = aliases.get(field_name)
+        if isinstance(alias, str) and alias:
+            return alias
+    return field_name

--- a/tests/ui/validation/test_campaign_validation_launcher.py
+++ b/tests/ui/validation/test_campaign_validation_launcher.py
@@ -15,6 +15,7 @@ from src.ui.validation.campaign_validation_launcher import (
     build_campaign_validation_hierarchy,
     campaign_option_from_item,
     load_campaign_options,
+    save_validation_sources,
 )
 from src.ui.validation.campaign_scenario_entity_hierarchy import (
     campaign_validation_reference_config,
@@ -863,3 +864,66 @@ def test_build_campaign_validation_hierarchy_reports_lightweight_phases():
 
     assert "Scanning arcs..." in phases
     assert "Scanning scenarios..." in phases
+
+
+def test_campaign_validation_removes_multiple_stale_index_references_and_saves_sources():
+    """Validation fixes keep going after earlier removals shift reference indexes."""
+
+    class SavingWrapper(FakeWrapper):
+        def __init__(self, items):
+            super().__init__(items)
+            self.saved_items = []
+
+        def save_item(self, item):
+            self.saved_items.append(dict(item))
+
+    campaign = {
+        "id": "c1",
+        "Name": "Dragonfall",
+        "Arcs": {"arcs": [{"name": "Arc 1", "scenarios": ["Main Quest"]}]},
+    }
+    scenario = {
+        "Title": "Main Quest",
+        "Places": ["Mutated Mariner Camp", "Sunken Dock"],
+    }
+    campaign_wrapper = SavingWrapper([campaign])
+    scenario_wrapper = SavingWrapper([scenario])
+    wrappers = {"campaigns": campaign_wrapper, "scenarios": scenario_wrapper}
+    rules = discover_scenario_linked_entity_rules(wrappers)
+    hierarchy = build_campaign_validation_hierarchy(
+        wrappers,
+        campaign,
+        scenario_link_rules=rules,
+        include_source_metadata=True,
+    )
+    graph = validate_reference_graph(
+        hierarchy,
+        campaign=campaign,
+        config=campaign_validation_reference_config(rules),
+    )
+    controller = ValidationWizardController(
+        tuple(
+            ValidationWizardIssue(
+                issue=issue,
+                reference=resolve_reference_for_issue(issue, graph.references),
+                target=resolve_target_for_issue(issue, graph.entities),
+            )
+            for issue in graph.issues
+        ),
+        campaign=graph.campaign,
+        on_successful_change=lambda _result: save_validation_sources(graph),
+    )
+
+    assert [issue.payload.referenced_name for issue in graph.issues] == [
+        "Mutated Mariner Camp",
+        "Sunken Dock",
+    ]
+    controller.start()
+    second_step = controller.submit_action("remove")
+    assert second_step.status == ValidationWizardStatus.SHOW_ISSUE
+    final_step = controller.submit_action("remove")
+
+    assert final_step.status == ValidationWizardStatus.COMPLETED
+    assert scenario["Places"] == []
+    assert scenario_wrapper.saved_items[-1]["Places"] == []
+    assert campaign_wrapper.saved_items


### PR DESCRIPTION
### Motivation

- Fix the issue where a validation error (e.g. the screenshot case) stopped the process and prevented the campaign from being modified by making interactive reference fixes resilient to list-index shifts.  
- Ensure that when a user resolves a validation issue (remap/remove/create/attach) the concrete persisted campaign/scenario/entity is updated immediately so subsequent fixes don't require re-running the whole validation.

### Description

- Add optional source metadata for normalized validation nodes so a projected node can remember its original persisted item, wrapper, and any field aliases by introducing `src/validation/source_metadata.py`.  
- Make reference-fix operations resilient to stale list indexes by locating reference occurrences by value when indexes have shifted and add helper `_editable_reference_index` and `_reference_value_matches` in `src/services/reference_fix_service.py`.  
- Mirror mutations back to the original source items (when metadata is present) for removals, remaps, child attachments and entity creations via `_mirror_reference_field`, `_mirror_node_field`, and `_remove_mirrored_reference_field` in `src/services/reference_fix_service.py`.  
- Wire validation launches to attach source metadata when building the validation hierarchy and supply a controller callback to persist changes immediately after each successful mutating action in `src/ui/validation/campaign_validation_launcher.py` and `src/ui/validation/validation_wizard_controller.py`.  
- Preserve source metadata when resolved scenarios/entities are attached into arc/scenario nodes by copying nodes that already carry metadata in `src/ui/validation/campaign_scenario_hierarchy.py` and `src/ui/validation/campaign_scenario_entity_hierarchy.py`.  
- Add a focused regression test covering consecutive removals from the same list and immediate persistence to wrappers in `tests/ui/validation/test_campaign_validation_launcher.py`.

### Testing

- Compiled modified modules with `python -m py_compile` which succeeded for the patched files.  
- Ran `pytest tests/ui/validation/test_validation_wizard_controller.py tests/ui/validation/test_campaign_validation_launcher.py -q` and both targeted test files passed (33 tests).  
- Ran a full `pytest -q`; collection failed due to unrelated environment/test-stub issues (duplicate test module basename, incomplete customtkinter stubs, and missing PIL submodules) that pre-existed and are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02cb6a8e08832ba9a1bcdc9b13683c)