### PR TITLE
Centralize GM Table rename path (MainWindow.rename_gm_table)

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1502,13 +1502,38 @@ class MainWindow(ctk.CTk):
         ):
             self.current_gm_table = None
 
+    def rename_gm_table(self, table_id: str, new_name: str) -> None:
+        """Persist a GM Table display name and synchronize every launcher label."""
+        table_id = self._normalize_gm_table_id(table_id)
+        GMTableLayoutStore().save_table_name(table_id, new_name)
+        self.refresh_gm_table_window_names()
+        self._refresh_gm_table_launcher_labels()
+
+    def _refresh_gm_table_launcher_labels(self) -> None:
+        """Refresh future sidebar or launcher labels that expose GM Table names."""
+        refresh_callbacks = (
+            "refresh_gm_table_launcher_labels",
+            "refresh_gm_table_sidebar_labels",
+            "refresh_gm_table_labels",
+        )
+        for callback_name in refresh_callbacks:
+            callback = getattr(self, callback_name, None)
+            if callable(callback):
+                try:
+                    callback()
+                except Exception as exc:
+                    log_warning(
+                        f"Unable to refresh GM Table launcher labels via '{callback_name}': {exc}",
+                        func_name="MainWindow._refresh_gm_table_launcher_labels",
+                    )
+
     def refresh_gm_table_window_names(self) -> None:
         """Refresh titles and switch labels in every open GM Table window."""
+        table_name_store = GMTableLayoutStore()
         for table in GM_TABLES:
             window = self._get_gm_table_window(table.table_id)
             if window is None:
                 continue
-            table_name_store = GMTableLayoutStore()
             view = getattr(window, "_gm_table_view", None)
             if view is not None and hasattr(view, "refresh_table_names"):
                 view.layout_store = table_name_store

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -425,12 +425,14 @@ class GMTableView(ctk.CTkFrame):
         entry.select_range(0, "end")
 
     def rename_table(self, name: str) -> None:
-        """Persist this table display name and refresh every open GM Table window."""
+        """Delegate table renames to the root app so every label stays in sync."""
+        root_app = self._root_app
+        if root_app is not None and hasattr(root_app, "rename_gm_table"):
+            root_app.rename_gm_table(self.table_id, name)
+            return
+
         self.layout_store.save_table_name(self.table_id, name)
         self.refresh_table_names()
-        root_app = self._root_app
-        if root_app is not None and hasattr(root_app, "refresh_gm_table_window_names"):
-            root_app.refresh_gm_table_window_names()
 
     def _handle_table_switch(self, table_name: str) -> None:
         """Request that the application opens or focuses another GM Table."""

--- a/tests/test_calendar_dock_lifecycle.py
+++ b/tests/test_calendar_dock_lifecycle.py
@@ -281,6 +281,12 @@ class _FakeGMTableView:
         self.pack_calls = []
         self.after_idle_callbacks = []
         self.log_workspace_opened_calls = 0
+        self.refresh_table_names_calls = 0
+
+    def refresh_table_names(self):
+        """Record table-name refreshes."""
+        self.refresh_table_names_calls += 1
+        self.table_name = self.layout_store.get_table_name(self.table_id)
 
     def pack(self, **kwargs):
         """Handle pack."""
