### PR TITLE
Add lightweight campaign overview repository

### DIFF
--- a/modules/campaigns/ui/graphical_display/panel.py
+++ b/modules/campaigns/ui/graphical_display/panel.py
@@ -55,18 +55,27 @@ open_scenario_in_embedded_gm_screen = getattr(
 )
 
 
+def _first_configured_db_path(*wrappers) -> str | None:
+    """Return the first explicit database path configured on a wrapper."""
+    for wrapper in wrappers:
+        db_path = getattr(wrapper, "_db_path", None)
+        if db_path:
+            return db_path
+    return None
+
 
 class CampaignGraphPanel(ctk.CTkFrame):
     """RPG-forward campaign visualizer with focused arc and scenario browsing."""
 
-    def __init__(self, master, *, campaign_wrapper=None, scenario_wrapper=None):
+    def __init__(self, master, *, campaign_wrapper=None, scenario_wrapper=None, overview_repository=None):
         """Initialize the CampaignGraphPanel instance."""
         super().__init__(master, fg_color=DASHBOARD_THEME.panel_bg)
         self.campaign_wrapper = campaign_wrapper or GenericModelWrapper("campaigns")
         self.scenario_wrapper = scenario_wrapper or GenericModelWrapper("scenarios")
+        self._overview_repository = overview_repository or self._build_overview_repository()
 
-        self._campaign_items = self._safe_load(self.campaign_wrapper)
-        self._scenario_items = self._safe_load(self.scenario_wrapper)
+        self._campaign_items = self._overview_repository.list_campaigns_for_overview()
+        self._scenario_items = []
         self._campaign_options, self._campaign_index = build_campaign_option_index(self._campaign_items)
         self._selection_store = CampaignOverviewSelectionStore()
         self._selected_campaign: CampaignGraphPayload | None = None
@@ -118,17 +127,20 @@ class CampaignGraphPanel(ctk.CTkFrame):
         else:
             self._render_empty_state("No campaigns found in the active database.")
 
-    def _safe_load(self, wrapper):
-        """Internal helper for safe load."""
-        try:
-            return wrapper.load_items()
-        except Exception:
-            return []
+    def _build_overview_repository(self):
+        """Build the lightweight overview repository from wrapper database settings."""
+        repository_class = getattr(_graph_services, "CampaignOverviewRepository", None)
+        if repository_class is None:
+            from .services.overview_repository import CampaignOverviewRepository as repository_class
+
+        db_path = _first_configured_db_path(self.campaign_wrapper, self.scenario_wrapper)
+        return repository_class(db_path=db_path)
 
     def _on_campaign_selected(self, selected_name: str) -> None:
         """Handle campaign selected."""
         self._cancel_pending_sidebar_render()
         campaign = self._campaign_index.get(selected_name)
+        self._scenario_items = self._overview_repository.load_scenarios_for_campaign(campaign)
         self._selected_campaign = build_campaign_graph_payload(campaign, self._scenario_items)
         self._selected_arc_index = 0
         self._selected_scenario_index = 0

--- a/modules/campaigns/ui/graphical_display/services/__init__.py
+++ b/modules/campaigns/ui/graphical_display/services/__init__.py
@@ -2,5 +2,6 @@
 
 from .gm_screen_router import open_scenario_in_embedded_gm_screen
 from .selection_state import CampaignOverviewSelectionStore
+from .overview_repository import CampaignOverviewRepository
 
-__all__ = ["open_scenario_in_embedded_gm_screen", "CampaignOverviewSelectionStore"]
+__all__ = ["open_scenario_in_embedded_gm_screen", "CampaignOverviewSelectionStore", "CampaignOverviewRepository"]

