### PR TITLE
Update minimized tray: thematic label, skin-aware compact buttons, responsive layout

### DIFF
--- a/modules/scenarios/gm_table/minimized_tray.py
+++ b/modules/scenarios/gm_table/minimized_tray.py
@@ -1,0 +1,73 @@
+"""Helpers for rendering the GM Table minimized-panel tray."""
+
+from __future__ import annotations
+
+from modules.scenarios.gm_table.panel_skins import PanelSkin
+
+MINIMIZED_TRAY_BUTTON_WIDTH = 118
+MINIMIZED_TRAY_BUTTON_GAP = 8
+MINIMIZED_TRAY_BUTTON_MIN_COLUMNS = 1
+MINIMIZED_TRAY_NARROW_BREAKPOINT = 360
+MINIMIZED_TRAY_TITLE_LIMIT = 18
+DEFAULT_TRAY_TEXT_COLOR = "#F4F7FB"
+
+
+def readable_text_color(color: str, *, fallback: str = DEFAULT_TRAY_TEXT_COLOR) -> str:
+    """Return a readable text color for a solid ``#RRGGBB`` background."""
+    value = str(color or "").strip().lstrip("#")
+    if len(value) != 6:
+        return fallback
+    try:
+        red = int(value[0:2], 16)
+        green = int(value[2:4], 16)
+        blue = int(value[4:6], 16)
+    except ValueError:
+        return fallback
+    brightness = red * 0.299 + green * 0.587 + blue * 0.114
+    return "#111827" if brightness > 158 else "#F8FAFC"
+
+
+def compact_tray_title(title: str) -> str:
+    """Return a button title that remains legible in compact tray layouts."""
+    clean_title = " ".join(str(title or "Panel").split()) or "Panel"
+    if len(clean_title) <= MINIMIZED_TRAY_TITLE_LIMIT:
+        return clean_title
+    return f"{clean_title[: MINIMIZED_TRAY_TITLE_LIMIT - 1].rstrip()}…"
+
+
+def minimized_tray_button_style(skin: PanelSkin) -> dict[str, object]:
+    """Return a compact restore-button style matching a panel's physical skin."""
+    if skin.show_spine:
+        fg_color = skin.border_color
+        hover_color = skin.header_color
+        border_color = skin.accent_color
+        corner_radius = 8
+    elif skin.show_file_tab:
+        fg_color = skin.header_color
+        hover_color = skin.accent_color
+        border_color = skin.border_color
+        corner_radius = 14
+    elif skin.show_page_edges:
+        fg_color = skin.body_color
+        hover_color = skin.header_color
+        border_color = skin.border_color
+        corner_radius = 10
+    else:
+        fg_color = skin.control_bg
+        hover_color = skin.control_hover
+        border_color = skin.panel_border
+        corner_radius = 12
+    return {
+        "fg_color": fg_color,
+        "hover_color": hover_color,
+        "border_color": border_color,
+        "text_color": readable_text_color(str(fg_color)),
+        "corner_radius": corner_radius,
+    }
+
+
+def minimized_tray_columns(available_width: int) -> int:
+    """Return the number of fixed-width tray buttons that fit in a row."""
+    safe_width = max(MINIMIZED_TRAY_BUTTON_WIDTH, int(available_width or 0))
+    button_span = MINIMIZED_TRAY_BUTTON_WIDTH + MINIMIZED_TRAY_BUTTON_GAP
+    return max(MINIMIZED_TRAY_BUTTON_MIN_COLUMNS, safe_width // button_span)

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -13,7 +13,15 @@ from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
 from modules.scenarios.gm_table.drag_controller import GMTableDragController
 from modules.scenarios.gm_table.window_hit_testing import point_inside_map_tool
 from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
-from modules.scenarios.gm_table.panel_skins import PanelSkin, resolve_panel_skin
+from modules.scenarios.gm_table.panel_skins import resolve_panel_skin
+from modules.scenarios.gm_table.minimized_tray import (
+    MINIMIZED_TRAY_BUTTON_GAP,
+    MINIMIZED_TRAY_BUTTON_WIDTH,
+    MINIMIZED_TRAY_NARROW_BREAKPOINT,
+    compact_tray_title,
+    minimized_tray_button_style,
+    minimized_tray_columns,
+)
 from modules.scenarios.gm_table.panel_depth_styles import (
     PanelDepthStyle,
     resolve_panel_depth_style,
@@ -79,6 +87,7 @@ CAMERA_ZOOM_STEP = 0.15
 MINIMAP_WIDTH = 176
 MINIMAP_HEIGHT = 118
 MINIMAP_PADDING = 16
+
 SNAP_LAYOUT_MODES = {
     "left",
     "right",
@@ -1439,7 +1448,7 @@ class GMTableWorkspace(ctk.CTkFrame):
 
         self.tray_label = ctk.CTkLabel(
             self.tray,
-            text="Minimized",
+            text="File Stack",
             text_color=TABLE_PALETTE["muted"],
             font=ctk.CTkFont(size=13, weight="bold"),
         )
@@ -1447,6 +1456,8 @@ class GMTableWorkspace(ctk.CTkFrame):
 
         self.tray_buttons = ctk.CTkFrame(self.tray, fg_color="transparent")
         self.tray_buttons.grid(row=0, column=1, padx=(0, 12), pady=8, sticky="ew")
+        self._tray_button_widgets: list[ctk.CTkButton] = []
+        self.tray_buttons.bind("<Configure>", self._layout_minimized_tray_buttons, add="+")
 
         self._empty_state = ctk.CTkLabel(
             self.surface,
@@ -1508,6 +1519,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             return
         for child in buttons_frame.winfo_children():
             child.destroy()
+        self._tray_button_widgets = []
         minimized_ids = self._minimized_panel_ids()
         if not minimized_ids:
             tray.grid_remove()
@@ -1517,16 +1529,74 @@ class GMTableWorkspace(ctk.CTkFrame):
             definition = self._definitions.get(panel_id)
             if definition is None:
                 continue
-            ctk.CTkButton(
+            skin = resolve_panel_skin(definition.kind, definition.state)
+            style = minimized_tray_button_style(skin)
+            label = f"{skin.icon} {compact_tray_title(definition.title)}".strip()
+            button = ctk.CTkButton(
                 buttons_frame,
-                text=definition.title,
+                text=label,
+                width=MINIMIZED_TRAY_BUTTON_WIDTH,
                 height=30,
-                fg_color=TABLE_PALETTE["table_chip"],
-                hover_color="#283146",
-                text_color=TABLE_PALETTE["text"],
-                corner_radius=12,
+                border_width=1,
+                font=ctk.CTkFont(size=12, weight="bold"),
                 command=lambda value=panel_id: self.restore_panel(value),
-            ).pack(side="left", padx=(0, 8))
+                **style,
+            )
+            self._tray_button_widgets.append(button)
+        if not self._tray_button_widgets:
+            tray.grid_remove()
+            return
+        self._layout_minimized_tray_buttons()
+
+    def _layout_minimized_tray_buttons(self, _event=None) -> None:
+        """Wrap minimized restore buttons so the tray stays readable when narrow."""
+        buttons = getattr(self, "_tray_button_widgets", [])
+        buttons_frame = getattr(self, "tray_buttons", None)
+        if buttons_frame is None:
+            return
+        for child in buttons_frame.winfo_children():
+            child.grid_forget()
+        if not buttons:
+            return
+        tray = getattr(self, "tray", None)
+        tray_width = int(tray.winfo_width() or 0) if tray is not None else 0
+        if tray is not None and tray_width and tray_width < MINIMIZED_TRAY_NARROW_BREAKPOINT:
+            self.tray_label.grid(
+                row=0,
+                column=0,
+                columnspan=2,
+                padx=(14, 12),
+                pady=(10, 0),
+                sticky="w",
+            )
+            buttons_frame.grid(
+                row=1,
+                column=0,
+                columnspan=2,
+                padx=(14, 12),
+                pady=(4, 10),
+                sticky="ew",
+            )
+        else:
+            self.tray_label.grid(
+                row=0, column=0, columnspan=1, padx=(14, 10), pady=10, sticky="w"
+            )
+            buttons_frame.grid(
+                row=0, column=1, columnspan=1, padx=(0, 12), pady=8, sticky="ew"
+            )
+        available_width = int(buttons_frame.winfo_width() or MINIMIZED_TRAY_BUTTON_WIDTH)
+        columns = minimized_tray_columns(available_width)
+        for column in range(max(columns, len(buttons))):
+            buttons_frame.grid_columnconfigure(column, weight=0)
+        for index, button in enumerate(buttons):
+            row, column = divmod(index, columns)
+            button.grid(
+                row=row,
+                column=column,
+                padx=(0, MINIMIZED_TRAY_BUTTON_GAP),
+                pady=(0, 4),
+                sticky="w",
+            )
 
     def _bind_surface_navigation(self) -> None:
         """Bind camera navigation to the empty table surface."""

--- a/tests/scenarios/gm_table/test_minimized_tray.py
+++ b/tests/scenarios/gm_table/test_minimized_tray.py
@@ -1,0 +1,55 @@
+from modules.scenarios.gm_table.minimized_tray import (
+    MINIMIZED_TRAY_BUTTON_GAP,
+    MINIMIZED_TRAY_BUTTON_WIDTH,
+    compact_tray_title,
+    minimized_tray_button_style,
+    minimized_tray_columns,
+)
+from modules.scenarios.gm_table.panel_skins import resolve_panel_skin
+
+
+def test_minimized_tray_button_style_uses_spine_for_book_skin() -> None:
+    skin = resolve_panel_skin("campaign_dashboard", {})
+
+    style = minimized_tray_button_style(skin)
+
+    assert style["fg_color"] == skin.border_color
+    assert style["border_color"] == skin.accent_color
+    assert style["text_color"] == "#F8FAFC"
+
+
+def test_minimized_tray_button_style_uses_tab_for_file_skin() -> None:
+    skin = resolve_panel_skin("entity", {"entity_type": "NPCs"})
+
+    style = minimized_tray_button_style(skin)
+
+    assert style["fg_color"] == skin.header_color
+    assert style["hover_color"] == skin.accent_color
+    assert style["border_color"] == skin.border_color
+
+
+def test_minimized_tray_button_style_keeps_paper_skin_readable() -> None:
+    skin = resolve_panel_skin("handouts", {})
+
+    style = minimized_tray_button_style(skin)
+
+    assert style["fg_color"] == skin.body_color
+    assert style["text_color"] == "#111827"
+
+
+def test_compact_tray_title_normalizes_and_truncates_long_titles() -> None:
+    assert (
+        compact_tray_title("  Villain    Master Plan Notes  ") == "Villain Master Pl…"
+    )
+    assert compact_tray_title("") == "Panel"
+
+
+def test_minimized_tray_columns_keeps_small_width_to_single_column() -> None:
+    assert minimized_tray_columns(1) == 1
+    assert minimized_tray_columns(MINIMIZED_TRAY_BUTTON_WIDTH) == 1
+    assert (
+        minimized_tray_columns(
+            (MINIMIZED_TRAY_BUTTON_WIDTH + MINIMIZED_TRAY_BUTTON_GAP) * 2
+        )
+        == 2
+    )


### PR DESCRIPTION
### Motivation
- Improve the minimized-panel tray visuals to match panel skins and be more thematic and legible in small windows.
- Reuse the existing panel skin resolver so minimized items visually align with the panel types (file-like, book-like, paper-like).
- Keep restore behavior unchanged while making the tray helper logic easier to maintain by splitting it out.

### Description
- Renamed the tray header from `Minimized` to the thematic `File Stack` in `GMTableWorkspace`. (UI label change).
- Added `modules/scenarios/gm_table/minimized_tray.py` which centralizes tray constants and helper functions: compact title truncation, readable text color calculation, skin-aware compact button style, and column calculation for responsive wrapping.
- Updated `modules/scenarios/gm_table/workspace.py` to import and use the new helpers and to resolve each minimized item skin via `resolve_panel_skin(definition.kind, definition.state)`; tray buttons now use the computed style and display `skin.icon + compact title`, and each button still calls `self.restore_panel(panel_id)` when pressed.
- Improved small-width behavior by moving the tray label above the button grid under a narrow breakpoint and wrapping buttons into computed columns so the tray remains readable on narrow windows.
- Added focused unit tests in `tests/scenarios/gm_table/test_minimized_tray.py` that validate book/tab/paper style branches, title compaction, and column calculation.

### Testing
- Ran `python -m pytest tests/scenarios/gm_table/test_minimized_tray.py -q` which passed (`5 passed`).
- Ran `python -m pytest tests/scenarios/gm_table/test_panel_skins.py tests/scenarios/gm_table/test_minimized_tray.py -q` which passed (`10 passed`).
- Ran `python -m pytest tests/scenarios/gm_table/test_workspace.py -q -k 'minimize or restore_panel or panel_skin'` which exercised the targeted workspace behaviors and showed `3 passed, 46 deselected`.
- Ran `python -m py_compile` on the modified modules and tests which succeeded with no syntax errors.
- Known non-target test result: running the entire `tests/scenarios/gm_table/test_workspace.py` suite reports unrelated failures (7 failed, 42 passed) due to existing snap-preview/middle-drag fake-object expectations and headless Tk `$DISPLAY` issues; these failures are not related to the minimized-tray changes.

Changed files:
- Added: `modules/scenarios/gm_table/minimized_tray.py`
- Modified: `modules/scenarios/gm_table/workspace.py`
- Added tests: `tests/scenarios/gm_table/test_minimized_tray.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c2fd035e8832ba8482fd14c0ab951)