### PR TITLE
Highlight completed scenario selector cards

### DIFF
--- a/modules/campaigns/ui/graphical_display/components/navigation.py
+++ b/modules/campaigns/ui/graphical_display/components/navigation.py
@@ -130,6 +130,7 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
         self._on_select = on_select
         self._scenario_signature: tuple[str, ...] = tuple(_scenario_signature(scenario) for scenario in self._scenarios)
         self._card_frames: list[ctk.CTkFrame] = []
+        self._eyebrow_labels: list[ctk.CTkLabel] = []
         self._title_labels: list[ctk.CTkLabel] = []
 
         self.grid_columnconfigure(0, weight=1)
@@ -180,6 +181,7 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
             return
 
         self._card_frames = []
+        self._eyebrow_labels = []
         self._title_labels = []
         for child in self.inner.winfo_children():
             child.destroy()
@@ -188,12 +190,13 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
         card_width = 196 if many_scenarios else 224
         for index, scenario in enumerate(self._scenarios):
             selected = index == self._selected_index
+            card_style = self._scenario_card_style(scenario, selected=selected)
             card = ctk.CTkFrame(
                 self.inner,
-                fg_color=DASHBOARD_THEME.button_fg if selected else DASHBOARD_THEME.panel_bg,
+                fg_color=card_style["fg_color"],
                 corner_radius=14,
-                border_width=2 if selected else 1,
-                border_color=DASHBOARD_THEME.accent_soft if selected else DASHBOARD_THEME.card_border,
+                border_width=card_style["border_width"],
+                border_color=card_style["border_color"],
                 width=card_width,
                 height=104,
             )
@@ -201,17 +204,18 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
             card.grid_propagate(False)
             card.grid_columnconfigure(0, weight=1)
 
