### PR TITLE
Add decorative depth layers and skin styles to GMTablePanel

### DIFF
--- a/modules/scenarios/gm_table/panel_depth_styles.py
+++ b/modules/scenarios/gm_table/panel_depth_styles.py
@@ -1,0 +1,206 @@
+"""Decorative depth-layer styles for GM Table floating panels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DepthLayerStyle:
+    """A sibling frame rendered behind a real panel."""
+
+    offset_x: int
+    offset_y: int
+    expand_width: int
+    expand_height: int
+    color: str
+    border_color: str | None = None
+    border_width: int = 0
+    corner_radius: int = 22
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeAccentStyle:
+    """A thin inner edge accent rendered on top of a panel."""
+
+    side: str
+    color: str
+    thickness: int = 3
+    inset: int = 8
+
+
+@dataclass(frozen=True, slots=True)
+class PanelDepthStyle:
+    """Complete decorative style bundle for a panel skin."""
+
+    shadow_layers: tuple[DepthLayerStyle, ...]
+    edge_accents: tuple[EdgeAccentStyle, ...]
+    stack_strip_side: str | None = None
+    stack_strip_color: str | None = None
+    stack_strip_width: int = 8
+
+
+_COMMON_EDGE_ACCENTS = (
+    EdgeAccentStyle("top", "#FFFFFF", thickness=2, inset=12),
+    EdgeAccentStyle("left", "#FFFFFF", thickness=2, inset=12),
+    EdgeAccentStyle("right", "#050813", thickness=3, inset=12),
+    EdgeAccentStyle("bottom", "#050813", thickness=3, inset=12),
+)
+
+_DEFAULT_STYLE = PanelDepthStyle(
+    shadow_layers=(DepthLayerStyle(9, 11, 0, 0, "#070A12", corner_radius=22),),
+    edge_accents=_COMMON_EDGE_ACCENTS,
+)
+
+_SKIN_DEPTH_STYLES: dict[str, PanelDepthStyle] = {
+    "binder": PanelDepthStyle(
+        shadow_layers=(DepthLayerStyle(10, 12, 2, 2, "#07040A", corner_radius=22),),
+        edge_accents=(
+            EdgeAccentStyle("top", "#6B4A32", thickness=3, inset=14),
+            EdgeAccentStyle("left", "#7C4A33", thickness=3, inset=14),
+            EdgeAccentStyle("right", "#0A0610", thickness=4, inset=14),
+            EdgeAccentStyle("bottom", "#0A0610", thickness=4, inset=14),
+        ),
+        stack_strip_side="right",
+        stack_strip_color="#EAD7A2",
+        stack_strip_width=9,
+    ),
+    "dossier": PanelDepthStyle(
+        shadow_layers=(
+            DepthLayerStyle(
+                7,
+                9,
+                6,
+                7,
+                "#6B5127",
+                border_color="#92713A",
+                border_width=1,
+                corner_radius=18,
+            ),
+            DepthLayerStyle(11, 14, 3, 3, "#3D2B14", corner_radius=18),
+        ),
+        edge_accents=(
+            EdgeAccentStyle("top", "#D4B875", thickness=3, inset=12),
+            EdgeAccentStyle("left", "#C59E4B", thickness=3, inset=12),
+            EdgeAccentStyle("right", "#4A3417", thickness=4, inset=12),
+            EdgeAccentStyle("bottom", "#3B2A15", thickness=4, inset=12),
+        ),
+        stack_strip_side="bottom",
+        stack_strip_color="#CDAA60",
+        stack_strip_width=6,
+    ),
+    "paper_stack": PanelDepthStyle(
+        shadow_layers=(
+            DepthLayerStyle(
+                6,
+                7,
+                0,
+                0,
+                "#F8F2E5",
+                border_color="#D7C29A",
+                border_width=1,
+                corner_radius=18,
+            ),
+            DepthLayerStyle(
+                13,
+                15,
+                0,
+                0,
+                "#EADCC2",
+                border_color="#CDB58C",
+                border_width=1,
+                corner_radius=18,
+            ),
+            DepthLayerStyle(18, 20, 0, 0, "#C7B391", corner_radius=18),
+        ),
+        edge_accents=(
+            EdgeAccentStyle("top", "#FFF8E8", thickness=2, inset=14),
+            EdgeAccentStyle("left", "#FFF8E8", thickness=2, inset=14),
+            EdgeAccentStyle("right", "#C9B893", thickness=3, inset=14),
+            EdgeAccentStyle("bottom", "#BCA982", thickness=3, inset=14),
+        ),
+        stack_strip_side="right",
+        stack_strip_color="#D8C6A2",
+        stack_strip_width=7,
+    ),
+    "parchment": PanelDepthStyle(
+        shadow_layers=(
+            DepthLayerStyle(
+                5,
+                7,
+                0,
+                0,
+                "#F5E4B8",
+                border_color="#D1A85A",
+                border_width=1,
+                corner_radius=18,
+            ),
+            DepthLayerStyle(
+                12,
+                13,
+                0,
+                0,
+                "#D6B16B",
+                border_color="#B98224",
+                border_width=1,
+                corner_radius=18,
+            ),
+        ),
+        edge_accents=(
+            EdgeAccentStyle("top", "#FFE9B6", thickness=2, inset=14),
+            EdgeAccentStyle("left", "#FFE9B6", thickness=2, inset=14),
+            EdgeAccentStyle("right", "#9A6A19", thickness=3, inset=14),
+            EdgeAccentStyle("bottom", "#8A5A14", thickness=3, inset=14),
+        ),
+        stack_strip_side="bottom",
+        stack_strip_color="#C9973E",
+        stack_strip_width=7,
+    ),
+    "index_cards": PanelDepthStyle(
+        shadow_layers=(
+            DepthLayerStyle(
+                6,
+                6,
+                0,
+                0,
+                "#FFFFFF",
+                border_color="#CBD5E1",
+                border_width=1,
+                corner_radius=16,
+            ),
+            DepthLayerStyle(
+                12,
+                12,
+                0,
+                0,
+                "#E2E8F0",
+                border_color="#CBD5E1",
+                border_width=1,
+                corner_radius=16,
+            ),
+        ),
+        edge_accents=(
+            EdgeAccentStyle("top", "#FFFFFF", thickness=2, inset=12),
+            EdgeAccentStyle("left", "#FFFFFF", thickness=2, inset=12),
+            EdgeAccentStyle("right", "#CBD5E1", thickness=3, inset=12),
+            EdgeAccentStyle("bottom", "#CBD5E1", thickness=3, inset=12),
+        ),
+        stack_strip_side="right",
+        stack_strip_color="#CBD5E1",
+        stack_strip_width=6,
+    ),
+    "slate": PanelDepthStyle(
+        shadow_layers=(DepthLayerStyle(9, 11, 0, 0, "#06100E", corner_radius=22),),
+        edge_accents=(
+            EdgeAccentStyle("top", "#3A7A68", thickness=2, inset=12),
+            EdgeAccentStyle("left", "#3A7A68", thickness=2, inset=12),
+            EdgeAccentStyle("right", "#06100E", thickness=3, inset=12),
+            EdgeAccentStyle("bottom", "#06100E", thickness=3, inset=12),
+        ),
+    ),
+}
+
+
+def resolve_panel_depth_style(skin_name: str) -> PanelDepthStyle:
+    """Return decorative depth styling for a resolved panel skin name."""
+    return _SKIN_DEPTH_STYLES.get(skin_name, _DEFAULT_STYLE)

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -14,6 +14,10 @@ from modules.scenarios.gm_table.drag_controller import GMTableDragController
 from modules.scenarios.gm_table.window_hit_testing import point_inside_map_tool
 from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
 from modules.scenarios.gm_table.panel_skins import PanelSkin, resolve_panel_skin
+from modules.scenarios.gm_table.panel_depth_styles import (
+    PanelDepthStyle,
+    resolve_panel_depth_style,
+)
 
 
 TABLE_PALETTE = {
@@ -524,6 +528,9 @@ class GMTablePanel(ctk.CTkFrame):
         self._panel_bg = paper_body_colors.get("panel_bg", self._skin.panel_bg)
         self._panel_border = paper_body_colors.get("panel_border", self._skin.panel_border)
         self._panel_border_width = 1 if self._is_paper_skin else self._skin.border_width
+        self._depth_style = resolve_panel_depth_style(self._skin_name)
+        self._depth_layers: list[ctk.CTkFrame] = []
+        self._edge_accent_widgets: list[tk.Widget] = []
         super().__init__(
             master,
             width=width,
@@ -592,6 +599,8 @@ class GMTablePanel(ctk.CTkFrame):
         except Exception:
             pass
 
+        self._build_depth_accents(self._depth_style)
+
         self._bind_focus(self)
         self._bind_focus(self.body)
         for widget in self._header_drag_widgets:
@@ -599,6 +608,139 @@ class GMTablePanel(ctk.CTkFrame):
         self._install_drag_bindings()
         self._install_resize_bindings()
         self._refresh_window_controls()
+
+    def attach_depth_layers(self, layers: list[ctk.CTkFrame]) -> None:
+        """Attach sibling depth layers that should follow this panel geometry."""
+        if self._depth_layers:
+            self.destroy_depth_layers()
+        self._depth_layers = list(layers)
+        self._sync_depth_layers()
+
+    def destroy_depth_layers(self) -> None:
+        """Destroy sibling depth layers owned by this panel."""
+        for layer in list(self._depth_layers):
+            try:
+                layer.destroy()
+            except Exception:
+                pass
+        self._depth_layers.clear()
+
+    def lift_depth_layers(self) -> None:
+        """Raise sibling depth layers without raising the real panel."""
+        for layer in self._depth_layers:
+            try:
+                layer.lift()
+            except Exception:
+                continue
+
+    def lift_with_depth(self) -> None:
+        """Raise sibling depth layers immediately beneath the real panel."""
+        self.lift_depth_layers()
+        self.lift()
+
+    def _hide_depth_layers(self) -> None:
+        """Hide depth layers without affecting panel state."""
+        for layer in self._depth_layers:
+            try:
+                layer.place_forget()
+            except Exception:
+                pass
+
+    def _sync_depth_layers(self) -> None:
+        """Keep decorative sibling layers aligned to the current panel rectangle."""
+        if self._layout_mode == "minimized":
+            self._hide_depth_layers()
+            return
+        width = self._current_geometry["width"]
+        height = self._current_geometry["height"]
+        for layer, layer_style in zip(
+            self._depth_layers,
+            self._depth_style.shadow_layers,
+            strict=False,
+        ):
+            layer.place_configure(
+                x=self._current_geometry["x"] + layer_style.offset_x,
+                y=self._current_geometry["y"] + layer_style.offset_y,
+                width=max(self.MIN_WIDTH, width + layer_style.expand_width),
+                height=max(self.MIN_HEIGHT, height + layer_style.expand_height),
+            )
+
+    def _build_depth_accents(self, style: PanelDepthStyle) -> None:
+        """Render inner edge highlights and skin-specific stack strips."""
+        for accent in style.edge_accents:
+            widget = tk.Frame(self, bg=accent.color, highlightthickness=0, bd=0)
+            if accent.side == "top":
+                widget.place(
+                    x=accent.inset,
+                    y=accent.inset,
+                    relwidth=1.0,
+                    width=-(accent.inset * 2),
+                    height=accent.thickness,
+                )
+            elif accent.side == "bottom":
+                widget.place(
+                    x=accent.inset,
+                    rely=1.0,
+                    y=-(accent.inset + accent.thickness),
+                    relwidth=1.0,
+                    width=-(accent.inset * 2),
+                    height=accent.thickness,
+                )
+            elif accent.side == "left":
+                widget.place(
+                    x=accent.inset,
+                    y=accent.inset,
+                    width=accent.thickness,
+                    relheight=1.0,
+                    height=-(accent.inset * 2),
+                )
+            elif accent.side == "right":
+                widget.place(
+                    relx=1.0,
+                    x=-(accent.inset + accent.thickness),
+                    y=accent.inset,
+                    width=accent.thickness,
+                    relheight=1.0,
+                    height=-(accent.inset * 2),
+                )
+            else:
+                continue
+            self._edge_accent_widgets.append(widget)
+
+        if style.stack_strip_side and style.stack_strip_color:
+            strip = tk.Frame(
+                self,
+                bg=style.stack_strip_color,
+                highlightthickness=0,
+                bd=0,
+            )
+            if style.stack_strip_side == "right":
+                strip.place(
+                    relx=1.0,
+                    x=-(style.stack_strip_width + 7),
+                    y=18,
+                    width=style.stack_strip_width,
+                    relheight=1.0,
+                    height=-36,
+                )
+            elif style.stack_strip_side == "bottom":
+                strip.place(
+                    x=18,
+                    rely=1.0,
+                    y=-(style.stack_strip_width + 7),
+                    relwidth=1.0,
+                    width=-36,
+                    height=style.stack_strip_width,
+                )
+            self._edge_accent_widgets.append(strip)
+
+        for widget in self._edge_accent_widgets:
+            self._bind_focus(widget)
+            try:
+                widget.lower()
+            except Exception:
+                pass
+        self.resize_handle.lift()
 
     def _build_book_spine(self) -> None:
         """Add a narrow book-like spine to binder panels."""
@@ -797,6 +939,11 @@ class GMTablePanel(ctk.CTkFrame):
         widget.bind("<ButtonRelease-1>", self._stop_resize, add="+")
 
     @property
+    def depth_style(self) -> PanelDepthStyle:
+        """Return the decorative sibling-layer style for this panel."""
+        return self._depth_style
+
+    @property
     def layout_mode(self) -> str:
         """Return the current layout mode."""
         return self._layout_mode
@@ -868,6 +1015,7 @@ class GMTablePanel(ctk.CTkFrame):
         self._minimized_restore_mode = restore_mode
         self._layout_mode = "minimized"
         self.place_forget()
+        self._hide_depth_layers()
         self._refresh_window_controls()
 
     def restore_from_minimized(self, *, surface_w: int, surface_h: int) -> bool:
@@ -1122,6 +1270,7 @@ class GMTablePanel(ctk.CTkFrame):
         }
         self._set_size(self._current_geometry["width"], self._current_geometry["height"])
         self.place_configure(x=self._current_geometry["x"], y=self._current_geometry["y"])
+        self._sync_depth_layers()
 
     def _set_size(self, width: int, height: int) -> None:
         """Update the CTk widget size."""
@@ -1133,6 +1282,11 @@ class GMTablePanel(ctk.CTkFrame):
         except Exception:
             pass
         self.resize_handle.lift()
+
+    def destroy(self) -> None:
+        """Destroy the real panel and any sibling decorative layers."""
+        self.destroy_depth_layers()
+        super().destroy()
 
     def _resolve_drag_snap_mode(self, event) -> str | None:
         """Resolve the current drag pointer against the workspace snap map."""
@@ -1867,9 +2021,20 @@ class GMTableWorkspace(ctk.CTkFrame):
         for current_id, panel in self._panels.items():
             is_target = current_id == panel_id and panel.layout_mode != "minimized"
             panel.set_focus_state(is_target)
-            if is_target:
-                panel.lift()
+        self._restack_panel_layers()
         self._raise_workspace_overlays()
+
+    def _restack_panel_layers(self) -> None:
+        """Keep decorative depth layers below real panels so they do not steal panel clicks."""
+        ordered_panels = [
+            self._panels[panel_id]
+            for panel_id in self._z_order
+            if panel_id in self._panels and self._panels[panel_id].layout_mode != "minimized"
+        ]
+        for panel in ordered_panels:
+            panel.lift_depth_layers()
+        for panel in ordered_panels:
+            panel.lift()
 
     def _raise_workspace_overlays(self) -> None:
         """Keep the camera HUD and minimap above every desk panel."""
@@ -1986,6 +2151,20 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._raise_workspace_overlays()
         self._schedule_layout_changed()
 
+    def _create_panel_depth_layers(self, panel: GMTablePanel) -> list[ctk.CTkFrame]:
+        """Create non-interactive sibling layers that sit behind a panel."""
+        layers: list[ctk.CTkFrame] = []
+        for layer_style in panel.depth_style.shadow_layers:
+            frame = ctk.CTkFrame(
+                self.surface,
+                fg_color=layer_style.color,
+                corner_radius=layer_style.corner_radius,
+                border_width=layer_style.border_width,
+                border_color=layer_style.border_color or layer_style.color,
+            )
+            layers.append(frame)
+        return layers
+
     def remove_panel(self, panel_id: str) -> None:
         """Close a panel."""
         panel = self._panels.pop(panel_id, None)
@@ -2062,6 +2241,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             on_toggle_maximize=self.toggle_panel_maximize,
             on_window_action=self.handle_window_action,
         )
+        panel.attach_depth_layers(self._create_panel_depth_layers(panel))
         self._apply_floating_geometry(panel, world_geometry)
         panel_payload = self._build_panel(panel.body, definition)
         self._mount_payload_widget(panel.body, panel_payload)
@@ -2488,6 +2668,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             if layout_mode == "minimized":
                 panel._layout_mode = "minimized"
                 panel.place_forget()
+                panel._hide_depth_layers()
                 panel._refresh_window_controls()
             elif layout_mode in SNAP_LAYOUT_MODES:
                 surface_w, surface_h = self._surface_geometry()


### PR DESCRIPTION
### Motivation
- Improve the visual depth of floating panels in the GM Table by adding decorative shadows, inner edge accents and optional stack/spine strips to better distinguish book/file/paper skins.
- Keep decorative elements non-interactive and ensure they behave as purely visual siblings so hit-testing and drag behavior remain attached to the real panel.
- Ensure lifecycle and z-order remain correct so decorations are created, hidden, raised and destroyed alongside their associated panel.

### Description
- Add `modules/scenarios/gm_table/panel_depth_styles.py` which defines `DepthLayerStyle`, `EdgeAccentStyle` and `PanelDepthStyle` dataclasses and provides skin-specific depth bundles for `binder`, `dossier`, `paper_stack`, `parchment`, `index_cards` and fallbacks.
- Wire `GMTablePanel` to resolve a `depth_style`, render inner edge accents and stack strips, and expose methods to `attach_depth_layers`, `destroy_depth_layers`, `lift_depth_layers`, `lift_with_depth`, `_hide_depth_layers`, and `_sync_depth_layers` so decorative frames follow panel geometry while remaining non-interactive.
- Update `GMTableWorkspace` so panel creation (`add_panel`) constructs non-interactive sibling depth frames via a `_create_panel_depth_layers()` factory and `panel.attach_depth_layers(...)`, and add a `_restack_panel_layers()` that raises depth layers first then the real panels to avoid decorations stealing clicks.
- Fix restore/minimize flows so depth layers are hidden when a panel is minimized or restored-from-minimized, and ensure `destroy()` removes any attached depth layers so `remove_panel()` cleans up decorations.

### Testing
- ✅ Syntax/compile checks: `python -m py_compile modules/scenarios/gm_table/workspace.py modules/scenarios/gm_table/panel_depth_styles.py modules/scenarios/gm_table/panel_skins.py` succeeded.
- ✅ Style and data assertions: a small import script validated `resolve_panel_depth_style(...)` returns expected `stack_strip_side`, `shadow_layers` counts and `edge_accents` for the main skins.
- ✅ Source-level behavior checks: automated assertions confirmed presence of `attach_depth_layers`, `destroy_depth_layers`, `lift_depth_layers`, `panel.lift_depth_layers()` usage, and that the depth-layer factory does not bind interactive events to the decorative frames.
- ⚠️ Runtime/UI integration tests were not executed because `customtkinter` is not available in this environment, however QA discovered and a minimal fix was applied for a restored-minimized panel where depth layers could remain visible, and the fix was validated by source inspection and the above checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ae926d120832b9b662c84a839c7ef)