### PR TITLE
Limit arc card title to a single line and adjust truncation/tests

### DIFF
--- a/modules/campaigns/ui/graphical_display/arc_selector/cards.py
+++ b/modules/campaigns/ui/graphical_display/arc_selector/cards.py
@@ -127,7 +127,6 @@ def draw_arc_card(
         text=truncate_to_width(payload.name, title_limit),
         fill=colors.title,
         anchor="nw",
-        width=max(metrics.width - 32, 40),
         font=("Segoe UI", 12, "bold"),
         tags=tags,
     )
@@ -161,9 +160,9 @@ def truncate_to_width(value: str, limit: int) -> str:
 
 
 def _title_limit_for_width(width: float) -> int:
-    """Estimate a two-line title budget for a Segoe UI 12 bold canvas label."""
-    chars_per_line = max(int((width - 32) / 7), 14)
-    return min(chars_per_line * 2, 54)
+    """Estimate a one-line title budget for a Segoe UI 12 bold canvas label."""
+    chars_per_line = max(int((width - 32) / 8), 14)
+    return min(chars_per_line, 34)
 
 
 def _draw_status_pill(

--- a/tests/campaigns/ui/test_campaign_graph_navigation.py
+++ b/tests/campaigns/ui/test_campaign_graph_navigation.py
@@ -299,7 +299,8 @@ def test_arc_selector_strip_renders_clean_card_elements(monkeypatch):
         on_select=lambda *_args: None,
     )
 
-    assert any(text == "PharmaCorp Protection & Espionage" for text in fake_canvas.text_calls)
+    assert any(text == "PharmaCorp Protection..." for text in fake_canvas.text_calls)
+    assert all(text != "PharmaCorp Protection & Espionage" for text in fake_canvas.text_calls)
     assert any(text == "Planned" for text in fake_canvas.text_calls)
     assert any(text == "3 scenarios" for text in fake_canvas.text_calls)
 

--- a/tests/test_arc_selector_cards.py
+++ b/tests/test_arc_selector_cards.py
@@ -58,8 +58,13 @@ def test_draw_arc_card_keeps_status_and_count_separate():
 
     draw_arc_card(canvas, metrics, payload, colors, tags=("arc:0",))
 
-    text_values = [kwargs["text"] for kind, _args, kwargs in canvas.calls if kind == "text"]
+    text_calls = [(args, kwargs) for kind, args, kwargs in canvas.calls if kind == "text"]
+    text_values = [kwargs["text"] for _args, kwargs in text_calls]
+    title_call = next((args, kwargs) for args, kwargs in text_calls if kwargs["text"].startswith("Welcome to"))
+
     assert "ARC 1" in text_values
     assert "Planned" in text_values
     assert "10 scenarios" in text_values
-    assert any(value.startswith("Welcome to") and value.endswith("...") for value in text_values)
+    assert "Welcome to the comm..." in text_values
+    assert title_call[1]["text"].endswith("...")
+    assert "width" not in title_call[1]


### PR DESCRIPTION
### Motivation
- Prevent long arc titles from wrapping to two lines on canvas cards and ensure a predictable single-line truncation with an ASCII ellipsis.
- Remove explicit `width` wrapping for the title so the canvas text remains a single logical element that can be asserted in tests.

### Description
- Change `_title_limit_for_width` to estimate a one-line character budget for Segoe UI 12 bold labels and reduce the overall maximum characters returned by the helper.
- Adjust the characters-per-pixel heuristic (divisor changed) and caps to produce a smaller single-line limit.
- Stop passing the `width` kwarg to `canvas.create_text` for the title so the text is not forced to wrap onto multiple lines.
- Update unit tests to expect truncated single-line titles and to assert that the full title is not present and that the title call contains no `width` argument.

### Testing
- Ran `pytest tests/test_arc_selector_cards.py` and the arc card truncation and title assertions passed.
- Ran `pytest tests/campaigns/ui/test_campaign_graph_navigation.py::test_arc_selector_strip_renders_clean_card_elements` and the updated truncation expectations passed.
- Relevant modified tests were updated to assert ASCII ellipsis behavior and all modified assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04be5cfa14832ba12b86fbcbf3602f)