### PR TITLE
Add ambiance wallpaper bundle support

### DIFF
--- a/modules/generic/ambiance_wallpaper_bundle.py
+++ b/modules/generic/ambiance_wallpaper_bundle.py
@@ -1,0 +1,259 @@
+"""Bundle helpers for campaign ambiance wallpaper library assets."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from modules.ui.ambiance.library.index_store import CampaignWallpaperIndexStore
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
+BUNDLE_DIR = Path("ambiance_wallpapers")
+FILES_DIR_NAME = "files"
+INDEX_FILE_NAME = "index.json"
+MANIFEST_KEY = "ambiance_wallpapers"
+
+
+def export_wallpaper_bundle(campaign_root: Path, bundle_root: Path) -> dict[str, Any] | None:
+    """Copy wallpaper media/metadata into a bundle staging root and return manifest metadata."""
+    store = CampaignWallpaperIndexStore(str(campaign_root))
+    items = _valid_existing_items(store)
+    if not items:
+        return None
+
+    bundle_dir = bundle_root / BUNDLE_DIR
+    bundle_files_dir = bundle_dir / FILES_DIR_NAME
+    entries: list[dict[str, Any]] = []
+
+    for item in items:
+        source = Path(store.absolute_path(item))
+        safe_relative = _safe_relative_path(item.relative_path)
+        if (
+            safe_relative is None
+            or not _is_within(source, store.wallpapers_dir)
+            or not source.exists()
+            or not source.is_file()
+        ):
+            continue
+
+        destination = bundle_files_dir / safe_relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        entries.append(_item_to_manifest_entry(item))
+
+    if not entries:
+        return None
+
+    index_path = bundle_dir / INDEX_FILE_NAME
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        json.dumps({"version": 1, "items": entries}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    return {
+        "count": len(entries),
+        "index_path": (BUNDLE_DIR / INDEX_FILE_NAME).as_posix(),
+        "files_path": (BUNDLE_DIR / FILES_DIR_NAME).as_posix(),
+        "items": entries,
+    }
+
+
+def load_wallpaper_manifest(bundle_root: Path, manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Load wallpaper metadata entries from an extracted bundle."""
+    section = manifest.get(MANIFEST_KEY)
+    if not isinstance(section, dict):
+        return []
+
+    raw_items = section.get("items")
+    if isinstance(raw_items, list):
+        return [_entry for item in raw_items if (_entry := _normalize_entry(item)) is not None]
+
+    index_path_value = str(section.get("index_path") or "").strip()
+    if not index_path_value:
+        return []
+    safe_index_path = _safe_relative_path(index_path_value)
+    if safe_index_path is None:
+        return []
+    index_path = bundle_root / safe_index_path
+    if not _is_within(index_path, bundle_root) or not index_path.exists():
+        return []
+
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    return [_entry for item in items if (_entry := _normalize_entry(item)) is not None]
+
+
+def merge_wallpaper_bundle(
+    bundle_root: Path,
+    target_campaign_root: Path,
+    entries: list[dict[str, Any]],
+    *,
+    overwrite: bool,
+) -> dict[str, int]:
+    """Restore bundled wallpaper files and merge them into the target campaign index."""
+    summary = {
+        "ambiance_wallpapers_imported": 0,
+        "ambiance_wallpapers_updated": 0,
+        "ambiance_wallpapers_skipped": 0,
+    }
+    if not entries:
+        return summary
+
+    store = CampaignWallpaperIndexStore(str(target_campaign_root))
+    existing_items = store.load()
+    by_id = {item.id: item for item in existing_items if item.id}
+    by_relative = {item.relative_path: item for item in existing_items if item.relative_path}
+    merged_by_id = {item.id: item for item in existing_items if item.id}
+
+    for entry in entries:
+        relative_path = entry["relative_path"]
+        safe_relative = _safe_relative_path(relative_path)
+        if safe_relative is None:
+            summary["ambiance_wallpapers_skipped"] += 1
+            continue
+
+        source = bundle_root / BUNDLE_DIR / FILES_DIR_NAME / safe_relative
+        destination = store.wallpapers_dir / safe_relative
+        existing = by_relative.get(relative_path) or by_id.get(entry["id"])
+
+        if (existing or destination.exists()) and not overwrite:
+            summary["ambiance_wallpapers_skipped"] += 1
+            continue
+        if not source.exists() or not source.is_file():
+            summary["ambiance_wallpapers_skipped"] += 1
+            continue
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+        item = _entry_to_item(entry)
+        if existing:
+            merged_by_id.pop(existing.id, None)
+            summary["ambiance_wallpapers_updated"] += 1
+        else:
+            summary["ambiance_wallpapers_imported"] += 1
+        merged_by_id[item.id] = item
+        by_id[item.id] = item
+        by_relative[item.relative_path] = item
+
+    store.save(list(merged_by_id.values()))
+    return summary
+
+
+def install_wallpaper_bundle(bundle_root: Path, target_campaign_root: Path, manifest: dict[str, Any]) -> dict[str, int]:
+    """Restore bundled wallpapers during full campaign installation."""
+    entries = load_wallpaper_manifest(bundle_root, manifest)
+    return merge_wallpaper_bundle(bundle_root, target_campaign_root, entries, overwrite=True)
+
+
+def _valid_existing_items(store: CampaignWallpaperIndexStore) -> list[WallpaperLibraryItem]:
+    items: list[WallpaperLibraryItem] = []
+    for item in store.load():
+        if _safe_relative_path(item.relative_path) is None:
+            continue
+        source = Path(store.absolute_path(item))
+        if source.exists() and source.is_file():
+            items.append(item)
+    return items
+
+
+def _item_to_manifest_entry(item: WallpaperLibraryItem) -> dict[str, Any]:
+    return {
+        "id": item.id,
+        "relative_path": item.relative_path,
+        "filename": item.filename,
+        "media_type": item.media_type,
+        "width": item.width,
+        "height": item.height,
+        "filesize": item.filesize,
+        "created_at": item.created_at,
+        "tags": list(item.tags),
+    }
+
+
+def _entry_to_item(entry: dict[str, Any]) -> WallpaperLibraryItem:
+    return WallpaperLibraryItem(
+        id=entry["id"],
+        relative_path=entry["relative_path"],
+        filename=entry["filename"],
+        media_type="video" if entry.get("media_type") == "video" else "image",
+        width=_to_optional_int(entry.get("width")),
+        height=_to_optional_int(entry.get("height")),
+        filesize=max(0, _to_int(entry.get("filesize"), 0)),
+        created_at=_to_float(entry.get("created_at"), 0.0),
+        tags=tuple(str(tag).strip() for tag in entry.get("tags", []) if str(tag).strip())
+        if isinstance(entry.get("tags"), list)
+        else (),
+    )
+
+
+def _normalize_entry(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    relative_path = str(raw.get("relative_path") or "").replace("\\", "/").strip()
+    item_id = str(raw.get("id") or "").strip()
+    filename = str(raw.get("filename") or Path(relative_path).name).strip()
+    if not relative_path or not item_id or not filename or _safe_relative_path(relative_path) is None:
+        return None
+    tags_raw = raw.get("tags")
+    tags = [str(tag).strip() for tag in tags_raw if str(tag).strip()] if isinstance(tags_raw, list) else []
+    return {
+        "id": item_id,
+        "relative_path": relative_path,
+        "filename": filename,
+        "media_type": "video" if str(raw.get("media_type") or "").lower() == "video" else "image",
+        "width": _to_optional_int(raw.get("width")),
+        "height": _to_optional_int(raw.get("height")),
+        "filesize": max(0, _to_int(raw.get("filesize"), 0)),
+        "created_at": _to_float(raw.get("created_at"), 0.0),
+        "tags": tags,
+    }
+
+
+def _safe_relative_path(value: str) -> Path | None:
+    normalized = str(value or "").replace("\\", "/").strip()
+    if not normalized:
+        return None
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or any(part in ("", ".", "..") or ":" in part for part in path.parts):
+        return None
+    return Path(*path.parts)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _to_optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -11,10 +11,17 @@ import tempfile
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from modules.audio.entity_audio import normalize_audio_reference
+from modules.generic.ambiance_wallpaper_bundle import (
+    MANIFEST_KEY as AMBIANCE_WALLPAPERS_MANIFEST_KEY,
+    export_wallpaper_bundle,
+    install_wallpaper_bundle,
+    load_wallpaper_manifest,
+    merge_wallpaper_bundle,
+)
 from modules.generic.cross_campaign_bundle_extras import collect_full_campaign_extra_files
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.config_helper import ConfigHelper
@@ -70,6 +77,7 @@ class BundleAnalysis:
     database: Optional[dict] = None
     world_maps: Optional[Dict[str, dict]] = None
     systems: Optional[List[dict]] = None
+    ambiance_wallpapers: Optional[List[dict]] = None
 
 
 def _resolve_active_campaign() -> CampaignDatabase:
@@ -748,6 +756,10 @@ def export_bundle(
                 "data_path": "data/world_maps.json",
             }
 
+        wallpaper_manifest = export_wallpaper_bundle(source_campaign.root, temp_root)
+        if wallpaper_manifest:
+            manifest[AMBIANCE_WALLPAPERS_MANIFEST_KEY] = wallpaper_manifest
+
         if include_database:
             try:
                 # Keep bundle resilient if this step fails.
@@ -790,6 +802,29 @@ def export_bundle(
     return manifest
 
 
+def _safe_extract_zip(zf: zipfile.ZipFile, target_dir: Path) -> None:
+    """Extract *zf* while rejecting members that would escape *target_dir*."""
+    root = target_dir.resolve()
+    for member in zf.infolist():
+        name = str(member.filename or "")
+        normalized = name.replace("\\", "/")
+        member_path = PurePosixPath(normalized)
+        parts = member_path.parts
+        if (
+            not normalized
+            or name != normalized
+            or member_path.is_absolute()
+            or any(part in ("", ".", "..") or ":" in part for part in parts)
+        ):
+            raise ValueError(f"Unsafe bundle member path: {member.filename}")
+        destination = (root / Path(*parts)).resolve()
+        try:
+            destination.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"Unsafe bundle member path: {member.filename}") from exc
+    zf.extractall(root)
+
+
 def _call_progress(callback, message: str, fraction: float) -> None:
     """Internal helper for call progress."""
     if callback is None:
@@ -810,7 +845,7 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
     try:
         # Keep analyze bundle resilient if this step fails.
         with zipfile.ZipFile(bundle_path, "r") as zf:
-            zf.extractall(temp_dir)
+            _safe_extract_zip(zf, temp_dir)
 
         manifest_path = temp_dir / "manifest.json"
         if not manifest_path.exists():
@@ -910,6 +945,8 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
                             func_name="modules.generic.cross_campaign_asset_service.analyze_bundle",
                         )
 
