### PR TITLE
Add GM Table add-panel menu to container windows

### DIFF
--- a/modules/scenarios/gm_table/container_window.py
+++ b/modules/scenarios/gm_table/container_window.py
@@ -30,13 +30,20 @@ class GMTableContainerPage(ctk.CTkFrame):
         master,
         *,
         initial_state: dict | None = None,
+        add_menu_options: list | None = None,
+        on_add_panel=None,
+        panel_builder=None,
         on_layout_changed=None,
     ) -> None:
         super().__init__(master, fg_color="transparent")
         self.grid_rowconfigure(1, weight=1)
         self.grid_columnconfigure(0, weight=1)
         self._initial_state = initial_state or {}
+        self._add_menu_options = add_menu_options or []
+        self._on_add_panel = on_add_panel
+        self._panel_builder = panel_builder
         self._on_layout_changed = on_layout_changed
+        self._add_menu = self._build_add_menu()
         self._build_toolbar()
         self.workspace = GMTableWorkspace(
             self,
@@ -69,6 +76,10 @@ class GMTableContainerPage(ctk.CTkFrame):
         actions = ctk.CTkFrame(toolbar, fg_color="transparent")
         actions.grid(row=0, column=1, sticky="e", padx=8, pady=6)
 
+        self.add_panel_button = self._accent_button(
+            actions, "+ Add Panel", self._show_add_menu
+        )
+        self.add_panel_button.pack(side="left", padx=(0, 6))
         self._add_button(actions, "New Window", self.add_window).pack(
             side="left", padx=(0, 6)
         )
@@ -80,6 +91,54 @@ class GMTableContainerPage(ctk.CTkFrame):
             side="left", padx=(0, 6)
         )
         self._add_button(actions, "Restore", self.restore_windows).pack(side="left")
+
+    def _build_add_menu(self):
+        """Build the same add-panel menu used by the main GM Table toolbar."""
+        import tkinter as tk
+
+        menu = tk.Menu(self, tearoff=0)
+        for option in self._add_menu_options:
+            if option == "separator":
+                menu.add_separator()
+                continue
+            if isinstance(option, tuple):
+                label, command = option
+                menu.add_command(label=label, command=command)
+                continue
+            menu.add_command(
+                label=option,
+                command=lambda value=option: self._handle_add_panel_option(value),
+            )
+        return menu
+
+    def _show_add_menu(self) -> None:
+        """Open the add-panel menu under the container toolbar button."""
+        x = self.add_panel_button.winfo_rootx()
+        y = self.add_panel_button.winfo_rooty() + self.add_panel_button.winfo_height()
+        try:
+            self._add_menu.tk_popup(x, y)
+        finally:
+            self._add_menu.grab_release()
+
+    def _handle_add_panel_option(self, option: str) -> None:
+        """Route main-table add-panel choices into this nested workspace."""
+        if callable(self._on_add_panel):
+            self._on_add_panel(option, self.workspace)
+
+    @staticmethod
+    def _accent_button(master, text: str, command):
+        """Create the highlighted add-panel toolbar button."""
+        return ctk.CTkButton(
+            master,
+            text=text,
+            width=112,
+            height=28,
+            fg_color=TABLE_PALETTE["accent"],
+            hover_color="#D97706",
+            text_color="#10131B",
+            corner_radius=14,
+            command=command,
+        )
 
     @staticmethod
     def _add_button(master, text: str, command):
@@ -174,6 +233,14 @@ class GMTableContainerPage(ctk.CTkFrame):
                 session_controls_enabled=False,
                 scenario_actions_enabled=False,
             )
+        if definition.kind == "container_card":
+            return GMTableContainerCard(
+                parent,
+                title=definition.title,
+                body=str(definition.state.get("body") or ""),
+            )
+        if callable(self._panel_builder):
+            return self._panel_builder(parent, definition)
         return GMTableContainerCard(
             parent,
             title=definition.title,

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -598,32 +598,76 @@ class GMTableView(ctk.CTkFrame):
         }
 
     def _create_panel(
-        self, kind: str, title: str, state: dict, *, geometry: dict | None = None
+        self,
+        kind: str,
+        title: str,
+        state: dict,
+        *,
+        geometry: dict | None = None,
+        workspace: GMTableWorkspace | None = None,
     ) -> str:
-        """Create a new floating panel."""
+        """Create a new floating panel in the requested workspace."""
         definition = PanelDefinition(
             panel_id=uuid4().hex,
             kind=kind,
             title=title,
             state=dict(state or {}),
         )
