### PR TITLE
Add 'Status' field to scenarios template and add regression tests

### DIFF
--- a/modules/scenarios/scenarios_template.json
+++ b/modules/scenarios/scenarios_template.json
@@ -1,6 +1,7 @@
 {
   "fields": [
       {"name": "Title", "type": "text"},
+      {"name": "Status", "type": "text"},
       {"name": "Summary", "type": "longtext"},
       {"name": "Secrets", "type": "longtext"},
       {"name": "Scenes", "type": "list_longtext"},

--- a/tests/test_scenario_template.py
+++ b/tests/test_scenario_template.py
@@ -1,0 +1,18 @@
+"""Regression tests for scenario template fields."""
+
+from db.db import load_schema_from_json
+from modules.helpers.template_loader import load_template
+
+
+def test_scenario_template_exposes_status_after_title():
+    """Verify that scenarios expose Status as a built-in field for UI columns."""
+    field_names = [field["name"] for field in load_template("scenarios")["fields"]]
+
+    assert field_names[:2] == ["Title", "Status"]
+
+
+def test_scenario_schema_includes_status_column():
+    """Verify that schema sync can add Status to existing campaign databases."""
+    schema = dict(load_schema_from_json("scenarios"))
+
+    assert schema["Status"] == "TEXT"


### PR DESCRIPTION
### Motivation
- Expose a built-in `Status` field for scenarios so the UI can show a Status column immediately after `Title`.
- Ensure schema synchronization can add a `Status` column to existing campaign databases so data and UI remain consistent.

### Description
- Inserted `{"name": "Status", "type": "text"}` into `modules/scenarios/scenarios_template.json` directly after the `Title` field.
- Added `tests/test_scenario_template.py` with two regression tests: `test_scenario_template_exposes_status_after_title` and `test_scenario_schema_includes_status_column` which use `load_template("scenarios")` and `load_schema_from_json("scenarios")` respectively.

### Testing
- Ran `pytest tests/test_scenario_template.py` and the two new tests passed.
- No other automated test failures were observed when running the targeted test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0390a94688832ba8d8b61c25c1c0f1)