@@ -404,6 +410,69 @@ def test_gm_table_switch_callback_opens_other_table_without_closing_current(monk
     assert table_two_window._gm_table_view.on_switch_table is not None
     assert window.current_gm_table is table_two_window._gm_table_view
 
+
+def test_rename_gm_table_saves_and_refreshes_every_open_table(monkeypatch, tmp_path):
+    """Root-level GM Table renames should persist once and refresh all labels."""
+    window = MainWindow.__new__(MainWindow)
+    table_one_window = _FakeToplevel()
+    table_two_window = _FakeToplevel()
+    table_one_view = _FakeGMTableView(
+        None, table_id="table_1", table_name="Main", root_app=window
+    )
+    table_two_view = _FakeGMTableView(
+        None, table_id="table_2", table_name="Table2", root_app=window
+    )
+    table_one_window._gm_table_view = table_one_view
+    table_two_window._gm_table_view = table_two_view
+    window._gm_table_windows = {"table_1": table_one_window, "table_2": table_two_window}
+    window.current_gm_table = table_one_view
+    window.launcher_refreshes = 0
+    window.refresh_gm_table_launcher_labels = lambda: setattr(
+        window, "launcher_refreshes", window.launcher_refreshes + 1
+    )
+
+    monkeypatch.setattr(
+        "modules.scenarios.gm_table.layout_store.ConfigHelper.get_campaign_dir",
+        lambda: str(tmp_path),
+    )
+
+    MainWindow.rename_gm_table(window, "table_1", "War Room")
+
+    assert table_one_view.table_name == "War Room"
+    assert table_two_view.table_name == "Table2"
+    assert table_one_view.refresh_table_names_calls == 1
+    assert table_two_view.refresh_table_names_calls == 1
+    assert window.launcher_refreshes == 1
+
+    from modules.scenarios.gm_table.layout_store import GMTableLayoutStore
+
+    assert GMTableLayoutStore().get_table_name("table_1") == "War Room"
+
+
+def test_gm_table_view_rename_delegates_to_root_app():
+    """GMTableView should not save names directly when a root app is available."""
+    from modules.scenarios.gm_table_view import GMTableView
+
+    view = GMTableView.__new__(GMTableView)
+    view.table_id = "table_2"
+    view._root_app = SimpleNamespace(rename_calls=[])
+
+    def _rename_gm_table(table_id, name):
+        view._root_app.rename_calls.append((table_id, name))
+
+    view._root_app.rename_gm_table = _rename_gm_table
+    view.layout_store = SimpleNamespace(
+        save_table_name=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("rename_table should delegate to root app")
+        )
+    )
+    view.refresh_table_names = lambda: (_ for _ in ()).throw(
+        AssertionError("root app handles GM Table refreshes")
+    )
+
+    GMTableView.rename_table(view, "Side Table")
+
+    assert view._root_app.rename_calls == [("table_2", "Side Table")]
 
 def test_gm_table_window_close_clears_tracked_references(monkeypatch):
     """Closing the detached GM Table should drop the window references."""


### PR DESCRIPTION
### Motivation
- Ensure all GM Table display-name changes flow through a single root-level path so open windows, launcher/sidebar labels, and persisted names remain synchronized.
- Avoid duplicated persistence logic in `GMTableView` and keep UI refreshes coordinated by the application root.

### Description
- Added a root-level method `MainWindow.rename_gm_table(table_id: str, new_name: str)` that normalizes `table_id`, saves the new name via `GMTableLayoutStore().save_table_name(...)`, calls `refresh_gm_table_window_names()`, and triggers launcher/sidebar label refresh hooks via `_refresh_gm_table_launcher_labels()`.
- Implemented `MainWindow._refresh_gm_table_launcher_labels()` which attempts to call a small set of optional refresh callbacks (`refresh_gm_table_launcher_labels`, `refresh_gm_table_sidebar_labels`, `refresh_gm_table_labels`) if present on the `MainWindow` instance.
- Reworked `MainWindow.refresh_gm_table_window_names()` to reuse a single `GMTableLayoutStore()` instance when refreshing multiple open GM Table windows.
- Updated `GMTableView.rename_table` to delegate to `root_app.rename_gm_table(self.table_id, name)` when the view is hosted by a `MainWindow`, falling back to the previous local save/refresh behavior when no root app is present.
- Added regression tests to `tests/test_calendar_dock_lifecycle.py` validating that `rename_gm_table` persists the name, refreshes open windows (via fake views), invokes launcher refresh hooks, and that `GMTableView.rename_table` delegates to the root app when available; added a small `refresh_table_names()` recorder to the fake view used in tests.

### Testing
- Ran static compile checks with `python -m py_compile main_window.py modules/scenarios/gm_table_view.py tests/test_calendar_dock_lifecycle.py`, which succeeded.
- Ran targeted unit tests with `pytest tests/scenarios/gm_table/test_layout_store.py tests/scenarios/gm_table/test_table_name_labels.py -q`, which passed (`11 passed`).
- Attempted `pytest tests/test_calendar_dock_lifecycle.py -q` to exercise the added integration tests, but collection was blocked by an environment import issue where a local `docx.py` shadowed `python-docx`, yielding `ModuleNotFoundError: No module named 'docx.shared'; 'docx' is not a package` during test discovery (this is an external environment dependency, not related to the changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d33768638832b814580cab170e705)