### PR TITLE
Add scenario Status handling, progress calculations, and campaign overview UI

### DIFF
--- a/json/scenarios_template.json
+++ b/json/scenarios_template.json
@@ -1,11 +1,35 @@
 {
     "fields": [
-        {"name": "Title", "type": "text"},
-        {"name": "Summary", "type": "longtext"},
-        {"name": "Secrets", "type": "longtext"},
-        {"name": "Places", "type": "list", "linked_type": "Places"},
-        {"name": "NPCs", "type": "list", "linked_type": "NPCs"},
-        {"name": "Objects", "type": "list", "linked_type": "Objects"}
+        {
+            "name": "Title",
+            "type": "text"
+        },
+        {
+            "name": "Status",
+            "type": "text"
+        },
+        {
+            "name": "Summary",
+            "type": "longtext"
+        },
+        {
+            "name": "Secrets",
+            "type": "longtext"
+        },
+        {
+            "name": "Places",
+            "type": "list",
+            "linked_type": "Places"
+        },
+        {
+            "name": "NPCs",
+            "type": "list",
+            "linked_type": "NPCs"
+        },
+        {
+            "name": "Objects",
+            "type": "list",
+            "linked_type": "Objects"
+        }
     ]
-  }
-  
+}

--- a/modules/campaigns/services/ai/generated_scenario_persistence.py
+++ b/modules/campaigns/services/ai/generated_scenario_persistence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from modules.campaigns.services.ai.arc_scenario_entities import ENTITY_WRAPPER_SPECS
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS, canonicalize_scenario_status
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 
 
@@ -34,6 +35,10 @@ class GeneratedScenarioPersistence:
                 self._save_created_entities(scenario)
                 payload = dict(scenario)
                 payload.pop("EntityCreations", None)
+                payload["Status"] = canonicalize_scenario_status(
+                    payload.get("Status"),
+                    default=DEFAULT_SCENARIO_STATUS,
+                )
                 payload["Title"] = self._make_unique_title(payload.get("Title"), reserved_titles)
                 reserved_titles.add(payload["Title"].casefold())
                 self.scenario_wrapper.save_item(payload, key_field="Title")

--- a/modules/campaigns/shared/arc_status.py
+++ b/modules/campaigns/shared/arc_status.py
@@ -1,8 +1,12 @@
-"""Status helpers for campaign arc."""
+"""Shared status helpers for campaign arcs and scenarios."""
 from __future__ import annotations
 
 CANONICAL_ARC_STATUSES = ("Planned", "In Progress", "Paused", "Completed")
+CANONICAL_SCENARIO_STATUSES = CANONICAL_ARC_STATUSES
+CANONICAL_PROGRESS_STATUSES = CANONICAL_ARC_STATUSES
+
 DEFAULT_ARC_STATUS = "Planned"