--- a/modules/campaigns/ui/graphical_display/services/overview_repository.py
+++ b/modules/campaigns/ui/graphical_display/services/overview_repository.py
@@ -1,0 +1,191 @@
+"""Lightweight data access for the campaign overview dashboard."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Iterable, Sequence
+
+from db.db import get_connection
+from modules.campaigns.shared.arc_parser import coerce_arc_list
+from modules.campaigns.ui.graphical_display.data import iter_scenario_link_fields
+from modules.generic.json_value_deserializer import deserialize_possible_json
+
+CAMPAIGN_OVERVIEW_COLUMNS: tuple[str, ...] = (
+    "Name",
+    "Logline",
+    "Genre",
+    "Tone",
+    "Status",
+    "Setting",
+    "MainObjective",
+    "Stakes",
+    "Themes",
+    "LinkedScenarios",
+    "Arcs",
+)
+
+CAMPAIGN_CONFIG_COLUMNS: tuple[str, ...] = (
+    "overview_selected_arc",
+    "overview_selected_scenario",
+)
+
+SCENARIO_OVERVIEW_COLUMNS: tuple[str, ...] = (
+    "Title",
+    "Summary",
+    "Briefing",
+    "ScenarioBriefing",
+    "GMBriefing",
+    "SessionBriefing",
+    "Brief",
+    "Objective",
+    "Objectives",
+    "Goal",
+    "Goals",
+    "CurrentObjective",
+    "MainObjective",
+    "DesiredOutcome",
+    "Hook",
+    "Hooks",
+    "PlotHook",
+    "PlotHooks",
+    "IntroHook",
+    "IncitingIncident",
+    "SceneSummary",
+    "Stakes",
+    "Consequences",
+    "Outcome",
+    "FailureState",
+    "Threat",
+    "Threats",
+    "Scenes",
+    "Secrets",
+)
+
+
+class CampaignOverviewRepository:
+    """Load only the columns required by the graphical campaign overview."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        """Initialize the repository with an optional database override."""
+        self._db_path = db_path
+
+    def list_campaigns_for_overview(self) -> list[dict[str, Any]]:
+        """Return campaign rows with only overview fields and saved focus metadata."""
+        try:
+            with self._connect() as conn:
+                conn.row_factory = sqlite3.Row
+                campaign_columns = self._existing_columns(conn, "campaigns", CAMPAIGN_OVERVIEW_COLUMNS)
+                if "Name" not in campaign_columns:
+                    return []
+
+                config_columns = self._existing_columns(conn, "campaign_config", CAMPAIGN_CONFIG_COLUMNS)
+                select_expressions = [f'c.{_quote_identifier(column)}' for column in campaign_columns]
+                join_clause = ""
+                if config_columns:
+                    select_expressions.extend(
+                        f'cfg.{_quote_identifier(column)} AS {_quote_identifier(column)}'
+                        for column in config_columns
+                    )
+                    join_clause = "LEFT JOIN campaign_config cfg ON cfg.campaign_name = c.Name"
+
+                cursor = conn.execute(
+                    f"""
+                    SELECT {', '.join(select_expressions)}
+                    FROM campaigns c
+                    {join_clause}
+                    ORDER BY c.Name COLLATE NOCASE
+                    """
+                )
+                return [_deserialize_row(row) for row in cursor.fetchall()]
+        except sqlite3.Error:
+            return []
+
+    def load_scenarios_for_campaign(self, campaign: dict[str, Any] | None) -> list[dict[str, Any]]:
+        """Return only scenarios referenced by the selected campaign overview data."""
+        scenario_titles = self._linked_scenario_titles(campaign)
+        if not scenario_titles:
+            return []
+
+        try:
+            with self._connect() as conn:
+                conn.row_factory = sqlite3.Row
+                scenario_columns = self._scenario_columns(conn)
+                if "Title" not in scenario_columns:
+                    return []
+
+                placeholders = ", ".join("?" for _ in scenario_titles)
+                cursor = conn.execute(
+                    f"""
+                    SELECT {', '.join(_quote_identifier(column) for column in scenario_columns)}
+                    FROM scenarios
+                    WHERE Title IN ({placeholders})
+                    """,
+                    scenario_titles,
+                )
+                rows_by_title = {
+                    str(item.get("Title") or "").strip(): item
+                    for item in (_deserialize_row(row) for row in cursor.fetchall())
+                }
+                return [rows_by_title[title] for title in scenario_titles if title in rows_by_title]
+        except sqlite3.Error:
+            return []
+
+    def list_campaigns(self) -> list[dict[str, Any]]:
+        """Backward-compatible alias for overview campaign listing."""
+        return self.list_campaigns_for_overview()
+
+    def list_linked_scenarios(self, campaign: dict[str, Any] | None) -> list[dict[str, Any]]:
+        """Backward-compatible alias for selected-campaign scenario loading."""
+        return self.load_scenarios_for_campaign(campaign)
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._db_path:
+            return sqlite3.connect(self._db_path)
+        return get_connection()
+
+    def _scenario_columns(self, conn: sqlite3.Connection) -> list[str]:
+        link_columns = tuple(field_name for _linked_type, field_name in iter_scenario_link_fields())
+        return self._existing_columns(conn, "scenarios", (*SCENARIO_OVERVIEW_COLUMNS, *link_columns))
+
+    @staticmethod
+    def _existing_columns(conn: sqlite3.Connection, table: str, requested_columns: Sequence[str]) -> list[str]:
+        cursor = conn.execute(f"PRAGMA table_info({_quote_identifier(table)})")
+        existing = {str(row[1]) for row in cursor.fetchall()}
+        return [column for column in requested_columns if column in existing]
+
+    @staticmethod
+    def _linked_scenario_titles(campaign: dict[str, Any] | None) -> list[str]:
+        if not isinstance(campaign, dict):
+            return []
+
+        titles: list[str] = []
+        _extend_unique_titles(titles, _coerce_title_list(campaign.get("LinkedScenarios")))
+        for arc in coerce_arc_list(campaign.get("Arcs")):
+            _extend_unique_titles(titles, _coerce_title_list(arc.get("scenarios")))
+        return titles
+
+
+def _deserialize_row(row: sqlite3.Row) -> dict[str, Any]:
+    return {key: deserialize_possible_json(row[key]) for key in row.keys()}
+
+
+def _coerce_title_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [title for title in (str(item or "").strip() for item in value) if title]
+    if isinstance(value, tuple):
+        return [title for title in (str(item or "").strip() for item in value) if title]
+    text = str(value or "").strip()
+    return [text] if text else []
+
+
+def _extend_unique_titles(target: list[str], titles: Iterable[str]) -> None:
+    seen = set(target)
+    for title in titles:
+        if title in seen:
+            continue
+        target.append(title)
+        seen.add(title)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + str(identifier).replace('"', '""') + '"'

--- a/tests/campaigns/ui/test_overview_repository.py
+++ b/tests/campaigns/ui/test_overview_repository.py
@@ -1,0 +1,171 @@
+"""Tests for the lightweight campaign overview repository."""
+
+import json
+import sqlite3
+
+from modules.campaigns.ui.graphical_display.services.overview_repository import CampaignOverviewRepository
+
+
+def test_list_campaigns_loads_only_overview_columns_with_focus(tmp_path):
+    """Campaign list should skip editor-only columns and include saved overview focus."""
+    db_path = tmp_path / "campaign.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE campaigns (
+                Name TEXT PRIMARY KEY,
+                Logline TEXT,
+                Genre TEXT,
+                Tone TEXT,
+                Status TEXT,
+                Setting TEXT,
+                MainObjective TEXT,
+                Stakes TEXT,
+                Themes TEXT,
+                LinkedScenarios TEXT,
+                Arcs TEXT,
+                Notes TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE campaign_config (
+                campaign_name TEXT PRIMARY KEY,
+                overview_selected_arc TEXT,
+                overview_selected_scenario TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO campaigns (
+                Name, Logline, Genre, Tone, Status, Setting, MainObjective,
+                Stakes, Themes, LinkedScenarios, Arcs, Notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "Dragonfall",
+                "Stop the wyrm cult.",
+                "Fantasy",
+                "Heroic",
+                "Active",
+                "Ash Coast",
+                "Seal the rift",
+                "A city burns",
+                "Duty",
+                json.dumps(["Opening Gambit"]),
+                json.dumps([{"name": "Act I", "scenarios": ["Opening Gambit"]}]),
+                "Large editor-only notes should not be loaded by the dashboard.",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO campaign_config VALUES (?, ?, ?)",
+            ("Dragonfall", "Act I", "Opening Gambit"),
+        )
+
+    campaigns = CampaignOverviewRepository(db_path=str(db_path)).list_campaigns_for_overview()
+
+    assert campaigns == [
+        {
+            "Name": "Dragonfall",
+            "Logline": "Stop the wyrm cult.",
+            "Genre": "Fantasy",
+            "Tone": "Heroic",
+            "Status": "Active",
+            "Setting": "Ash Coast",
+            "MainObjective": "Seal the rift",
+            "Stakes": "A city burns",
+            "Themes": "Duty",
+            "LinkedScenarios": ["Opening Gambit"],
+            "Arcs": [{"name": "Act I", "scenarios": ["Opening Gambit"]}],
+            "overview_selected_arc": "Act I",
+            "overview_selected_scenario": "Opening Gambit",
+        }
+    ]
+
+
+def test_list_linked_scenarios_loads_only_campaign_references_and_payload_fields(tmp_path):
+    """Scenario loading should be scoped to the selected campaign and dashboard fields."""
+    db_path = tmp_path / "campaign.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE scenarios (
+                Title TEXT PRIMARY KEY,
+                Summary TEXT,
+                Briefing TEXT,
+                Objective TEXT,
+                Hook TEXT,
+                Stakes TEXT,
+                Scenes TEXT,
+                Secrets TEXT,
+                Places TEXT,
+                Factions TEXT,
+                Notes TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO scenarios (
+                Title, Summary, Briefing, Objective, Hook, Stakes, Scenes,
+                Secrets, Places, Factions, Notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "Opening Gambit",
+                "Begin at the gala.",
+                "Brief the GM.",
+                "Find the spy",
+                "A masked warning",
+                "The spy escapes",
+                json.dumps([{"Title": "Gala"}]),
+                "The duke is compromised.",
+                json.dumps(["Moon Palace"]),
+                json.dumps(["Glass Court"]),
+                "Editor-only notes",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO scenarios (
+                Title, Summary, Briefing, Objective, Hook, Stakes, Scenes,
+                Secrets, Places, Factions, Notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "Unlinked Scenario",
+                "Should not load.",
+                "",
+                "",
+                "",
+                "",
+                json.dumps([]),
+                "",
+                json.dumps([]),
+                json.dumps([]),
+                "",
+            ),
+        )
+
+    campaign = {
+        "LinkedScenarios": ["Opening Gambit"],
+        "Arcs": [{"name": "Act I", "scenarios": ["Opening Gambit"]}],
+    }
+    scenarios = CampaignOverviewRepository(db_path=str(db_path)).load_scenarios_for_campaign(campaign)
+
+    assert scenarios == [
+        {
+            "Title": "Opening Gambit",
+            "Summary": "Begin at the gala.",
+            "Briefing": "Brief the GM.",
+            "Objective": "Find the spy",
+            "Hook": "A masked warning",
+            "Stakes": "The spy escapes",
+            "Scenes": [{"Title": "Gala"}],
+            "Secrets": "The duke is compromised.",
+            "Places": ["Moon Palace"],
+            "Factions": ["Glass Court"],
+        }
+    ]


### PR DESCRIPTION
### Motivation
- The campaign overview/dashboard was loading full records via `GenericModelWrapper.load_items()` which is heavy and exposes editor-only fields; the overview only needs a small set of columns and linked scenarios for rendering. 
- Introduce a focused, read-only data path to improve performance and avoid unnecessary deserialization of large editor fields for the dashboard.

### Description
- Added `modules/campaigns/ui/graphical_display/services/overview_repository.py` implementing `CampaignOverviewRepository` with `list_campaigns_for_overview()` and `load_scenarios_for_campaign()` that only select the required columns and deserialize JSON values. 
- Kept backward-compatible aliases `list_campaigns()` and `list_linked_scenarios()` on the repository while making the targeted names explicit for clarity.
- Updated `modules/campaigns/ui/graphical_display/services/__init__.py` to export `CampaignOverviewRepository`. 
- Updated `CampaignGraphPanel` to accept an optional `overview_repository` and to use the lightweight repository for the dashboard: it now calls `list_campaigns_for_overview()` to populate campaigns and `load_scenarios_for_campaign()` when a campaign is selected, while preserving `GenericModelWrapper` instances for full-editing flows and adding `_build_overview_repository()` and `_first_configured_db_path()` helpers. 
- Added tests in `tests/campaigns/ui/test_overview_repository.py` that assert column filtering, saved overview focus inclusion, linked-scenario scoping, and JSON deserialization.

### Testing
- Ran the new repository unit tests with `pytest tests/campaigns/ui/test_overview_repository.py`, which passed. 
- Ran broader UI/data tests with `pytest tests/campaigns/ui/test_campaign_graph_panel.py tests/campaigns/ui/test_campaign_graph_data.py` and the full selection including the new tests with `pytest tests/campaigns/ui/test_overview_repository.py tests/campaigns/ui/test_campaign_graph_panel.py tests/campaigns/ui/test_campaign_graph_data.py`, all tests passed (13 passed). 
- Compiled package modules with `python -m compileall modules/campaigns/ui/graphical_display`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03674f5304832bb1c5c461af7d82ee)