### PR TITLE
Include custom templates in full campaign bundles

### DIFF
--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -17,6 +17,7 @@ _GM_TABLE_MARKS_FILES = (
 )
 _MAPTOOLS_INFO_FILE = Path("world_maps/world_map_data.json")
 _MAP_MASKS_DIR = Path("masks")
+_TEMPLATES_DIR = Path("templates")
 
 
 def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, str]]:
@@ -60,6 +61,18 @@ def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, s
     maptools_info_file = (root / _MAPTOOLS_INFO_FILE).resolve()
     if maptools_info_file.exists() and maptools_info_file.is_file():
         collected.append((maptools_info_file, _MAPTOOLS_INFO_FILE.as_posix()))
+
+    templates_dir = (root / _TEMPLATES_DIR).resolve()
+    if templates_dir.exists() and templates_dir.is_dir():
+        for file_path in sorted(templates_dir.glob("*.json")):
+            if not file_path.is_file():
+                continue
+            resolved_file = file_path.resolve()
+            try:
+                relative_path = resolved_file.relative_to(root).as_posix()
+            except ValueError:
+                continue
+            collected.append((resolved_file, relative_path))
 
     map_masks_dir = (root / _MAP_MASKS_DIR).resolve()
     if map_masks_dir.exists() and map_masks_dir.is_dir():

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -402,6 +402,39 @@ def test_install_full_campaign_bundle_restores_campaign_custom_random_tables_fil
     assert restored_campaign_custom.read_text(encoding="utf-8") == '{"tables": []}'
 
 
+def test_install_full_campaign_bundle_restores_custom_templates(tmp_path):
+    """Installing a full campaign bundle should restore custom entity template files."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+
+    custom_entities = source_root / "templates" / "custom_entities.json"
+    custom_entities.parent.mkdir(parents=True, exist_ok=True)
+    custom_entities.write_text('{"entities": ["rivals"]}', encoding="utf-8")
+
+    rivals_template = source_root / "templates" / "rivals_template.json"
+    rivals_template.write_text('{"name": "Rivals", "fields": []}', encoding="utf-8")
+
+    source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
+    bundle_path = tmp_path / "full_bundle.zip"
+    manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+    extra_paths = {entry.get("relative_path") for entry in manifest.get("extra_files") or []}
+
+    assert "templates/custom_entities.json" in extra_paths
+    assert "templates/rivals_template.json" in extra_paths
+
+    target_root = tmp_path / "installed_campaign"
+    installed = install_full_campaign_bundle(bundle_path, target_root)
+
+    restored_custom_entities = installed.root / "templates" / "custom_entities.json"
+    restored_rivals_template = installed.root / "templates" / "rivals_template.json"
+    assert restored_custom_entities.exists()
+    assert restored_custom_entities.read_text(encoding="utf-8") == '{"entities": ["rivals"]}'
+    assert restored_rivals_template.exists()
+    assert restored_rivals_template.read_text(encoding="utf-8") == '{"name": "Rivals", "fields": []}'
+
+
 def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_path):
     """Installing a full campaign bundle should restore maptools + GM table extra files."""
     source_root = tmp_path / "source"


### PR DESCRIPTION
### Motivation

- Ensure custom entity templates stored under `templates/` are packaged with full-campaign exports so they survive export/install cycles. 
- Restore top-level templates (including `templates/custom_entities.json`) safely under the installed campaign root to preserve user customizations.

### Description

- Add `_TEMPLATES_DIR = Path("templates")` and extend `collect_full_campaign_extra_files(campaign_root)` to scan `templates/*.json` and include files resolved under `campaign_root` using the existing safe pattern. 
- Each template file is resolved and converted to a POSIX relative path via `resolved_file.relative_to(root).as_posix()` before being appended to the returned `List[Tuple[Path,str]]`. 
- Add regression test `test_install_full_campaign_bundle_restores_custom_templates` in `tests/test_cross_campaign_asset_service.py` that creates `templates/custom_entities.json` and `templates/rivals_template.json`, exports with `include_database=True`, asserts both paths appear in the manifest `extra_files`, installs with `install_full_campaign_bundle(...)`, and verifies the files are restored.

### Testing

- Ran the specific new test with `pytest -q tests/test_cross_campaign_asset_service.py::test_install_full_campaign_bundle_restores_custom_templates` and it passed. 
- Ran a focused subset `pytest -q tests/test_cross_campaign_asset_service.py::test_install_full_campaign_bundle_restores_custom_templates tests/test_cross_campaign_asset_service.py::test_install_full_campaign_bundle_restores_random_tables_files tests/test_cross_campaign_asset_service.py::test_install_full_campaign_bundle_restores_campaign_custom_random_tables_file` and all targeted tests passed. 
- Ran the full file `pytest -q tests/test_cross_campaign_asset_service.py` and the suite passed (with existing `DeprecationWarning` notices unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cc1f96e4832b8a46b06de03632be)