-        self.workspace.add_panel(definition, geometry=geometry)
+        target_workspace = workspace or self.workspace
+        target_workspace.add_panel(definition, geometry=geometry)
         return definition.panel_id
 
-    def _add_image_panel_from_library_result(self, image_result) -> None:
+    def _create_panel_in_workspace(
+        self,
+        kind: str,
+        title: str,
+        state: dict,
+        *,
+        geometry: dict | None = None,
+        workspace: GMTableWorkspace | None = None,
+    ) -> str:
+        """Create a panel while preserving older call sites that monkeypatch _create_panel."""
+        if workspace is None:
+            if geometry is None:
+                return self._create_panel(kind, title, state)
+            return self._create_panel(kind, title, state, geometry=geometry)
+        return self._create_panel(
+            kind, title, state, geometry=geometry, workspace=workspace
+        )
+
+    def _create_panel_in_selection_workspace(
+        self,
+        kind: str,
+        title: str,
+        state: dict,
+        *,
+        geometry: dict | None = None,
+        workspace: GMTableWorkspace | None = None,
+    ) -> str:
+        """Alias used by delayed picker callbacks to target the initiating workspace."""
+        return self._create_panel_in_workspace(
+            kind, title, state, geometry=geometry, workspace=workspace
+        )
+
+    def _add_image_panel_from_library_result(
+        self, image_result, *, workspace: GMTableWorkspace | None = None
+    ) -> None:
         """Create a floating image window from an image-library selection."""
         image_path = str(getattr(image_result, "path", "") or "").strip()
         if not image_path:
             messagebox.showerror("GM Table", "The selected image has no usable path.")
             return
         image_title = str(getattr(image_result, "name", "") or "").strip() or "Image"
