### PR TITLE
Fix scenario status alias handling and campaign progress calculation

### DIFF
--- a/modules/campaigns/shared/progress.py
+++ b/modules/campaigns/shared/progress.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from modules.campaigns.shared.arc_status import CANONICAL_PROGRESS_STATUSES, canonicalize_scenario_status
+from modules.campaigns.shared.scenario_status import read_scenario_status
 
 _PLANNED, _IN_PROGRESS, _PAUSED, _COMPLETED = CANONICAL_PROGRESS_STATUSES
 _STATUS_PROGRESS = {
@@ -25,7 +26,7 @@ def arc_progress_from_scenarios(scenarios: Iterable[Any] | None) -> float:
     scenario_list = list(scenarios or [])
     if not scenario_list:
         return 0.0
-    return sum(status_progress(_read_status(scenario)) for scenario in scenario_list) / len(scenario_list)
+    return sum(status_progress(read_scenario_status(scenario)) for scenario in scenario_list) / len(scenario_list)
 
 
 def campaign_progress_from_arcs(arcs: Iterable[Any] | None) -> float:
@@ -34,13 +35,6 @@ def campaign_progress_from_arcs(arcs: Iterable[Any] | None) -> float:
     if not arc_list:
         return 0.0
     return sum(arc_progress_from_scenarios(_read_scenarios(arc)) for arc in arc_list) / len(arc_list)
-
-
-def _read_status(scenario: Any) -> object:
-    """Read a status from either a dataclass-style object or a dictionary."""
-    if isinstance(scenario, dict):
-        return scenario.get("Status") or scenario.get("status")
-    return getattr(scenario, "status", None)
 
 
 def _read_scenarios(arc: Any) -> Iterable[Any] | None:

--- a/modules/campaigns/shared/scenario_status.py
+++ b/modules/campaigns/shared/scenario_status.py
@@ -1,0 +1,52 @@
+"""Scenario status field resolution helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS, canonicalize_scenario_status
+
+_SCENARIO_STATUS_KEYS = (
+    "Status",
+    "status",
+    "Statut",
+    "statut",
+    "ScenarioStatus",
+    "scenario_status",
+)
+
+
+def read_scenario_status(scenario: Any, default: str = DEFAULT_SCENARIO_STATUS) -> str:
+    """Return the canonical status from a scenario object or mapping.
+
+    Scenario records can come from generic editor dictionaries, generated payloads,
+    or dataclass-like dashboard payloads. Older/custom records may also carry a
+    localized ``Statut`` key, so resolve all known aliases before applying the
+    canonical campaign status rules.
+    """
+    raw_status = _read_raw_status(scenario)
+    return canonicalize_scenario_status(raw_status, default=default)
+
+
+def _read_raw_status(scenario: Any) -> Any:
+    """Read the first non-empty status-like value from supported scenario shapes."""
+    if scenario is None:
+        return None
+
+    if isinstance(scenario, dict):
+        for key in _SCENARIO_STATUS_KEYS:
+            value = scenario.get(key)
+            if _has_value(value):
+                return value
+        return None
+
+    for attr_name in ("status", "Status", "statut", "Statut", "scenario_status"):
+        value = getattr(scenario, attr_name, None)
+        if _has_value(value):
+            return value
+
+    return None
+
+
+def _has_value(value: Any) -> bool:
+    """Return whether a status candidate contains a meaningful value."""
+    return str(value or "").strip() != ""

--- a/modules/campaigns/ui/graphical_display/data.py
+++ b/modules/campaigns/ui/graphical_display/data.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from typing import Any, Iterable
 
 from modules.campaigns.shared.arc_parser import coerce_arc_list
-from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS, canonicalize_scenario_status
+from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS
+from modules.campaigns.shared.scenario_status import read_scenario_status
 from modules.helpers.template_loader import load_template
 from modules.helpers.text_helpers import coerce_text
 from modules.campaigns.ui.graphical_display.text_safety import (
@@ -236,7 +237,7 @@ def _build_scenario_payload(
     return CampaignGraphScenario(
         title=title or "Untitled scenario",
         summary=summary,
-        status=canonicalize_scenario_status(scenario.get("Status")),
+        status=read_scenario_status(scenario),
         briefing=briefing,
         objective=objective,
         hook=hook,

--- a/tests/campaigns/test_graphical_display_data.py
+++ b/tests/campaigns/test_graphical_display_data.py
@@ -1,0 +1,19 @@
+"""Regression tests for campaign graphical display data helpers."""
+
+from modules.campaigns.shared.progress import campaign_progress_from_arcs
+from modules.campaigns.ui.graphical_display.data import build_campaign_graph_payload
+
+
+def test_campaign_graph_payload_prefers_status_over_stale_statut():
+    """Scenario cards and campaign percentages use the canonical Status value."""
+    payload = build_campaign_graph_payload(
+        {
+            "Name": "Test Campaign",
+            "Arcs": [{"name": "Act I", "scenarios": ["Opening"]}],
+        },
+        [{"Title": "Opening", "Status": "Completed", "Statut": "Planned"}],
+    )
+
+    assert payload is not None
+    assert payload.arcs[0].scenarios[0].status == "Completed"
+    assert campaign_progress_from_arcs(payload.arcs) == 1.0

--- a/tests/campaigns/test_progress.py
+++ b/tests/campaigns/test_progress.py
@@ -27,6 +27,22 @@ def test_arc_progress_averages_linked_scenario_statuses_and_empty_arcs_are_zero(
     ]) == 0.5
 
 
+def test_arc_progress_uses_canonical_status_alias_fields():
+    """Verify localized/lower-case scenario status fields drive advancement."""
+    assert arc_progress_from_scenarios([
+        {"Statut": "Completed"},
+        {"status": "In Progress"},
+        {"ScenarioStatus": "Planned"},
+    ]) == 0.5
+
+
+def test_arc_progress_prefers_status_over_stale_statut_field():
+    """Verify the real Status field wins when a stale Statut value is present."""
+    assert arc_progress_from_scenarios([
+        {"Status": "Completed", "Statut": "Planned"},
+    ]) == 1.0
+
+
 def test_campaign_progress_averages_arc_advancement():
     """Verify campaign advancement averages per-arc scenario advancement."""
     arcs = [


### PR DESCRIPTION
### Motivation
- Scenarios were sometimes carrying localized or legacy keys (e.g. `Statut`) which could override the real `Status` value, causing scenario cards to show the wrong status and campaign progress to compute as `0%` incorrectly.
- The goal is to canonicalize scenario status resolution across UI and progress calculations so the visible status and percent complete reflect the true `Status` field.

### Description
- Added a shared resolver `modules/campaigns/shared/scenario_status.py` that reads status from multiple aliases (`Status`, `status`, `Statut`, `statut`, `ScenarioStatus`, `scenario_status`) and returns a canonical status via `canonicalize_scenario_status`.
- Updated progress calculations in `modules/campaigns/shared/progress.py` to use `read_scenario_status` so arc and campaign advancement use the resolved status values.
- Updated graphical payload building in `modules/campaigns/ui/graphical_display/data.py` to use `read_scenario_status` when populating `CampaignGraphScenario.status` so UI scenario cards and campaign percentages reflect the canonical value.
- Added regression tests (`tests/campaigns/test_progress.py` and `tests/campaigns/test_graphical_display_data.py`) to cover alias handling, precedence of `Status` over stale `Statut`, and correct campaign percentage calculation.

### Testing
- Ran the focused test suite with `pytest tests/campaigns/test_progress.py tests/campaigns/test_graphical_display_data.py` and all tests passed (`6 passed`).
- Performed static-sanity checks with `python -m py_compile` on the modified modules to ensure they compile without syntax errors and that succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03957ba6dc832bbe63cac7925a9550)