### PR TITLE
Generalize full-campaign database backfill

### DIFF
--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -31,6 +31,7 @@ from modules.helpers.logging_helper import (
     log_module_import,
     log_warning,
 )
+from modules.helpers.template_loader import list_known_entities
 
 log_module_import(__name__)
 
@@ -134,6 +135,11 @@ def discover_databases_in_directory(directory: Path) -> List[CampaignDatabase]:
     return results
 
 
+def _is_missing_table_error(exc: sqlite3.OperationalError) -> bool:
+    """Return True when SQLite reports a missing table."""
+    return "no such table" in str(exc).lower()
+
+
 def load_entities(entity_type: str, db_path: Path) -> List[dict]:
     """Load entities."""
     wrapper = GenericModelWrapper(entity_type, db_path=str(db_path))
@@ -141,7 +147,7 @@ def load_entities(entity_type: str, db_path: Path) -> List[dict]:
         # Keep entities resilient if this step fails.
         return wrapper.load_items()
     except sqlite3.OperationalError as exc:
-        if "no such table" in str(exc).lower():
+        if _is_missing_table_error(exc):
             log_warning(
                 f"Skipping entity type '{entity_type}' in {db_path}: {exc}",
                 func_name="modules.generic.cross_campaign_asset_service.load_entities",
@@ -154,6 +160,26 @@ def save_entities(entity_type: str, db_path: Path, items: List[dict], *, replace
     """Save entities."""
     wrapper = GenericModelWrapper(entity_type, db_path=str(db_path))
     wrapper.save_items(items, replace=replace)
+
+
+def _load_full_campaign_records(source_campaign: CampaignDatabase, selected_for_bundle: dict) -> None:
+    """Backfill all known entity records for full-campaign exports.
+
+    Explicit selections are authoritative: if a type is already present in
+    ``selected_for_bundle``, keep those records and only load missing types.
+    """
+    for entity_type in list_known_entities():
+        if entity_type in selected_for_bundle:
+            continue
+        try:
+            selected_for_bundle[entity_type] = load_entities(entity_type, source_campaign.db_path)
+        except sqlite3.OperationalError as exc:
+            if not _is_missing_table_error(exc):
+                raise
+            log_warning(
+                f"Skipping entity type '{entity_type}' for full campaign export: {exc}",
+                func_name="modules.generic.cross_campaign_asset_service._load_full_campaign_records",
+            )
 
 
 def _ensure_campaign_systems_table(conn: sqlite3.Connection) -> None:
@@ -630,24 +656,8 @@ def export_bundle(
         raise FileNotFoundError(source_campaign.db_path)
 
     selected_for_bundle = {entity: list(records) for entity, records in selected_records.items()}
-    if include_database and "image_assets" not in selected_for_bundle:
-        try:
-            selected_for_bundle["image_assets"] = load_entities("image_assets", source_campaign.db_path)
-        except Exception as exc:
-            log_warning(
-                f"Unable to include image library records for full campaign export: {exc}",
-                func_name="modules.generic.cross_campaign_asset_service.export_bundle",
-            )
-    if include_database and "maps" not in selected_for_bundle:
-        # Full-campaign exports should always include map records so fog-mask
-        # files and token/marker media can be discovered and bundled.
-        try:
-            selected_for_bundle["maps"] = load_entities("maps", source_campaign.db_path)
-        except Exception as exc:
-            log_warning(
-                f"Unable to include map records for full campaign export: {exc}",
-                func_name="modules.generic.cross_campaign_asset_service.export_bundle",
-            )
+    if include_database:
+        _load_full_campaign_records(source_campaign, selected_for_bundle)
 
     data_dir = Path(tempfile.mkdtemp(prefix="asset_export_"))
     temp_root = Path(data_dir)

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -215,6 +215,147 @@ def test_export_bundle_full_campaign_includes_image_assets_even_without_selectio
     assert any(asset.get("asset_type") == "image_library" for asset in manifest["assets"])
 
 
+def test_export_bundle_full_campaign_keeps_explicit_selections(tmp_path, monkeypatch):
+    """Explicitly selected entity lists should not be replaced by full-campaign backfill."""
+    campaign_root = tmp_path / "source_campaign"
+    campaign_root.mkdir(parents=True, exist_ok=True)
+    db_path = campaign_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    selected_villain = {"Name": "Selected Villain"}
+    loaded_types = []
+
+    def fake_load_entities(entity_type, _db_path):
+        loaded_types.append(entity_type)
+        if entity_type == "villains":
+            return [{"Name": "Database Villain"}]
+        if entity_type == "campaigns":
+            return [{"Name": "Loaded Campaign"}]
+        return []
+
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.list_known_entities",
+        lambda: ["villains", "campaigns"],
+    )
+    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+
+    manifest = export_bundle(
+        tmp_path / "bundle.zip",
+        CampaignDatabase(name="Source", root=campaign_root, db_path=db_path),
+        selected_records={"villains": [selected_villain]},
+        include_database=True,
+    )
+
+    assert loaded_types == ["campaigns"]
+    assert manifest["entities"]["villains"]["count"] == 1
+    assert manifest["entities"]["campaigns"]["count"] == 1
+
+    with zipfile.ZipFile(tmp_path / "bundle.zip", "r") as zf:
+        villains = zf.read("data/villains.json").decode("utf-8")
+    assert "Selected Villain" in villains
+    assert "Database Villain" not in villains
+
+
+def test_export_bundle_full_campaign_skips_missing_backfill_tables(tmp_path, monkeypatch):
+    """Missing tables during full-campaign backfill should not stop later entity types."""
+    campaign_root = tmp_path / "source_campaign"
+    campaign_root.mkdir(parents=True, exist_ok=True)
+    db_path = campaign_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    loaded_types = []
+
+    def fake_load_entities(entity_type, _db_path):
+        loaded_types.append(entity_type)
+        if entity_type == "missing_entities":
+            raise sqlite3.OperationalError("no such table: missing_entities")
+        if entity_type == "campaigns":
+            return [{"Name": "Loaded Campaign"}]
+        return []
+
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.list_known_entities",
+        lambda: ["missing_entities", "campaigns"],
+    )
+    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+
+    manifest = export_bundle(
+        tmp_path / "bundle.zip",
+        CampaignDatabase(name="Source", root=campaign_root, db_path=db_path),
+        selected_records={},
+        include_database=True,
+    )
+
+    assert loaded_types == ["missing_entities", "campaigns"]
+    assert "missing_entities" not in manifest["entities"]
+    assert manifest["entities"]["campaigns"]["count"] == 1
+
+
+def test_export_bundle_full_campaign_loads_all_known_entities_and_villain_media(tmp_path, monkeypatch):
+    """Full campaign exports should backfill every known entity type and villain media."""
+    campaign_root = tmp_path / "source_campaign"
+    campaign_root.mkdir(parents=True, exist_ok=True)
+    db_path = campaign_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    image_file = campaign_root / "assets" / "image_library" / "tiles" / "forest.png"
+    portrait_file = campaign_root / "portraits" / "villains" / "lich.png"
+    audio_file = campaign_root / "audio" / "villains" / "lich_theme.mp3"
+    for media_file, content in (
+        (image_file, b"forest-bytes"),
+        (portrait_file, b"portrait-bytes"),
+        (audio_file, b"audio-bytes"),
+    ):
+        media_file.parent.mkdir(parents=True, exist_ok=True)
+        media_file.write_bytes(content)
+
+    records_by_type = {
+        "villains": [
+            {
+                "Name": "The Ashen Lich",
+                "Portrait": "portraits/villains/lich.png",
+                "Audio": "audio/villains/lich_theme.mp3",
+            }
+        ],
+        "campaigns": [{"Name": "Embers of Dusk"}],
+        "scenarios": [{"Name": "The First Spark"}],
+        "image_assets": [{"Name": "Forest Tile", "RelativePath": "assets/image_library/tiles/forest.png"}],
+        "maps": [{"Name": "Cavern"}],
+    }
+
+    def fake_load_entities(entity_type, _db_path):
+        return records_by_type.get(entity_type, [])
+
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.list_known_entities",
+        lambda: ["villains", "campaigns", "scenarios", "image_assets", "maps"],
+    )
+    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+
+    manifest = export_bundle(
+        tmp_path / "bundle.zip",
+        CampaignDatabase(name="Source", root=campaign_root, db_path=db_path),
+        selected_records={},
+        include_database=True,
+    )
+
+    for entity_type in ("villains", "campaigns", "scenarios", "image_assets", "maps"):
+        assert manifest["entities"][entity_type]["count"] == 1
+
+    villain_assets = {
+        asset["asset_type"]: asset
+        for asset in manifest["assets"]
+        if asset["entity_type"] == "villains" and asset["record_key"] == "The Ashen Lich"
+    }
+    assert villain_assets["portrait"]["original_path"] == "portraits/villains/lich.png"
+    assert villain_assets["audio"]["original_path"] == "audio/villains/lich_theme.mp3"
+
+    with zipfile.ZipFile(tmp_path / "bundle.zip", "r") as zf:
+        names = set(zf.namelist())
+    assert "assets/portraits/villains/lich.png" in names
+    assert "assets/audio/villains/lich_theme.mp3" in names
+
+
 def test_install_full_campaign_bundle_restores_random_tables_files(tmp_path):
     """Installing a full campaign bundle should restore random table JSON files."""
     source_root = tmp_path / "source"


