### PR TITLE
Optimize campaign graph payload caching and index only referenced scenarios

### DIFF
--- a/modules/campaigns/ui/graphical_display/data.py
+++ b/modules/campaigns/ui/graphical_display/data.py
@@ -93,10 +93,11 @@ def build_campaign_graph_payload(
     if not isinstance(campaign_item, dict):
         return None
 
-    scenario_index = _build_scenario_index(scenario_items)
-    link_fields = iter_scenario_link_fields()
     arcs = coerce_arc_list(campaign_item.get("Arcs"))
     linked_scenarios = _coerce_string_list(campaign_item.get("LinkedScenarios"))
+    needed_scenario_titles = _collect_campaign_scenario_titles(arcs, linked_scenarios)
+    scenario_index = _build_scenario_index(scenario_items, needed_titles=needed_scenario_titles)
+    link_fields = iter_scenario_link_fields()
     used_scenarios: set[str] = set()
 
     rendered_arcs: list[CampaignGraphArc] = []
@@ -142,15 +143,33 @@ def build_campaign_graph_payload(
     )
 
 
-def _build_scenario_index(scenario_items: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    """Build scenario index."""
+def _collect_campaign_scenario_titles(arcs: Iterable[dict[str, Any]], linked_scenarios: Iterable[str]) -> set[str]:
+    """Return the display-safe scenario titles referenced by campaign links and arcs."""
+    titles = set(linked_scenarios)
+    for arc in arcs:
+        # Process each arc from arcs.
+        if not isinstance(arc, dict):
+            continue
+        titles.update(_coerce_string_list(arc.get("scenarios")))
+    return {title for title in titles if title}
+
+
+def _build_scenario_index(
+    scenario_items: Iterable[dict[str, Any]],
+    *,
+    needed_titles: set[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Build a scenario index limited to titles required by the campaign graph."""
+    if needed_titles is not None and not needed_titles:
+        return {}
+
     index: dict[str, dict[str, Any]] = {}
     for raw in scenario_items:
         # Process each raw from scenario_items.
         if not isinstance(raw, dict):
             continue
         title = safe_display_text(raw.get("Title"), max_chars=LABEL_DISPLAY_LIMIT)
-        if not title:
+        if not title or (needed_titles is not None and title not in needed_titles):
             continue
         index[title] = raw
     return index

--- a/modules/campaigns/ui/graphical_display/panel.py
+++ b/modules/campaigns/ui/graphical_display/panel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import tkinter as tk
 from pathlib import Path
+from typing import Any
 from tkinter import filedialog, messagebox
 
 import customtkinter as ctk
@@ -27,6 +28,7 @@ from .components import (
     ScenarioSelectorStrip,
 )
 from .data import CampaignGraphArc, CampaignGraphPayload, CampaignGraphScenario, build_campaign_graph_payload, build_campaign_option_index
+from .services.payload_cache import cache_campaign_graph_payload, clear_campaign_graph_caches
 
 # Import the services submodule directly to avoid the package lazy __getattr__ hook.
 _graph_services = importlib.import_module(f"{__package__}.services")
@@ -74,9 +76,13 @@ class CampaignGraphPanel(ctk.CTkFrame):
         self.scenario_wrapper = scenario_wrapper or GenericModelWrapper("scenarios")
         self._overview_repository = overview_repository or self._build_overview_repository()
 
-        self._campaign_items = self._overview_repository.list_campaigns_for_overview()
-        self._scenario_items = []
-        self._campaign_options, self._campaign_index = build_campaign_option_index(self._campaign_items)
+        self._payload_cache: dict[str, CampaignGraphPayload] = {}
+        self._scenario_items_cache: dict[str, list[dict[str, Any]]] = {}
+        self._scenario_items: list[dict[str, Any]] = []
+        self._campaign_items: list[dict[str, Any]] = []
+        self._campaign_options: list[str] = []
+        self._campaign_index: dict[str, dict[str, Any]] = {}
+        self._load_campaign_overview_data()
         self._selection_store = CampaignOverviewSelectionStore()
         self._selected_campaign: CampaignGraphPayload | None = None
         self._selected_arc_index = 0
@@ -98,6 +104,12 @@ class CampaignGraphPanel(ctk.CTkFrame):
 
         self._build_body()
         self._load_initial_campaign()
+
+    def _load_campaign_overview_data(self) -> None:
+        """Load campaign overview rows and invalidate payload caches."""
+        self._campaign_items = self._overview_repository.list_campaigns_for_overview()
+        self._campaign_options, self._campaign_index = build_campaign_option_index(self._campaign_items)
+        clear_campaign_graph_caches(self._payload_cache, self._scenario_items_cache)
 
     def _build_body(self) -> None:
         """Build body."""
@@ -140,8 +152,21 @@ class CampaignGraphPanel(ctk.CTkFrame):
         """Handle campaign selected."""
         self._cancel_pending_sidebar_render()
         campaign = self._campaign_index.get(selected_name)
-        self._scenario_items = self._overview_repository.load_scenarios_for_campaign(campaign)
-        self._selected_campaign = build_campaign_graph_payload(campaign, self._scenario_items)
+        cached_payload = self._payload_cache.get(selected_name)
+        if cached_payload is None:
+            self._scenario_items = self._overview_repository.load_scenarios_for_campaign(campaign)
+            self._selected_campaign = build_campaign_graph_payload(campaign, self._scenario_items)
+            cache_campaign_graph_payload(
+                selected_name,
+                self._selected_campaign,
+                self._scenario_items,
+                self._payload_cache,
+                self._scenario_items_cache,
+            )
+        else:
+            self._scenario_items = list(self._scenario_items_cache.get(selected_name, ()))
+            self._selected_campaign = cached_payload
+
         self._selected_arc_index = 0
         self._selected_scenario_index = 0
         self._apply_saved_focus_state(campaign)

--- a/modules/campaigns/ui/graphical_display/services/payload_cache.py
+++ b/modules/campaigns/ui/graphical_display/services/payload_cache.py
@@ -1,0 +1,33 @@
+"""Small helpers for campaign graph payload caches."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from modules.campaigns.ui.graphical_display.data import CampaignGraphPayload
+
+
+def clear_campaign_graph_caches(
+    payload_cache: dict[str, CampaignGraphPayload],
+    scenario_items_cache: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Invalidate cached campaign graph payloads and their scenario rows."""
+    payload_cache.clear()
+    scenario_items_cache.clear()
+
+
+def cache_campaign_graph_payload(
+    campaign_name: str,
+    payload: CampaignGraphPayload | None,
+    scenario_items: list[dict[str, Any]],
+    payload_cache: dict[str, CampaignGraphPayload],
+    scenario_items_cache: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Store a graph payload and scenario rows for a campaign selection."""
+    if payload is None:
+        payload_cache.pop(campaign_name, None)
+        scenario_items_cache.pop(campaign_name, None)
+        return
+
+    payload_cache[campaign_name] = payload
+    scenario_items_cache[campaign_name] = list(scenario_items)

--- a/tests/campaigns/ui/test_campaign_graph_data.py
+++ b/tests/campaigns/ui/test_campaign_graph_data.py
@@ -15,7 +15,6 @@ spec.loader.exec_module(module)
 build_campaign_graph_payload = module.build_campaign_graph_payload
 build_campaign_option_index = module.build_campaign_option_index
 
-
 def test_build_campaign_option_index_ignores_blank_names():
     """Verify that build campaign option index ignores blank names."""
     options, index = build_campaign_option_index([
@@ -27,7 +26,6 @@ def test_build_campaign_option_index_ignores_blank_names():
 
     assert options == ["Duskfall", "Iron Crown"]
     assert set(index) == {"Duskfall", "Iron Crown"}
-
 
 def test_build_campaign_graph_payload_includes_loose_threads(monkeypatch):
     """Verify that build campaign graph payload includes loose threads."""
@@ -82,6 +80,34 @@ def test_build_campaign_graph_payload_includes_loose_threads(monkeypatch):
     assert len(calls) == 1
 
 
+def test_build_campaign_graph_payload_indexes_only_referenced_scenarios(monkeypatch):
+    """Verify graph payload indexing ignores full-list scenarios not referenced by the campaign."""
+    monkeypatch.setattr(module, "iter_scenario_link_fields", lambda: [])
+    original_builder = module._build_scenario_payload
+    indexed_titles = []
+
+    def _spy_build_scenario_payload(title, scenario_index, link_fields):
+        indexed_titles.append(set(scenario_index))
+        return original_builder(title, scenario_index, link_fields)
+
+    monkeypatch.setattr(module, "_build_scenario_payload", _spy_build_scenario_payload)
+
+    campaign = {
+        "Name": "Lean Campaign",
+        "LinkedScenarios": ["Needed Scenario"],
+        "Arcs": [{"name": "Act I", "scenarios": ["Needed Scenario"]}],
+    }
+    scenarios = [
+        {"Title": "Needed Scenario", "Summary": "Keep this row."},
+        {"Title": "Unlinked Scenario", "Summary": "Do not index this row."},
+    ]
+
+    payload = build_campaign_graph_payload(campaign, scenarios)
+
+    assert payload is not None
+    assert indexed_titles == [{"Needed Scenario"}]
+    assert payload.arcs[0].scenarios[0].record_exists is True
+
 def test_build_campaign_graph_payload_repairs_legacy_mojibake(monkeypatch):
     """Verify that legacy mojibake text is repaired during overview payload build."""
     monkeypatch.setattr(module, "iter_scenario_link_fields", lambda: [])
@@ -124,7 +150,6 @@ def test_build_campaign_graph_payload_repairs_legacy_mojibake(monkeypatch):
     assert payload.arcs[0].scenarios[0].summary == clean_summary
     assert payload.arcs[0].scenarios[0].briefing == clean_briefing
     assert payload.arcs[0].scenarios[0].title == "Retrouver agent fugueur Miyazato Hokichi"
-
 
 def test_build_campaign_graph_payload_truncates_oversized_display_text(monkeypatch):
     """Verify oversized imported text is bounded before reaching Tk widgets."""

--- a/tests/campaigns/ui/test_campaign_graph_panel.py
+++ b/tests/campaigns/ui/test_campaign_graph_panel.py
@@ -298,6 +298,43 @@ def _make_panel(canvas=None):
     return panel
 
 
+def test_on_campaign_selected_reuses_cached_payload(monkeypatch):
+    """Verify selecting the same campaign reuses the payload cache instead of rebuilding."""
+    payload = types.SimpleNamespace(name="Duskfall", arcs=[])
+    scenario_rows = [{"Title": "Opening Gambit"}]
+    calls = {"loads": 0, "builds": 0}
+
+    class _Repository:
+        def load_scenarios_for_campaign(self, campaign):
+            calls["loads"] += 1
+            return list(scenario_rows)
+
+    def _build_payload(campaign, scenarios):
+        calls["builds"] += 1
+        assert scenarios == scenario_rows
+        return payload
+
+    monkeypatch.setattr(module, "build_campaign_graph_payload", _build_payload)
+
+    panel = CampaignGraphPanel.__new__(CampaignGraphPanel)
+    panel._overview_repository = _Repository()
+    panel._campaign_index = {"Duskfall": {"Name": "Duskfall"}}
+    panel._payload_cache = {}
+    panel._scenario_items_cache = {}
+    panel._scenario_items = []
+    panel._selected_campaign = None
+    panel._cancel_pending_sidebar_render = lambda: None
+    panel._apply_saved_focus_state = lambda campaign: None
+    panel._scroll_to_top = lambda: None
+    panel._refresh_campaign_content = lambda: None
+
+    panel._on_campaign_selected("Duskfall")
+    panel._on_campaign_selected("Duskfall")
+
+    assert calls == {"loads": 1, "builds": 1}
+    assert panel._selected_campaign is payload
+    assert panel._scenario_items == scenario_rows
+
 def test_preserve_scroll_position_restores_canvas_fraction():
     """Verify that preserve scroll position restores canvas fraction."""
     canvas = _CanvasStub(fraction=0.62)
@@ -310,7 +347,6 @@ def test_preserve_scroll_position_restores_canvas_fraction():
     assert canvas.update_calls == 1
     assert canvas.moveto_calls == [0.62]
 
-
 def test_scroll_to_top_moves_canvas_to_origin():
     """Verify that scroll to top moves canvas to origin."""
     canvas = _CanvasStub(fraction=0.48)
@@ -320,7 +356,6 @@ def test_scroll_to_top_moves_canvas_to_origin():
 
     assert canvas.moveto_calls == [0.0]
     assert canvas.fraction == 0.0
-
 
 def test_get_scroll_fraction_returns_none_without_canvas():
     """Verify that get scroll fraction returns none without canvas."""
@@ -338,7 +373,6 @@ class _HostApp:
         """Open GM screen."""
         self.calls.append(kwargs)
 
-
 def test_open_scenario_gm_screen_prefers_embedded_host(monkeypatch):
     """Verify that open scenario GM screen prefers embedded host."""
     panel = CampaignGraphPanel.__new__(CampaignGraphPanel)
@@ -351,7 +385,6 @@ def test_open_scenario_gm_screen_prefers_embedded_host(monkeypatch):
     panel._open_scenario_gm_screen("Night Run")
 
     assert host.calls == [{"show_empty_message": True, "scenario_name": "Night Run"}]
-
 
 def test_scenario_focus_updates_in_place_and_defers_sidebar(monkeypatch):
     """Verify that scenario focus updates reuse the shell and defer the sidebar."""
@@ -450,7 +483,6 @@ def test_scenario_focus_updates_in_place_and_defers_sidebar(monkeypatch):
     assert _ScenarioEntityBrowserStub.created == 1
     assert len(panel._scenario_sidebar_container.winfo_children()) == 1
 
-
 def test_refresh_scenario_focus_builds_initial_shell(monkeypatch):
     """Verify that the first scenario refresh builds the shell and defers the sidebar."""
     _SelectorStripStub.created = 0
@@ -537,7 +569,6 @@ def test_refresh_scenario_focus_builds_initial_shell(monkeypatch):
     assert _ScenarioEntityBrowserStub.created == 1
     assert canceled == []
     assert len(panel._scenario_sidebar_container.winfo_children()) == 1
-
 
 def test_destroy_cancels_pending_sidebar_job(monkeypatch):
     """Verify that destroying the panel cancels deferred sidebar work."""


### PR DESCRIPTION
### Motivation
- Avoid building a full in-memory scenario index and repeated payload construction when only a subset of scenarios is referenced by a campaign, and reduce DB / processing overhead on repeated campaign selections.

### Description
- Limit indexing in `build_campaign_graph_payload` by first collecting scenario titles from `Arcs` and `LinkedScenarios` and passing that set into a narrowed `_build_scenario_index`, with a fast return when no titles are needed (`modules/campaigns/ui/graphical_display/data.py`).
- Add small cache helpers `cache_campaign_graph_payload` and `clear_campaign_graph_caches` in `modules/campaigns/ui/graphical_display/services/payload_cache.py` to store payloads and their scenario rows.
- Add a payload + scenario-row cache to `CampaignGraphPanel` as `_payload_cache` / `_scenario_items_cache` and change `_on_campaign_selected` to reuse cached payloads (or store them after building) instead of rebuilding on repeated selections (`modules/campaigns/ui/graphical_display/panel.py`).
- Add regression tests to assert that indexing only touches referenced scenarios and that selecting the same campaign reuses the payload cache (`tests/campaigns/ui/test_campaign_graph_data.py`, `tests/campaigns/ui/test_campaign_graph_panel.py`).

### Testing
- Ran `pytest tests/campaigns/ui/test_campaign_graph_data.py` and all tests passed (`5 passed`).
- Ran `pytest tests/campaigns/ui/test_campaign_graph_panel.py` and all tests passed (`8 passed`).
- Ran `pytest tests/campaigns/ui/test_overview_repository.py` and all tests passed (`2 passed`).
- Compiled modified modules with `python3 -m compileall modules/campaigns/ui/graphical_display/data.py modules/campaigns/ui/graphical_display/panel.py modules/campaigns/ui/graphical_display/services/payload_cache.py` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037fb21e28832bbd0d4266b77c6b4b)