### PR TITLE
Add table switch dropdown to GM Table toolbar

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -2972,6 +2972,9 @@ class MainWindow(ctk.CTk):
                 detail_container,
                 table_id=table_id,
                 table_name=table_name,
+                on_switch_table=lambda target_table_id: self.open_gm_table(
+                    table_id=target_table_id
+                ),
                 root_app=self,
                 layout_store=layout_store,
             )

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -23,7 +23,11 @@ from modules.objects.object_shelf_panel import create_object_shelf_panel
 from modules.puzzles.puzzle_display_window import create_puzzle_display_frame
 from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
-from modules.scenarios.gm_table.table_registry import get_table_name, normalize_table_id
+from modules.scenarios.gm_table.table_registry import (
+    GM_TABLES,
+    get_table_name,
+    normalize_table_id,
+)
 from modules.scenarios.gm_table.attachments import (
     collect_entity_attachments,
     entity_has_attachments,
@@ -78,6 +82,7 @@ class GMTableView(ctk.CTkFrame):
         *,
         table_id: str,
         table_name: str,
+        on_switch_table=None,
         root_app=None,
         layout_store: GMTableLayoutStore | None = None,
     ) -> None:
@@ -92,6 +97,7 @@ class GMTableView(ctk.CTkFrame):
         )
         self.scenario = {}
         self.scenario_name = ""
+        self._on_switch_table = on_switch_table
         self._root_app = root_app
         self.layout_store = layout_store or GMTableLayoutStore()
         self._layout_settle_scheduler = LayoutSettleScheduler(self)
@@ -199,6 +205,27 @@ class GMTableView(ctk.CTkFrame):
 
         actions = ctk.CTkFrame(bar, fg_color="transparent")
         actions.grid(row=0, column=1, padx=12, pady=8, sticky="e")
+
+        table_names = [table.name for table in GM_TABLES]
+        self._table_name_to_id = {table.name: table.table_id for table in GM_TABLES}
+        self.table_switch_var = tk.StringVar(value=self.table_name)
+        self.table_switch_menu = ctk.CTkOptionMenu(
+            actions,
+            values=table_names,
+            variable=self.table_switch_var,
+            width=132,
+            height=30,
+            fg_color=TABLE_PALETTE["table_chip"],
+            button_color=TABLE_PALETTE["accent"],
+            button_hover_color="#D97706",
+            dropdown_fg_color=TABLE_PALETTE["table_alt"],
+            dropdown_hover_color="#283146",
+            text_color=TABLE_PALETTE["text"],
+            dropdown_text_color=TABLE_PALETTE["text"],
+            corner_radius=14,
+            command=self._handle_table_switch,
+        )
+        self.table_switch_menu.pack(side="left", padx=(0, 10))
 
         self.add_button = ctk.CTkButton(
             actions,
@@ -333,6 +360,23 @@ class GMTableView(ctk.CTkFrame):
             corner_radius=14,
             command=self.reset_table,
         ).pack(side="left")
+
+    def _handle_table_switch(self, table_name: str) -> None:
+        """Request that the application opens or focuses another GM Table."""
+        table_id = self._table_name_to_id.get(table_name)
+        if table_id is None:
+            self.table_switch_var.set(self.table_name)
+            return
+
+        if table_id == self.table_id:
+            return
+
+        if self._on_switch_table is None:
+            self.table_switch_var.set(self.table_name)
+            return
+
+        self._on_switch_table(table_id)
+        self.table_switch_var.set(self.table_name)
 
     def _build_fog_menu(self) -> tk.Menu:
         """Build tabletop fog actions for the active map-capable panel."""

--- a/tests/test_calendar_dock_lifecycle.py
+++ b/tests/test_calendar_dock_lifecycle.py
@@ -260,12 +260,23 @@ class _FakeFrame:
 class _FakeGMTableView:
     """Fake GM Table view mounted inside the detached window."""
 
-    def __init__(self, master, *, table_id, table_name, root_app):
+    def __init__(
+        self,
+        master,
+        *,
+        table_id,
+        table_name,
+        on_switch_table=None,
+        root_app,
+        layout_store=None,
+    ):
         """Initialize the _FakeGMTableView instance."""
         self.master = master
         self.table_id = table_id
         self.table_name = table_name
