### PR TITLE
Log GM Table exception diagnostics

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1411,7 +1411,11 @@ class MainWindow(ctk.CTk):
             if not window.winfo_exists():
                 self._unregister_gm_table_window(table_id, window)
                 return None
-        except Exception:
+        except Exception as exc:
+            log_warning(
+                f"Unable to validate GM Table window '{table_id}'; unregistering it: {exc}",
+                func_name="MainWindow._get_gm_table_window",
+            )
             self._unregister_gm_table_window(table_id, window)
             return None
 
@@ -1421,38 +1425,57 @@ class MainWindow(ctk.CTk):
         """Bring a detached window to the front."""
         try:
             window.lift()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to lift detached window: {exc}",
+                func_name="MainWindow._focus_detached_window",
+            )
 
         try:
             window.focus_force()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to focus detached window: {exc}",
+                func_name="MainWindow._focus_detached_window",
+            )
 
         try:
             window.attributes("-topmost", True)
             window.after_idle(lambda: window.attributes("-topmost", False))
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to toggle detached window topmost state: {exc}",
+                func_name="MainWindow._focus_detached_window",
+            )
 
     def _maximize_detached_window(self, window) -> None:
         """Open a detached window at a desktop-friendly full size."""
         try:
             screen_width = int(window.winfo_screenwidth())
             screen_height = int(window.winfo_screenheight())
-        except Exception:
+        except Exception as exc:
+            log_warning(
+                f"Unable to read detached window screen size; using fallback geometry: {exc}",
+                func_name="MainWindow._maximize_detached_window",
+            )
             screen_width = 1920
             screen_height = 1080
 
         try:
             window.geometry(f"{screen_width}x{screen_height}+0+0")
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to set detached window geometry: {exc}",
+                func_name="MainWindow._maximize_detached_window",
+            )
 
         try:
             window.minsize(min(screen_width, 1600), min(screen_height, 900))
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to set detached window minimum size: {exc}",
+                func_name="MainWindow._maximize_detached_window",
+            )
 
     def _register_gm_table_window(self, table_id: str, window, view=None) -> None:
         """Track a detached GM Table window by table id."""
@@ -1495,8 +1518,11 @@ class MainWindow(ctk.CTk):
                 try:
                     window.title(f"GM Table - {table_name}")
                     window._gm_table_name = table_name
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log_warning(
+                        f"Unable to refresh GM Table window title for '{table.table_id}': {exc}",
+                        func_name="MainWindow.refresh_gm_table_window_names",
+                    )
 
     def _close_gm_table_window(self, table_id: str = DEFAULT_GM_TABLE_ID) -> None:
         """Close the detached GM Table window for a single table id if it is open."""
@@ -1509,8 +1535,11 @@ class MainWindow(ctk.CTk):
         self._unregister_gm_table_window(table_id, window)
         try:
             window.destroy()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to destroy GM Table window '{table_id}': {exc}",
+                func_name="MainWindow._close_gm_table_window",
+            )
 
     def _focus_gm_table_window(self, table_id: str = DEFAULT_GM_TABLE_ID):
         """Focus an existing GM Table window by table id."""
@@ -2980,8 +3009,11 @@ class MainWindow(ctk.CTk):
                 self._unregister_gm_table_window(table_id, window)
                 try:
                     window.destroy()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log_warning(
+                        f"Unable to destroy GM Table window '{table_id}' during close: {exc}",
+                        func_name="MainWindow.open_gm_table._on_close",
+                    )
 
             window.protocol("WM_DELETE_WINDOW", _on_close)
 

--- a/modules/scenarios/gm_table/pages.py
+++ b/modules/scenarios/gm_table/pages.py
@@ -9,6 +9,7 @@ import customtkinter as ctk
 from PIL import Image
 
 from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.logging_helper import log_exception, log_warning
 from modules.helpers.portrait_helper import resolve_portrait_candidate
 from modules.image_assets import ImageAssetsService
 from modules.scenarios.gm_table.attachments import EntityAttachment