-            ctk.CTkLabel(
+            eyebrow_label = ctk.CTkLabel(
                 card,
-                text=f"SCN {index + 1}",
-                text_color="#8fb0dd",
+                text=self._scenario_label_text(index, scenario),
+                text_color=card_style["eyebrow_color"],
                 font=ctk.CTkFont(size=9, weight="bold"),
                 anchor="w",
-            ).grid(row=0, column=0, sticky="w", padx=12, pady=(8, 2))
+            )
+            eyebrow_label.grid(row=0, column=0, sticky="w", padx=12, pady=(8, 2))
             title_label = ctk.CTkLabel(
                 card,
                 text=_truncate_middle(scenario.title, 46 if not many_scenarios else 36),
-                text_color="#f8fbff" if selected else DASHBOARD_THEME.text_primary,
+                text_color=card_style["title_color"],
                 font=ctk.CTkFont(size=13, weight="bold"),
                 anchor="w",
                 justify="left",
@@ -225,6 +229,7 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
                 clickable.bind("<Leave>", lambda _event, target=card: target.configure(cursor=""))
 
             self._card_frames.append(card)
+            self._eyebrow_labels.append(eyebrow_label)
             self._title_labels.append(title_label)
 
         self.after_idle(self._sync_scrollregion)
@@ -238,15 +243,54 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
         """Restyle existing cards to match the selected scenario."""
         for index, card in enumerate(self._card_frames):
             selected = index == self._selected_index
+            scenario = self._scenarios[index] if index < len(self._scenarios) else None
+            card_style = self._scenario_card_style(scenario, selected=selected)
             card.configure(
-                fg_color=DASHBOARD_THEME.button_fg if selected else DASHBOARD_THEME.panel_bg,
-                border_width=2 if selected else 1,
-                border_color=DASHBOARD_THEME.accent_soft if selected else DASHBOARD_THEME.card_border,
+                fg_color=card_style["fg_color"],
+                border_width=card_style["border_width"],
+                border_color=card_style["border_color"],
             )
+            if index < len(self._eyebrow_labels):
+                self._eyebrow_labels[index].configure(
+                    text=self._scenario_label_text(index, scenario),
+                    text_color=card_style["eyebrow_color"],
+                )
             if index < len(self._title_labels):
                 self._title_labels[index].configure(
-                    text_color="#f8fbff" if selected else DASHBOARD_THEME.text_primary,
+                    text_color=card_style["title_color"],
                 )
+
+    def _scenario_card_style(self, scenario: CampaignGraphScenario | None, *, selected: bool) -> dict[str, str | int]:
+        """Return the colors for a scenario selector card."""
+        completed = _scenario_is_completed(scenario)
+        if selected:
+            return {
+                "fg_color": DASHBOARD_THEME.button_fg,
+                "border_width": 2,
+                "border_color": DASHBOARD_THEME.arc_complete if completed else DASHBOARD_THEME.accent_soft,
+                "title_color": "#f8fbff",
+                "eyebrow_color": "#d7ffe7" if completed else "#8fb0dd",
+            }
+        if completed:
+            return {
+                "fg_color": "#064e3b",
+                "border_width": 1,
+                "border_color": DASHBOARD_THEME.arc_complete,
+                "title_color": "#f8fbff",
+                "eyebrow_color": "#d7ffe7",
+            }
+        return {
+            "fg_color": DASHBOARD_THEME.panel_bg,
+            "border_width": 1,
+            "border_color": DASHBOARD_THEME.card_border,
+            "title_color": DASHBOARD_THEME.text_primary,
+            "eyebrow_color": "#8fb0dd",
+        }
+
+    def _scenario_label_text(self, index: int, scenario: CampaignGraphScenario | None) -> str:
+        """Return the accessible scenario number label text."""
+        prefix = "✓ " if _scenario_is_completed(scenario) else ""
+        return f"{prefix}SCN {index + 1}"
 
     def _resize_window(self, event) -> None:
         """Internal helper for resize window."""
@@ -274,6 +318,11 @@ def _truncate_middle(value: str, limit: int) -> str:
     head = max(remaining // 2, 1)
     tail = max(remaining - head, 1)
     return f"{text[:head].rstrip()}{ellipsis}{text[-tail:].lstrip()}"
+
+
+def _scenario_is_completed(scenario: CampaignGraphScenario | None) -> bool:
+    """Return whether a scenario has the canonical completed status."""
+    return str(getattr(scenario, "status", "") or "").strip().casefold() == "completed"
 
 
 def _scenario_signature(scenario: CampaignGraphScenario) -> str:

--- a/tests/campaigns/ui/test_campaign_graph_navigation.py
+++ b/tests/campaigns/ui/test_campaign_graph_navigation.py
@@ -13,7 +13,7 @@ class _DummyFrame:
         """Initialize the _DummyFrame instance."""
         self._children = []
         self._destroyed = False
-        self._configured = {}
+        self._configured = dict(kwargs)
         if args:
             parent = args[0]
             if hasattr(parent, "_children"):
@@ -154,6 +154,7 @@ sys.modules["modules.scenarios.gm_screen.dashboard.styles.dashboard_theme"] = ty
         card_border="#555555",
         text_primary="#ffffff",
         text_secondary="#cccccc",
+        arc_complete="#22c55e",
     )
 )
 
@@ -165,8 +166,8 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
 
-def _make_scenario(title: str):
-    return types.SimpleNamespace(title=title)
+def _make_scenario(title: str, *, status: str = "Planned"):
+    return types.SimpleNamespace(title=title, status=status)
 
 
 def test_scenario_selector_strip_updates_selection_without_rebuild(monkeypatch):