-        self._create_panel(
+        self._create_panel_in_workspace(
             "image",
             image_title,
             {"image_path": image_path, "image_title": image_title},
+            workspace=workspace,
         )
 
-    def _open_image_library_for_table_image(self) -> None:
+    def _open_image_library_for_table_image(
+        self, *, workspace: GMTableWorkspace | None = None
+    ) -> None:
         """Open the shared image library dialog in attach-to-table mode."""
         try:
             from modules.ui.image_library.dialogs.library_browser_dialog import (
@@ -637,7 +681,9 @@ class GMTableView(ctk.CTkFrame):
 
         dialog = ImageLibraryBrowserDialog(
             self.winfo_toplevel(),
-            on_attach_to_entity=self._add_image_panel_from_library_result,
+            on_attach_to_entity=lambda result: self._add_image_panel_from_library_result(
+                result, workspace=workspace
+            ),
         )
         dialog.title("Add Image to GM Table")
 
@@ -830,66 +876,121 @@ class GMTableView(ctk.CTkFrame):
             "GM Table", "The active map panel does not support fog tools."
         )
 
-    def _handle_add_option(self, option: str) -> None:
-        """Route add-menu options."""
+    def _handle_add_option(
+        self, option: str, *, workspace: GMTableWorkspace | None = None
+    ) -> None:
+        """Route add-menu options to the main table or a nested container workspace."""
         if option == "Campaign Dashboard":
-            self._create_panel("campaign_dashboard", "Campaign Dashboard", {})
+            self._create_panel_in_workspace(
+                "campaign_dashboard", "Campaign Dashboard", {}, workspace=workspace
+            )
             return
         if option == "World Map":
-            self._create_panel("world_map", "World Map", {})
+            self._create_panel_in_workspace(
+                "world_map", "World Map", {}, workspace=workspace
+            )
             return
         if option == "Map Tool":
-            self._create_panel("map_tool", "Map Tool", {})
+            self._create_panel_in_workspace(
+                "map_tool", "Map Tool", {}, workspace=workspace
+            )
             return
         if option == "Scene Flow":
-            self._open_scenario_selection_for_panel("scene_flow")
+            (
+                self._open_scenario_selection_for_panel("scene_flow")
+                if workspace is None
+                else self._open_scenario_selection_for_panel(
+                    "scene_flow", workspace=workspace
+                )
+            )
             return
         if option == "Image Library":
-            self._create_panel("image_library", "Image Library", {})
+            self._create_panel_in_workspace(
+                "image_library", "Image Library", {}, workspace=workspace
+            )
             return
         if option == "Image from Library":
-            self._open_image_library_for_table_image()
+            (
+                self._open_image_library_for_table_image()
+                if workspace is None
+                else self._open_image_library_for_table_image(workspace=workspace)
+            )
             return
         if option == "Handouts":
-            self._open_scenario_selection_for_panel("handouts")
+            (
+                self._open_scenario_selection_for_panel("handouts")
+                if workspace is None
+                else self._open_scenario_selection_for_panel(
+                    "handouts", workspace=workspace
+                )
+            )
             return
         if option == "Container Window":
-            self._create_panel("container_window", "Container Window", {})
+            self._create_panel_in_workspace(
+                "container_window", "Container Window", {}, workspace=workspace
+            )
             return
         if option == "Loot Generator":
-            self._create_panel("loot_generator", "Loot Generator", {})
+            self._create_panel_in_workspace(
+                "loot_generator", "Loot Generator", {}, workspace=workspace
+            )
             return
         if option == "Object Shelf":
-            self._create_panel("object_shelf", "Object Shelf", {})
+            self._create_panel_in_workspace(
+                "object_shelf", "Object Shelf", {}, workspace=workspace
+            )
             return
         if option == "Whiteboard":
-            self._create_panel("whiteboard", "Whiteboard", {})
+            self._create_panel_in_workspace(
+                "whiteboard", "Whiteboard", {}, workspace=workspace
+            )
             return
         if option == "Random Tables":
-            self._create_panel("random_tables", "Random Tables", {})
+            self._create_panel_in_workspace(
+                "random_tables", "Random Tables", {}, workspace=workspace
+            )
             return
         if option == "Plot Twists":
-            self._create_panel("plot_twists", "Plot Twists", {})
+            self._create_panel_in_workspace(
+                "plot_twists", "Plot Twists", {}, workspace=workspace
+            )
             return
         if option == "Puzzle Display":
-            self._open_puzzle_selection()
+            (
+                self._open_puzzle_selection()
+                if workspace is None
+                else self._open_puzzle_selection(workspace=workspace)
+            )
             return
         if option == "Note Tab":
             existing_notes = [
                 panel
-                for panel in self.workspace.serialize().get("panels", [])
+                for panel in (workspace or self.workspace).serialize().get("panels", [])
                 if panel.get("kind") == "note"
             ]
-            self._create_panel("note", f"Note {len(existing_notes) + 1}", {"text": ""})
+            self._create_panel_in_workspace(
+                "note",
+                f"Note {len(existing_notes) + 1}",
+                {"text": ""},
+                workspace=workspace,
+            )
             return
         if option == "Character Graph":
-            self._create_panel("character_graph", "Character Graph", {})
+            self._create_panel_in_workspace(
+                "character_graph", "Character Graph", {}, workspace=workspace
+            )
             return
         if option == "Scenario Graph Editor":
-            self._create_panel("scenario_graph", "Scenario Graph", {})
+            self._create_panel_in_workspace(
+                "scenario_graph", "Scenario Graph", {}, workspace=workspace
+            )
             return
         if option in ENTITY_TYPES:
-            self._open_entity_selection(option)
+            (
+                self._open_entity_selection(option)
+                if workspace is None
+                else self._open_entity_selection(option, workspace=workspace)
+            )
             return
 
     def _mount_panel_content(self, parent: ctk.CTkFrame, definition: PanelDefinition):
@@ -962,6 +1063,11 @@ class GMTableView(ctk.CTkFrame):
                 return GMTableContainerPage(
                     parent,
                     initial_state=definition.state,
+                    add_menu_options=getattr(self, "_add_menu_options", []),
+                    on_add_panel=lambda option, target_workspace: self._handle_add_option(
+                        option, workspace=target_workspace
+                    ),
+                    panel_builder=self._mount_panel_content,
                     on_layout_changed=self._persist_layout,
                 )
             if kind == "loot_generator":
@@ -1300,9 +1406,11 @@ class GMTableView(ctk.CTkFrame):
         entity_name: str,
         *,
         item: dict | None = None,
+        workspace: GMTableWorkspace | None = None,
     ) -> str | None:
-        """Return the existing entity panel id when present."""
-        layout = self.workspace.serialize()
+        """Return the existing entity panel id when present in a workspace."""
+        target_workspace = workspace or self.workspace
+        layout = target_workspace.serialize()
         lookup_names = self._entity_aliases(
             entity_type, item=item, fallback=entity_name
         )
@@ -1317,8 +1425,15 @@ class GMTableView(ctk.CTkFrame):
                 return str(panel.get("panel_id"))
         return None
 
-    def open_entity_panel(self, entity_type: str, name: str) -> None:
-        """Open a specific entity inside the GM Table."""
+    def open_entity_panel(
+        self,
+        entity_type: str,
+        name: str,
+        *,
+        workspace: GMTableWorkspace | None = None,
+    ) -> None:
+        """Open a specific entity inside the GM Table or a nested container."""
+        target_workspace = workspace or self.workspace
         try:
             item = self._load_entity_item(entity_type, name)
         except Exception as exc:
