### PR TITLE
Include `villains` in portrait and audio cross-campaign asset handling

### DIFF
--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -37,8 +37,8 @@ log_module_import(__name__)
 BUNDLE_VERSION = 1
 
 
-PORTRAIT_ENTITY_TYPES = {"npcs", "objects", "pcs", "creatures", "places", "clues", "factions"}
-AUDIO_ENTITY_TYPES = {"npcs", "pcs", "creatures", "places"}
+PORTRAIT_ENTITY_TYPES = {"npcs", "objects", "pcs", "creatures", "places", "clues", "factions", "villains"}
+AUDIO_ENTITY_TYPES = {"npcs", "pcs", "creatures", "places", "villains"}
 ATTACHMENT_FIELDS = {
     "clues": "Attachment",
     "informations": "Attachment",

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -127,6 +127,45 @@ def test_collect_assets_includes_image_library_files(tmp_path):
     assert assets[0].absolute_path == image_file.resolve()
 
 
+def test_villain_assets_collect_and_rewrite_portrait_and_audio(tmp_path):
+    """Villains should export and import both portrait and audio media paths."""
+    campaign_root = tmp_path / "campaign"
+    portrait_path = "portraits/villains/lich.png"
+    audio_path = "audio/villains/lich_theme.mp3"
+    portrait_file = campaign_root / portrait_path
+    audio_file = campaign_root / audio_path
+    portrait_file.parent.mkdir(parents=True, exist_ok=True)
+    audio_file.parent.mkdir(parents=True, exist_ok=True)
+    portrait_file.write_bytes(b"portrait-bytes")
+    audio_file.write_bytes(b"audio-bytes")
+    record = {
+        "Name": "The Ashen Lich",
+        "Portrait": portrait_path,
+        "Audio": audio_path,
+    }
+
+    assets = collect_assets("villains", [record], campaign_root)
+
+    assets_by_type = {asset.asset_type: asset for asset in assets}
+    assert set(assets_by_type) == {"portrait", "audio"}
+    assert assets_by_type["portrait"].original_path == portrait_path
+    assert assets_by_type["portrait"].absolute_path == portrait_file.resolve()
+    assert assets_by_type["audio"].original_path == audio_path
+    assert assets_by_type["audio"].absolute_path == audio_file.resolve()
+
+    updated = _rewrite_record_paths(
+        "villains",
+        record,
+        {
+            portrait_path: "assets/portraits/villains/lich.png",
+            audio_path: "assets/audio/villains/lich_theme.mp3",
+        },
+    )
+
+    assert updated["Portrait"] == "assets/portraits/villains/lich.png"
+    assert updated["Audio"] == "assets/audio/villains/lich_theme.mp3"
+
+
 def test_rewrite_record_paths_updates_image_library_fields(tmp_path):
     """Image library rows should update Path + RelativePath after import."""
     target_campaign_root = (tmp_path / "target").resolve()


### PR DESCRIPTION
### Motivation
- Ensure villain records have their `Portrait` and `Audio` media included in cross-campaign bundle export/import so villain assets are copied and record paths are rewritten like other entity types.

### Description
- Add `"villains"` to `PORTRAIT_ENTITY_TYPES` and to `AUDIO_ENTITY_TYPES` in `modules/generic/cross_campaign_asset_service.py` so villains are processed by the shared portrait/audio collection and rewrite logic.
- Add regression test `test_villain_assets_collect_and_rewrite_portrait_and_audio` to `tests/test_cross_campaign_asset_service.py` that creates a villain record, writes temporary portrait and audio files, asserts `collect_assets("villains", ...)` returns both `portrait` and `audio` assets, and asserts `_rewrite_record_paths("villains", ...)` rewrites both fields.
- Verify `collect_assets` and `_rewrite_record_paths` already rely on the `PORTRAIT_ENTITY_TYPES` and `AUDIO_ENTITY_TYPES` sets, so this service-level constant change integrates villains into both export and import flows.
- Confirm both local bundle export and GitHub publishing flows call `export_bundle(...)` (see `modules/generic/cross_campaign_asset_library.py`) so the single service-level fix covers both paths.

### Testing
- Ran `python -m pytest tests/test_cross_campaign_asset_service.py -q` and the test suite passed (new regression test included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c3b117dc832bb32dfea9cc7ae5c5)