### PR TITLE
Refactor GM table windows by stable table ids

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1,4 +1,4 @@
-﻿"""Main application window and startup orchestration."""
+"""Main application window and startup orchestration."""
 
 import os
 import sys
@@ -84,6 +84,12 @@ from modules.events.services.calendar_state_store import CalendarStateStore
 from modules.generic.generic_list_view import GenericListView
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.scenarios.gm_layout_manager import GMScreenLayoutManager
+from modules.scenarios.gm_table.table_registry import (
+    DEFAULT_GM_TABLE_ID,
+    GM_TABLES,
+    get_table_name,
+    normalize_table_id,
+)
 from modules.scenarios.scenario_importer import ScenarioImportWindow
 from modules.objects.object_importer import ObjectImportWindow
 from modules.scenarios.scenario_generator_view import ScenarioGeneratorView
@@ -187,7 +193,7 @@ class MainWindow(ctk.CTk):
         self.current_gm_view = None
         self.current_gm_table = None
         self._gm_mode = False
-        self._gm_table_window = None
+        self._gm_table_windows = {table.table_id: None for table in GM_TABLES}
         self.dice_roller_window = None
         self.dice_bar_window = None
         self.audio_controller = get_audio_controller()
@@ -1378,18 +1384,34 @@ class MainWindow(ctk.CTk):
 
         return dock
 
-    def _get_gm_table_window(self):
-        """Return the detached GM Table window if it is still alive."""
-        window = self.__dict__.get("_gm_table_window")
+    def _get_gm_table_registry(self) -> dict[str, object | None]:
+        """Return the per-table detached-window registry."""
+        registry = self.__dict__.setdefault("_gm_table_windows", {})
+        legacy_window = self.__dict__.pop("_gm_table_window", None)
+        for table in GM_TABLES:
+            registry.setdefault(table.table_id, None)
+        if legacy_window is not None and registry.get(DEFAULT_GM_TABLE_ID) is None:
+            registry[DEFAULT_GM_TABLE_ID] = legacy_window
+        return registry
+
+    def _normalize_gm_table_id(self, table_id: str | None = None) -> str:
+        """Return a known GM Table id, falling back to the primary table."""
+        return normalize_table_id(table_id)
+
+    def _get_gm_table_window(self, table_id: str = DEFAULT_GM_TABLE_ID):
+        """Return a detached GM Table window by stable table id if it is alive."""
+        table_id = self._normalize_gm_table_id(table_id)
+        registry = self._get_gm_table_registry()
+        window = registry.get(table_id)
         if window is None:
             return None
 
         try:
             if not window.winfo_exists():
-                self._clear_gm_table_window_reference(window)
+                self._unregister_gm_table_window(table_id, window)
                 return None
         except Exception:
-            self._clear_gm_table_window_reference(window)
+            self._unregister_gm_table_window(table_id, window)
             return None
 
         return window
@@ -1431,27 +1453,52 @@ class MainWindow(ctk.CTk):
         except Exception:
             pass
 
-    def _clear_gm_table_window_reference(self, window=None) -> None:
-        """Forget the detached GM Table window if it matches the tracked one."""
-        tracked_window = self.__dict__.get("_gm_table_window")
+    def _register_gm_table_window(self, table_id: str, window, view=None) -> None:
+        """Track a detached GM Table window by table id."""
+        table_id = self._normalize_gm_table_id(table_id)
+        self._get_gm_table_registry()[table_id] = window
+        self.current_gm_table = view
+
+    def _unregister_gm_table_window(self, table_id: str, window=None) -> None:
+        """Forget a detached GM Table window if it matches the tracked table."""
+        table_id = self._normalize_gm_table_id(table_id)
+        registry = self._get_gm_table_registry()
+        tracked_window = registry.get(table_id)
         if window is not None and tracked_window is not window:
             return
 
-        self._gm_table_window = None
-        self.current_gm_table = None
+        registry[table_id] = None
+        current_view = (
+            getattr(window, "_gm_table_view", None) if window is not None else None
+        )
+        active_view = getattr(self, "current_gm_table", None)
+        active_table_id = getattr(active_view, "table_id", None)
+        if self.current_gm_table is current_view or (
+            window is None and active_table_id == table_id
+        ):
+            self.current_gm_table = None
 
-    def _close_gm_table_window(self) -> None:
-        """Close the detached GM Table window if it is open."""
-        window = self._get_gm_table_window()
+    def _close_gm_table_window(self, table_id: str = DEFAULT_GM_TABLE_ID) -> None:
+        """Close the detached GM Table window for a single table id if it is open."""
+        table_id = self._normalize_gm_table_id(table_id)
+        window = self._get_gm_table_window(table_id)
         if window is None:
-            self._clear_gm_table_window_reference()
+            self._unregister_gm_table_window(table_id)
             return
 
-        self._clear_gm_table_window_reference(window)
+        self._unregister_gm_table_window(table_id, window)
         try:
             window.destroy()
         except Exception:
             pass
+
+    def _focus_gm_table_window(self, table_id: str = DEFAULT_GM_TABLE_ID):
+        """Focus an existing GM Table window by table id."""
+        window = self._get_gm_table_window(table_id)
+        if window is not None:
+            self.current_gm_table = getattr(window, "_gm_table_view", None)
+            self._focus_detached_window(window)
+        return window
 
     def _toggle_calendar_dock(self):
         """Toggle calendar dock."""
