### PR TITLE
Fix object shelf mounting and enable shelf interactions

### DIFF
--- a/modules/objects/object_shelf_panel.py
+++ b/modules/objects/object_shelf_panel.py
@@ -34,6 +34,7 @@ class ObjectShelfPanel(ctk.CTkFrame):
         self.items: list[dict] = []
         self.filtered_items: list[dict] = []
         self.selected_iids: set[str] = set()
+        self.view_mode = "shelf"
         self.search_var = tk.StringVar(master=self)
 
         self.shelf_view = ObjectShelfView(self, OBJECT_CATEGORY_ALLOWED)

--- a/modules/scenarios/gm_table/pages.py
+++ b/modules/scenarios/gm_table/pages.py
@@ -27,8 +27,21 @@ class GMTableHostedPage(ctk.CTkFrame):
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
         self._payload = builder(self)
+        self._grid_payload_if_needed()
         self._state_getter = state_getter
         self._close_callback = close_callback
+
+    def _grid_payload_if_needed(self) -> None:
+        """Mount returned widget payloads that were not laid out by their builder."""
+        payload = self._payload
+        if not hasattr(payload, "grid") or not hasattr(payload, "winfo_manager"):
+            return
+        try:
+            if payload.winfo_manager():
+                return
+            payload.grid(row=0, column=0, sticky="nsew")
+        except Exception:
+            pass
 
     def get_state(self) -> dict:
         """Return any serializable page state."""

--- a/tests/scenarios/gm_screen/test_object_shelf_menu.py
+++ b/tests/scenarios/gm_screen/test_object_shelf_menu.py
@@ -71,3 +71,13 @@ def test_add_menu_routing_opens_object_shelf_tab() -> None:
     GMScreenView.open_selection_window(view, "Object Shelf")
 
     assert captured == ["opened"]
+
+
+def test_object_shelf_panel_defaults_to_shelf_view_mode() -> None:
+    """Shared Object Shelf hosts should expose shelf mode for canvas interactions."""
+    module = __import__("modules.objects.object_shelf_panel", fromlist=["ObjectShelfPanel"])
+    source_names = module.ObjectShelfPanel.__init__.__code__.co_names
+    source_values = module.ObjectShelfPanel.__init__.__code__.co_consts
+
+    assert "view_mode" in source_names
+    assert "shelf" in source_values

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -488,3 +488,51 @@ def test_mount_panel_content_builds_object_shelf_page(monkeypatch) -> None:
 
     assert isinstance(mounted, _DummyHostedPage)
     assert built == {"host": "host-frame", "callback": view.open_entity_panel}
+
+
+def test_hosted_page_grids_unmounted_widget_payload() -> None:
+    """Hosted page should mount widgets returned ungridded by builders."""
+    from modules.scenarios.gm_table.pages import GMTableHostedPage
+
+    class _Payload:
+        def __init__(self) -> None:
+            self.manager = ""
+            self.grid_calls = []
+
+        def winfo_manager(self):
+            return self.manager
+
+        def grid(self, **kwargs):
+            self.grid_calls.append(kwargs)
+            self.manager = "grid"
+
+    page = GMTableHostedPage.__new__(GMTableHostedPage)
+    payload = _Payload()
+    page._payload = payload
+
+    GMTableHostedPage._grid_payload_if_needed(page)
+
+    assert payload.grid_calls == [{"row": 0, "column": 0, "sticky": "nsew"}]
+
+
+def test_hosted_page_keeps_already_managed_payload_in_place() -> None:
+    """Hosted page should not re-layout widgets that builders already mounted."""
+    from modules.scenarios.gm_table.pages import GMTableHostedPage
+
+    class _Payload:
+        def __init__(self) -> None:
+            self.grid_calls = []
+
+        def winfo_manager(self):
+            return "pack"
+
+        def grid(self, **kwargs):
+            self.grid_calls.append(kwargs)
+
+    page = GMTableHostedPage.__new__(GMTableHostedPage)
+    payload = _Payload()
+    page._payload = payload
+
+    GMTableHostedPage._grid_payload_if_needed(page)
+
+    assert payload.grid_calls == []


### PR DESCRIPTION
### Motivation
- The Object Shelf panel could render empty and canvas shelf rows would not expand because hosted payloads sometimes returned unmanaged widgets and the shared shelf host did not expose the `shelf` view mode required by canvas handlers.
- Make hosted pages robust so builders that return a ready widget still get mounted into the GM Table panel, restoring visible content.

### Description
- Expose shelf mode on the shared shelf host by setting `self.view_mode = "shelf"` in `ObjectShelfPanel.__init__` so canvas click/scroll handlers accept shelf interactions. (`modules/objects/object_shelf_panel.py`)
- Add `_grid_payload_if_needed()` to `GMTableHostedPage` and call it after the builder returns, which grids returned widget payloads when `winfo_manager()` is empty and preserves payloads already managed by their builder. (`modules/scenarios/gm_table/pages.py`)
- Add regression tests for both behaviors: automatic mounting of unmanaged payloads and presence of `view_mode`/`shelf` in the Object Shelf initializer. (`tests/scenarios/gm_table/test_gm_table_view.py`, `tests/scenarios/gm_screen/test_object_shelf_menu.py`)

### Testing
- Ran `python -m compileall -q modules/objects/object_shelf_panel.py modules/scenarios/gm_table/pages.py` and the files compiled cleanly. (success)
- Ran targeted tests with `pytest tests/scenarios/gm_table/test_gm_table_view.py tests/scenarios/gm_screen/test_object_shelf_menu.py -q` and the targeted suite passed: `25 passed`. (success)
- Ran a broader test set including `tests/scenarios/gm_table/test_workspace.py`; that run shows unrelated/headless failures (Tk `$DISPLAY` and pre-existing workspace fake-state assumptions) which are outside the scope of this patch and did not repro in the focused tests above. (unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a628c2a0832b96276d4c062163ad)