### PR TITLE
Widen Cross-Campaign Asset Library and add horizontal scrollbar

### DIFF
--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -45,8 +45,8 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         """Initialize the CrossCampaignAssetLibraryWindow instance."""
         super().__init__(master)
         self.title("Cross-campaign Asset Library")
-        self.geometry("1200x720")
-        self.minsize(1000, 620)
+        self.geometry("1400x760")
+        self.minsize(1200, 620)
         self.transient(master)
         self.lift()
         self.focus_force()
@@ -117,13 +117,16 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             tree = ttk.Treeview(tab, columns=columns, show="headings", selectmode="extended", height=14)
             tree.heading("name", text="Name")
             tree.heading("summary", text="Summary")
-            tree.column("name", width=220, anchor="w")
-            tree.column("summary", width=360, anchor="w")
+            tree.column("name", width=280, anchor="w", stretch=False)
+            tree.column("summary", width=760, anchor="w", stretch=False)
             tree.grid(row=0, column=0, sticky="nsew")
             tree.bind("<<TreeviewSelect>>", lambda _evt, et=entity_type: self.update_preview_from_tree(et))
+
             yscroll = ttk.Scrollbar(tab, orient="vertical", command=tree.yview)
-            tree.configure(yscrollcommand=yscroll.set)
+            xscroll = ttk.Scrollbar(tab, orient="horizontal", command=tree.xview)
+            tree.configure(yscrollcommand=yscroll.set, xscrollcommand=xscroll.set)
             yscroll.grid(row=0, column=1, sticky="ns")
+            xscroll.grid(row=1, column=0, sticky="ew")
             self.treeviews[entity_type] = tree
 
         self.preview_frame = ctk.CTkFrame(self.right_frame)


### PR DESCRIPTION
### Motivation
- The cross-campaign asset library table was too narrow at launch and long entity records caused columns to be squeezed, making it hard to inspect/export all entity fields.
- Provide a wider default window and enable horizontal scrolling so users can see all columns without truncation.

### Description
- Increased the window launch geometry and minimum size by updating the CrossCampaignAssetLibrary window to `1400x760` with `minsize(1200, 620)` in `modules/generic/cross_campaign_asset_library.py`.
- Set fixed, wider column widths for the entity export `Treeview` (`name` and `summary`) and disabled automatic stretching so content can overflow horizontally instead of shrinking.
- Added a horizontal `ttk.Scrollbar` per tab and wired it to the `Treeview` `xview`, while preserving the existing vertical scrollbar and selection behavior.
- Kept the change minimal and localized to `modules/generic/cross_campaign_asset_library.py` to avoid affecting unrelated UI areas.

### Testing
- Ran `python -m py_compile modules/generic/cross_campaign_asset_library.py` with no syntax errors.
- Ran `python -m pytest tests/test_cross_campaign_asset_service.py -q` which passed (`20 passed` with existing warnings unrelated to this UI change).
- Attempted full test suite with `python -m pytest -q` and `python -m pytest -q --import-mode=importlib`, but collection was blocked by unrelated pre-existing test collection/import issues, so broader suite results are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d1b6c948832bba17d8fa9c27ca04)