+DEFAULT_SCENARIO_STATUS = DEFAULT_ARC_STATUS
 
 _STATUS_ALIASES = {
     "planned": "Planned",
@@ -18,10 +22,19 @@ _STATUS_ALIASES = {
 }
 
 
-def canonicalize_arc_status(raw_status: object, default: str = DEFAULT_ARC_STATUS) -> str:
-    """Handle canonicalize arc status."""
+def canonicalize_progress_status(raw_status: object, default: str = DEFAULT_ARC_STATUS) -> str:
+    """Return a canonical campaign progress status shared by arcs and scenarios."""
     text = str(raw_status or "").strip()
     if not text:
         return default
     return _STATUS_ALIASES.get(text.lower(), default)
 
+
+def canonicalize_arc_status(raw_status: object, default: str = DEFAULT_ARC_STATUS) -> str:
+    """Return a canonical arc status."""
+    return canonicalize_progress_status(raw_status, default=default)
+
+
+def canonicalize_scenario_status(raw_status: object, default: str = DEFAULT_SCENARIO_STATUS) -> str:
+    """Return a canonical scenario status."""
+    return canonicalize_progress_status(raw_status, default=default)

--- a/modules/campaigns/shared/progress.py
+++ b/modules/campaigns/shared/progress.py
@@ -1,0 +1,50 @@
+"""Progress calculations shared by campaign advancement UI."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from modules.campaigns.shared.arc_status import CANONICAL_PROGRESS_STATUSES, canonicalize_scenario_status
+
+_PLANNED, _IN_PROGRESS, _PAUSED, _COMPLETED = CANONICAL_PROGRESS_STATUSES
+_STATUS_PROGRESS = {
+    _PLANNED: 0.0,
+    _IN_PROGRESS: 0.5,
+    _PAUSED: 0.5,
+    _COMPLETED: 1.0,
+}
+
+
+def status_progress(status: object) -> float:
+    """Return normalized progress for a scenario-like status value."""
+    return _STATUS_PROGRESS[canonicalize_scenario_status(status)]
+
+
+def arc_progress_from_scenarios(scenarios: Iterable[Any] | None) -> float:
+    """Return an arc's advancement as the average progress of linked scenarios."""
+    scenario_list = list(scenarios or [])
+    if not scenario_list:
+        return 0.0
+    return sum(status_progress(_read_status(scenario)) for scenario in scenario_list) / len(scenario_list)
+
+
+def campaign_progress_from_arcs(arcs: Iterable[Any] | None) -> float:
+    """Return campaign advancement as the average advancement of its arcs."""
+    arc_list = list(arcs or [])
+    if not arc_list:
+        return 0.0
+    return sum(arc_progress_from_scenarios(_read_scenarios(arc)) for arc in arc_list) / len(arc_list)
+
+
+def _read_status(scenario: Any) -> object:
+    """Read a status from either a dataclass-style object or a dictionary."""
+    if isinstance(scenario, dict):
+        return scenario.get("Status") or scenario.get("status")
+    return getattr(scenario, "status", None)
+
+
+def _read_scenarios(arc: Any) -> Iterable[Any] | None:
+    """Read scenarios from either a dataclass-style object or a dictionary."""
+    if isinstance(arc, dict):
+        return arc.get("scenarios") or arc.get("Scenarios")
+    return getattr(arc, "scenarios", None)

--- a/modules/campaigns/ui/graphical_display/components/campaign_overview.py
+++ b/modules/campaigns/ui/graphical_display/components/campaign_overview.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import customtkinter as ctk
 
+from modules.campaigns.shared.progress import arc_progress_from_scenarios, campaign_progress_from_arcs
 from modules.scenarios.gm_screen.dashboard.styles.dashboard_theme import DASHBOARD_THEME
 from modules.scenarios.gm_screen.dashboard.widgets.arc_display.arc_momentum_meter import ArcMomentumMeter
 from ..data import CampaignGraphPayload
@@ -170,19 +171,45 @@ class CampaignOverviewHero(ctk.CTkFrame):
 
         progress = ctk.CTkFrame(sidebar, fg_color=DASHBOARD_THEME.panel_bg, corner_radius=18)
         progress.grid(row=0, column=0, rowspan=2, sticky="nsew", padx=(0, 10))
+        campaign_progress = campaign_progress_from_arcs(self._payload.arcs)
         ArcMomentumMeter(
             progress,
-            completed_steps=sum(1 for arc in self._payload.arcs if arc.status.lower() == "completed"),
-            total_steps=max(len(self._payload.arcs), 1),
-            label="Arc completion",
+            completed_steps=round(campaign_progress * 100),
+            total_steps=100,
+            label="Campaign advancement",
         ).pack(padx=12, pady=(10, 6))
         ctk.CTkLabel(
             progress,
             text=f"{self._payload.linked_scenario_count} linked scenarios",
             justify="center",
             text_color=DASHBOARD_THEME.text_secondary,
-            wraplength=120,
-        ).pack(padx=8, pady=(0, 10))
+            wraplength=140,
+        ).pack(padx=8, pady=(0, 6))
+
+        arc_progress_items = self._arc_progress_summaries()
+        if arc_progress_items:
+            arc_list = ctk.CTkFrame(progress, fg_color="transparent")
+            arc_list.pack(fill="x", padx=12, pady=(0, 10))
+            for name, percent, scenario_count in arc_progress_items:
+                context = f"{scenario_count} scenario{'s' if scenario_count != 1 else ''}"
+                ctk.CTkLabel(
+                    arc_list,
+                    text=f"{name} — {percent}%",
+                    justify="left",
+                    text_color=DASHBOARD_THEME.text_primary,
+                    font=ctk.CTkFont(size=11, weight="bold"),
+                    anchor="w",
+                    wraplength=150,
+                ).pack(fill="x", pady=(4, 0))
+                ctk.CTkLabel(
+                    arc_list,
+                    text=context,
+                    justify="left",
+                    text_color=DASHBOARD_THEME.text_secondary,
+                    font=ctk.CTkFont(size=10),
+                    anchor="w",
+                    wraplength=150,
+                ).pack(fill="x")
 
         fact_items = [
             ("Setting", self._payload.setting),
@@ -199,6 +226,17 @@ class CampaignOverviewHero(ctk.CTkFrame):
             column = (slot % 2) + 1
             _FactTile(sidebar, label=label, value=value).grid(row=row, column=column, sticky="nsew", pady=(0, 10) if row == 0 else 0, padx=(0, 10) if column == 1 else 0)
             slot += 1
+
+    def _arc_progress_summaries(self) -> list[tuple[str, int, int]]:
+        """Return display-ready per-arc advancement summaries."""
+        summaries: list[tuple[str, int, int]] = []
+        for arc in self._payload.arcs:
+            summaries.append((
+                arc.name,
+                round(arc_progress_from_scenarios(arc.scenarios) * 100),
+                len(arc.scenarios),
+            ))
+        return summaries
 
 
 class _CompactChip(ctk.CTkFrame):

--- a/modules/campaigns/ui/graphical_display/data.py
+++ b/modules/campaigns/ui/graphical_display/data.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Iterable
 
 from modules.campaigns.shared.arc_parser import coerce_arc_list
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS, canonicalize_scenario_status
 from modules.helpers.template_loader import load_template
 from modules.helpers.text_helpers import coerce_text
 from modules.campaigns.ui.graphical_display.text_safety import (
@@ -26,6 +27,7 @@ class ScenarioEntityLink:
 class CampaignGraphScenario:
     title: str
     summary: str
+    status: str = DEFAULT_SCENARIO_STATUS
     briefing: str = ""
     objective: str = ""
     hook: str = ""
@@ -234,6 +236,7 @@ def _build_scenario_payload(
     return CampaignGraphScenario(
         title=title or "Untitled scenario",
         summary=summary,
+        status=canonicalize_scenario_status(scenario.get("Status")),
         briefing=briefing,
         objective=objective,
         hook=hook,

--- a/modules/generic/editor/shared/campaign_status_field.py
+++ b/modules/generic/editor/shared/campaign_status_field.py
@@ -1,10 +1,11 @@
 """Helpers for campaign Status field widgets in the generic editor."""
 
-from modules.campaigns.shared.arc_status import CANONICAL_ARC_STATUSES, canonicalize_arc_status
+from modules.campaigns.shared.arc_status import CANONICAL_PROGRESS_STATUSES, canonicalize_progress_status
 
 
 CAMPAIGN_STATUS_FIELD_NAME = "Status"
 CAMPAIGN_ENTITY_SLUG = "campaigns"
+SCENARIO_ENTITY_SLUG = "scenarios"
 
 
 def is_campaign_status_field(*, entity_type: str, field_name: str) -> bool:
@@ -12,11 +13,17 @@ def is_campaign_status_field(*, entity_type: str, field_name: str) -> bool:
     return (entity_type or "").strip().lower() == CAMPAIGN_ENTITY_SLUG and field_name == CAMPAIGN_STATUS_FIELD_NAME
 
 
+def is_campaign_or_scenario_status_field(*, entity_type: str, field_name: str) -> bool:
+    """Return whether the field uses the shared campaign progress status values."""
+    entity_slug = (entity_type or "").strip().lower()
+    return entity_slug in {CAMPAIGN_ENTITY_SLUG, SCENARIO_ENTITY_SLUG} and field_name == CAMPAIGN_STATUS_FIELD_NAME
+
+
 def campaign_status_choices() -> list[str]:
     """Handle campaign status choices."""
-    return list(CANONICAL_ARC_STATUSES)
+    return list(CANONICAL_PROGRESS_STATUSES)
 
 
 def canonical_campaign_status(raw_value: object) -> str:
     """Handle canonical campaign status."""
-    return canonicalize_arc_status(raw_value)
+    return canonicalize_progress_status(raw_value)

--- a/modules/generic/editor/window_components/list_and_basic_fields.py
+++ b/modules/generic/editor/window_components/list_and_basic_fields.py
@@ -6,7 +6,7 @@ from modules.generic.editor.window_components.dynamic_linked_entities import res
 from modules.generic.editor.shared.campaign_status_field import (
     campaign_status_choices,
     canonical_campaign_status,
-    is_campaign_status_field,
+    is_campaign_or_scenario_status_field,
 )
 
 
@@ -261,7 +261,7 @@ class GenericEditorWindowListAndBasicFields:
         field_type = str(field.get("type", "")).strip().lower()
         entity_type = str(getattr(self.model_wrapper, "entity_type", "") or "")
 
-        if is_campaign_status_field(entity_type=entity_type, field_name=field_name):
+        if is_campaign_or_scenario_status_field(entity_type=entity_type, field_name=field_name):
             canonical_status = canonical_campaign_status(value)
             status_var = ctk.StringVar(value=canonical_status)
             option_menu = ctk.CTkOptionMenu(

--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -22,6 +22,7 @@ from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.logging_helper import log_module_import, log_info, log_exception
 from modules.helpers.template_loader import load_template, load_entity_definitions
 from modules.helpers.text_helpers import coerce_text
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS, canonicalize_scenario_status
 from modules.scenarios.scene_flow_components import (
     SceneFlowPreview,
 )
@@ -2120,11 +2121,19 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
                     f"A scenario titled '{title}' already exists. Overwrite it?",
                 ):
                     return False, False
+                payload["Status"] = canonicalize_scenario_status(
+                    payload.get("Status"),
+                    default=DEFAULT_SCENARIO_STATUS,
+                )
                 items[idx] = payload
                 replaced = True
                 break
 
         if not replaced:
+            payload["Status"] = canonicalize_scenario_status(
+                payload.get("Status"),
+                default=DEFAULT_SCENARIO_STATUS,
+            )
             items.append(payload)
 
         log_info(
@@ -2153,6 +2162,10 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
 
         payload = {
             "Title": title,
+            "Status": canonicalize_scenario_status(
+                self.wizard_state.get("Status"),
+                default=DEFAULT_SCENARIO_STATUS,
+            ),
             "Summary": self.wizard_state.get("Summary", ""),
             "Secrets": secrets,
             "Secret": secrets,

--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -8,6 +8,7 @@ import customtkinter as ctk
 
 from campaign_generator import GENERATOR_FUNCTIONS, export_to_docx
 from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS
 from modules.helpers.logging_helper import log_module_import
 
 log_module_import(__name__)
@@ -149,6 +150,7 @@ class ScenarioGeneratorView(ctk.CTkFrame):
         summary = "\n".join(f"{k}: {v}" for k, v in self.current_campaign.items())
         scenario_entity = {
             "Title": title,
+            "Status": DEFAULT_SCENARIO_STATUS,
             "Summary": summary,
             "Secrets": "",
             "Places": [],

--- a/modules/scenarios/scenario_importer.py
+++ b/modules/scenarios/scenario_importer.py
@@ -6,6 +6,7 @@ import customtkinter as ctk
 from tkinter import messagebox, filedialog
 import threading
 from modules.helpers.text_helpers import ai_text_to_rtf_json
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.ai.local_ai_client import LocalAIClient
 from modules.helpers.importing.merge_helper import merge_with_confirmation
@@ -192,6 +193,7 @@ def import_formatted_scenario(text):
     # --- Build Scenario Entity ---
     scenario_entity = {
         "Title": title,
+        "Status": DEFAULT_SCENARIO_STATUS,
         "Summary": {
             "text": introduction,
             "formatting": default_formatting
@@ -578,6 +580,7 @@ class ScenarioImportWindow(ctk.CTkToplevel):
             current_scenarios = scenarios_wrapper.load_items()
             scenario_item = {
                 "Title": title,
+                "Status": DEFAULT_SCENARIO_STATUS,
                 "Summary": to_longtext(summary_expanded or summary_draft or ""),
                 "Secrets": to_longtext(""),
                 "Scenes": scenes_expanded_list,

--- a/tests/campaigns/test_progress.py
+++ b/tests/campaigns/test_progress.py
@@ -1,0 +1,37 @@
+"""Regression tests for campaign advancement progress helpers."""
+
+from modules.campaigns.shared.progress import (
+    arc_progress_from_scenarios,
+    campaign_progress_from_arcs,
+    status_progress,
+)
+
+
+def test_status_progress_canonicalizes_shared_status_values():
+    """Verify aliases, blanks, and invalid values use shared scenario status rules."""
+    assert status_progress("Planned") == 0.0
+    assert status_progress("running") == 0.5
+    assert status_progress("Paused") == 0.5
+    assert status_progress("done") == 1.0
+    assert status_progress("") == 0.0
+    assert status_progress("nonsense") == 0.0
+
+
+def test_arc_progress_averages_linked_scenario_statuses_and_empty_arcs_are_zero():
+    """Verify arc advancement comes from linked scenario statuses."""
+    assert arc_progress_from_scenarios([]) == 0.0
+    assert arc_progress_from_scenarios([
+        {"Status": "Completed"},
+        {"Status": "In Progress"},
+        {"Status": "Planned"},
+    ]) == 0.5
+
+
+def test_campaign_progress_averages_arc_advancement():
+    """Verify campaign advancement averages per-arc scenario advancement."""
+    arcs = [
+        {"scenarios": [{"Status": "Completed"}, {"Status": "In Progress"}]},
+        {"scenarios": []},
+    ]
+
+    assert campaign_progress_from_arcs(arcs) == 0.375

--- a/tests/campaigns/ui/test_campaign_graph_data.py
+++ b/tests/campaigns/ui/test_campaign_graph_data.py
@@ -80,6 +80,38 @@ def test_build_campaign_graph_payload_includes_loose_threads(monkeypatch):
     assert len(calls) == 1
 
 
+def test_build_campaign_graph_payload_canonicalizes_scenario_statuses(monkeypatch):
+    """Verify graph payload scenario status defaults and canonicalization are compatibility-safe."""
+    monkeypatch.setattr(module, "iter_scenario_link_fields", lambda: [])
+    campaign = {
+        "Name": "Status Campaign",
+        "LinkedScenarios": ["Known", "Blank", "Missing"],
+        "Arcs": [
+            {
+                "name": "Opening",
+                "status": "Completed",
+                "scenarios": ["Known", "Blank", "Missing", "Absent"],
+            }
+        ],
+    }
+    scenarios = [
+        {"Title": "Known", "Summary": "Has alias.", "Status": "running"},
+        {"Title": "Blank", "Summary": "Blank status.", "Status": ""},
+        {"Title": "Missing", "Summary": "No status."},
+    ]
+
+    payload = build_campaign_graph_payload(campaign, scenarios)
+
+    assert payload is not None
+    assert [scenario.status for scenario in payload.arcs[0].scenarios] == [
+        "In Progress",
+        "Planned",
+        "Planned",
+        "Planned",
+    ]
+    assert payload.arcs[0].scenarios[-1].record_exists is False
+
+
 def test_build_campaign_graph_payload_indexes_only_referenced_scenarios(monkeypatch):
     """Verify graph payload indexing ignores full-list scenarios not referenced by the campaign."""
     monkeypatch.setattr(module, "iter_scenario_link_fields", lambda: [])

--- a/tests/test_campaign_status_field.py
+++ b/tests/test_campaign_status_field.py
@@ -3,6 +3,7 @@
 from modules.generic.editor.shared.campaign_status_field import (
     campaign_status_choices,
     canonical_campaign_status,
+    is_campaign_or_scenario_status_field,
     is_campaign_status_field,
 )
 
@@ -12,6 +13,9 @@ def test_campaign_status_field_detection():
     assert is_campaign_status_field(entity_type="campaigns", field_name="Status")
     assert is_campaign_status_field(entity_type=" Campaigns ", field_name="Status")
     assert not is_campaign_status_field(entity_type="events", field_name="Status")
+    assert is_campaign_or_scenario_status_field(entity_type="scenarios", field_name="Status")
+    assert is_campaign_or_scenario_status_field(entity_type="campaigns", field_name="Status")
+    assert not is_campaign_or_scenario_status_field(entity_type="events", field_name="Status")
     assert not is_campaign_status_field(entity_type="campaigns", field_name="State")
 
 


### PR DESCRIPTION
### Motivation

- Introduce explicit `Status` for scenarios and canonicalize status values to ensure compatibility and consistent defaults across imports, generators, persistence, and the editor.
- Provide reusable progress calculations for campaign advancement and expose them in the graphical overview to give a quick sense of campaign/arc progress.

### Description

- Added a `Status` field to `json/scenarios_template.json` and threaded `Status` handling into scenario creation and persistence code paths by defaulting and canonicalizing to `DEFAULT_SCENARIO_STATUS` in `scenario_builder_wizard.py`, `scenario_importer.py`, `scenario_generator_view.py`, and `generated_scenario_persistence.py`.
- Refactored status helpers into `modules/campaigns/shared/arc_status.py`, introducing shared canonicalization (`canonicalize_progress_status`, `canonicalize_scenario_status`) and constants (`CANONICAL_PROGRESS_STATUSES`, `DEFAULT_SCENARIO_STATUS`).
- Added `modules/campaigns/shared/progress.py` containing `status_progress`, `arc_progress_from_scenarios`, and `campaign_progress_from_arcs` to compute normalized advancement values.
- Updated campaign UI (`CampaignOverviewHero`) to display campaign advancement using the new progress helpers and added per-arc percentage summaries via `_arc_progress_summaries`.
- Adjusted data transformation (`modules/campaigns/ui/graphical_display/data.py`) to canonicalize scenario statuses when building graph payloads and default scenario dataclass `status` to `DEFAULT_SCENARIO_STATUS`.
- Editor changes: made status field detection use the shared progress statuses for both campaigns and scenarios by adding `is_campaign_or_scenario_status_field` and switching `create_text_entry` logic accordingly.
- Added unit tests: `tests/campaigns/test_progress.py`, extended graph payload tests in `tests/campaigns/ui/test_campaign_graph_data.py`, and updated `tests/test_campaign_status_field.py` to cover detection and canonicalization.

### Testing

- Added and ran unit tests for progress helpers in `tests/campaigns/test_progress.py` and status-field behavior in `tests/test_campaign_status_field.py` using `pytest`, and they passed.
- Exercised the campaign graph payload tests in `tests/campaigns/ui/test_campaign_graph_data.py` which include status canonicalization assertions, and they passed.
- Ran the relevant test suite locally (`pytest`) to validate integration of status defaults and UI progress calculations, and there were no failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0386ae93c0832b96bf1b21e38fd897)