@@ -1326,11 +1441,13 @@ class GMTableView(ctk.CTkFrame):
             return
 
         label = self._entity_label(entity_type, item, fallback=name)
-        existing = self._find_existing_entity_panel(entity_type, label, item=item)
+        existing = self._find_existing_entity_panel(
+            entity_type, label, item=item, workspace=target_workspace
+        )
         if existing is not None:
-            self.workspace.bring_to_front(existing)
+            target_workspace.bring_to_front(existing)
             preferred = self._preferred_entity_geometry(entity_type)
-            self.workspace.ensure_panel_minimum_size(
+            target_workspace.ensure_panel_minimum_size(
                 existing,
                 preferred["width"],
                 preferred["height"],
@@ -1351,11 +1468,12 @@ class GMTableView(ctk.CTkFrame):
         }
         if entity_type != "Scenarios":
             state["attachment_only"] = True
-        self._create_panel(
+        self._create_panel_in_workspace(
             "entity",
             f"{singular}: {label}",
             state,
             geometry=self._preferred_entity_geometry(entity_type),
+            workspace=workspace,
         )
 
     def _load_scenario_item(self, scenario_name: str) -> dict:
@@ -1368,7 +1486,9 @@ class GMTableView(ctk.CTkFrame):
             return {}
         return item if isinstance(item, dict) else {}
 
-    def _open_scenario_selection_for_panel(self, panel_kind: str) -> None:
+    def _open_scenario_selection_for_panel(
+        self, panel_kind: str, *, workspace: GMTableWorkspace | None = None
+    ) -> None:
         """Ask which scenario should power a scenario-specific panel."""
         wrapper = self.wrappers.get("Scenarios")
         template = self._templates.get("Scenarios")
@@ -1392,17 +1512,19 @@ class GMTableView(ctk.CTkFrame):
                 "Scenarios", item, fallback=selected_name
             )
             if panel_kind == "scene_flow":
-                self._create_panel(
+                self._create_panel_in_selection_workspace(
                     "scene_flow",
                     f"Scene Flow: {scenario_title}",
                     {"scenario_title": scenario_title},
+                    workspace=workspace,
                 )
                 return
             if panel_kind == "handouts":
-                self._create_panel(
+                self._create_panel_in_selection_workspace(
                     "handouts",
                     f"Handouts: {scenario_title}",
                     {"scenario_name": scenario_title},
+                    workspace=workspace,
                 )
 
         view = GenericListSelectionView(
@@ -1410,7 +1532,9 @@ class GMTableView(ctk.CTkFrame):
         )
         view.pack(fill="both", expand=True)
 
-    def _open_entity_selection(self, entity_type: str) -> None:
+    def _open_entity_selection(
+        self, entity_type: str, *, workspace: GMTableWorkspace | None = None
+    ) -> None:
         """Open the generic picker for entity-backed panels."""
         wrapper = self.wrappers.get(entity_type)
         template = self._templates.get(entity_type)
@@ -1431,6 +1555,7 @@ class GMTableView(ctk.CTkFrame):
             self.open_entity_panel(
                 selected_type,
                 self._entity_label(selected_type, item, fallback=selected_name),
+                workspace=workspace,
             )
 
         view = GenericListSelectionView(
@@ -1438,7 +1563,9 @@ class GMTableView(ctk.CTkFrame):
         )
         view.pack(fill="both", expand=True)
 
-    def _open_puzzle_selection(self) -> None:
+    def _open_puzzle_selection(
+        self, *, workspace: GMTableWorkspace | None = None
+    ) -> None:
         """Open the puzzle selector for a display panel."""
         popup = ctk.CTkToplevel(self)
         popup.title("Select Puzzle")
@@ -1449,10 +1576,11 @@ class GMTableView(ctk.CTkFrame):
 
         def _open_selected(_entity_type: str, selected_name: str) -> None:
             popup.destroy()
-            self._create_panel(
+            self._create_panel_in_selection_workspace(
                 "puzzle_display",
                 f"Puzzle Display: {selected_name}",
                 {"puzzle_name": selected_name},
+                workspace=workspace,
             )
 
         view = GenericListSelectionView(

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -322,7 +322,9 @@ def test_handle_add_option_routes_handouts_to_scenario_selection() -> None:
     """Add menu handouts option should ask which scenario powers the panel."""
     captured = []
     view = GMTableView.__new__(GMTableView)
-    view._open_scenario_selection_for_panel = lambda panel_kind: captured.append(panel_kind)
+    view._open_scenario_selection_for_panel = lambda panel_kind: captured.append(
+        panel_kind
+    )
 
     GMTableView._handle_add_option(view, "Handouts")
 
@@ -356,7 +358,10 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
     assert isinstance(mounted, _DummyHandoutsPage)
     assert captured["kwargs"]["scenario_name"] == "Night Run"
     assert captured["kwargs"]["scenario_item"] == {"Title": "Night Run"}
-    assert captured["kwargs"]["initial_state"] == {"scenario_name": "Night Run", "query": "map"}
+    assert captured["kwargs"]["initial_state"] == {
+        "scenario_name": "Night Run",
+        "query": "map",
+    }
 
 
 def test_seed_default_panels_opens_table_level_panels() -> None:
@@ -628,7 +633,9 @@ def test_filter_attachmentless_entity_panels_preserves_normal_entity_panels() ->
     assert [panel["panel_id"] for panel in filtered["panels"]] == ["normal-entity"]
 
 
-def test_filter_attachmentless_entity_panels_keeps_missing_entities_for_fallback() -> None:
+def test_filter_attachmentless_entity_panels_keeps_missing_entities_for_fallback() -> (
+    None
+):
     """Missing saved entities should remain so the unavailable fallback can explain it."""
     view = GMTableView.__new__(GMTableView)
 
@@ -750,6 +757,47 @@ def test_container_window_restores_explicitly_empty_layout_without_seeding() -> 
     GMTableContainerPage._restore_or_seed_layout(page)
 
     assert calls == [("restore", {"panels": []})]
+
+
+def test_container_add_panel_menu_routes_choice_to_nested_workspace() -> None:
+    """Container Add Panel should add main-table panel types to the nested workspace."""
+    from modules.scenarios.gm_table.container_window import GMTableContainerPage
+
+    calls = []
+    workspace = object()
+    page = GMTableContainerPage.__new__(GMTableContainerPage)
+    page.workspace = workspace
+    page._on_add_panel = lambda option, target_workspace: calls.append(
+        (option, target_workspace)
+    )
+
+    GMTableContainerPage._handle_add_panel_option(page, "Random Tables")
+
+    assert calls == [("Random Tables", workspace)]
+
+
+def test_container_mounts_main_table_panel_types_with_shared_builder() -> None:
+    """Container workspaces should render non-container panel definitions via GM Table builder."""
+    from modules.scenarios.gm_table.container_window import GMTableContainerPage
+
+    parent = object()
+    definition = gm_table_view_module.PanelDefinition(
+        panel_id="panel-random-tables",
+        kind="random_tables",
+        title="Random Tables",
+        state={},
+    )
+    rendered = object()
+    page = GMTableContainerPage.__new__(GMTableContainerPage)
+    page._panel_builder = lambda host, panel_definition: (
+        host,
+        panel_definition,
+        rendered,
+    )
+
+    mounted = GMTableContainerPage._mount_container_panel(page, parent, definition)
+
+    assert mounted == (parent, definition, rendered)
 
 
 def test_handle_add_option_creates_container_window_panel() -> None:


### PR DESCRIPTION
### Motivation
- Container windows should offer the same `+ Add Panel` experience as the main GM Table so GMs can add the same panel types directly into a nested workspace.
- Selections that open follow-up pickers (scenarios, entities, puzzles, images) must target the initiating workspace so added panels appear inside the container rather than the global table.
- Reusing the main GM Table panel builder inside containers prevents duplication and ensures consistent panel rendering across nested and top-level workspaces.

### Description
- Added a highlighted `+ Add Panel` button and popup menu to the nested container toolbar in `modules/scenarios/gm_table/container_window.py` and routed its choices into the container workspace via an `on_add_panel` callback and `_handle_add_panel_option` handler.
- Extended `GMTableView` (`modules/scenarios/gm_table_view.py`) to support targeting a specific `workspace` when creating panels by adding optional `workspace` parameters and helper wrappers (`_create_panel_in_workspace`, `_create_panel_in_selection_workspace`) to preserve backward-compatible call sites.
- Made selection-driven flows (scenario picker, entity picker, puzzle selector, image library) accept a `workspace` target so resulting panels are created inside the initiating container when appropriate, and wired container instances to reuse the main table's `_mount_panel_content` builder for non-container panel types.
- Added two unit tests to `tests/scenarios/gm_table/test_gm_table_view.py` validating that container add-menu routing and shared panel mounting behave correctly, and adjusted small expectations to match the new behavior.

### Testing
- Ran the targeted GM Table tests with `pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and received `33 passed`.
- The modified files were type/compiled and the test run completed with all assertions passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6f8a233c832b98bc3d5749e2744c)