### PR DESCRIPTION
### Motivation

- Full-campaign exports previously special-cased only `image_assets` and `maps` when `include_database=True`, which missed other entity types and their media assets such as villain portraits/audio. 
- The change aims to backfill every known entity type for full exports while keeping explicit selections authoritative and preserving resilience to missing database tables.

### Description

- Import `list_known_entities` and add `_load_full_campaign_records(source_campaign: CampaignDatabase, selected_for_bundle: dict)` to iterate `list_known_entities()` and load missing entity types via `load_entities` without overwriting explicit selections; this helper lives in `modules/generic/cross_campaign_asset_service.py`.
- Add `_is_missing_table_error()` and update `load_entities()` to centralize missing-table detection and keep missing-table resilience while re-raising unexpected SQLite errors.
- Replace the old special-case backfill for `image_assets` and `maps` in `export_bundle` with a call to `_load_full_campaign_records(...)` so all known entities are backfilled when `include_database=True` (file: `modules/generic/cross_campaign_asset_service.py`).
- Add tests in `tests/test_cross_campaign_asset_service.py` covering preservation of explicit selections, skipping missing-table backfills without aborting, and a full-campaign case that proves `villains`, `campaigns`, `scenarios`, `image_assets`, and `maps` are included and that villain portrait/audio media are bundled.

### Testing

- Ran `pytest -q tests/test_cross_campaign_asset_service.py` and the suite passed with all tests succeeding (no failures, warnings only for unrelated deprecation). 
- Ran `pytest -q tests/test_cross_campaign_asset_service.py tests/test_template_loader_entities.py` and both test files passed (no failures).
- QA verified the `include_database=True` flow backfills known entities, preserves explicit selections, tolerates missing tables, and includes villain portrait/audio in the generated bundle manifest and zip.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ca75176c832bb203a6386213630a)