### PR TITLE
Polish campaign arc overview cards

### DIFF
--- a/modules/campaigns/ui/graphical_display/arc_selector/__init__.py
+++ b/modules/campaigns/ui/graphical_display/arc_selector/__init__.py
@@ -1,0 +1,21 @@
+"""Arc selector drawing helpers for the campaign graphical overview."""
+
+from .cards import (
+    ArcCardColors,
+    ArcCardMetrics,
+    ArcCardPayload,
+    calculate_arc_card_metrics,
+    draw_arc_card,
+    scenario_count_label,
+    truncate_to_width,
+)
+
+__all__ = [
+    "ArcCardColors",
+    "ArcCardMetrics",
+    "ArcCardPayload",
+    "calculate_arc_card_metrics",
+    "draw_arc_card",
+    "scenario_count_label",
+    "truncate_to_width",
+]

--- a/modules/campaigns/ui/graphical_display/arc_selector/cards.py
+++ b/modules/campaigns/ui/graphical_display/arc_selector/cards.py
@@ -1,0 +1,291 @@
+"""Canvas drawing primitives for campaign arc selector cards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class CanvasLike(Protocol):
+    """Small protocol for the tkinter Canvas methods used by these helpers."""
+
+    def create_rectangle(self, *args, **kwargs): ...
+    def create_polygon(self, *args, **kwargs): ...
+    def create_text(self, *args, **kwargs): ...
+
+
+@dataclass(frozen=True, slots=True)
+class ArcCardColors:
+    """Resolved colors used to draw one selector card."""
+
+    fill: str
+    outline: str
+    title: str
+    eyebrow: str
+    meta: str
+    status_text: str
+    status_fill: str
+    progress_track: str
+    progress_fill: str
+    accent: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArcCardMetrics:
+    """Geometry for an arc selector card."""
+
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    width: float
+    height: float
+    content_x: float
+    content_right: float
+    title_y: float
+    meta_y: float
+    progress_y: float
+
+
+@dataclass(frozen=True, slots=True)
+class ArcCardPayload:
+    """Display payload for one arc selector card."""
+
+    index: int
+    name: str
+    status: str
+    scenario_count: int
+    completed_scenarios: int = 0
+
+
+def calculate_arc_card_metrics(x1: float, y1: float, card_width: float, card_height: float) -> ArcCardMetrics:
+    """Return padded geometry for an arc selector card."""
+    content_x = x1 + 16
+    content_right = x1 + card_width - 16
+    return ArcCardMetrics(
+        x1=x1,
+        y1=y1,
+        x2=x1 + card_width,
+        y2=y1 + card_height,
+        width=card_width,
+        height=card_height,
+        content_x=content_x,
+        content_right=content_right,
+        title_y=y1 + 43,
+        meta_y=y1 + card_height - 31,
+        progress_y=y1 + card_height - 13,
+    )
+
+
+def draw_arc_card(
+    canvas: CanvasLike,
+    metrics: ArcCardMetrics,
+    payload: ArcCardPayload,
+    colors: ArcCardColors,
+    *,
+    tags: tuple[str, ...],
+) -> None:
+    """Draw a clean campaign arc selector card on a canvas."""
+    radius = 14
+    _rounded_rectangle(
+        canvas,
+        metrics.x1,
+        metrics.y1,
+        metrics.x2,
+        metrics.y2,
+        radius,
+        fill=colors.fill,
+        outline=colors.outline,
+        width=2,
+        tags=tags,
+    )
+    canvas.create_rectangle(
+        metrics.x1 + 1,
+        metrics.y1 + 12,
+        metrics.x1 + 4,
+        metrics.y2 - 12,
+        fill=colors.accent,
+        outline="",
+        tags=tags,
+    )
+
+    canvas.create_text(
+        metrics.content_x,
+        metrics.y1 + 18,
+        text=f"ARC {payload.index + 1}",
+        fill=colors.eyebrow,
+        anchor="w",
+        font=("Segoe UI", 9, "bold"),
+        tags=tags,
+    )
+    _draw_status_pill(canvas, metrics, payload.status, colors, tags=tags)
+
+    title_limit = _title_limit_for_width(metrics.width)
+    canvas.create_text(
+        metrics.content_x,
+        metrics.title_y,
+        text=truncate_to_width(payload.name, title_limit),
+        fill=colors.title,
+        anchor="nw",
+        width=max(metrics.width - 32, 40),
+        font=("Segoe UI", 12, "bold"),
+        tags=tags,
+    )
+
+    canvas.create_text(
+        metrics.content_x,
+        metrics.meta_y,
+        text=scenario_count_label(payload.scenario_count),
+        fill=colors.meta,
+        anchor="w",
+        font=("Segoe UI", 9),
+        tags=tags,
+    )
+    _draw_progress(canvas, metrics, payload, colors, tags=tags)
+
+
+def scenario_count_label(count: int) -> str:
+    """Return a compact scenario count label with correct pluralization."""
+    safe_count = max(int(count or 0), 0)
+    noun = "scenario" if safe_count == 1 else "scenarios"
+    return f"{safe_count} {noun}"
+
+
+def truncate_to_width(value: str, limit: int) -> str:
+    """Truncate text for a fixed-width canvas card."""
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    ellipsis = "..."
+    return text[: max(limit - len(ellipsis), 0)].rstrip() + ellipsis
+
+
+def _title_limit_for_width(width: float) -> int:
+    """Estimate a two-line title budget for a Segoe UI 12 bold canvas label."""
+    chars_per_line = max(int((width - 32) / 7), 14)
+    return min(chars_per_line * 2, 54)
+
+
+def _draw_status_pill(
+    canvas: CanvasLike,
+    metrics: ArcCardMetrics,
+    status: str,
+    colors: ArcCardColors,
+    *,
+    tags: tuple[str, ...],
+) -> None:
+    status_text = truncate_to_width(status or "Planned", 14)
+    pill_width = min(max(len(status_text) * 7 + 18, 68), max(metrics.width * 0.45, 68))
+    x2 = metrics.content_right
+    x1 = x2 - pill_width
+    y1 = metrics.y1 + 9
+    y2 = y1 + 20
+    _rounded_rectangle(
+        canvas,
+        x1,
+        y1,
+        x2,
+        y2,
+        10,
+        fill=colors.status_fill,
+        outline="",
+        width=1,
+        tags=tags,
+    )
+    canvas.create_text(
+        (x1 + x2) / 2,
+        (y1 + y2) / 2,
+        text=status_text,
+        fill=colors.status_text,
+        anchor="center",
+        font=("Segoe UI", 8, "bold"),
+        tags=tags,
+    )
+
+
+def _draw_progress(
+    canvas: CanvasLike,
+    metrics: ArcCardMetrics,
+    payload: ArcCardPayload,
+    colors: ArcCardColors,
+    *,
+    tags: tuple[str, ...],
+) -> None:
+    track_x1 = metrics.content_x
+    track_x2 = metrics.content_right
+    track_y1 = metrics.progress_y
+    track_y2 = metrics.progress_y + 4
+    _rounded_rectangle(
+        canvas,
+        track_x1,
+        track_y1,
+        track_x2,
+        track_y2,
+        2,
+        fill=colors.progress_track,
+        outline="",
+        width=1,
+        tags=tags,
+    )
+
+    total = max(payload.scenario_count, 1)
+    completed = max(min(payload.completed_scenarios, total), 0)
+    if completed <= 0:
+        return
+    fill_x2 = track_x1 + ((track_x2 - track_x1) * (completed / total))
+    _rounded_rectangle(
+        canvas,
+        track_x1,
+        track_y1,
+        fill_x2,
+        track_y2,
+        2,
+        fill=colors.progress_fill,
+        outline="",
+        width=1,
+        tags=tags,
+    )
+
+
+def _rounded_rectangle(
+    canvas: CanvasLike,
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    radius: float,
+    **kwargs,
+) -> None:
+    """Draw a rounded rectangle using a smoothed polygon."""
+    points = [
+        x1 + radius,
+        y1,
+        x2 - radius,
+        y1,
+        x2,
+        y1,
+        x2,
+        y1 + radius,
+        x2,
+        y2 - radius,
+        x2,
+        y2,
+        x2 - radius,
+        y2,
+        x1 + radius,
+        y2,
+        x1,
+        y2,
+        x1,
+        y2 - radius,
+        x1,
+        y1 + radius,
+        x1,
+        y1,
+    ]
+    if hasattr(canvas, "create_polygon"):
+        canvas.create_polygon(points, smooth=True, splinesteps=8, **kwargs)
+        return
+
+    # Lightweight test canvases often only implement rectangles; keep those paths importable.
+    canvas.create_rectangle(x1, y1, x2, y2, **kwargs)

--- a/modules/campaigns/ui/graphical_display/components/navigation.py
+++ b/modules/campaigns/ui/graphical_display/components/navigation.py
@@ -7,6 +7,12 @@ from typing import Callable, Sequence
 import customtkinter as ctk
 
 from modules.scenarios.gm_screen.dashboard.styles.dashboard_theme import DASHBOARD_THEME
+from ..arc_selector import (
+    ArcCardColors,
+    ArcCardPayload,
+    calculate_arc_card_metrics,
+    draw_arc_card,
+)
 from ..data import CampaignGraphArc, CampaignGraphScenario
 
 
@@ -46,7 +52,7 @@ class ArcSelectorStrip(_CanvasSelector):
         self._arcs = list(arcs)
         self._selected_index = selected_index
         self._on_select = on_select
-        super().__init__(parent, height=124, bg_color=DASHBOARD_THEME.panel_alt_bg)
+        super().__init__(parent, height=136, bg_color=_theme_attr("panel_alt_bg", "#111111"))
 
     def _render(self, *_args, **_kwargs) -> None:
         """Render the operation."""
@@ -56,60 +62,64 @@ class ArcSelectorStrip(_CanvasSelector):
 
         canvas.delete("all")
         width = max(canvas.winfo_width(), 420)
-        height = max(canvas.winfo_height(), 124)
+        height = max(canvas.winfo_height(), 136)
         canvas.create_rectangle(0, 0, width, height, fill=self._bg_color, outline="")
 
         count = max(len(self._arcs), 1)
         margin = 20
         gap = 12
-        card_width = max(min((width - (margin * 2) - (gap * (count - 1))) / count, 220), 118)
+        card_height = height - 32
+        card_width = max(min((width - (margin * 2) - (gap * (count - 1))) / count, 236), 150)
         total_width = card_width * count + gap * max(count - 1, 0)
         start_x = max((width - total_width) / 2, margin)
 
         for index, arc in enumerate(self._arcs):
             x1 = start_x + index * (card_width + gap)
-            x2 = x1 + card_width
-            y1 = 18
-            y2 = height - 18
             selected = index == self._selected_index
             tag = f"arc:{index}"
-            fill = DASHBOARD_THEME.button_fg if selected else DASHBOARD_THEME.panel_bg
-            outline = DASHBOARD_THEME.accent_soft if selected else DASHBOARD_THEME.card_border
-            title_color = "#f8fbff" if selected else DASHBOARD_THEME.text_primary
-            meta_color = "#d6e9ff" if selected else DASHBOARD_THEME.text_secondary
-
-            canvas.create_rectangle(x1, y1, x2, y2, fill=fill, outline=outline, width=2, tags=(tag,))
-            canvas.create_text(
-                x1 + 14,
-                y1 + 18,
-                text=f"Arc {index + 1}",
-                fill="#8fb0dd",
-                anchor="w",
-                font=("Segoe UI", 10, "bold"),
-                tags=(tag,),
+            colors = self._arc_card_colors(arc, selected=selected)
+            payload = ArcCardPayload(
+                index=index,
+                name=arc.name,
+                status=arc.status,
+                scenario_count=len(arc.scenarios),
+                completed_scenarios=self._completed_scenario_count(arc),
             )
-            canvas.create_text(
-                x1 + 14,
-                y1 + 42,
-                text=_truncate(arc.name, 24),
-                fill=title_color,
-                anchor="w",
-                width=max(card_width - 28, 40),
-                font=("Segoe UI", 12, "bold"),
-                tags=(tag,),
-            )
-            canvas.create_text(
-                x1 + 14,
-                y2 - 18,
-                text=f"{arc.status} \u2022 {len(arc.scenarios)} scenarios",
-                fill=meta_color,
-                anchor="sw",
-                font=("Segoe UI", 9, "bold"),
+            draw_arc_card(
+                canvas,
+                calculate_arc_card_metrics(x1, 16, card_width, card_height),
+                payload,
+                colors,
                 tags=(tag,),
             )
             canvas.tag_bind(tag, "<Button-1>", lambda _e=None, idx=index: self._on_select(idx))
             canvas.tag_bind(tag, "<Enter>", lambda _e=None: canvas.configure(cursor="hand2"))
             canvas.tag_bind(tag, "<Leave>", lambda _e=None: canvas.configure(cursor=""))
+
+    def _arc_card_colors(self, arc: CampaignGraphArc, *, selected: bool) -> ArcCardColors:
+        """Return the color palette for a single arc selector card."""
+        status_color = _arc_status_color(arc.status)
+        completed = self._arc_is_complete(arc)
+        return ArcCardColors(
+            fill=_theme_attr("button_fg", "#222222") if selected else _theme_attr("panel_bg", "#333333"),
+            outline=_theme_attr("accent_soft", "#444444") if selected else _theme_attr("card_border", "#555555"),
+            title="#f8fbff" if selected else _theme_attr("text_primary", "#ffffff"),
+            eyebrow="#d7ffe7" if completed else "#8fb0dd",
+            meta="#d6e9ff" if selected else _theme_attr("text_secondary", "#cccccc"),
+            status_text="#0f172a",
+            status_fill=status_color,
+            progress_track=_theme_attr("arc_track", "#333333"),
+            progress_fill=status_color,
+            accent=status_color if selected or completed else _theme_attr("card_border", "#555555"),
+        )
+
+    def _completed_scenario_count(self, arc: CampaignGraphArc) -> int:
+        """Return completed scenarios for arc progress rendering."""
+        return sum(1 for scenario in arc.scenarios if _scenario_is_completed(scenario))
+
+    def _arc_is_complete(self, arc: CampaignGraphArc) -> bool:
+        """Return whether an arc should be presented as complete."""
+        return str(arc.status or "").strip().casefold() == "completed"
 
 
 class ScenarioSelectorStrip(ctk.CTkFrame):
@@ -295,6 +305,23 @@ class ScenarioSelectorStrip(ctk.CTkFrame):
     def _resize_window(self, event) -> None:
         """Internal helper for resize window."""
         self.canvas.itemconfigure(self.canvas_window, height=event.height)
+
+
+def _theme_attr(name: str, fallback: str) -> str:
+    """Return a dashboard theme attribute while tolerating lean test stubs."""
+    return getattr(DASHBOARD_THEME, name, fallback)
+
+
+def _arc_status_color(status: str) -> str:
+    """Return the accent color associated with an arc status."""
+    normalized = str(status or "").strip().casefold()
+    if normalized == "completed":
+        return _theme_attr("arc_complete", "#22c55e")
+    if normalized in {"in progress", "running"}:
+        return _theme_attr("arc_active", "#f59e0b")
+    if normalized in {"paused", "blocked"}:
+        return _theme_attr("accent_soft", "#a78bfa")
+    return _theme_attr("arc_planned", "#60a5fa")
 
 
 def _truncate(value: str, limit: int) -> str:

--- a/tests/campaigns/ui/test_campaign_graph_navigation.py
+++ b/tests/campaigns/ui/test_campaign_graph_navigation.py
@@ -287,8 +287,8 @@ def test_scenario_selector_strip_syncs_completed_state_without_rebuild(monkeypat
     assert strip._card_frames[0]._configured["border_color"] == module.DASHBOARD_THEME.arc_complete
     assert strip._eyebrow_labels[0]._configured["text"] == "✓ SCN 1"
 
-def test_arc_selector_strip_renders_clean_separator(monkeypatch):
-    """Verify that the arc selector uses a real bullet separator in the subtitle."""
+def test_arc_selector_strip_renders_clean_card_elements(monkeypatch):
+    """Verify that the arc selector renders title, status, and scenario count as separate elements."""
     fake_canvas = _FakeCanvas()
     monkeypatch.setattr(module.tk, "Canvas", lambda *args, **kwargs: fake_canvas)
 
@@ -299,8 +299,9 @@ def test_arc_selector_strip_renders_clean_separator(monkeypatch):
         on_select=lambda *_args: None,
     )
 
-    assert any(text == "PharmaCorp Protection..." for text in fake_canvas.text_calls)
-    assert any(text == "Planned • 3 scenarios" for text in fake_canvas.text_calls)
+    assert any(text == "PharmaCorp Protection & Espionage" for text in fake_canvas.text_calls)
+    assert any(text == "Planned" for text in fake_canvas.text_calls)
+    assert any(text == "3 scenarios" for text in fake_canvas.text_calls)
 
 
 def test_arc_selector_truncation_helpers_emit_ascii_ellipsis():

--- a/tests/test_arc_selector_cards.py
+++ b/tests/test_arc_selector_cards.py
@@ -1,0 +1,65 @@
+from modules.campaigns.ui.graphical_display.arc_selector import (
+    ArcCardColors,
+    ArcCardPayload,
+    calculate_arc_card_metrics,
+    draw_arc_card,
+    scenario_count_label,
+    truncate_to_width,
+)
+
+
+class FakeCanvas:
+    def __init__(self):
+        self.calls = []
+
+    def create_rectangle(self, *args, **kwargs):
+        self.calls.append(("rectangle", args, kwargs))
+
+    def create_polygon(self, *args, **kwargs):
+        self.calls.append(("polygon", args, kwargs))
+
+    def create_text(self, *args, **kwargs):
+        self.calls.append(("text", args, kwargs))
+
+
+def test_scenario_count_label_pluralizes_cleanly():
+    assert scenario_count_label(0) == "0 scenarios"
+    assert scenario_count_label(1) == "1 scenario"
+    assert scenario_count_label(3) == "3 scenarios"
+
+
+def test_truncate_to_width_uses_single_ellipsis():
+    assert truncate_to_width("Short", 12) == "Short"
+    assert truncate_to_width("Welcome to the common rooms", 18) == "Welcome to the..."
+
+
+def test_draw_arc_card_keeps_status_and_count_separate():
+    canvas = FakeCanvas()
+    metrics = calculate_arc_card_metrics(10, 16, 210, 104)
+    colors = ArcCardColors(
+        fill="#111",
+        outline="#222",
+        title="#eee",
+        eyebrow="#8fb0dd",
+        meta="#aaa",
+        status_text="#000",
+        status_fill="#60a5fa",
+        progress_track="#333",
+        progress_fill="#60a5fa",
+        accent="#60a5fa",
+    )
+    payload = ArcCardPayload(
+        index=0,
+        name="Welcome to the common rooms with a long descriptive title",
+        status="Planned",
+        scenario_count=10,
+        completed_scenarios=0,
+    )
+
+    draw_arc_card(canvas, metrics, payload, colors, tags=("arc:0",))
+
+    text_values = [kwargs["text"] for kind, _args, kwargs in canvas.calls if kind == "text"]
+    assert "ARC 1" in text_values
+    assert "Planned" in text_values
+    assert "10 scenarios" in text_values
+    assert any(value.startswith("Welcome to") and value.endswith("...") for value in text_values)


### PR DESCRIPTION
### Motivation
- Improve readability and visual separation of arc cards in the campaign overview so arc label, title, status, counts and progress are no longer cramped into a single line.

### Description
- Add a dedicated arc selector drawing module `modules/campaigns/ui/graphical_display/arc_selector/cards.py` and public `arc_selector` package to centralize canvas card rendering and helpers like `ArcCardPayload`, `ArcCardColors`, `calculate_arc_card_metrics`, `draw_arc_card`, `truncate_to_width`, and `scenario_count_label`.
- Replace the cramped inline canvas drawing in `modules/campaigns/ui/graphical_display/components/navigation.py` with the new drawing pipeline and a roomier card layout, plus theme-fallback helper `_theme_attr` and arc-related color/resolution helpers.
- Tidy up truncation and pluralization behavior to use ASCII ellipses and consistent plural forms and make the selector use a compact progress bar and status pill for clarity.
- Add and update unit tests under `tests/test_arc_selector_cards.py` and `tests/campaigns/ui/test_campaign_graph_navigation.py` to validate truncation, pluralization, and that title/status/count render as separate elements.

### Testing
- Ran targeted compilation and unit tests: `python -m compileall -q modules/campaigns/ui/graphical_display ...` and `python -m pytest tests/campaigns/ui/test_arc_selector_strip.py tests/campaigns/ui/test_campaign_graph_navigation.py tests/test_arc_selector_cards.py tests/test_guided_tour_entry.py -q`, which completed successfully (targeted tests passed; e.g. the focused suite reported 14 passed).
- Added a small canvas-driven unit test `tests/test_arc_selector_cards.py` that passed and verifies drawing semantics and truncation behavior.
- Note: running the entire repository test collection (`python -m pytest -q`) still triggers unrelated collection/import errors in this environment (duplicate test-module names and lightweight `customtkinter`/theme stubs lacking some UI attributes), so full-suite green is blocked by existing test-environment issues unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b5353974832bb76c7b5dbd9f5d85)