### PR TITLE
Filter only attachment-only entity panels and add unavailable-entity fallback

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -490,7 +490,7 @@ class GMTableView(ctk.CTkFrame):
         self._workspace_loaded = True
 
     def _filter_attachmentless_entity_panels(self, layout: dict) -> dict:
-        """Drop saved non-scenario entity panels that no longer have attachments."""
+        """Drop only saved attachment-gallery panels that no longer have attachments."""
         if not isinstance(layout, dict):
             return {}
         filtered = dict(layout)
@@ -500,14 +500,15 @@ class GMTableView(ctk.CTkFrame):
                 panels.append(panel)
                 continue
             state = panel.get("state") or {}
-            entity_type = str(state.get("entity_type") or "")
-            entity_name = str(state.get("entity_name") or "")
-            if entity_type == "Scenarios":
+            if not isinstance(state, dict) or state.get("attachment_only") is not True:
                 panels.append(panel)
                 continue
+            entity_type = str(state.get("entity_type") or "")
+            entity_name = str(state.get("entity_name") or "")
             try:
                 item = self._load_entity_item(entity_type, entity_name)
             except Exception:
+                panels.append(panel)
                 continue
             if entity_has_attachments(item):
                 panels.append(panel)
@@ -1114,7 +1115,12 @@ class GMTableView(ctk.CTkFrame):
         """Build an entity detail page."""
         entity_type = state.get("entity_type")
         entity_name = state.get("entity_name")
-        item = self._load_entity_item(entity_type, entity_name)
+        try:
+            item = self._load_entity_item(entity_type, entity_name)
+        except Exception:
+            return self._build_unavailable_entity_content(
+                host, entity_type=entity_type, entity_name=entity_name
+            )
         attachments = collect_entity_attachments(item)
 
         if attachments:
@@ -1156,6 +1162,38 @@ class GMTableView(ctk.CTkFrame):
             spotlight_only=True,
         )
         frame.grid(row=0, column=0, sticky="nsew")
+        return frame
+
+    def _build_unavailable_entity_content(
+        self, host, *, entity_type: str | None, entity_name: str | None
+    ):
+        """Build a clear fallback for saved entity panels whose record is gone."""
+        host.grid_rowconfigure(0, weight=1)
+        host.grid_columnconfigure(0, weight=1)
+        label = str(entity_name or "Unnamed").strip() or "Unnamed"
+        type_label = str(entity_type or "entity").strip() or "entity"
+        frame = ctk.CTkFrame(host, fg_color="transparent")
+        frame.grid(row=0, column=0, sticky="nsew", padx=24, pady=24)
+        frame.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(
+            frame,
+            text="Entity unavailable",
+            text_color=TABLE_PALETTE["text"],
+            font=ctk.CTkFont(size=18, weight="bold"),
+            anchor="w",
+        ).grid(row=0, column=0, sticky="ew")
+        ctk.CTkLabel(
+            frame,
+            text=(
+                f"The saved panel points to {type_label} '{label}', "
+                "but that record could not be found. The panel was kept so you "
+                "can decide whether to close it or recreate the entity."
+            ),
+            text_color=TABLE_PALETTE["muted"],
+            justify="left",
+            wraplength=460,
+            anchor="w",
+        ).grid(row=1, column=0, sticky="ew", pady=(10, 0))
         return frame
 
     @staticmethod
@@ -1272,13 +1310,16 @@ class GMTableView(ctk.CTkFrame):
             return
 
         singular = entity_type[:-1] if entity_type.endswith("s") else entity_type
+        state = {
+            "entity_type": entity_type,
+            "entity_name": label,
+        }
+        if entity_type != "Scenarios":
+            state["attachment_only"] = True
         self._create_panel(
             "entity",
             f"{singular}: {label}",
-            {
-                "entity_type": entity_type,
-                "entity_name": label,
-            },
+            state,
             geometry=self._preferred_entity_geometry(entity_type),
         )
 

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -598,3 +598,58 @@ def test_hosted_page_keeps_already_managed_payload_in_place() -> None:
     GMTableHostedPage._grid_payload_if_needed(page)
 
     assert payload.grid_calls == []
+
+
+def test_filter_attachmentless_entity_panels_preserves_normal_entity_panels() -> None:
+    """Only attachment-only entity panels should be eligible for attachment filtering."""
+    view = GMTableView.__new__(GMTableView)
+    view._load_entity_item = lambda _entity_type, _name: {"Name": "No Media"}
+    layout = {
+        "panels": [
+            {
+                "panel_id": "normal-entity",
+                "kind": "entity",
+                "state": {"entity_type": "NPCs", "entity_name": "No Media"},
+            },
+            {
+                "panel_id": "attachment-gallery",
+                "kind": "entity",
+                "state": {
+                    "entity_type": "NPCs",
+                    "entity_name": "No Media",
+                    "attachment_only": True,
+                },
+            },
+        ]
+    }
+
+    filtered = GMTableView._filter_attachmentless_entity_panels(view, layout)
+
+    assert [panel["panel_id"] for panel in filtered["panels"]] == ["normal-entity"]
+
+
+def test_filter_attachmentless_entity_panels_keeps_missing_entities_for_fallback() -> None:
+    """Missing saved entities should remain so the unavailable fallback can explain it."""
+    view = GMTableView.__new__(GMTableView)
+
+    def _missing(_entity_type, _name):
+        raise KeyError("missing")
+
+    view._load_entity_item = _missing
+    layout = {
+        "panels": [
+            {
+                "panel_id": "missing-gallery",
+                "kind": "entity",
+                "state": {
+                    "entity_type": "NPCs",
+                    "entity_name": "Gone",
+                    "attachment_only": True,
+                },
+            }
+        ]
+    }
+
+    filtered = GMTableView._filter_attachmentless_entity_panels(view, layout)
+
+    assert filtered["panels"] == layout["panels"]


### PR DESCRIPTION
### Motivation
- Previously the table restore logic dropped every non-scenario `entity` panel that lacked attachments, which removed normal entity-detail panels unintentionally.
- Panels created via the attachment/gallery flow should be removable when attachments disappear, while full entity-detail panels must be preserved.
- When a saved panel points to an entity that no longer exists the UI should show a clear fallback instead of silently discarding the saved panel.

### Description
- Change `_filter_attachmentless_entity_panels` to only consider panels for removal when `panel["state"]["attachment_only"] is True` and preserve other `entity` panels unchanged.
- Mark entity panels created by the attachment-oriented flow with `state["attachment_only"] = True` when `entity_type != "Scenarios"` so restorations can distinguish gallery-only panels from normal detail panels.
- Add `_build_unavailable_entity_content(host, *, entity_type, entity_name)` and use it from `_build_entity_content` when `_load_entity_item` raises, providing a visible "Entity unavailable" fallback instead of dropping the panel.
- Add targeted tests `test_filter_attachmentless_entity_panels_preserves_normal_entity_panels` and `test_filter_attachmentless_entity_panels_keeps_missing_entities_for_fallback` to verify preservation of normal entity panels and retention of missing-entity panels for the unavailable fallback.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table_view.py` which succeeded with no syntax errors.
- Ran targeted tests with `pytest tests/scenarios/gm_table/test_gm_table_view.py -q -k 'filter_attachmentless or open_entity_panel_uses_useful_geometry_for_new_scenario_panel or build_entity_content_calls_detail_factory'` and they passed.
- Ran the full file tests with `pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and observed a pre-existing unrelated test failure (`AttributeError: type object 'GMTableView' has no attribute '_apply_fog_action'`) which is not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d09993fbc832b9e664bf5ed08e424)