### PR TITLE
Restrict GM table attachments to attachment fields

### DIFF
--- a/modules/scenarios/gm_table/attachments.py
+++ b/modules/scenarios/gm_table/attachments.py
@@ -13,7 +13,6 @@ from modules.helpers.portrait_helper import (
 )
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
-MEDIA_FIELDS = ("Portrait", "portrait", "Image", "image")
 ATTACHMENT_FIELDS = ("Attachment", "Attachments", "attachment", "attachments")
 
 
@@ -42,17 +41,12 @@ def _split_attachment_value(value) -> list[str]:
 
 
 def _candidate_values(record: dict) -> Iterable[tuple[str, str]]:
-    """Yield raw candidate paths from known media and attachment fields."""
+    """Yield raw candidate paths from explicit attachment fields only."""
     if not isinstance(record, dict):
         return
-    for field_name in (*MEDIA_FIELDS, *ATTACHMENT_FIELDS):
+    for field_name in ATTACHMENT_FIELDS:
         value = record.get(field_name)
-        parser = (
-            parse_portrait_value
-            if field_name in MEDIA_FIELDS
-            else _split_attachment_value
-        )
-        for path in parser(value):
+        for path in _split_attachment_value(value):
             cleaned = str(path or "").strip()
             if cleaned:
                 yield field_name, cleaned
@@ -68,7 +62,7 @@ def _attachment_label(path: str, resolved_path: str | None) -> str:
 def collect_entity_attachments(
     record: dict, *, campaign_dir: str | None = None
 ) -> list[EntityAttachment]:
-    """Collect de-duplicated media/attachment paths from an entity record."""
+    """Collect de-duplicated paths from explicit entity attachment fields."""
     base_dir = campaign_dir or ConfigHelper.get_campaign_dir()
     attachments: list[EntityAttachment] = []
     seen: set[str] = set()
@@ -92,5 +86,5 @@ def collect_entity_attachments(
 
 
 def entity_has_attachments(record: dict, *, campaign_dir: str | None = None) -> bool:
-    """Return whether an entity has at least one linked attachment/media path."""
+    """Return whether an entity has at least one explicit attachment path."""
     return bool(collect_entity_attachments(record, campaign_dir=campaign_dir))

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1457,7 +1457,7 @@ class GMTableView(ctk.CTkFrame):
         if entity_type != "Scenarios" and not entity_has_attachments(item):
             messagebox.showinfo(
                 "GM Table",
-                f"{label} has no linked portrait, image, or attachment to display on the table.",
+                f"{label} has no linked attachment to display on the table.",
             )
             return
 

--- a/tests/scenarios/gm_table/test_entity_attachments.py
+++ b/tests/scenarios/gm_table/test_entity_attachments.py
@@ -16,33 +16,33 @@ def _file(path: Path) -> None:
 def test_collect_entity_attachments_handles_multiple_attachment_formats(
     tmp_path: Path,
 ) -> None:
-    """Attachments can come from images, portrait lists, and delimited attachment fields."""
-    portrait = tmp_path / "assets" / "portrait.png"
+    """Attachments come only from explicit attachment fields."""
     clue = tmp_path / "assets" / "clue.png"
     pdf = tmp_path / "docs" / "note.pdf"
-    _file(portrait)
     _file(clue)
     pdf.parent.mkdir(parents=True, exist_ok=True)
     pdf.write_bytes(b"%PDF-1.4\n")
 
     record = {
         "Portrait": ["assets/portrait.png"],
+        "Image": "assets/ignored-image.png",
         "Attachment": "docs/note.pdf, assets/clue.png",
     }
 
     attachments = collect_entity_attachments(record, campaign_dir=str(tmp_path))
 
     assert [attachment.label for attachment in attachments] == [
-        "portrait.png",
         "note.pdf",
         "clue.png",
     ]
-    assert [attachment.is_image for attachment in attachments] == [True, False, True]
+    assert [attachment.is_image for attachment in attachments] == [False, True]
     assert entity_has_attachments(record, campaign_dir=str(tmp_path))
 
 
-def test_collect_entity_attachments_deduplicates_media_paths(tmp_path: Path) -> None:
-    """The same file listed in Portrait and Image should render once."""
+def test_collect_entity_attachments_ignores_media_without_attachment_field(
+    tmp_path: Path,
+) -> None:
+    """Portrait and Image fields should not create GM Table attachments."""
     portrait = tmp_path / "assets" / "portrait.png"
     _file(portrait)
 
@@ -51,5 +51,8 @@ def test_collect_entity_attachments_deduplicates_media_paths(tmp_path: Path) -> 
         campaign_dir=str(tmp_path),
     )
 
-    assert len(attachments) == 1
-    assert attachments[0].label == "portrait.png"
+    assert attachments == []
+    assert not entity_has_attachments(
+        {"Portrait": "assets/portrait.png", "Image": "assets/portrait.png"},
+        campaign_dir=str(tmp_path),
+    )


### PR DESCRIPTION
### Motivation
- The GM Table should only show entries that are explicitly provided via `Attachment`/`Attachments` fields and not treat `Portrait` or `Image` fields as attachments.
- This prevents portraits/tokens from being displayed as downloadable or gallery attachments in GM Table panels.

### Description
- Updated `modules/scenarios/gm_table/attachments.py` to stop scanning `Portrait`/`Image` fields and only collect paths from `ATTACHMENT_FIELDS` via `_candidate_values`.
- Kept path resolution and image-detection logic (using `resolve_portrait_candidate` and `IMAGE_EXTENSIONS`) so attachment deduplication and image flagging still work.
- Adjusted the user-facing message in `modules/scenarios/gm_table_view.py` to reference attachments only (`"no linked attachment to display on the table."`).
- Modified `tests/scenarios/gm_table/test_entity_attachments.py` to reflect the new behavior and added an assertion that `Portrait`/`Image` fields alone do not produce GM Table attachments.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_entity_attachments.py tests/scenarios/gm_table/test_gm_table_view.py -q` which executed the updated tests.
- All tests passed (`35 passed in 1.56s`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d71dd307c832bb8fb777aec0fc786)