### PR TITLE
GM Table: add Image-from-Library panels and entity attachment galleries

### DIFF
--- a/modules/scenarios/gm_table/attachments.py
+++ b/modules/scenarios/gm_table/attachments.py
@@ -1,0 +1,96 @@
+"""Attachment discovery helpers for GM Table entity panels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.portrait_helper import (
+    parse_portrait_value,
+    resolve_portrait_candidate,
+)
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
+MEDIA_FIELDS = ("Portrait", "portrait", "Image", "image")
+ATTACHMENT_FIELDS = ("Attachment", "Attachments", "attachment", "attachments")
+
+
+@dataclass(frozen=True, slots=True)
+class EntityAttachment:
+    """One displayable or downloadable entity attachment."""
+
+    field_name: str
+    path: str
+    resolved_path: str | None
+    label: str
+    is_image: bool
+
+
+def _split_attachment_value(value) -> list[str]:
+    """Parse attachment values saved as lists, literals, lines, or delimited text."""
+    paths = parse_portrait_value(value)
+    if len(paths) == 1:
+        text = paths[0]
+        for delimiter in (",",):
+            if delimiter in text:
+                parts = [part.strip() for part in text.split(delimiter) if part.strip()]
+                if parts:
+                    return parts
+    return paths
+
+
+def _candidate_values(record: dict) -> Iterable[tuple[str, str]]:
+    """Yield raw candidate paths from known media and attachment fields."""
+    if not isinstance(record, dict):
+        return
+    for field_name in (*MEDIA_FIELDS, *ATTACHMENT_FIELDS):
+        value = record.get(field_name)
+        parser = (
+            parse_portrait_value
+            if field_name in MEDIA_FIELDS
+            else _split_attachment_value
+        )
+        for path in parser(value):
+            cleaned = str(path or "").strip()
+            if cleaned:
+                yield field_name, cleaned
+
+
+def _attachment_label(path: str, resolved_path: str | None) -> str:
+    """Return a compact label for an attachment path."""
+    source = resolved_path or path
+    name = Path(source).name
+    return name or str(path)
+
+
+def collect_entity_attachments(
+    record: dict, *, campaign_dir: str | None = None
+) -> list[EntityAttachment]:
+    """Collect de-duplicated media/attachment paths from an entity record."""
+    base_dir = campaign_dir or ConfigHelper.get_campaign_dir()
+    attachments: list[EntityAttachment] = []
+    seen: set[str] = set()
+    for field_name, path in _candidate_values(record):
+        resolved = resolve_portrait_candidate(path, base_dir)
+        key = str(Path(resolved or path)).strip().casefold()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        suffix = Path(resolved or path).suffix.casefold()
+        attachments.append(
+            EntityAttachment(
+                field_name=field_name,
+                path=path,
+                resolved_path=resolved,
+                label=_attachment_label(path, resolved),
+                is_image=suffix in IMAGE_EXTENSIONS,
+            )
+        )
+    return attachments
+
+
+def entity_has_attachments(record: dict, *, campaign_dir: str | None = None) -> bool:
+    """Return whether an entity has at least one linked attachment/media path."""
+    return bool(collect_entity_attachments(record, campaign_dir=campaign_dir))

--- a/modules/scenarios/gm_table/pages.py
+++ b/modules/scenarios/gm_table/pages.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable
 
 import customtkinter as ctk
+from PIL import Image
 
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.portrait_helper import resolve_portrait_candidate
 from modules.image_assets import ImageAssetsService
+from modules.scenarios.gm_table.attachments import EntityAttachment
 from modules.ui.image_library.browser_panel import ImageBrowserPanel
 from modules.ui.image_library.result_card import ImageResult
 from modules.ui.image_library.toolbar import ToolbarState
+
+IMAGE_PANEL_SIZE = (520, 390)
 
 
 class GMTableHostedPage(ctk.CTkFrame):
@@ -88,10 +95,121 @@ class GMTableNotePage(ctk.CTkFrame):
         return {"text": self.textbox.get("1.0", "end-1c")}
 
 
+class GMTableImagePage(ctk.CTkFrame):
+    """Display one image as a resizable GM Table window."""
+
+    def __init__(self, master, *, image_path: str, title: str = "Image") -> None:
+        super().__init__(master, fg_color="transparent")
+        self.grid_rowconfigure(1, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self._image_path = str(image_path or "").strip()
+        self._title = str(title or Path(self._image_path).name or "Image")
+        self._ctk_image: ctk.CTkImage | None = None
+        self._source_image: Image.Image | None = None
+
+        ctk.CTkLabel(
+            self,
+            text=self._title,
+            font=ctk.CTkFont(size=16, weight="bold"),
+            anchor="w",
+        ).grid(row=0, column=0, sticky="ew", pady=(0, 8))
+
+        self.image_label = ctk.CTkLabel(self, text="Loading image…", anchor="center")
+        self.image_label.grid(row=1, column=0, sticky="nsew")
+        self.bind("<Configure>", self._refresh_image, add="+")
+        self._load_image()
+
+    def _resolve_image_path(self) -> str | None:
+        return resolve_portrait_candidate(
+            self._image_path, ConfigHelper.get_campaign_dir()
+        )
+
+    def _load_image(self) -> None:
+        resolved = self._resolve_image_path()
+        if not resolved:
+            self.image_label.configure(
+                text=f"Image not found:\n{self._image_path}", image=None
+            )
+            return
+        try:
+            self._source_image = Image.open(resolved).convert("RGBA")
+        except Exception as exc:
+            self.image_label.configure(text=f"Unable to load image:\n{exc}", image=None)
+            return
+        self._refresh_image()
+
+    def _refresh_image(self, _event=None) -> None:
+        if self._source_image is None:
+            return
+        width = max(160, int(self.winfo_width() or IMAGE_PANEL_SIZE[0]) - 24)
+        height = max(120, int(self.winfo_height() or IMAGE_PANEL_SIZE[1]) - 58)
+        render = self._source_image.copy()
+        render.thumbnail((width, height), Image.Resampling.LANCZOS)
+        if render.width <= 0 or render.height <= 0:
+            return
+        self._ctk_image = ctk.CTkImage(
+            light_image=render, dark_image=render, size=render.size
+        )
+        self.image_label.configure(text="", image=self._ctk_image)
+
+    def get_state(self) -> dict:
+        return {"image_path": self._image_path, "image_title": self._title}
+
+
+class GMTableAttachmentGallery(ctk.CTkFrame):
+    """Compact gallery for entity attachments on the GM Table."""
+
+    def __init__(self, master, *, attachments: list[EntityAttachment]) -> None:
+        super().__init__(master, fg_color="transparent")
+        self._images: list[ctk.CTkImage] = []
+        self.grid_columnconfigure(0, weight=1)
+        title = f"Attachments ({len(attachments)})"
+        ctk.CTkLabel(
+            self, text=title, font=ctk.CTkFont(size=15, weight="bold"), anchor="w"
+        ).grid(row=0, column=0, sticky="ew", pady=(0, 8))
+        body = ctk.CTkFrame(self, fg_color="transparent")
+        body.grid(row=1, column=0, sticky="ew")
+        for index, attachment in enumerate(attachments):
+            card = ctk.CTkFrame(body, corner_radius=12)
+            card.grid(row=index // 2, column=index % 2, sticky="ew", padx=6, pady=6)
+            card.grid_columnconfigure(0, weight=1)
+            if attachment.is_image and attachment.resolved_path:
+                self._add_image_preview(card, attachment)
+            else:
+                ctk.CTkLabel(card, text="📎", font=ctk.CTkFont(size=28)).grid(
+                    row=0, column=0, pady=(10, 2)
+                )
+            ctk.CTkLabel(
+                card, text=attachment.label, wraplength=220, justify="center"
+            ).grid(row=1, column=0, padx=10, pady=(2, 10), sticky="ew")
+
+    def _add_image_preview(self, parent, attachment: EntityAttachment) -> None:
+        try:
+            image = Image.open(attachment.resolved_path).convert("RGBA")
+            image.thumbnail((220, 150), Image.Resampling.LANCZOS)
+            ctk_image = ctk.CTkImage(
+                light_image=image, dark_image=image, size=image.size
+            )
+            self._images.append(ctk_image)
+            ctk.CTkLabel(parent, text="", image=ctk_image).grid(
+                row=0, column=0, padx=10, pady=(10, 2)
+            )
+        except Exception:
+            ctk.CTkLabel(parent, text="🖼", font=ctk.CTkFont(size=28)).grid(
+                row=0, column=0, pady=(10, 2)
+            )
+
+
 class GMTableImageLibraryPage(ctk.CTkFrame):
     """Embedded shared image library browser."""
 
-    def __init__(self, master, *, initial_state: dict | None = None) -> None:
+    def __init__(
+        self,
+        master,
+        *,
+        initial_state: dict | None = None,
+        on_attach_to_table: Callable[[ImageResult], None] | None = None,
+    ) -> None:
         super().__init__(master, fg_color="transparent")
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
@@ -109,6 +227,7 @@ class GMTableImageLibraryPage(ctk.CTkFrame):
                 size_label=str(state.get("size_label") or "Medium"),
                 sort_label=str(state.get("sort_label") or "Newest"),
             ),
+            on_attach_to_entity=on_attach_to_table,
             on_toolbar_state_changed=self._on_toolbar_state_changed,
         )
         self._panel.grid(row=0, column=0, sticky="nsew")
@@ -118,7 +237,11 @@ class GMTableImageLibraryPage(ctk.CTkFrame):
         """Fetch and map image records for the browser."""
         toolbar_state = self._panel.toolbar.state
         selected_folder = (toolbar_state.folder_name or "").strip()
-        filters = {"source_folder_names": [selected_folder]} if selected_folder and selected_folder != "All" else None
+        filters = (
+            {"source_folder_names": [selected_folder]}
+            if selected_folder and selected_folder != "All"
+            else None
+        )
         rows, _total = self._service.search_images(
             query=toolbar_state.query,
             filters=filters,

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -55,6 +55,7 @@ DEFAULT_PANEL_SIZES = {
     "world_map": (860, 620),
     "map_tool": (900, 640),
     "scene_flow": (860, 600),
+    "image": (620, 520),
     "image_library": (860, 580),
     "handouts": (760, 560),
     "ambiance": (820, 580),

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -23,10 +23,16 @@ from modules.objects.object_shelf_panel import create_object_shelf_panel
 from modules.puzzles.puzzle_display_window import create_puzzle_display_frame
 from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
+from modules.scenarios.gm_table.attachments import (
+    collect_entity_attachments,
+    entity_has_attachments,
+)
 from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
 from modules.scenarios.gm_table.pages import (
+    GMTableAttachmentGallery,
     GMTableHostedPage,
     GMTableImageLibraryPage,
+    GMTableImagePage,
     GMTableNotePage,
 )
 from modules.scenarios.gm_table.workspace import (
@@ -43,7 +49,6 @@ from modules.ui.chatbot_dialog import (
     open_chatbot_dialog,
 )
 from modules.whiteboard.controllers.whiteboard_controller import WhiteboardController
-
 
 ENTITY_TYPES = (
     "Factions",
@@ -125,6 +130,7 @@ class GMTableView(ctk.CTkFrame):
             "Map Tool",
             "Scene Flow",
             "Image Library",
+            "Image from Library",
             "Handouts",
             "Loot Generator",
             "Object Shelf",
@@ -380,11 +386,37 @@ class GMTableView(ctk.CTkFrame):
     def _restore_or_seed_layout(self) -> None:
         """Restore saved workspace or create a starter tabletop."""
         layout = self.layout_store.get_scenario_layout(self.scenario_name)
+        layout = self._filter_attachmentless_entity_panels(layout)
         if layout.get("panels"):
             self.workspace.restore(layout)
         else:
             self._seed_default_panels()
         self._workspace_loaded = True
+
+    def _filter_attachmentless_entity_panels(self, layout: dict) -> dict:
+        """Drop saved non-scenario entity panels that no longer have attachments."""
+        if not isinstance(layout, dict):
+            return {}
+        filtered = dict(layout)
+        panels = []
+        for panel in list(layout.get("panels") or []):
+            if not isinstance(panel, dict) or panel.get("kind") != "entity":
+                panels.append(panel)
+                continue
+            state = panel.get("state") or {}
+            entity_type = str(state.get("entity_type") or "")
+            entity_name = str(state.get("entity_name") or "")
+            if entity_type == "Scenarios":
+                panels.append(panel)
+                continue
+            try:
+                item = self._load_entity_item(entity_type, entity_name)
+            except Exception:
+                continue
+            if entity_has_attachments(item):
+                panels.append(panel)
+        filtered["panels"] = panels
+        return filtered
 
     def _seed_default_panels(self) -> None:
         """Build the default workspace focused on scenario and handouts."""
@@ -479,6 +511,37 @@ class GMTableView(ctk.CTkFrame):
         )
         self.workspace.add_panel(definition, geometry=geometry)
         return definition.panel_id
+
+    def _add_image_panel_from_library_result(self, image_result) -> None:
+        """Create a floating image window from an image-library selection."""
+        image_path = str(getattr(image_result, "path", "") or "").strip()
+        if not image_path:
+            messagebox.showerror("GM Table", "The selected image has no usable path.")
+            return
+        image_title = str(getattr(image_result, "name", "") or "").strip() or "Image"
+        self._create_panel(
+            "image",
+            image_title,
+            {"image_path": image_path, "image_title": image_title},
+        )
+
+    def _open_image_library_for_table_image(self) -> None:
+        """Open the shared image library dialog in attach-to-table mode."""
+        try:
+            from modules.ui.image_library.dialogs.library_browser_dialog import (
+                ImageLibraryBrowserDialog,
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                "Image Library", f"Image library is unavailable: {exc}"
+            )
+            return
+
+        dialog = ImageLibraryBrowserDialog(
+            self.winfo_toplevel(),
+            on_attach_to_entity=self._add_image_panel_from_library_result,
+        )
+        dialog.title("Add Image to GM Table")
 
     def _preferred_entity_geometry(self, entity_type: str) -> dict[str, int]:
         """Return the default geometry for an entity panel."""
@@ -697,6 +760,9 @@ class GMTableView(ctk.CTkFrame):
         if option == "Image Library":
             self._create_panel("image_library", "Image Library", {})
             return
+        if option == "Image from Library":
+            self._open_image_library_for_table_image()
+            return
         if option == "Handouts":
             self._create_panel(
                 "handouts", "Handouts", {"scenario_name": self.scenario_name}
@@ -781,7 +847,17 @@ class GMTableView(ctk.CTkFrame):
                     ),
                 )
             if kind == "image_library":
-                return GMTableImageLibraryPage(parent, initial_state=definition.state)
+                return GMTableImageLibraryPage(
+                    parent,
+                    initial_state=definition.state,
+                    on_attach_to_table=self._add_image_panel_from_library_result,
+                )
+            if kind == "image":
+                return GMTableImagePage(
+                    parent,
+                    image_path=str(definition.state.get("image_path") or ""),
+                    title=str(definition.state.get("image_title") or definition.title),
+                )
             if kind == "handouts":
                 return GMTableHandoutsPage(
                     parent,
@@ -944,6 +1020,26 @@ class GMTableView(ctk.CTkFrame):
         entity_type = state.get("entity_type")
         entity_name = state.get("entity_name")
         item = self._load_entity_item(entity_type, entity_name)
+        attachments = collect_entity_attachments(item)
+
+        if attachments:
+            host.grid_rowconfigure(0, weight=1)
+            host.grid_columnconfigure(0, weight=1)
+            scrollable_host = build_scroll_host(host)
+            attachment_gallery = GMTableAttachmentGallery(
+                scrollable_host,
+                attachments=attachments,
+            )
+            attachment_gallery.pack(fill="x", padx=8, pady=(8, 12))
+            detail_frame = create_entity_detail_frame(
+                entity_type,
+                item,
+                master=scrollable_host,
+                open_entity_callback=self.open_entity_panel,
+                spotlight_only=False,
+            )
+            detail_frame.pack(fill="both", expand=True, padx=8, pady=(0, 8))
+            return scrollable_host
 
         if self._uses_readable_entity_detail(entity_type):
             scrollable_host = build_scroll_host(host)
@@ -1070,6 +1166,13 @@ class GMTableView(ctk.CTkFrame):
                 existing,
                 preferred["width"],
                 preferred["height"],
+            )
+            return
+
+        if entity_type != "Scenarios" and not entity_has_attachments(item):
+            messagebox.showinfo(
+                "GM Table",
+                f"{label} has no linked portrait, image, or attachment to display on the table.",
             )
             return
 

--- a/tests/scenarios/gm_table/test_entity_attachments.py
+++ b/tests/scenarios/gm_table/test_entity_attachments.py
@@ -1,0 +1,55 @@
+"""Regression tests for GM Table entity attachment discovery."""
+
+from pathlib import Path
+
+from modules.scenarios.gm_table.attachments import (
+    collect_entity_attachments,
+    entity_has_attachments,
+)
+
+
+def _file(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"fixture")
+
+
+def test_collect_entity_attachments_handles_multiple_attachment_formats(
+    tmp_path: Path,
+) -> None:
+    """Attachments can come from images, portrait lists, and delimited attachment fields."""
+    portrait = tmp_path / "assets" / "portrait.png"
+    clue = tmp_path / "assets" / "clue.png"
+    pdf = tmp_path / "docs" / "note.pdf"
+    _file(portrait)
+    _file(clue)
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    record = {
+        "Portrait": ["assets/portrait.png"],
+        "Attachment": "docs/note.pdf, assets/clue.png",
+    }
+
+    attachments = collect_entity_attachments(record, campaign_dir=str(tmp_path))
+
+    assert [attachment.label for attachment in attachments] == [
+        "portrait.png",
+        "note.pdf",
+        "clue.png",
+    ]
+    assert [attachment.is_image for attachment in attachments] == [True, False, True]
+    assert entity_has_attachments(record, campaign_dir=str(tmp_path))
+
+
+def test_collect_entity_attachments_deduplicates_media_paths(tmp_path: Path) -> None:
+    """The same file listed in Portrait and Image should render once."""
+    portrait = tmp_path / "assets" / "portrait.png"
+    _file(portrait)
+
+    attachments = collect_entity_attachments(
+        {"Portrait": "assets/portrait.png", "Image": "assets/portrait.png"},
+        campaign_dir=str(tmp_path),
+    )
+
+    assert len(attachments) == 1
+    assert attachments[0].label == "portrait.png"


### PR DESCRIPTION
### Motivation
- Allow GMs to create a floating image window from the shared Image Library directly from the GM Table add-menu and to show entity attachments on the table when present.
- Ensure entity windows are only opened/restored for non-scenario entities when they actually have linked media/attachments.
- Centralize attachment discovery/parsing, campaign-relative resolution, and de-duplication so the UI can reliably surface image previews and downloadable attachments.

### Description
- Added a reusable attachment helper `modules/scenarios/gm_table/attachments.py` that discovers `Portrait`/`Image` and `Attachment`/`Attachments` fields, resolves campaign-relative paths, de-duplicates entries, and classifies images via `collect_entity_attachments()` and `entity_has_attachments()`.
- Implemented a resizable floating image page and attachment gallery in `modules/scenarios/gm_table/pages.py` as `GMTableImagePage` and `GMTableAttachmentGallery`, and kept CTk image references to avoid Tk garbage collection.
- Wired the GM Table add-menu and image-library integration in `modules/scenarios/gm_table_view.py` to add the `Image from Library` option, open the library in attach-to-table mode, create `image` panels from selections, and to inject attachment galleries above entity details when attachments exist.
- Added a default image panel size in `modules/scenarios/gm_table/workspace.py` and included focused regression tests `tests/scenarios/gm_table/test_entity_attachments.py` for multi-format parsing and deduplication.

### Testing
- Compiled modified modules with `python -m py_compile modules/scenarios/gm_table/attachments.py modules/scenarios/gm_table/pages.py modules/scenarios/gm_table/workspace.py modules/scenarios/gm_table_view.py` and compilation succeeded.
- Ran `pytest tests/scenarios/gm_table/test_entity_attachments.py` and `pytest tests/scenarios/gm_table/test_gm_table_view.py`, which passed for the targeted functionality.
- Ran the broader table test set `pytest tests/scenarios/gm_table`, where the changed-area tests passed but the full suite reports unrelated pre-existing failures (97 passed, 7 failed), including panel-skin/minimized-tray expectation mismatches and two display-dependent Tk tests failing in this headless environment due to missing `$DISPLAY`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cda3c989c832b8cb5b20550fe014d)