@@ -2883,79 +2930,33 @@ class MainWindow(ctk.CTk):
         """Backward-compatible alias that now launches the campaign overview."""
         self._auto_open_campaign_overview()
 
-    def open_gm_table(self, *, show_empty_message=True, scenario_name=None):
-        """Open the virtual tabletop style GM Table."""
-        scenario_wrapper = self.entity_wrappers.get("scenarios") or GenericModelWrapper("scenarios")
-        self.entity_wrappers.setdefault("scenarios", scenario_wrapper)
-        scenarios = scenario_wrapper.load_items()
-        if not scenarios:
-            if show_empty_message:
-                messagebox.showwarning("No Scenarios", "No scenarios available.")
-            else:
-                log_info(
-                    "Skipped opening GM Table because no scenarios are available",
-                    func_name="main_window.MainWindow.open_gm_table",
-                )
-            return
+    def open_gm_table(
+        self,
+        *,
+        show_empty_message=True,
+        scenario_name=None,
+        table_id: str = DEFAULT_GM_TABLE_ID,
+    ):
+        """Open a virtual tabletop window without requiring scenario selection."""
+        del show_empty_message
+        table_id = self._normalize_gm_table_id(table_id)
+        table_name = get_table_name(table_id)
 
-        def _resolve_scenario_title(item):
-            """Resolve scenario title."""
-            return str((item or {}).get("Title") or (item or {}).get("Name") or "").strip()
-
-        selected = None
-        if scenario_name:
-            selected = next(
-                (item for item in scenarios if _resolve_scenario_title(item) == scenario_name),
-                None,
-            )
-            if selected is None:
-                messagebox.showwarning("GM Table", f"Scenario '{scenario_name}' not found.")
-                return
-        elif len(scenarios) == 1:
-            selected = scenarios[0]
-
-        if selected is None:
-            selection_popup = ctk.CTkToplevel(self)
-            selection_popup.title("Open GM Table")
-            selection_popup.geometry("1200x800")
-            selection_popup.transient(self.winfo_toplevel())
-            selection_popup.grab_set()
-            selection_popup.focus_force()
-
-            def _open_selected(_entity_type, name):
-                """Open the chosen scenario in the GM Table."""
-                selection_popup.destroy()
-                self.open_gm_table(show_empty_message=show_empty_message, scenario_name=name)
-
-            picker = GenericListSelectionView(
-                selection_popup,
-                "Scenarios",
-                scenario_wrapper,
-                load_template("scenarios"),
-                _open_selected,
-            )
-            picker.pack(fill="both", expand=True)
-            return
-
-        selected_title = _resolve_scenario_title(selected)
-        existing_window = self._get_gm_table_window()
+        existing_window = self._focus_gm_table_window(table_id)
         if existing_window is not None:
-            if getattr(existing_window, "_gm_table_scenario_name", None) == selected_title or scenario_name is None:
-                self._focus_detached_window(existing_window)
-                return existing_window
-            self._close_gm_table_window()
+            return existing_window
 
         try:
             from modules.scenarios.gm_table_view import GMTableView
 
             window = ctk.CTkToplevel(self)
-            window.title(f"GM Table - {selected_title}")
+            window.title(f"GM Table - {table_name}")
             self._maximize_detached_window(window)
             self._focus_detached_window(window)
 
             def _on_close():
                 """Handle GM Table close."""
-                self._clear_gm_table_window_reference(window)
+                self._unregister_gm_table_window(table_id, window)
                 try:
                     window.destroy()
                 except Exception:
@@ -2967,18 +2968,21 @@ class MainWindow(ctk.CTk):
             detail_container.pack(fill="both", expand=True)
             view = GMTableView(
                 detail_container,
-                scenario_item=selected,
+                table_id=table_id,
+                table_name=table_name,
                 root_app=self,
             )
             view.pack(fill="both", expand=True)
             window._gm_table_view = view
-            window._gm_table_scenario_name = selected_title
-            self._gm_table_window = window
-            self.current_gm_table = view
+            window._gm_table_id = table_id
+            window._gm_table_name = table_name
+            self._register_gm_table_window(table_id, window, view)
             view.after_idle(view.log_workspace_opened)
+            if scenario_name:
+                view.after_idle(lambda: view.open_entity_panel("Scenarios", scenario_name))
             return window
         except Exception:
-            self._close_gm_table_window()
+            self._close_gm_table_window(table_id)
             raise
 
     def open_gm_screen(self, *, show_empty_message=True, scenario_name=None, initial_layout=None):

--- a/modules/scenarios/gm_table/layout_store.py
+++ b/modules/scenarios/gm_table/layout_store.py
@@ -11,13 +11,13 @@ from modules.helpers.logging_helper import log_info, log_warning
 
 
 class GMTableLayoutStore:
-    """Persist GM Table workspace state per campaign and scenario."""
+    """Persist GM Table workspace state per campaign and table id."""
 
     FILE_NAME = "gm_table_layouts.json"
 
     def __init__(self) -> None:
         self.path = os.path.join(ConfigHelper.get_campaign_dir(), self.FILE_NAME)