@@ -215,6 +216,76 @@ def test_scenario_selector_strip_only_rebuilds_when_scenarios_change(monkeypatch
     assert rebuilt_child_ids != initial_child_ids
     assert len(rebuilt_child_ids) == 2
 
+
+def test_scenario_selector_strip_marks_completed_cards(monkeypatch):
+    """Verify completed, non-selected scenarios get distinct styling and a text marker."""
+    fake_canvas = _FakeCanvas()
+    monkeypatch.setattr(module.tk, "Canvas", lambda *args, **kwargs: fake_canvas)
+
+    strip = module.ScenarioSelectorStrip(
+        _DummyFrame(),
+        scenarios=[
+            _make_scenario("Moonlit Wake"),
+            _make_scenario("Catacomb Chase", status="completed"),
+        ],
+        selected_index=0,
+        on_select=lambda *_args: None,
+    )
+
+    planned_card, completed_card = strip._card_frames
+
+    assert planned_card._configured["fg_color"] == module.DASHBOARD_THEME.button_fg
+    assert completed_card._configured["fg_color"] == "#064e3b"
+    assert completed_card._configured["border_color"] == module.DASHBOARD_THEME.arc_complete
+    assert strip._eyebrow_labels[1]._configured["text"] == "✓ SCN 2"
+    assert strip._title_labels[1]._configured["text_color"] == "#f8fbff"
+
+
+def test_scenario_selector_strip_preserves_selected_completed_dominance(monkeypatch):
+    """Verify selected completed scenarios keep selected fill with completed border."""
+    fake_canvas = _FakeCanvas()
+    monkeypatch.setattr(module.tk, "Canvas", lambda *args, **kwargs: fake_canvas)
+
+    strip = module.ScenarioSelectorStrip(
+        _DummyFrame(),
+        scenarios=[
+            _make_scenario("Moonlit Wake"),
+            _make_scenario("Catacomb Chase", status="COMPLETED"),
+        ],
+        selected_index=0,
+        on_select=lambda *_args: None,
+    )
+
+    strip.set_selected_index(1)
+
+    completed_card = strip._card_frames[1]
+    planned_card = strip._card_frames[0]
+
+    assert completed_card._configured["fg_color"] == module.DASHBOARD_THEME.button_fg
+    assert completed_card._configured["border_width"] == 2
+    assert completed_card._configured["border_color"] == module.DASHBOARD_THEME.arc_complete
+    assert planned_card._configured["fg_color"] == module.DASHBOARD_THEME.panel_bg
+    assert strip._eyebrow_labels[1]._configured["text"] == "✓ SCN 2"
+
+
+def test_scenario_selector_strip_syncs_completed_state_without_rebuild(monkeypatch):
+    """Verify status-only updates restyle existing cards and marker labels."""
+    fake_canvas = _FakeCanvas()
+    monkeypatch.setattr(module.tk, "Canvas", lambda *args, **kwargs: fake_canvas)
+
+    strip = module.ScenarioSelectorStrip(
+        _DummyFrame(),
+        scenarios=[_make_scenario("Moonlit Wake")],
+        selected_index=0,
+        on_select=lambda *_args: None,
+    )
+    initial_child_ids = [id(child) for child in strip.inner.winfo_children()]
+
+    strip.set_scenarios([_make_scenario("Moonlit Wake", status="Completed")], 0)
+
+    assert [id(child) for child in strip.inner.winfo_children()] == initial_child_ids
+    assert strip._card_frames[0]._configured["border_color"] == module.DASHBOARD_THEME.arc_complete
+    assert strip._eyebrow_labels[0]._configured["text"] == "✓ SCN 1"
 
 def test_arc_selector_strip_renders_clean_separator(monkeypatch):
     """Verify that the arc selector uses a real bullet separator in the subtitle."""


### PR DESCRIPTION
### Motivation
- Make completed scenarios visually distinct and accessible in the scenario selector so users (including color-blind users) can quickly identify finished scenarios.
- Use canonical `scenario.status` (already canonicalized via `read_scenario_status`) to determine completed state case-insensitively.

### Description
- Added a small helper `def _scenario_is_completed(scenario)` that returns True when `scenario.status` equals "completed" casefolded.
- Centralized card styling via `ScenarioSelectorStrip._scenario_card_style(...)` and applied it in `_render` and `_sync_selection_state` so completed, non-selected cards use a muted success fill (`"#064e3b"`) and `DASHBOARD_THEME.arc_complete` as border, while selected cards remain visually dominant (selected fill) and selected+completed use the completed border.
- Introduced an eyebrow label and `_scenario_label_text(...)` which prefixes `SCN N` with a checkmark (`✓`) for completed scenarios so a non-color marker exists.
- Updated tests in `tests/campaigns/ui/test_campaign_graph_navigation.py` to cover completed-card styling, selected-completed dominance, and status-only sync without a rebuild.

### Testing
- Ran `pytest -q tests/campaigns/ui/test_campaign_graph_navigation.py`, which passed (7 tests, all green).
- Ran `python -m compileall -q modules/campaigns/ui/graphical_display/components/navigation.py tests/campaigns/ui/test_campaign_graph_navigation.py`, which succeeded with no compile errors.
- Additional UI behavior covered by the updated unit tests: completed cards show the completed color and border, selected completed cards remain selected visually, and status-only updates restyle existing cards without rebuilding them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b25c0a84832b9532f187276ac1d4)