### PR TITLE
Include built-in campaign templates in campaign seeds

### DIFF
--- a/modules/campaigns/services/campaign_storage.py
+++ b/modules/campaigns/services/campaign_storage.py
@@ -8,20 +8,24 @@ import sqlite3
 from pathlib import Path
 from typing import Iterable, Sequence
 
-
 DEFAULT_TEMPLATE_ENTITIES: tuple[str, ...] = (
+    "events",
+    "campaigns",
+    "scenarios",
     "pcs",
     "npcs",
-    "scenarios",
+    "villains",
+    "creatures",
     "factions",
     "bases",
     "places",
     "objects",
-    "creatures",
     "informations",
     "clues",
+    "puzzles",
     "maps",
     "books",
+    "image_assets",
 )
 
 
@@ -50,7 +54,11 @@ def seed_default_templates(
     template_dir = campaign_dir / "templates"
     template_dir.mkdir(parents=True, exist_ok=True)
 
-    project_root_path = Path(project_root) if project_root is not None else Path(__file__).resolve().parents[3]
+    project_root_path = (
+        Path(project_root)
+        if project_root is not None
+        else Path(__file__).resolve().parents[3]
+    )
     for entity in entities:
         # Process each entity from entities.
         src = project_root_path / "modules" / entity / f"{entity}_template.json"

--- a/tests/campaigns/services/test_campaign_storage.py
+++ b/tests/campaigns/services/test_campaign_storage.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
 from pathlib import Path
 
@@ -13,6 +12,7 @@ from modules.campaigns.services.campaign_storage import (
     normalize_campaign_db_path,
     seed_default_templates,
 )
+from modules.helpers.template_loader import _BUILTIN_ENTITY_METADATA
 
 
 def test_normalize_campaign_db_path_returns_absolute_path(tmp_path: Path) -> None:
@@ -35,25 +35,61 @@ def test_ensure_campaign_directory_creates_parent_directory(tmp_path: Path) -> N
     assert Path(normalized).name == "state.db"
 
 
-def test_seed_default_templates_copies_missing_templates(tmp_path: Path) -> None:
-    """Verify that seed default templates copies missing templates."""
+def test_default_template_entities_match_builtin_metadata_order() -> None:
+    """Verify campaign template defaults mirror built-in entity metadata order."""
+    assert DEFAULT_TEMPLATE_ENTITIES == tuple(_BUILTIN_ENTITY_METADATA)
+
+
+def test_seed_default_templates_copies_all_default_templates_when_present(
+    tmp_path: Path,
+) -> None:
+    """Verify that seed default templates copies every default entity template."""
     db_path = tmp_path / "campaigns" / "lot3.db"
     project_root = tmp_path / "project"
 
-    for entity in DEFAULT_TEMPLATE_ENTITIES[:2]:
+    for entity in DEFAULT_TEMPLATE_ENTITIES:
         entity_dir = project_root / "modules" / entity
         entity_dir.mkdir(parents=True)
-        (entity_dir / f"{entity}_template.json").write_text(f"{{\"entity\": \"{entity}\"}}", encoding="utf-8")
+        (entity_dir / f"{entity}_template.json").write_text(
+            f'{{"entity": "{entity}"}}',
+            encoding="utf-8",
+        )
 
     template_dir = seed_default_templates(
         str(db_path),
-        entities=DEFAULT_TEMPLATE_ENTITIES[:2],
         project_root=project_root,
     )
 
     assert template_dir == db_path.parent / "templates"
-    assert (template_dir / "pcs_template.json").read_text(encoding="utf-8") == '{"entity": "pcs"}'
-    assert (template_dir / "npcs_template.json").read_text(encoding="utf-8") == '{"entity": "npcs"}'
+    for entity in DEFAULT_TEMPLATE_ENTITIES:
+        assert (template_dir / f"{entity}_template.json").read_text(
+            encoding="utf-8"
+        ) == (f'{{"entity": "{entity}"}}')
+
+
+def test_seed_default_templates_skips_missing_source_templates(tmp_path: Path) -> None:
+    """Verify that missing default template source files are skipped gracefully."""
+    db_path = tmp_path / "campaigns" / "lot3.db"
+    project_root = tmp_path / "project"
+
+    villains_dir = project_root / "modules" / "villains"
+    villains_dir.mkdir(parents=True)
+    (villains_dir / "villains_template.json").write_text(
+        '{"entity": "villains"}',
+        encoding="utf-8",
+    )
+
+    template_dir = seed_default_templates(
+        str(db_path),
+        entities=("villains", "puzzles", "image_assets"),
+        project_root=project_root,
+    )
+
+    assert (template_dir / "villains_template.json").read_text(encoding="utf-8") == (
+        '{"entity": "villains"}'
+    )
+    assert not (template_dir / "puzzles_template.json").exists()
+    assert not (template_dir / "image_assets_template.json").exists()
 
 
 def test_seed_default_templates_preserves_existing_files(tmp_path: Path) -> None:
@@ -62,7 +98,9 @@ def test_seed_default_templates_preserves_existing_files(tmp_path: Path) -> None
     project_root = tmp_path / "project"
     entity_dir = project_root / "modules" / "pcs"
     entity_dir.mkdir(parents=True)
-    (entity_dir / "pcs_template.json").write_text('{"entity": "source"}', encoding="utf-8")
+    (entity_dir / "pcs_template.json").write_text(
+        '{"entity": "source"}', encoding="utf-8"
+    )
 
     existing_template = db_path.parent / "templates" / "pcs_template.json"
     existing_template.parent.mkdir(parents=True)
@@ -73,7 +111,9 @@ def test_seed_default_templates_preserves_existing_files(tmp_path: Path) -> None
     assert existing_template.read_text(encoding="utf-8") == '{"entity": "existing"}'
 
 
-def test_seed_default_templates_uses_service_relative_project_root_when_not_provided(tmp_path: Path, monkeypatch) -> None:
+def test_seed_default_templates_uses_service_relative_project_root_when_not_provided(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Verify that seed default templates uses service relative project root when not provided."""
     db_path = tmp_path / "campaigns" / "lot3.db"
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
### Motivation

- Ensure campaign seed behavior ships every built-in template that should travel with a campaign, including `campaigns`, `events`, `villains`, `puzzles`, and `image_assets`, and present them in a user-friendly order.
- Keep the default template ordering strictly aligned with the built-in entity metadata so UI and seeding remain consistent. 

### Description

- Updated `DEFAULT_TEMPLATE_ENTITIES` in `modules/campaigns/services/campaign_storage.py` to include the full built-in set (ordered to match `modules.helpers.template_loader._BUILTIN_ENTITY_METADATA`).
- Kept the existing `seed_default_templates(...)` copy/skip logic intact (the `if dst.exists() or not src.exists(): continue` branch remains and is preserved). 
- Added/updated tests in `tests/campaigns/services/test_campaign_storage.py` including `test_default_template_entities_match_builtin_metadata_order`, an expanded seed copy test that asserts all present default templates are copied, and a test that verifies missing source templates are skipped gracefully while present templates (e.g. `villains_template.json`) are copied. 
- Files changed: `modules/campaigns/services/campaign_storage.py` and `tests/campaigns/services/test_campaign_storage.py`.

### Testing

- Ran `python -m black --check modules/campaigns/services/campaign_storage.py tests/campaigns/services/test_campaign_storage.py` and formatting check passed. 
- Ran `git diff --check` with no whitespace/diff issues detected. 
- Ran `pytest tests/campaigns/services/test_campaign_storage.py` and the targeted test module passed (8 tests passed). 
- Ran full `pytest` and observed unrelated collection errors (25 errors) caused by preexisting issues outside this change, namely duplicate test module basename import mismatch and incomplete `customtkinter`/theme stubs; these do not affect the targeted campaign-storage tests which pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ce40dc2c832b83bd84f2ff2f8cd1)