-        self.data: dict[str, Any] = {"scenarios": {}, "global": {}}
+        self.data: dict[str, Any] = {"scenarios": {}, "tables": {}, "global": {}}
         self._read()
 
     def _read(self) -> None:
@@ -29,6 +29,7 @@ class GMTableLayoutStore:
                 loaded = json.load(handle)
             if isinstance(loaded, dict):
                 self.data["scenarios"] = dict(loaded.get("scenarios") or {})
+                self.data["tables"] = dict(loaded.get("tables") or {})
                 self.data["global"] = dict(loaded.get("global") or {})
         except Exception as exc:
             log_warning(
@@ -50,6 +51,32 @@ class GMTableLayoutStore:
     def _deep_copy(payload: Any) -> Any:
         """Return a deep copy that is safe to mutate."""
         return json.loads(json.dumps(payload))
+
+
+    def get_table_layout(self, table_id: str) -> dict[str, Any]:
+        """Return the saved layout for a stable table id."""
+        if not table_id:
+            return {}
+        layout = self.data.get("tables", {}).get(table_id) or {}
+        if not isinstance(layout, dict):
+            return {}
+        return self._deep_copy(layout)
+
+    def save_table_layout(self, table_id: str, layout: dict[str, Any]) -> None:
+        """Persist a layout for a stable table id."""
+        if not table_id:
+            return
+        self.data.setdefault("tables", {})[table_id] = self._deep_copy(layout or {})
+        self._write()
+
+    def clear_table_layout(self, table_id: str) -> None:
+        """Delete the layout for a stable table id."""
+        if not table_id:
+            return
+        tables = self.data.setdefault("tables", {})
+        if table_id in tables:
+            tables.pop(table_id, None)
+            self._write()
 
     def get_scenario_layout(self, scenario_title: str) -> dict[str, Any]:
         """Return the saved layout for a scenario."""

--- a/modules/scenarios/gm_table/panel_skins.py
+++ b/modules/scenarios/gm_table/panel_skins.py
@@ -192,7 +192,7 @@ _PANEL_SKINS: dict[str, PanelSkin] = {
         accent_color="#22D4FF",
         object_type="Campaign Dossier",
         icon="📚",
-        show_spine=False,
+        show_spine=True,
         show_file_tab=False,
         show_page_edges=False,
         control_surface="#142240",
@@ -211,17 +211,17 @@ _PANEL_SKINS: dict[str, PanelSkin] = {
         show_spine=False,
         show_file_tab=True,
         show_page_edges=False,
-        control_surface="#1C1E3C",
+        control_surface="#222B3D",
         control_hover_color="#2E3062",
     ),
     # Obsidian Archive — cold dark slate with vivid sky blue.
     # Evokes a stack of classified documents in low light.
     "paper_stack": PanelSkin(
         name="paper_stack",
-        body_color="#0A1422",
-        header_color="#0D1A2E",
-        border_color="#1A3254",
-        accent_color="#0EB4E7",
+        body_color="#111927",
+        header_color="#172235",
+        border_color="#2D3A52",
+        accent_color="#22D3EE",
         object_type="Handout Deck",
         icon="📎",
         show_spine=False,
@@ -293,7 +293,7 @@ _PANEL_SKINS: dict[str, PanelSkin] = {
 }
 
 _PANEL_CHROME: dict[str, PanelChrome] = {
-    "paper_stack": PanelChrome(panel_bg="#0A1422", panel_border="#1A3254", marker="HANDOUT"),
+    "paper_stack": PanelChrome(panel_bg="#111927", panel_border="#2D3A52", marker="HANDOUT"),
     "parchment": PanelChrome(panel_bg="#091A14", panel_border="#165C3A", marker="MAP"),
     "index_cards": PanelChrome(panel_bg="#0D1526", panel_border="#1E3458", marker="NOTE"),
 }

--- a/modules/scenarios/gm_table/table_registry.py
+++ b/modules/scenarios/gm_table/table_registry.py
@@ -1,0 +1,36 @@
+"""Stable GM Table identifiers and default display names."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+DEFAULT_GM_TABLE_NAMES = ("Main", "Table2", "Table3", "Table4", "Table5", "Table6")
+DEFAULT_GM_TABLE_ID = "table_1"
+
+
+@dataclass(frozen=True)
+class GMTableRegistration:
+    """A stable GM Table slot available in the application."""
+
+    table_id: str
+    name: str
+
+
+GM_TABLES = tuple(
+    GMTableRegistration(table_id=f"table_{index}", name=name)
+    for index, name in enumerate(DEFAULT_GM_TABLE_NAMES, start=1)
+)
+GM_TABLE_IDS = frozenset(table.table_id for table in GM_TABLES)
+_GM_TABLE_NAMES_BY_ID = {table.table_id: table.name for table in GM_TABLES}
+
+
+def normalize_table_id(table_id: str | None = None) -> str:
+    """Return a known GM Table id, falling back to the primary table."""
+    candidate = str(table_id or DEFAULT_GM_TABLE_ID).strip()
+    return candidate if candidate in GM_TABLE_IDS else DEFAULT_GM_TABLE_ID
+
+
+def get_table_name(table_id: str) -> str:
+    """Return the default display name for a stable table id."""
+    return _GM_TABLE_NAMES_BY_ID[normalize_table_id(table_id)]

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -23,6 +23,7 @@ from modules.objects.object_shelf_panel import create_object_shelf_panel
 from modules.puzzles.puzzle_display_window import create_puzzle_display_frame
 from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
+from modules.scenarios.gm_table.table_registry import get_table_name, normalize_table_id
 from modules.scenarios.gm_table.attachments import (
     collect_entity_attachments,
     entity_has_attachments,
@@ -75,7 +76,8 @@ class GMTableView(ctk.CTkFrame):
         self,
         master,
         *,
-        scenario_item: dict,
+        table_id: str,
+        table_name: str,
         root_app=None,
         layout_store: GMTableLayoutStore | None = None,
     ) -> None:
@@ -83,10 +85,13 @@ class GMTableView(ctk.CTkFrame):
         self.grid_rowconfigure(1, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
-        self.scenario = scenario_item or {}
-        self.scenario_name = (
-            self.scenario.get("Title") or self.scenario.get("Name") or "Scenario"
+        self.table_id = normalize_table_id(table_id)
+        default_table_name = get_table_name(self.table_id)
+        self.table_name = (
+            str(table_name or default_table_name).strip() or default_table_name
         )
+        self.scenario = {}
+        self.scenario_name = ""
         self._root_app = root_app
         self.layout_store = layout_store or GMTableLayoutStore()
         self._layout_settle_scheduler = LayoutSettleScheduler(self)
@@ -186,7 +191,7 @@ class GMTableView(ctk.CTkFrame):
 
         ctk.CTkLabel(
             bar,
-            text=self.scenario_name,
+            text=self.table_name,
             text_color=TABLE_PALETTE["text"],
             font=ctk.CTkFont(size=15, weight="bold"),
             anchor="w",
@@ -385,7 +390,7 @@ class GMTableView(ctk.CTkFrame):
 
     def _restore_or_seed_layout(self) -> None:
         """Restore saved workspace or create a starter tabletop."""
-        layout = self.layout_store.get_scenario_layout(self.scenario_name)
+        layout = self.layout_store.get_table_layout(self.table_id)
         layout = self._filter_attachmentless_entity_panels(layout)
         if layout.get("panels"):
             self.workspace.restore(layout)
@@ -419,21 +424,18 @@ class GMTableView(ctk.CTkFrame):
         return filtered
 
     def _seed_default_panels(self) -> None:
-        """Build the default workspace focused on scenario and handouts."""
+        """Build the default table workspace without binding it to a scenario."""
         self._create_panel(
-            "entity",
-            f"Scenario: {self.scenario_name}",
-            {
-                "entity_type": "Scenarios",
-                "entity_name": self.scenario_name,
-            },
-            geometry={"x": 24, "y": 24, "width": 1040, "height": 760},
+            "campaign_dashboard",
+            "Campaign Dashboard",
+            {},
+            geometry={"x": 24, "y": 24, "width": 900, "height": 700},
         )
         self._create_panel(
-            "handouts",
-            "Handouts",
-            {"scenario_name": self.scenario_name},
-            geometry={"x": 1080, "y": 24, "width": 560, "height": 760},
+            "note",
+            f"{self.table_name} Notes",
+            {"text": ""},
+            geometry={"x": 948, "y": 24, "width": 520, "height": 520},
         )
 
     def _persist_layout(self) -> None:
@@ -447,8 +449,8 @@ class GMTableView(ctk.CTkFrame):
     def _save_layout_snapshot(self) -> None:
         """Write the latest workspace snapshot to storage."""
         try:
-            self.layout_store.save_scenario_layout(
-                self.scenario_name, self.workspace.serialize()
+            self.layout_store.save_table_layout(
+                self.table_id, self.workspace.serialize()
             )
         except Exception as exc:
             log_warning(
@@ -459,17 +461,17 @@ class GMTableView(ctk.CTkFrame):
     def save_layout_now(self) -> None:
         """Persist immediately and notify the user."""
         self._save_layout_snapshot()
-        messagebox.showinfo("GM Table", f"Layout saved for '{self.scenario_name}'.")
+        messagebox.showinfo("GM Table", f"Layout saved for '{self.table_name}'.")
 
     def reset_table(self) -> None:
-        """Reset the scenario workspace to the starter layout."""
+        """Reset the table workspace to the starter layout."""
         if not messagebox.askyesno(
             "Reset GM Table",
             "Clear every panel on this table and recreate the starter layout?",
         ):
             return
         self.workspace.clear()
-        self.layout_store.clear_scenario_layout(self.scenario_name)
+        self.layout_store.clear_table_layout(self.table_id)
         self._seed_default_panels()
 
     def _tile_panels(self) -> None:
@@ -751,11 +753,7 @@ class GMTableView(ctk.CTkFrame):
             self._create_panel("map_tool", "Map Tool", {})
             return
         if option == "Scene Flow":
-            self._create_panel(
-                "scene_flow",
-                f"Scene Flow: {self.scenario_name}",
-                {"scenario_title": self.scenario_name},
-            )
+            self._open_scenario_selection_for_panel("scene_flow")
             return
         if option == "Image Library":
             self._create_panel("image_library", "Image Library", {})
@@ -764,9 +762,7 @@ class GMTableView(ctk.CTkFrame):
             self._open_image_library_for_table_image()
             return
         if option == "Handouts":
-            self._create_panel(
-                "handouts", "Handouts", {"scenario_name": self.scenario_name}
-            )
+            self._open_scenario_selection_for_panel("handouts")
             return
         if option == "Loot Generator":
             self._create_panel("loot_generator", "Loot Generator", {})
@@ -843,7 +839,6 @@ class GMTableView(ctk.CTkFrame):
                     ),
                     state_getter=lambda _payload: self._panel_state(
                         scenario_title=definition.state.get("scenario_title")
-                        or self.scenario_name
                     ),
                 )
             if kind == "image_library":
@@ -859,10 +854,12 @@ class GMTableView(ctk.CTkFrame):
                     title=str(definition.state.get("image_title") or definition.title),
                 )
             if kind == "handouts":
+                scenario_name = str(definition.state.get("scenario_name") or "").strip()
+                scenario_item = self._load_scenario_item(scenario_name) if scenario_name else {}
                 return GMTableHandoutsPage(
                     parent,
-                    scenario_name=self.scenario_name,
-                    scenario_item=self.scenario,
+                    scenario_name=scenario_name,
+                    scenario_item=scenario_item,
                     wrappers=self.wrappers,
                     map_wrapper=self.map_wrapper,
                     initial_state=definition.state,
@@ -983,7 +980,7 @@ class GMTableView(ctk.CTkFrame):
         """Build the scene flow page."""
         widget = create_scene_flow_frame(
             host,
-            scenario_title=state.get("scenario_title") or self.scenario_name,
+            scenario_title=state.get("scenario_title") or "",
         )
         widget.grid(row=0, column=0, sticky="nsew")
         return widget
@@ -1187,6 +1184,57 @@ class GMTableView(ctk.CTkFrame):
             geometry=self._preferred_entity_geometry(entity_type),
         )
 
+
+    def _load_scenario_item(self, scenario_name: str) -> dict:
+        """Resolve a scenario by title/name for scenario-specific panels."""
+        if not scenario_name:
+            return {}
+        try:
+            item = self._load_entity_item("Scenarios", scenario_name)
+        except Exception:
+            return {}
+        return item if isinstance(item, dict) else {}
+
+    def _open_scenario_selection_for_panel(self, panel_kind: str) -> None:
+        """Ask which scenario should power a scenario-specific panel."""
+        wrapper = self.wrappers.get("Scenarios")
+        template = self._templates.get("Scenarios")
+        if wrapper is None or template is None:
+            messagebox.showerror("GM Table", "Scenarios are not available.")
+            return
+
+        popup = ctk.CTkToplevel(self)
+        popup.title("Select Scenario")
+        popup.geometry("1200x800")
+        popup.transient(self.winfo_toplevel())
+        popup.grab_set()
+        popup.focus_force()
+
+        def _open_selected(
+            selected_type: str, selected_name: str, item: dict | None = None
+        ) -> None:
+            del selected_type
+            popup.destroy()
+            scenario_title = self._entity_label("Scenarios", item, fallback=selected_name)
+            if panel_kind == "scene_flow":
+                self._create_panel(
+                    "scene_flow",
+                    f"Scene Flow: {scenario_title}",
+                    {"scenario_title": scenario_title},
+                )
+                return
+            if panel_kind == "handouts":
+                self._create_panel(
+                    "handouts",
+                    f"Handouts: {scenario_title}",
+                    {"scenario_name": scenario_title},
+                )
+
+        view = GenericListSelectionView(
+            popup, "Scenarios", wrapper, template, _open_selected
+        )
+        view.pack(fill="both", expand=True)
+
     def _open_entity_selection(self, entity_type: str) -> None:
         """Open the generic picker for entity-backed panels."""
         wrapper = self.wrappers.get(entity_type)
@@ -1266,7 +1314,7 @@ class GMTableView(ctk.CTkFrame):
     def log_workspace_opened(self) -> None:
         """Write a trace entry once the view is live."""
         log_info(
-            f"Opened GM Table for {self.scenario_name}",
+            f"Opened GM Table {self.table_id} ({self.table_name})",
             func_name="GMTableView.log_workspace_opened",
         )
 

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -318,18 +318,15 @@ def test_context_menu_binding_helpers_skip_hosts_without_menu_api(monkeypatch) -
     assert recursive_calls[-1][0] is widget
 
 
-def test_handle_add_option_routes_handouts_panel_creation() -> None:
-    """Add menu handouts option should spawn a handouts panel."""
+def test_handle_add_option_routes_handouts_to_scenario_selection() -> None:
+    """Add menu handouts option should ask which scenario powers the panel."""
     captured = []
     view = GMTableView.__new__(GMTableView)
-    view.scenario_name = "Night Run"
-    view._create_panel = lambda kind, title, state: captured.append(
-        (kind, title, state)
-    )
+    view._open_scenario_selection_for_panel = lambda panel_kind: captured.append(panel_kind)
 
     GMTableView._handle_add_option(view, "Handouts")
 
-    assert captured == [("handouts", "Handouts", {"scenario_name": "Night Run"})]
+    assert captured == ["handouts"]
 
 
 def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
@@ -344,15 +341,14 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
     monkeypatch.setattr(gm_table_view_module, "GMTableHandoutsPage", _DummyHandoutsPage)
 
     view = GMTableView.__new__(GMTableView)
-    view.scenario_name = "Night Run"
-    view.scenario = {"Title": "Night Run"}
+    view._load_scenario_item = lambda scenario_name: {"Title": scenario_name}
     view.wrappers = {"NPCs": object()}
     view.map_wrapper = object()
     definition = gm_table_view_module.PanelDefinition(
         panel_id="panel-handouts",
         kind="handouts",
         title="Handouts",
-        state={"query": "map"},
+        state={"scenario_name": "Night Run", "query": "map"},
     )
 
     mounted = GMTableView._mount_panel_content(view, object(), definition)
@@ -360,15 +356,14 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
     assert isinstance(mounted, _DummyHandoutsPage)
     assert captured["kwargs"]["scenario_name"] == "Night Run"
     assert captured["kwargs"]["scenario_item"] == {"Title": "Night Run"}
-    assert captured["kwargs"]["initial_state"] == {"query": "map"}
+    assert captured["kwargs"]["initial_state"] == {"scenario_name": "Night Run", "query": "map"}
 
 
-def test_seed_default_panels_opens_scenario_and_handouts_panels() -> None:
-    """Starter tabletop should open scenario details alongside handouts."""
+def test_seed_default_panels_opens_table_level_panels() -> None:
+    """Starter tabletop should not bind the table identity to a scenario."""
     captured = []
     view = GMTableView.__new__(GMTableView)
-    view.scenario_name = "Night Run"
-    view.scenario = {"Title": "Night Run", "MapName": "Docks"}
+    view.table_name = "Main"
     view._create_panel = lambda kind, title, state, *, geometry=None: captured.append(
         (kind, title, state, geometry)
     )
@@ -377,16 +372,16 @@ def test_seed_default_panels_opens_scenario_and_handouts_panels() -> None:
 
     assert captured == [
         (
-            "entity",
-            "Scenario: Night Run",
-            {"entity_type": "Scenarios", "entity_name": "Night Run"},
-            {"x": 24, "y": 24, "width": 1040, "height": 760},
+            "campaign_dashboard",
+            "Campaign Dashboard",
+            {},
+            {"x": 24, "y": 24, "width": 900, "height": 700},
         ),
         (
-            "handouts",
-            "Handouts",
-            {"scenario_name": "Night Run"},
-            {"x": 1080, "y": 24, "width": 560, "height": 760},
+            "note",
+            "Main Notes",
+            {"text": ""},
+            {"x": 948, "y": 24, "width": 520, "height": 520},
         ),
     ]
 

--- a/tests/scenarios/gm_table/test_layout_store.py
+++ b/tests/scenarios/gm_table/test_layout_store.py
@@ -73,3 +73,32 @@ def test_layout_store_round_trips_camera_and_bookmarks(monkeypatch, tmp_path) ->
     assert loaded["camera"] == payload["camera"]
     assert loaded["home_camera"] == payload["home_camera"]
     assert loaded["bookmarks"] == payload["bookmarks"]
+
+
+def test_layout_store_round_trips_table_layout(monkeypatch, tmp_path) -> None:
+    """Table layouts should persist by stable table id instead of scenario title."""
+    monkeypatch.setattr(
+        "modules.scenarios.gm_table.layout_store.ConfigHelper.get_campaign_dir",
+        lambda: str(tmp_path),
+    )
+
+    first = GMTableLayoutStore()
+    first.save_table_layout(
+        "table_2",
+        {
+            "panels": [
+                {
+                    "panel_id": "panel-2",
+                    "kind": "note",
+                    "title": "Table Notes",
+                    "state": {"text": "Shared table context"},
+                }
+            ]
+        },
+    )
+
+    second = GMTableLayoutStore()
+    loaded = second.get_table_layout("table_2")
+
+    assert loaded["panels"][0]["title"] == "Table Notes"
+    assert loaded["panels"][0]["state"]["text"] == "Shared table context"

--- a/tests/scenarios/gm_table/test_table_registry.py
+++ b/tests/scenarios/gm_table/test_table_registry.py
@@ -1,0 +1,33 @@
+"""Tests for stable GM Table registry metadata."""
+
+from modules.scenarios.gm_table.table_registry import (
+    DEFAULT_GM_TABLE_ID,
+    DEFAULT_GM_TABLE_NAMES,
+    GM_TABLES,
+    get_table_name,
+    normalize_table_id,
+)
+
+
+def test_default_table_registry_exposes_six_stable_ids() -> None:
+    """GM Table windows should be keyed by table_1 through table_6."""
+    assert DEFAULT_GM_TABLE_ID == "table_1"
+    assert DEFAULT_GM_TABLE_NAMES == ("Main", "Table2", "Table3", "Table4", "Table5", "Table6")
+    assert [table.table_id for table in GM_TABLES] == [
+        "table_1",
+        "table_2",
+        "table_3",
+        "table_4",
+        "table_5",
+        "table_6",
+    ]
+    assert [table.name for table in GM_TABLES] == list(DEFAULT_GM_TABLE_NAMES)
+    assert get_table_name("table_1") == "Main"
+    assert get_table_name("table_6") == "Table6"
+
+
+def test_normalize_table_id_falls_back_to_primary_table() -> None:
+    """Unknown table ids should resolve to the default table."""
+    assert normalize_table_id("table_2") == "table_2"
+    assert normalize_table_id(" unknown ") == DEFAULT_GM_TABLE_ID
+    assert normalize_table_id(None) == DEFAULT_GM_TABLE_ID

--- a/tests/test_calendar_dock_lifecycle.py
+++ b/tests/test_calendar_dock_lifecycle.py
@@ -260,11 +260,13 @@ class _FakeFrame:
 class _FakeGMTableView:
     """Fake GM Table view mounted inside the detached window."""
 
-    def __init__(self, master, *, scenario_item, root_app):
+    def __init__(self, master, *, table_id, table_name, root_app):
         """Initialize the _FakeGMTableView instance."""
         self.master = master
-        self.scenario_item = scenario_item
+        self.table_id = table_id
+        self.table_name = table_name
         self.root_app = root_app
+        self.opened_entities = []
         self.pack_calls = []
         self.after_idle_callbacks = []
         self.log_workspace_opened_calls = 0
@@ -277,6 +279,10 @@ class _FakeGMTableView:
         """Handle after idle."""
         self.after_idle_callbacks.append(callback)
 
+    def open_entity_panel(self, entity_type, name):
+        """Record a requested entity panel."""
+        self.opened_entities.append((entity_type, name))
+
     def log_workspace_opened(self):
         """Handle log workspace opened."""
         self.log_workspace_opened_calls += 1
@@ -285,9 +291,8 @@ class _FakeGMTableView:
 def test_open_gm_table_launches_detached_window_without_clearing_main_content(monkeypatch):
     """GM Table should open in its own window and leave the main app alone."""
     window = MainWindow.__new__(MainWindow)
-    scenario = {"Title": "Storm Front"}
-    window.entity_wrappers = {"scenarios": SimpleNamespace(load_items=lambda: [scenario])}
-    window._gm_table_window = None
+    window.entity_wrappers = {}
+    window._gm_table_windows = {}
     window._gm_mode = False
     window.current_gm_table = None
     window.clear_current_content_called = False
@@ -307,16 +312,17 @@ def test_open_gm_table_launches_detached_window_without_clearing_main_content(mo
 
     gm_window = MainWindow.open_gm_table(window, scenario_name="Storm Front")
 
-    assert gm_window is window._gm_table_window
+    assert gm_window is window._gm_table_windows["table_1"]
     assert window._gm_mode is False
     assert window.clear_current_content_called is False
-    assert gm_window.title_text == "GM Table - Storm Front"
+    assert gm_window.title_text == "GM Table - Main"
     assert gm_window.geometry_calls[-1] == "1920x1080+0+0"
     assert gm_window.minsize_calls[-1] == (1600, 900)
     assert gm_window.lift_calls == 1
     assert gm_window.focus_force_calls == 1
     assert gm_window.attributes_calls[0] == ("-topmost", True)
-    assert window.current_gm_table.scenario_item == scenario
+    assert window.current_gm_table.table_id == "table_1"
+    assert window.current_gm_table.table_name == "Main"
     assert window.current_gm_table.root_app is window
     assert window.current_gm_table.pack_calls == [{"fill": "both", "expand": True}]
     assert window.current_gm_table.after_idle_callbacks[0] == window.current_gm_table.log_workspace_opened
@@ -324,17 +330,19 @@ def test_open_gm_table_launches_detached_window_without_clearing_main_content(mo
     gm_window.after_idle_callbacks[0]()
     assert gm_window.attributes_calls[-1] == ("-topmost", False)
     window.current_gm_table.after_idle_callbacks[0]()
+    window.current_gm_table.after_idle_callbacks[1]()
+    assert window.current_gm_table.opened_entities == [("Scenarios", "Storm Front")]
     assert window.current_gm_table.log_workspace_opened_calls == 1
 
 
 def test_open_gm_table_reuses_an_existing_detached_window(monkeypatch):
     """Opening GM Table twice should focus the existing window."""
     window = MainWindow.__new__(MainWindow)
-    scenario = {"Title": "Storm Front"}
-    window.entity_wrappers = {"scenarios": SimpleNamespace(load_items=lambda: [scenario])}
-    window._gm_table_window = _FakeToplevel()
-    window._gm_table_window._gm_table_scenario_name = "Storm Front"
-    window.current_gm_table = _FakeGMTableView(None, scenario_item=scenario, root_app=window)
+    window.entity_wrappers = {}
+    existing = _FakeToplevel()
+    window._gm_table_windows = {"table_1": existing}
+    window.current_gm_table = _FakeGMTableView(None, table_id="table_1", table_name="Main", root_app=window)
+    existing._gm_table_view = window.current_gm_table
     window._gm_mode = False
 
     import modules.scenarios.gm_table_view as gm_table_view_module
@@ -349,20 +357,19 @@ def test_open_gm_table_reuses_an_existing_detached_window(monkeypatch):
 
     gm_window = MainWindow.open_gm_table(window, scenario_name="Storm Front")
 
-    assert gm_window is window._gm_table_window
+    assert gm_window is window._gm_table_windows["table_1"]
     assert gm_window.lift_calls == 1
     assert gm_window.focus_force_calls == 1
     assert gm_window.geometry_calls == []
     assert gm_window.minsize_calls == []
-    assert window.current_gm_table.scenario_item == scenario
+    assert window.current_gm_table.table_id == "table_1"
 
 
 def test_gm_table_window_close_clears_tracked_references(monkeypatch):
     """Closing the detached GM Table should drop the window references."""
     window = MainWindow.__new__(MainWindow)
-    scenario = {"Title": "Storm Front"}
-    window.entity_wrappers = {"scenarios": SimpleNamespace(load_items=lambda: [scenario])}
-    window._gm_table_window = None
+    window.entity_wrappers = {}
+    window._gm_table_windows = {}
     window.current_gm_table = None
     window._gm_mode = False
 
@@ -378,7 +385,7 @@ def test_gm_table_window_close_clears_tracked_references(monkeypatch):
     close_callback()
 
     assert gm_window.destroy_calls == 1
-    assert window._gm_table_window is None
+    assert window._gm_table_windows["table_1"] is None
     assert window.current_gm_table is None
 
 
@@ -386,13 +393,32 @@ def test_get_gm_table_window_clears_dead_reference():
     """Dead detached GM Table windows should be forgotten immediately."""
     window = MainWindow.__new__(MainWindow)
     gm_table_view = object()
-    window._gm_table_window = _FakeToplevel()
-    window._gm_table_window._exists = False
+    dead_window = _FakeToplevel()
+    dead_window._exists = False
+    dead_window._gm_table_view = gm_table_view
+    window._gm_table_windows = {"table_1": dead_window}
     window.current_gm_table = gm_table_view
 
     assert MainWindow._get_gm_table_window(window) is None
-    assert window._gm_table_window is None
+    assert window._gm_table_windows["table_1"] is None
     assert window.current_gm_table is None
+
+
+def test_unregister_empty_table_does_not_clear_active_other_table():
+    """Clearing one empty table slot should not drop the active view for another table."""
+    window = MainWindow.__new__(MainWindow)
+    active_view = _FakeGMTableView(
+        None, table_id="table_2", table_name="Table2", root_app=window
+    )
+    table_2_window = _FakeToplevel()
+    table_2_window._gm_table_view = active_view
+    window._gm_table_windows = {"table_1": None, "table_2": table_2_window}
+    window.current_gm_table = active_view
+
+    MainWindow._unregister_gm_table_window(window, "table_1")
+
+    assert window.current_gm_table is active_view
+    assert window._gm_table_windows["table_2"] is table_2_window
 
 
 def test_toggle_calendar_dock_ignores_destroyed_widget():
@@ -433,7 +459,7 @@ def test_clear_current_content_preserves_calendar_dock():
     window.current_gm_view = object()
     gm_table_view = object()
     window.current_gm_table = gm_table_view
-    window._gm_table_window = _FakeToplevel()
+    window._gm_table_windows = {"table_1": _FakeToplevel()}
     window._teardown_whiteboard_controller = lambda: None
 
     MainWindow.clear_current_content(window)


### PR DESCRIPTION
### Motivation
- Decouple the GM tabletop window from a single scenario so a user can open named table slots without first selecting a scenario. 
- Introduce stable table ids and per-table persistence so layouts and detached windows are managed by table identity (`table_1`..`table_6`) rather than a scenario title.

### Description
- Add a dedicated registry module `modules/scenarios/gm_table/table_registry.py` that defines default table names and helpers `normalize_table_id` / `get_table_name` for stable ids and display names.
- Replace single-window tracking with a per-table registry on `MainWindow` (`_gm_table_windows`) and new helpers: `_get_gm_table_registry`, `_normalize_gm_table_id`, `_get_gm_table_window`, `_register_gm_table_window`, `_unregister_gm_table_window`, `_focus_gm_table_window`, and `_close_gm_table_window`, and update `open_gm_table` to accept an optional `table_id` and no longer require scenario selection.
- Update `GMTableView.__init__` to accept `table_id` and `table_name`, normalize the id, seed table-level default panels, and persist layouts by `table_id` via `GMTableLayoutStore` methods `get_table_layout` / `save_table_layout` / `clear_table_layout` instead of scenario title.
- Keep scenario-driven panels available through the “Add Panel” flows by showing a scenario picker for scenario-specific panel kinds (e.g. `scene_flow`, `handouts`), and fix related panel-skin regressions so panels render with expected chrome and spine properties.

### Testing
- Ran focused unit tests: `pytest -q tests/scenarios/gm_table/test_table_registry.py tests/scenarios/gm_table/test_layout_store.py tests/scenarios/gm_table/test_gm_table_view.py` which passed in this environment.
- Verified panel and minimized-tray styling with `pytest -q tests/scenarios/gm_table/test_panel_skins.py tests/scenarios/gm_table/test_minimized_tray.py` which passed (`14 passed`).
- Performed a broader GM Table test run with display-dependent tests skipped: `pytest -q tests/scenarios/gm_table -k 'not mount_payload_widget'` which passed, while the two `mount_payload_widget` tests fail in this headless environment due to lack of `$DISPLAY` (Tcl/Tk requirement).
- Noted an environment limitation: `tests/test_calendar_dock_lifecycle.py` collection is blocked by a missing `python-docx` dependency (`ModuleNotFoundError: No module named 'docx.shared'`) and package installation was not possible in this environment due to network/package-index restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cdf472288832bb5ffade68b722116)