### PR TITLE
Add 'Merge entities' action and merge utility

### DIFF
--- a/modules/generic/entities/merge.py
+++ b/modules/generic/entities/merge.py
@@ -1,0 +1,174 @@
+"""Utilities for merging generic entity records."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from modules.helpers.portrait_helper import parse_portrait_value, serialize_portrait_value
+
+
+MULTILINE_FIELD_TYPES = {"longtext", "list_longtext", "textarea", "multiline"}
+PORTRAIT_FIELD_NAMES = {"portrait", "portraits"}
+
+
+@dataclass(frozen=True)
+class EntityMergeResult:
+    """Result of a generic entity merge operation."""
+
+    items: list[dict]
+    survivor: dict
+    removed: list[dict]
+
+
+class EntityMergeError(ValueError):
+    """Raised when selected entities cannot be merged."""
+
+
+def merge_selected_entities(
+    items: Sequence[dict],
+    selected_entities: Sequence[dict],
+    template: Mapping | None,
+    unique_field: str | None,
+) -> EntityMergeResult:
+    """Merge selected generic entities into the first selected survivor.
+
+    The first selected entity survives and keeps its unique-field value unchanged.
+    Field values are merged in selection order, while non-survivors are removed
+    from the returned backing item list.
+    """
+
+    selected = [entity for entity in selected_entities if isinstance(entity, dict)]
+    if len(selected) < 2:
+        raise EntityMergeError("Select at least two entities to merge.")
+
+    survivor_source = selected[0]
+    survivor = copy.deepcopy(survivor_source)
+    field_types = _field_type_map(template)
+    all_keys = _keys_in_selection_order(selected)
+
+    for key in all_keys:
+        if unique_field and key == unique_field:
+            survivor[key] = copy.deepcopy(survivor_source.get(key, ""))
+            continue
+        if _is_portrait_field(key):
+            survivor[key] = _merge_portrait_values(entity.get(key) for entity in selected)
+            continue
+        survivor[key] = _merge_generic_field(
+            [entity.get(key) for entity in selected],
+            field_types.get(key, "text"),
+        )
+
+    selected_object_ids = {id(entity) for entity in selected[1:]}
+    selected_survivor_id = id(survivor_source)
+    survivor_replaced = False
+    remaining: list[dict] = []
+    for item in items:
+        item_id = id(item)
+        if item_id == selected_survivor_id and not survivor_replaced:
+            remaining.append(survivor)
+            survivor_replaced = True
+        elif item_id in selected_object_ids:
+            continue
+        else:
+            remaining.append(item)
+
+    if not survivor_replaced:
+        remaining.insert(0, survivor)
+
+    return EntityMergeResult(items=remaining, survivor=survivor, removed=list(selected[1:]))
+
+
+def _field_type_map(template: Mapping | None) -> dict[str, str]:
+    fields = template.get("fields", []) if isinstance(template, Mapping) else []
+    result: dict[str, str] = {}
+    for field in fields:
+        if not isinstance(field, Mapping):
+            continue
+        name = field.get("name")
+        if not name:
+            continue
+        result[str(name)] = str(field.get("type", "text")).strip().lower()
+    return result
+
+
+def _keys_in_selection_order(entities: Sequence[dict]) -> list[str]:
+    keys: list[str] = []
+    seen: set[str] = set()
+    for entity in entities:
+        for key in entity.keys():
+            if key in seen:
+                continue
+            seen.add(key)
+            keys.append(key)
+    return keys
+
+
+def _is_portrait_field(field_name: str) -> bool:
+    return str(field_name or "").strip().lower() in PORTRAIT_FIELD_NAMES
+
+
+def _merge_generic_field(values: Iterable, field_type: str):
+    meaningful = [_normalize_field_value(value) for value in values if not _is_empty_value(value)]
+    if not meaningful:
+        return ""
+    if _is_multiline_field(field_type):
+        return "\n".join(_stringify_for_merge(value) for value in meaningful)
+    return " ".join(_stringify_for_merge(value).replace("\n", " ") for value in meaningful)
+
+
+def _is_multiline_field(field_type: str) -> bool:
+    return str(field_type or "").strip().lower() in MULTILINE_FIELD_TYPES
+
+
+def _normalize_field_value(value):
+    if isinstance(value, dict) and "text" in value:
+        text = value.get("text")
+        if len(value) == 1 or isinstance(text, str):
+            return text
+    return value
+
+
+def _stringify_for_merge(value) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (list, tuple, set)):
+        return "\n".join(_stringify_for_merge(entry) for entry in value if not _is_empty_value(entry)).strip()
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return str(value).strip()
+
+
+def _merge_portrait_values(values: Iterable) -> str:
+    portraits: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for portrait in parse_portrait_value(value):
+            portrait_text = str(portrait).strip()
+            if not portrait_text:
+                continue
+            key = _portrait_identity(portrait_text)
+            if key in seen:
+                continue
+            seen.add(key)
+            portraits.append(portrait_text)
+    return serialize_portrait_value(portraits)
+
+
+def _portrait_identity(value: str) -> str:
+    normalized = value.strip().replace("\\", "/")
+    normalized = os.path.normpath(normalized).replace("\\", "/")
+    return normalized.casefold()
+
+
+def _is_empty_value(value) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False

--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -42,6 +42,7 @@ from modules.helpers.logging_helper import (
 from modules.objects.object_constants import OBJECT_CATEGORY_ALLOWED
 from modules.ai.pipeline import execute_ai_chat
 from modules.generic.entities.linking import entity_label_map, resolve_entity_slug
+from modules.generic.entities.merge import EntityMergeError, merge_selected_entities
 
 log_module_import(__name__)
 
@@ -3154,6 +3155,12 @@ class GenericListView(ctk.CTkFrame):
                 label="Turn to PC",
                 command=lambda: self.turn_npc_to_pc(iid),
             )
+        selected_items = self._selected_items_in_tree_order(iid)
+        if len(selected_items) >= 2:
+            menu.add_command(
+                label="Merge entities",
+                command=lambda: self.merge_selected_entities(iid),
+            )
         menu.add_command(
             label="Delete",
             command=lambda: self.delete_item(iid)
@@ -3291,6 +3298,82 @@ class GenericListView(ctk.CTkFrame):
         _, play_audio, _ = _lazy_audio()
         if not play_audio(audio_value, entity_label=name):
             messagebox.showwarning("Audio", f"Unable to play audio for {name}.")
+
+
+    def _selected_items_in_tree_order(self, iid=None):
+        """Return selected items in the current Treeview selection order."""
+        selection = []
+        if hasattr(self, "tree"):
+            try:
+                selection = list(self.tree.selection())
+            except Exception:
+                selection = []
+        if iid and iid not in selection:
+            selection = [iid]
+        selected_items = []
+        seen_item_ids = set()
+        for selected_iid in selection:
+            item, base_id = self._find_item_by_iid(selected_iid)
+            if not item or not base_id or id(item) in seen_item_ids:
+                continue
+            seen_item_ids.add(id(item))
+            selected_items.append(item)
+        return selected_items
+
+    def merge_selected_entities(self, iid=None):
+        """Merge the selected entities into the first selected entity."""
+        selected_items = self._selected_items_in_tree_order(iid)
+        if len(selected_items) < 2:
+            messagebox.showinfo("Merge entities", "Select at least two entities to merge.")
+            return
+        survivor_name = selected_items[0].get(self.unique_field, "") if self.unique_field else ""
+        try:
+            result = merge_selected_entities(
+                self.items,
+                selected_items,
+                self.template,
+                self.unique_field,
+            )
+        except EntityMergeError as exc:
+            messagebox.showinfo("Merge entities", str(exc))
+            return
+        except Exception as exc:
+            log_warning(
+                f"Failed to merge selected entities: {exc}",
+                func_name="GenericListView.merge_selected_entities",
+            )
+            messagebox.showerror("Merge entities", f"Unable to merge entities:\n{exc}")
+            return
+
+        self.items = result.items
+        survivor_base_id = self._get_base_id(result.survivor)
+        self.selected_iids = {survivor_base_id} if survivor_base_id else set()
+        self.model_wrapper.save_items(self.items)
+        self._save_list_order()
+        self.filter_items(self.search_var.get())
+        self._focus_surviving_entity(survivor_base_id)
+        if survivor_base_id:
+            self.after(50, lambda base_id=survivor_base_id: self._focus_surviving_entity(base_id))
+        log_info(
+            f"Merged {len(selected_items)} entities into {survivor_name!r}; removed {len(result.removed)}",
+            func_name="GenericListView.merge_selected_entities",
+        )
+
+    def _focus_surviving_entity(self, base_id):
+        """Select, focus, and scroll to the merged survivor when it is visible."""
+        if not base_id or not hasattr(self, "tree"):
+            return
+        tree_iids = self._base_to_iids.get(base_id, [])
+        if not tree_iids:
+            return
+        target_iid = tree_iids[0]
+        try:
+            self.tree.selection_set(target_iid)
+            self.tree.focus(target_iid)
+            self.tree.see(target_iid)
+        except Exception:
+            return
+        self._update_tree_selection_tags([target_iid])
 
     def delete_item(self, iid):
         """Delete item."""

--- a/tests/generic/entities/test_merge.py
+++ b/tests/generic/entities/test_merge.py
@@ -1,0 +1,64 @@
+"""Tests for generic entity merge utilities."""
+
+from modules.generic.entities.merge import merge_selected_entities
+
+
+_TEMPLATE = {
+    "fields": [
+        {"name": "Name", "type": "text"},
+        {"name": "Role", "type": "text"},
+        {"name": "Description", "type": "longtext"},
+        {"name": "Portrait", "type": "text"},
+    ]
+}
+
+
+def test_merge_preserves_first_entity_name():
+    items = [
+        {"Name": "Alpha", "Role": "Scout"},
+        {"Name": "Beta", "Role": "Guide"},
+    ]
+
+    result = merge_selected_entities(items, items, _TEMPLATE, "Name")
+
+    assert result.survivor["Name"] == "Alpha"
+
+
+def test_merge_text_fields_concatenate_in_selection_order():
+    items = [
+        {"Name": "Alpha", "Role": "Scout", "Description": "First line"},
+        {"Name": "Beta", "Role": "Guide", "Description": "Second line"},
+        {"Name": "Gamma", "Role": "Keeper", "Description": "Third line"},
+    ]
+
+    result = merge_selected_entities(items, items, _TEMPLATE, "Name")
+
+    assert result.survivor["Role"] == "Scout Guide Keeper"
+    assert result.survivor["Description"] == "First line\nSecond line\nThird line"
+
+
+def test_merge_portraits_are_deduplicated_by_path_identity():
+    items = [
+        {"Name": "Alpha", "Portrait": "assets/portraits/a.png\nassets/portraits/b.png"},
+        {"Name": "Beta", "Portrait": ["assets\\portraits\\a.png", "assets/portraits/c.png"]},
+    ]
+
+    result = merge_selected_entities(items, items, _TEMPLATE, "Name")
+
+    assert result.survivor["Portrait"].splitlines() == [
+        "assets/portraits/a.png",
+        "assets/portraits/b.png",
+        "assets/portraits/c.png",
+    ]
+
+
+def test_merge_removes_non_surviving_entities():
+    alpha = {"Name": "Alpha", "Role": "Scout"}
+    beta = {"Name": "Beta", "Role": "Guide"}
+    untouched = {"Name": "Untouched", "Role": "Witness"}
+    items = [alpha, beta, untouched]
+
+    result = merge_selected_entities(items, [alpha, beta], _TEMPLATE, "Name")
+
+    assert [item["Name"] for item in result.items] == ["Alpha", "Untouched"]
+    assert result.removed == [beta]

--- a/tests/test_generic_list_selection_view.py
+++ b/tests/test_generic_list_selection_view.py
@@ -59,3 +59,107 @@ def test_on_double_click_open_selected_mode_uses_open_selected():
     view.on_double_click(type("Evt", (), {"y": 10})())
 
     assert called == ["opened"]
+
+
+def test_generic_list_context_menu_hides_merge_for_single_selection(monkeypatch):
+    """Verify merge command is hidden when only one entity is selected."""
+    import modules.generic.generic_list_view as list_view_module
+    from modules.generic.generic_list_view import GenericListView
+
+    created_menus = []
+
+    class _Menu:
+        def __init__(self, *args, **kwargs):
+            self.labels = []
+            created_menus.append(self)
+
+        def add_command(self, **kwargs):
+            self.labels.append(kwargs.get("label"))
+
+        def add_separator(self):
+            pass
+
+        def add_cascade(self, **kwargs):
+            self.labels.append(kwargs.get("label"))
+
+        def post(self, *_args):
+            pass
+
+    class _Tree:
+        def selection(self):
+            return ("alpha",)
+
+    class _Model:
+        entity_type = "npcs"
+
+    monkeypatch.setattr(list_view_module.tk, "Menu", _Menu)
+
+    view = GenericListView.__new__(GenericListView)
+    view.model_wrapper = _Model()
+    view.unique_field = "Name"
+    view.tree = _Tree()
+    view._iid_to_item = {"alpha": {"Name": "Alpha", "Portrait": ""}}
+    view._base_to_iids = {"alpha": ["alpha"]}
+    view.filtered_items = [{"Name": "Alpha", "Portrait": ""}]
+    view.items = view.filtered_items
+    view.copied_items = []
+    view.color_options = {}
+    view._portrait_menu_images = []
+    view._get_audio_value = lambda _item: ""
+
+    view._show_item_menu("alpha", type("Evt", (), {"x_root": 1, "y_root": 2})())
+
+    assert "Merge entities" not in created_menus[0].labels
+
+
+def test_generic_list_context_menu_shows_merge_for_multiple_selection(monkeypatch):
+    """Verify merge command is visible when multiple entities are selected."""
+    import modules.generic.generic_list_view as list_view_module
+    from modules.generic.generic_list_view import GenericListView
+
+    created_menus = []
+
+    class _Menu:
+        def __init__(self, *args, **kwargs):
+            self.labels = []
+            created_menus.append(self)
+
+        def add_command(self, **kwargs):
+            self.labels.append(kwargs.get("label"))
+
+        def add_separator(self):
+            pass
+
+        def add_cascade(self, **kwargs):
+            self.labels.append(kwargs.get("label"))
+
+        def post(self, *_args):
+            pass
+
+    class _Tree:
+        def selection(self):
+            return ("alpha", "beta")
+
+    class _Model:
+        entity_type = "npcs"
+
+    monkeypatch.setattr(list_view_module.tk, "Menu", _Menu)
+
+    alpha = {"Name": "Alpha", "Portrait": ""}
+    beta = {"Name": "Beta", "Portrait": ""}
+    view = GenericListView.__new__(GenericListView)
+    view.model_wrapper = _Model()
+    view.unique_field = "Name"
+    view.tree = _Tree()
+    view._iid_to_item = {"alpha": alpha, "beta": beta}
+    view._base_to_iids = {"alpha": ["alpha"], "beta": ["beta"]}
+    view.filtered_items = [alpha, beta]
+    view.items = view.filtered_items
+    view.copied_items = []
+    view.color_options = {}
+    view._portrait_menu_images = []
+    view._get_audio_value = lambda _item: ""
+
+    view._show_item_menu("alpha", type("Evt", (), {"x_root": 1, "y_root": 2})())
+
+    assert "Merge entities" in created_menus[0].labels


### PR DESCRIPTION
### Motivation

- Provide a user-facing `Merge entities` action in the generic entity list so users can combine duplicate or related entities from the UI into a single record.
- Keep merge logic out of the view and implement it as a reusable helper in the entity/domain layer to keep UI code simple and testable.

### Description

- Add a dedicated merge utility `merge_selected_entities` with result type `EntityMergeResult` in `modules/generic/entities/merge.py` that uses the first selected entity as the survivor and returns the new backing items list, the survivor, and removed entities.
- Implement field merging rules: multiline fields concatenate non-empty values with `\n`, single-line fields concatenate with a single space, preserve unique-field values on the survivor, and include keys from every selected entity in selection order (helper functions `_keys_in_selection_order`, `_merge_generic_field`, `_normalize_field_value`).
- Merge portrait values into the survivor and deduplicate portraits by a stable normalized identity (`_portrait_identity`) using `parse_portrait_value` / `serialize_portrait_value` helpers.
- Add `Merge entities` context-menu item to `GenericListView` shown only when two or more entities are selected, wired to call the merge helper, update `self.items`, save via `model_wrapper.save_items`, refresh/filter the list, and focus/select the surviving entity; changes in `modules/generic/generic_list_view.py` include `_selected_items_in_tree_order`, `merge_selected_entities`, and `_focus_surviving_entity` UI wiring.
- Add unit tests for the merge utility and context-menu visibility in `tests/generic/entities/test_merge.py` and `tests/test_generic_list_selection_view.py` respectively.

### Testing

- Ran static compilation: `python -m compileall modules/generic/entities/merge.py modules/generic/generic_list_view.py` and it succeeded.
- Ran unit tests: `pytest tests/generic/entities/test_merge.py tests/test_generic_list_selection_view.py -q` which passed (`8 passed`).
- All automated checks in the repository for these changes completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d8c5978c832bb12d576e73d7b09c)