### PR TITLE
Clarify GM Table compatibility parameter

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -2987,7 +2987,9 @@ class MainWindow(ctk.CTk):
         table_id: str = DEFAULT_GM_TABLE_ID,
     ):
         """Open a virtual tabletop window without requiring scenario selection."""
-        del show_empty_message
+        # ``show_empty_message`` is retained for backwards-compatible callers.
+        # GM Table is now global, so opening it no longer depends on scenario
+        # availability and does not need a scenario-empty warning.
         table_id = self._normalize_gm_table_id(table_id)
         layout_store = GMTableLayoutStore()
         table_name = layout_store.get_table_name(table_id)


### PR DESCRIPTION
### Motivation
- Retain the `show_empty_message` parameter on `open_gm_table` for backwards compatibility and remove the meaningless `del show_empty_message` usage because the GM Table is now global and no scenario-empty warning is required.

### Description
- Replaced the bare `del show_empty_message` in `MainWindow.open_gm_table` with an explanatory comment and left the `show_empty_message` parameter in the signature for compatibility, and searched callers to ensure none are still passing `show_empty_message` to `open_gm_table` unnecessarily.

### Testing
- Ran `python -m py_compile main_window.py` and project-wide `rg` checks for `open_gm_table`/`show_empty_message`, both succeeded; attempted `pytest` for selected tests but collection failed due to an environment missing `docx.shared` (ModuleNotFoundError for `docx.shared`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2f0bea6c832bb203d9a1ab72ee7c)