@@ -48,8 +49,11 @@ class GMTableHostedPage(ctk.CTkFrame):
             if payload.winfo_manager():
                 return
             payload.grid(row=0, column=0, sticky="nsew")
-        except Exception:
-            pass
+        except Exception as exc:
+            log_exception(
+                f"Unable to mount hosted GM Table page payload: {exc}",
+                func_name="GMTableHostedPage._grid_payload_if_needed",
+            )
 
     def get_state(self) -> dict:
         """Return any serializable page state."""
@@ -57,7 +61,11 @@ class GMTableHostedPage(ctk.CTkFrame):
             return {}
         try:
             state = self._state_getter(self._payload) or {}
-        except Exception:
+        except Exception as exc:
+            log_warning(
+                f"Unable to collect hosted GM Table page state: {exc}",
+                func_name="GMTableHostedPage.get_state",
+            )
             state = {}
         return state if isinstance(state, dict) else {}
 
@@ -67,8 +75,11 @@ class GMTableHostedPage(ctk.CTkFrame):
             return
         try:
             self._close_callback(self._payload)
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to close hosted GM Table page payload: {exc}",
+                func_name="GMTableHostedPage.close",
+            )
 
 
 class GMTableNotePage(ctk.CTkFrame):

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -9,6 +9,7 @@ from typing import Callable
 
 import customtkinter as ctk
 from modules.helpers import theme_manager
+from modules.helpers.logging_helper import log_warning
 from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
 from modules.scenarios.gm_table.drag_controller import GMTableDragController
 from modules.scenarios.gm_table.window_hit_testing import point_inside_map_tool
@@ -2273,8 +2274,11 @@ class GMTableWorkspace(ctk.CTkFrame):
         if payload is not None and hasattr(payload, "close"):
             try:
                 payload.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                log_warning(
+                    f"Unable to close GM Table panel payload '{panel_id}': {exc}",
+                    func_name="GMTableWorkspace.remove_panel",
+                )
         if panel is not None:
             panel.destroy()
         self.clear_snap_preview()