+        ambiance_wallpapers = load_wallpaper_manifest(temp_dir, manifest)
+
         return BundleAnalysis(
             manifest=manifest,
             data_by_type=data_by_type,
@@ -919,6 +956,7 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
             database=database_entry,
             world_maps=world_maps or None,
             systems=systems,
+            ambiance_wallpapers=ambiance_wallpapers or None,
         )
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
@@ -1032,6 +1070,9 @@ def apply_import_for_entity_types(
             "systems_imported": 0,
             "systems_skipped": 0,
             "systems_updated": 0,
+            "ambiance_wallpapers_imported": 0,
+            "ambiance_wallpapers_updated": 0,
+            "ambiance_wallpapers_skipped": 0,
         }
 
     filtered_data = {
@@ -1058,6 +1099,7 @@ def apply_import_for_entity_types(
         database=analysis.database,
         world_maps=filtered_world_maps,
         systems=None,
+        ambiance_wallpapers=analysis.ambiance_wallpapers,
     )
     return apply_import(
         filtered_analysis,
@@ -1085,6 +1127,9 @@ def apply_import(
         "systems_imported": 0,
         "systems_skipped": 0,
         "systems_updated": 0,
+        "ambiance_wallpapers_imported": 0,
+        "ambiance_wallpapers_updated": 0,
+        "ambiance_wallpapers_skipped": 0,
     }
 
     try:
@@ -1238,6 +1283,14 @@ def apply_import(
         if analysis.world_maps:
             rewritten_world_maps = _rewrite_world_map_entries(analysis.world_maps, replacements)
             _merge_world_map_entries(target_campaign.root, rewritten_world_maps)
+
+        wallpaper_summary = merge_wallpaper_bundle(
+            analysis.temp_dir,
+            target_campaign.root,
+            analysis.ambiance_wallpapers or [],
+            overwrite=overwrite,
+        )
+        summary.update(wallpaper_summary)
     finally:
         shutil.rmtree(analysis.temp_dir, ignore_errors=True)
 
@@ -1260,7 +1313,7 @@ def install_full_campaign_bundle(
     try:
         # Keep install full campaign bundle resilient if this step fails.
         with zipfile.ZipFile(bundle_path, "r") as zf:
-            zf.extractall(temp_dir)
+            _safe_extract_zip(zf, temp_dir)
 
         manifest_path = temp_dir / "manifest.json"
         if not manifest_path.exists():
@@ -1293,7 +1346,8 @@ def install_full_campaign_bundle(
 
         assets = manifest.get("assets") or []
         extra_files = manifest.get("extra_files") or []
-        total_steps = max(len(assets) + len(extra_files) + 1, 1)
+        wallpaper_count = len(load_wallpaper_manifest(temp_dir, manifest))
+        total_steps = max(len(assets) + len(extra_files) + wallpaper_count + 1, 1)
         _call_progress(progress_callback, "Copying database", 1 / total_steps)
 
         target_root = target_dir.resolve()
@@ -1367,6 +1421,8 @@ def install_full_campaign_bundle(
                 f"Copying extra files ({index}/{len(extra_files)})",
                 min((extra_offset + index + 1) / total_steps, 1.0),
             )
+
+        install_wallpaper_bundle(temp_dir, target_root, manifest)
 
         campaign_name = str(manifest.get("source_campaign", {}).get("name") or target_dir.name)
         return CampaignDatabase(name=campaign_name, root=target_dir, db_path=db_destination)

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -1,8 +1,10 @@
 """Regression tests for cross campaign asset service."""
 
+import shutil
+import sqlite3
 import sys
 import types
-import sqlite3
+import zipfile
 
 import pytest
 
@@ -19,6 +21,9 @@ if "winsound" not in sys.modules:
     winsound_stub.PlaySound = _noop
     sys.modules["winsound"] = winsound_stub
 
+from modules.ui.ambiance.library.index_store import CampaignWallpaperIndexStore
+from modules.ui.ambiance.library.models import WallpaperLibraryItem
+
 from modules.generic.cross_campaign_asset_service import (
     CampaignDatabase,
     _rewrite_record_paths,
@@ -28,6 +33,57 @@ from modules.generic.cross_campaign_asset_service import (
     analyze_bundle,
     apply_import,
 )
+
+
+def test_analyze_bundle_rejects_unsafe_zip_member_path(tmp_path):
+    """Bundle extraction should reject zip members that escape the extraction root."""
+    bundle_path = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(bundle_path, "w") as zf:
+        zf.writestr("manifest.json", '{"version": 1}')
+        zf.writestr("../escape.txt", "nope")
+
+    with pytest.raises(ValueError, match="Unsafe bundle member path"):
+        analyze_bundle(bundle_path, tmp_path / "target.db")
+
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_analyze_bundle_ignores_unsafe_or_malformed_ambiance_wallpaper_entries(tmp_path):
+    """Wallpaper bundle metadata should sanitize relative paths and tolerate malformed numbers."""
+    bundle_path = tmp_path / "wallpapers.zip"
+    with zipfile.ZipFile(bundle_path, "w") as zf:
+        zf.writestr(
+            "manifest.json",
+            '{"version": 1, "ambiance_wallpapers": {"index_path": "ambiance_wallpapers/index.json"}}',
+        )
+        zf.writestr(
+            "ambiance_wallpapers/index.json",
+            (
+                '{"items": ['
+                '{"id": "safe", "relative_path": "nested/sky.png", "filename": "sky.png", '
+                '"created_at": "not-a-float"},'
+                '{"id": "unsafe", "relative_path": "../escape.png", "filename": "escape.png"}'
+                ']}'
+            ),
+        )
+
+    analysis = analyze_bundle(bundle_path, tmp_path / "target.db")
+    try:
+        assert analysis.ambiance_wallpapers == [
+            {
+                "id": "safe",
+                "relative_path": "nested/sky.png",
+                "filename": "sky.png",
+                "media_type": "image",
+                "width": None,
+                "height": None,
+                "filesize": 0,
+                "created_at": 0.0,
+                "tags": [],
+            }
+        ]
+    finally:
+        shutil.rmtree(analysis.temp_dir, ignore_errors=True)
 
 
 def test_export_bundle_raises_when_database_missing(tmp_path):
@@ -268,3 +324,139 @@ def test_apply_import_restores_extra_files_for_asset_bundle(tmp_path):
     assert restored.exists()
     assert restored.read_text(encoding="utf-8") == '{"categories": []}'
     assert summary.get("extra_files_imported", 0) >= 1
+
+
+def _write_wallpaper(campaign_root, relative_path="nested/sky.png", content=b"sky"):
+    store = CampaignWallpaperIndexStore(str(campaign_root))
+    media = store.wallpapers_dir / relative_path
+    media.parent.mkdir(parents=True, exist_ok=True)
+    media.write_bytes(content)
+    item = WallpaperLibraryItem(
+        id="wall-1",
+        relative_path=relative_path,
+        filename=media.name,
+        media_type="image",
+        width=1920,
+        height=1080,
+        filesize=len(content),
+        created_at=123.0,
+        tags=("night", "forest"),
+    )
+    store.save([item])
+    return item, media
+
+
+def test_export_bundle_includes_ambiance_wallpaper_files_and_metadata(tmp_path):
+    """Ambiance wallpaper media and index metadata should be bundled separately."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    item, _media = _write_wallpaper(source_root)
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "wallpapers.zip"
+
+    manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=False)
+
+    section = manifest["ambiance_wallpapers"]
+    assert section["count"] == 1
+    assert section["items"][0]["id"] == item.id
+    assert section["items"][0]["relative_path"] == item.relative_path
+    with zipfile.ZipFile(bundle_path, "r") as zf:
+        names = set(zf.namelist())
+    assert "ambiance_wallpapers/index.json" in names
+    assert "ambiance_wallpapers/files/nested/sky.png" in names
+
+
+def test_apply_import_restores_ambiance_wallpaper_media_and_index(tmp_path):
+    """Regular imports should restore wallpaper files and merge the target index."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    item, _media = _write_wallpaper(source_root)
+    bundle_path = tmp_path / "wallpapers.zip"
+    export_bundle(bundle_path, CampaignDatabase("Source", source_root, db_path), {}, include_database=False)
+
+    target_root = tmp_path / "target"
+    target_root.mkdir(parents=True, exist_ok=True)
+    target_db = target_root / "campaign.db"
+    sqlite3.connect(target_db).close()
+    target_campaign = CampaignDatabase("Target", target_root, target_db)
+
+    analysis = analyze_bundle(bundle_path, target_campaign.db_path)
+    assert analysis.ambiance_wallpapers[0]["relative_path"] == item.relative_path
+    summary = apply_import(analysis, target_campaign, overwrite=False)
+
+    target_store = CampaignWallpaperIndexStore(str(target_root))
+    restored = target_store.wallpapers_dir / item.relative_path
+    assert restored.read_bytes() == b"sky"
+    assert target_store.load()[0].tags == item.tags
+    assert summary["ambiance_wallpapers_imported"] == 1
+    assert summary["ambiance_wallpapers_updated"] == 0
+    assert summary["ambiance_wallpapers_skipped"] == 0
+
+
+def test_apply_import_skips_or_overwrites_existing_ambiance_wallpapers(tmp_path):
+    """Wallpaper import duplicates should match by relative_path or id and honor overwrite."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    item, _media = _write_wallpaper(source_root, content=b"new")
+    bundle_path = tmp_path / "wallpapers.zip"
+    export_bundle(bundle_path, CampaignDatabase("Source", source_root, db_path), {}, include_database=False)
+
+    target_root = tmp_path / "target"
+    target_root.mkdir(parents=True, exist_ok=True)
+    target_db = target_root / "campaign.db"
+    sqlite3.connect(target_db).close()
+    target_store = CampaignWallpaperIndexStore(str(target_root))
+    existing_media = target_store.wallpapers_dir / item.relative_path
+    existing_media.parent.mkdir(parents=True, exist_ok=True)
+    existing_media.write_bytes(b"old")
+    target_store.save([
+        WallpaperLibraryItem(
+            id="existing-id",
+            relative_path=item.relative_path,
+            filename=item.filename,
+            media_type="image",
+            width=100,
+            height=100,
+            filesize=3,
+            created_at=1.0,
+            tags=("old",),
+        )
+    ])
+    target_campaign = CampaignDatabase("Target", target_root, target_db)
+
+    skip_summary = apply_import(analyze_bundle(bundle_path, target_db), target_campaign, overwrite=False)
+    assert existing_media.read_bytes() == b"old"
+    assert target_store.load()[0].id == "existing-id"
+    assert skip_summary["ambiance_wallpapers_skipped"] == 1
+
+    overwrite_summary = apply_import(analyze_bundle(bundle_path, target_db), target_campaign, overwrite=True)
+    loaded = target_store.load()
+    assert existing_media.read_bytes() == b"new"
+    assert len(loaded) == 1
+    assert loaded[0].id == item.id
+    assert loaded[0].tags == item.tags
+    assert overwrite_summary["ambiance_wallpapers_updated"] == 1
+
+
+def test_install_full_campaign_bundle_restores_ambiance_wallpapers(tmp_path):
+    """Full campaign installation should restore ambiance wallpaper files and index."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    item, _media = _write_wallpaper(source_root)
+    bundle_path = tmp_path / "full_wallpapers.zip"
+    export_bundle(bundle_path, CampaignDatabase("Source", source_root, db_path), {}, include_database=True)
+
+    installed = install_full_campaign_bundle(bundle_path, tmp_path / "installed")
+
+    store = CampaignWallpaperIndexStore(str(installed.root))
+    assert (store.wallpapers_dir / item.relative_path).read_bytes() == b"sky"
+    assert store.load()[0].id == item.id


### PR DESCRIPTION
### Motivation

- Provide a first-class, modular asset category for campaign ambiance wallpapers so wallpaper media and index metadata can be exported, imported, and restored independently from other assets.  
- Preserve existing duplicate semantics (match by `relative_path` or `id`, respect `overwrite`), while keeping the bundle format simple and backwards compatible.  
- Harden bundle handling to avoid path traversal and malformed metadata from breaking bundle analysis or import.

### Description

- Add a new helper module `modules/generic/ambiance_wallpaper_bundle.py` implementing `export_wallpaper_bundle`, `load_wallpaper_manifest`, `merge_wallpaper_bundle`, and `install_wallpaper_bundle`, plus normalization and path-safety helpers.  
- Integrate the wallpaper helper into the main flow in `modules/generic/cross_campaign_asset_service.py` by: adding `ambiance_wallpapers` to the manifest during `export_bundle`, loading wallpaper metadata in `analyze_bundle`, merging/restoring wallpapers in `apply_import`, and restoring wallpapers during `install_full_campaign_bundle`.  
- Implement safe ZIP extraction (`_safe_extract_zip`) and strict relative-path validation (`_safe_relative_path` / `_is_within`) so archive members and wallpaper relative paths that attempt traversal or use unsafe separators are rejected or ignored.  
- Maintain duplicate behavior: matching by `relative_path` or `id`, skipping when `overwrite=False`, replacing and copying files when `overwrite=True`, and returning summary counters `ambiance_wallpapers_imported`, `ambiance_wallpapers_updated`, and `ambiance_wallpapers_skipped` from imports.

### Testing

- Ran syntax/compile checks with `python -m py_compile modules/generic/ambiance_wallpaper_bundle.py modules/generic/cross_campaign_asset_service.py tests/test_cross_campaign_asset_service.py` and it succeeded.  
- Ran unit tests for the modified test file with `pytest -q tests/test_cross_campaign_asset_service.py` and all coverage for these cases passed (`15 passed`, with existing deprecation warnings about `datetime.utcfromtimestamp`).  
- Ran targeted wallpaper/zip checks with `pytest -q tests/test_cross_campaign_asset_service.py -k 'ambiance_wallpaper or unsafe_zip_member_path'` which passed (`6 passed, 9 deselected`), and manual QA checks for duplicate-by-`id` scenarios were performed (`PYTHONPATH=/workspace/GMCampaignDesigner python /tmp/qa_wallpapers_check.py`) and passed.  
- Note: a full-suite `pytest -q` collection was attempted during development and hit pre-existing environment/collection issues unrelated to this change (duplicate test module name and incomplete UI stubs); these environment problems are outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082496d3f4832b986bd0cb60a9f22b)