### PR TITLE
Fix long arc card name truncation

### DIFF
--- a/modules/campaigns/ui/graphical_display/arc_selector/__init__.py
+++ b/modules/campaigns/ui/graphical_display/arc_selector/__init__.py
@@ -7,8 +7,8 @@ from .cards import (
     calculate_arc_card_metrics,
     draw_arc_card,
     scenario_count_label,
-    truncate_to_width,
 )
+from .text import title_limit_for_card_width, truncate_to_width
 
 __all__ = [
     "ArcCardColors",
@@ -17,5 +17,6 @@ __all__ = [
     "calculate_arc_card_metrics",
     "draw_arc_card",
     "scenario_count_label",
+    "title_limit_for_card_width",
     "truncate_to_width",
 ]

--- a/modules/campaigns/ui/graphical_display/arc_selector/cards.py
+++ b/modules/campaigns/ui/graphical_display/arc_selector/cards.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
+from .text import title_limit_for_card_width, truncate_to_width
+
 
 class CanvasLike(Protocol):
     """Small protocol for the tkinter Canvas methods used by these helpers."""
@@ -128,7 +130,7 @@ def draw_arc_card(
     )
     _draw_status_pill(canvas, metrics, payload.status, colors, tags=tags)
 
-    title_limit = _title_limit_for_width(metrics.width)
+    title_limit = title_limit_for_card_width(metrics.width)
     canvas.create_text(
         metrics.content_x,
         metrics.title_y,
@@ -156,21 +158,6 @@ def scenario_count_label(count: int) -> str:
     safe_count = max(int(count or 0), 0)
     noun = "scenario" if safe_count == 1 else "scenarios"
     return f"{safe_count} {noun}"
-
-
-def truncate_to_width(value: str, limit: int) -> str:
-    """Truncate text for a fixed-width canvas card."""
-    text = str(value or "").strip()
-    if len(text) <= limit:
-        return text
-    ellipsis = "..."
-    return text[: max(limit - len(ellipsis), 0)].rstrip() + ellipsis
-
-
-def _title_limit_for_width(width: float) -> int:
-    """Estimate a single-line title budget for a Segoe UI 12 bold canvas label."""
-    chars_per_line = max(int((width - 32) / 6), 14)
-    return min(chars_per_line, 34)
 
 
 def _draw_status_pill(

--- a/modules/campaigns/ui/graphical_display/arc_selector/text.py
+++ b/modules/campaigns/ui/graphical_display/arc_selector/text.py
@@ -1,0 +1,27 @@
+"""Text fitting helpers for campaign arc selector cards."""
+
+from __future__ import annotations
+
+ELLIPSIS = "..."
+MIN_TITLE_CHAR_BUDGET = 14
+MAX_TITLE_CHAR_BUDGET = 34
+ARC_TITLE_HORIZONTAL_PADDING = 32
+SEGEO_UI_BOLD_12_AVERAGE_CHAR_WIDTH = 8.2
+
+
+def title_limit_for_card_width(width: float) -> int:
+    """Estimate the title character budget that fits inside an arc card."""
+    usable_width = max(float(width or 0) - ARC_TITLE_HORIZONTAL_PADDING, 0)
+    chars_per_line = int(usable_width / SEGEO_UI_BOLD_12_AVERAGE_CHAR_WIDTH)
+    bounded_chars = max(chars_per_line, MIN_TITLE_CHAR_BUDGET)
+    return min(bounded_chars, MAX_TITLE_CHAR_BUDGET)
+
+
+def truncate_to_width(value: str, limit: int) -> str:
+    """Truncate text to a character budget and append one trailing ellipsis."""
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    if limit <= len(ELLIPSIS):
+        return ELLIPSIS[: max(limit, 0)]
+    return text[: limit - len(ELLIPSIS)].rstrip() + ELLIPSIS

--- a/tests/test_arc_selector_cards.py
+++ b/tests/test_arc_selector_cards.py
@@ -4,6 +4,7 @@ from modules.campaigns.ui.graphical_display.arc_selector import (
     calculate_arc_card_metrics,
     draw_arc_card,
     scenario_count_label,
+    title_limit_for_card_width,
     truncate_to_width,
 )
 
@@ -31,6 +32,11 @@ def test_scenario_count_label_pluralizes_cleanly():
 def test_truncate_to_width_uses_single_ellipsis():
     assert truncate_to_width("Short", 12) == "Short"
     assert truncate_to_width("Welcome to the common rooms", 18) == "Welcome to the..."
+
+
+def test_title_limit_for_card_width_matches_arc_card_content_area():
+    assert title_limit_for_card_width(236) == 24
+    assert title_limit_for_card_width(150) == 14
 
 
 def test_draw_arc_card_keeps_status_and_count_separate():
@@ -63,12 +69,12 @@ def test_draw_arc_card_keeps_status_and_count_separate():
     assert "ARC 1" in text_values
     assert "Planned" in text_values
     assert "10 scenarios" in text_values
-    assert "Welcome to the Commonwealth" in text_values
+    assert "Welcome to the Common..." in text_values
 
     title_call = next(
         (args, kwargs)
         for args, kwargs in text_calls
-        if kwargs["text"] == "Welcome to the Commonwealth"
+        if kwargs["text"] == "Welcome to the Common..."
     )
     scenario_count_call = next(
         (args, kwargs)


### PR DESCRIPTION
### Motivation
- Long arc names were drawn on selector cards without a reliable character budget, causing visual clipping instead of showing a trailing ellipsis for overflow.

### Description
- Add `modules/campaigns/ui/graphical_display/arc_selector/text.py` with `title_limit_for_card_width` and `truncate_to_width` helpers to centralize title sizing and ellipsis logic.
- Update `modules/campaigns/ui/graphical_display/arc_selector/cards.py` to use `title_limit_for_card_width(metrics.width)` and `truncate_to_width(...)` when rendering arc titles so long names end with `...` instead of being clipped.
- Export the new helper from `modules/campaigns/ui/graphical_display/arc_selector/__init__.py` for reuse and testing, and update `tests/test_arc_selector_cards.py` to assert the new truncation and add a title-limit test.

### Testing
- Compiled the modified modules with `python3 -m py_compile modules/campaigns/ui/graphical_display/arc_selector/cards.py modules/campaigns/ui/graphical_display/arc_selector/text.py` which succeeded.
- Ran unit tests `python3 -m pytest tests/test_arc_selector_cards.py tests/campaigns/ui/test_arc_selector_strip.py` and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c15822ec832ba6f0816872b49504)