@@ -2842,8 +2846,11 @@ class GMTableWorkspace(ctk.CTkFrame):
                     dynamic_state = payload.get_state() or {}
                     if isinstance(dynamic_state, dict):
                         snapshot.update(dynamic_state)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log_warning(
+                        f"Unable to collect GM Table panel state for '{definition.title}' ({definition.panel_id}): {exc}",
+                        func_name="GMTableWorkspace.serialize_layout",
+                    )
             panels.append(
                 {
                     "panel_id": definition.panel_id,

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -14,7 +14,7 @@ from modules.generic.entity_detail_factory import create_entity_detail_frame
 from modules.generic.generic_list_selection_view import GenericListSelectionView
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.layout_scheduler import LayoutSettleScheduler
-from modules.helpers.logging_helper import log_info, log_warning
+from modules.helpers.logging_helper import log_exception, log_info, log_warning
 from modules.helpers.template_loader import load_template as load_entity_template
 from modules.maps.controllers.display_map_controller import DisplayMapController
 from modules.maps.world_map_view import WorldMapPanel
@@ -385,8 +385,11 @@ class GMTableView(ctk.CTkFrame):
             top = self.winfo_toplevel()
             top.title(f"GM Table - {self.table_name}")
             top._gm_table_name = self.table_name
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to refresh GM Table window title for '{self.table_name}': {exc}",
+                func_name="GMTableView.refresh_table_names",
+            )
 
     def _open_rename_dialog(self) -> None:
         """Open a small dialog for editing this table display name."""
@@ -744,8 +747,11 @@ class GMTableView(ctk.CTkFrame):
             if target_map and hasattr(payload, "load_map"):
                 try:
                     payload.load_map(target_map, push_history=False)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log_exception(
+                        f"Unable to load world map '{target_map}' in existing GM Table panel: {exc}",
+                        func_name="GMTableView._focus_or_open_world_map_panel",
+                    )
             return panel_id
         return self._create_panel(
             "world_map",
@@ -769,8 +775,11 @@ class GMTableView(ctk.CTkFrame):
             if target_map and hasattr(payload, "open_map_by_name"):
                 try:
                     payload.open_map_by_name(target_map)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log_exception(
+                        f"Unable to load map '{target_map}' in existing GM Table map tool panel: {exc}",
+                        func_name="GMTableView._focus_or_open_map_tool_panel",
+                    )
             return panel_id
         return self._create_panel(
             "map_tool",
@@ -1039,8 +1048,11 @@ class GMTableView(ctk.CTkFrame):
         if map_name:
             try:
                 widget.load_map(map_name, push_history=False)
-            except Exception:
-                pass
+            except Exception as exc:
+                log_exception(
+                    f"Unable to restore world map '{map_name}' in GM Table panel: {exc}",
+                    func_name="GMTableView._build_world_map_content",
+                )
         return widget
 
     def _build_map_tool_content(self, host, state: dict):
@@ -1055,8 +1067,11 @@ class GMTableView(ctk.CTkFrame):
         if map_name and hasattr(controller, "open_map_by_name"):
             try:
                 controller.open_map_by_name(map_name)
-            except Exception:
-                pass
+            except Exception as exc:
+                log_exception(
+                    f"Unable to restore map tool map '{map_name}' in GM Table panel: {exc}",
+                    func_name="GMTableView._build_map_tool_content",
+                )
         return controller
 
     def _build_scene_flow_content(self, host, state: dict):
@@ -1407,14 +1422,23 @@ class GMTableView(ctk.CTkFrame):
         try:
             if self._workspace_loaded:
                 self._save_layout_snapshot()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_exception(
+                f"Unable to save GM Table layout during teardown: {exc}",
+                func_name="GMTableView.destroy",
+            )
         try:
             self._layout_settle_scheduler.cancel_all()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to cancel GM Table layout settle jobs during teardown: {exc}",
+                func_name="GMTableView.destroy",
+            )
         try:
             self.workspace.dispose()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_warning(
+                f"Unable to dispose GM Table workspace during teardown: {exc}",
+                func_name="GMTableView.destroy",
+            )
         super().destroy()


### PR DESCRIPTION
### Motivation
- Replace silent `except Exception: pass` handlers across GM Table code to surface actionable diagnostics for failures that are likely to indicate real issues. 
- Prioritize diagnostics for map/world-map loading, panel content mounting, layout save/restore, and table-window focus/register/unregister operations so failures can be triaged instead of silently ignored.

### Description
- Replace silent catches in `modules/scenarios/gm_table_view.py` with logged diagnostics using `log_exception` or `log_warning` for world-map/map-tool loading (`_focus_or_open_world_map_panel`, `_focus_or_open_map_tool_panel`), map restore (`_build_world_map_content`, `_build_map_tool_content`), and layout teardown (`destroy`), preserving existing cleanup behavior.
- Add logging to hosted page lifecycle in `modules/scenarios/gm_table/pages.py` for payload mounting (`GMTableHostedPage._grid_payload_if_needed`), state collection (`GMTableHostedPage.get_state`), and close callbacks (`GMTableHostedPage.close`) using `log_exception`/`log_warning` as appropriate.
- Add warnings in `modules/scenarios/gm_table/workspace.py` when closing panel payloads (`remove_panel`) and when collecting per-panel dynamic state during layout serialization (`serialize_layout`) to record failures without breaking teardown.
- Add diagnostics in `main_window.py` around detached GM Table window handling, including window validation in `_get_gm_table_window`, focus/topmost handling in `_focus_detached_window`, sizing in `_maximize_detached_window`, title refresh in `refresh_gm_table_window_names`, and destroy during close flows, using `log_warning` to report recoverable failures.
- Imported appropriate logging helpers and kept original cleanup/fallback semantics so the UI remains resilient while producing useful logs for debugging.

### Testing
- Ran `python -m compileall modules/scenarios/gm_table_view.py modules/scenarios/gm_table/workspace.py modules/scenarios/gm_table/pages.py main_window.py` which completed successfully.
- Ran `git diff --check` (whitespace/patch checks) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cff471a58832b903cd366f7a54ff0)