+        self.on_switch_table = on_switch_table
         self.root_app = root_app
+        self.layout_store = layout_store
         self.opened_entities = []
         self.pack_calls = []
         self.after_idle_callbacks = []
@@ -363,6 +374,35 @@ def test_open_gm_table_reuses_an_existing_detached_window(monkeypatch):
     assert gm_window.geometry_calls == []
     assert gm_window.minsize_calls == []
     assert window.current_gm_table.table_id == "table_1"
+
+
+def test_gm_table_switch_callback_opens_other_table_without_closing_current(monkeypatch):
+    """The table switch callback should open a separate table window."""
+    window = MainWindow.__new__(MainWindow)
+    window.entity_wrappers = {}
+    window._gm_table_windows = {}
+    window.current_gm_table = None
+    window._gm_mode = False
+
+    import modules.scenarios.gm_table_view as gm_table_view_module
+
+    monkeypatch.setattr(main_window.ctk, "CTkToplevel", _FakeToplevel)
+    monkeypatch.setattr(main_window.ctk, "CTkFrame", _FakeFrame)
+    monkeypatch.setattr(gm_table_view_module, "GMTableView", _FakeGMTableView)
+
+    main_window_ref = MainWindow.open_gm_table(window, table_id="table_1")
+    table_one_view = main_window_ref._gm_table_view
+
+    table_two_window = table_one_view.on_switch_table("table_2")
+
+    assert main_window_ref.destroy_calls == 0
+    assert main_window_ref is window._gm_table_windows["table_1"]
+    assert table_two_window is window._gm_table_windows["table_2"]
+    assert table_two_window.title_text == "GM Table - Table2"
+    assert table_two_window._gm_table_view.table_id == "table_2"
+    assert table_two_window._gm_table_view.table_name == "Table2"
+    assert table_two_window._gm_table_view.on_switch_table is not None
+    assert window.current_gm_table is table_two_window._gm_table_view
 
 
 def test_gm_table_window_close_clears_tracked_references(monkeypatch):


### PR DESCRIPTION
### Motivation
- Allow the GM to switch between the six registered GM tables from the GM Table toolbar without destroying the currently open table window. 
- Make the current table visible in the toolbar and ensure switching focuses or opens the target table window instead of replacing the active one.

### Description
- Added an `on_switch_table` callback parameter to `GMTableView` and stored it as `self._on_switch_table` so the view can request table switches via the host application. (`modules/scenarios/gm_table_view.py`).
- Added a table switch control (`ctk.CTkOptionMenu`) populated from `GM_TABLES` that shows all six display names and keeps the visible label in-sync with the current table name in the toolbar. (`modules/scenarios/gm_table_view.py`).
- Implemented `_handle_table_switch` to map the selected display name to a `table_id`, call the provided callback `on_switch_table(table_id)`, and reset the dropdown to the current table when appropriate. (`modules/scenarios/gm_table_view.py`).
- Wired `MainWindow.open_gm_table` to pass a switch callback into `GMTableView` (`on_switch_table=lambda target_table_id: self.open_gm_table(table_id=target_table_id)`), so the main app will focus an existing detached window or create a new `ctk.CTkToplevel` for the target table without destroying the current window. (`main_window.py`).
- Updated test fakes and added a regression test that exercises opening another table via the view callback without destroying the current table window. (`tests/test_calendar_dock_lifecycle.py`).

### Testing
- Ran `pytest tests/scenarios/gm_table/test_table_registry.py` which passed. 
- Ran `python -m py_compile main_window.py modules/scenarios/gm_table_view.py` which succeeded to sanity-check syntax. 
- Attempted to run `pytest tests/test_calendar_dock_lifecycle.py tests/scenarios/gm_table/test_table_registry.py`, but test collection was blocked by an environment dependency error (`ModuleNotFoundError: No module named 'docx.shared'`), so the new calendar-dock lifecycle tests were not executed in that run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cead0a884832b96cb95a9d5c4635e)