### PR TITLE
Make GM Table object panels readable (scrollable full detail + larger default size)

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -135,6 +135,8 @@ def resolve_default_panel_size(kind: str, state: dict | None = None) -> tuple[in
         return 920, 680
     if entity_type in {"Informations", "Places", "Bases"}:
         return 760, 580
+    if entity_type == "Objects":
+        return 960, 700
     if entity_type == "Creatures":
         return 680, 480
     return 680, 560

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 import customtkinter as ctk
 
 from modules.characters.character_graph_editor import CharacterGraphEditor
+from modules.generic.detail_ui import build_scroll_host
 from modules.generic.entity_detail_factory import create_entity_detail_frame
 from modules.generic.generic_list_selection_view import GenericListSelectionView
 from modules.generic.generic_model_wrapper import GenericModelWrapper
@@ -923,6 +924,19 @@ class GMTableView(ctk.CTkFrame):
         entity_type = state.get("entity_type")
         entity_name = state.get("entity_name")
         item = self._load_entity_item(entity_type, entity_name)
+
+        if self._uses_readable_entity_detail(entity_type):
+            scrollable_host = build_scroll_host(host)
+            frame = create_entity_detail_frame(
+                entity_type,
+                item,
+                master=scrollable_host,
+                open_entity_callback=self.open_entity_panel,
+                spotlight_only=False,
+            )
+            frame.pack(fill="both", expand=True)
+            return frame
+
         frame = create_entity_detail_frame(
             entity_type,
             item,
@@ -932,6 +946,11 @@ class GMTableView(ctk.CTkFrame):
         )
         frame.grid(row=0, column=0, sticky="nsew")
         return frame
+
+    @staticmethod
+    def _uses_readable_entity_detail(entity_type: str | None) -> bool:
+        """Return whether GM Table panels should show full text details."""
+        return entity_type == "Objects"
 
     def _build_puzzle_display_content(self, host, state: dict):
         """Build the puzzle display page."""

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -20,6 +20,16 @@ def test_resolve_default_panel_size_prefers_large_scenario_panels() -> None:
     assert scenario_size[1] > npc_size[1]
 
 
+def test_resolve_default_panel_size_opens_objects_readably() -> None:
+    """Object panels need room for description and stats text."""
+    object_size = resolve_default_panel_size("entity", {"entity_type": "Objects"})
+    npc_size = resolve_default_panel_size("entity", {"entity_type": "NPCs"})
+
+    assert object_size == (960, 700)
+    assert object_size[0] > npc_size[0]
+    assert object_size[1] > npc_size[1]
+
+
 def test_load_entity_item_accepts_title_or_name_case_insensitively() -> None:
     """Scenario lookups should work with legacy Name-only records too."""
     view = GMTableView.__new__(GMTableView)
@@ -163,6 +173,7 @@ def test_build_entity_content_calls_detail_factory(monkeypatch) -> None:
     view = GMTableView.__new__(GMTableView)
     expected_item = {"Title": "Night Run"}
     view._load_entity_item = lambda _entity_type, _name: expected_item
+
     def callback(*args, **kwargs):
         return None
 
@@ -186,6 +197,62 @@ def test_build_entity_content_calls_detail_factory(monkeypatch) -> None:
     assert captured["callback"] is callback
     assert captured["kwargs"] == {"spotlight_only": True}
     assert captured["grid"] == {"row": 0, "column": 0, "sticky": "nsew"}
+
+
+def test_build_object_entity_content_uses_scrollable_full_detail(monkeypatch) -> None:
+    """Object shelf panels should expose text fields, not only the image spotlight."""
+    captured = {}
+
+    class _DummyFrame:
+        def __init__(self) -> None:
+            self.pack_calls = []
+
+        def pack(self, **kwargs):
+            self.pack_calls.append(kwargs)
+
+    scroll_host = object()
+
+    def _fake_scroll_host(host):
+        captured["scroll_parent"] = host
+        return scroll_host
+
+    def _fake_factory(entity_type, item, *, master, open_entity_callback, **kwargs):
+        captured["entity_type"] = entity_type
+        captured["item"] = item
+        captured["master"] = master
+        captured["callback"] = open_entity_callback
+        captured["kwargs"] = kwargs
+        return _DummyFrame()
+
+    view = GMTableView.__new__(GMTableView)
+    expected_item = {"Name": "Assault Rifle", "Description": "Readable text"}
+    view._load_entity_item = lambda _entity_type, _name: expected_item
+
+    def callback(*args, **kwargs):
+        return None
+
+    view.open_entity_panel = callback
+    host = object()
+
+    monkeypatch.setattr(gm_table_view_module, "build_scroll_host", _fake_scroll_host)
+    monkeypatch.setattr(
+        gm_table_view_module, "create_entity_detail_frame", _fake_factory
+    )
+
+    frame = GMTableView._build_entity_content(
+        view,
+        host,
+        {"entity_type": "Objects", "entity_name": "Assault Rifle"},
+    )
+
+    assert isinstance(frame, _DummyFrame)
+    assert captured["scroll_parent"] is host
+    assert captured["entity_type"] == "Objects"
+    assert captured["item"] is expected_item
+    assert captured["master"] is scroll_host
+    assert captured["callback"] is callback
+    assert captured["kwargs"] == {"spotlight_only": False}
+    assert frame.pack_calls == [{"fill": "both", "expand": True}]
 
 
 def test_context_menu_handler_resolution_is_safe_without_gm_screen_api() -> None:


### PR DESCRIPTION
### Motivation
- Object detail windows opened from the GM Table/object shelf showed only the small spotlight (image) and hid `Description`/`Stats`, making them hard to read.  The change restores readable access to those long text fields.

### Description
- Use a scrollable full-detail host for object entities in `GMTableView._build_entity_content` by calling `build_scroll_host` and invoking `create_entity_detail_frame` with `spotlight_only=False` for `Objects`.
- Add `GMTableView._uses_readable_entity_detail` to centralize the decision for which entity types use the readable full-detail view (currently `Objects`).
- Increase default entity panel geometry for `Objects` in `resolve_default_panel_size` to `960x700` so description/stats have room when the panel opens.
- Add unit tests in `tests/scenarios/gm_table/test_gm_table_view.py` to cover the new object panel sizing and scrollable-detail behavior.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_gm_table_view.py tests/scenarios/gm_screen/test_object_shelf_menu.py` and received all tests passing (`27 passed`).
- Ran `python -m compileall modules/scenarios/gm_table_view.py modules/scenarios/gm_table/workspace.py` to validate compilation with no errors.
- Verified targeted UI construction paths via the new unit tests which assert the scrollable host is used for `Objects` and that the default size is `960x700`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ae3bbbd4832bbbb662b391ef7fc1)