### PR TITLE
Allow GM Table entity panels without attachments

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1431,6 +1431,7 @@ class GMTableView(ctk.CTkFrame):
         name: str,
         *,
         workspace: GMTableWorkspace | None = None,
+        attachment_only: bool = False,
     ) -> None:
         """Open a specific entity inside the GM Table or a nested container."""
         target_workspace = workspace or self.workspace
@@ -1441,6 +1442,7 @@ class GMTableView(ctk.CTkFrame):
             return
 
         label = self._entity_label(entity_type, item, fallback=name)
+        has_attachments = entity_type != "Scenarios" and entity_has_attachments(item)
         existing = self._find_existing_entity_panel(
             entity_type, label, item=item, workspace=target_workspace
         )
@@ -1454,19 +1456,12 @@ class GMTableView(ctk.CTkFrame):
             )
             return
 
-        if entity_type != "Scenarios" and not entity_has_attachments(item):
-            messagebox.showinfo(
-                "GM Table",
-                f"{label} has no linked attachment to display on the table.",
-            )
-            return
-
         singular = entity_type[:-1] if entity_type.endswith("s") else entity_type
         state = {
             "entity_type": entity_type,
             "entity_name": label,
         }
-        if entity_type != "Scenarios":
+        if has_attachments and attachment_only:
             state["attachment_only"] = True
         self._create_panel_in_workspace(
             "entity",

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -154,6 +154,89 @@ def test_open_entity_panel_uses_useful_geometry_for_new_scenario_panel() -> None
     assert captured["geometry"] == {"width": 920, "height": 680}
 
 
+def test_open_entity_panel_creates_attachmentless_entities_without_popup(
+    monkeypatch,
+) -> None:
+    """Normal entity opens should not require attachments or show attachment popups."""
+    captured = {}
+    view = GMTableView.__new__(GMTableView)
+    view.workspace = SimpleNamespace()
+    view._find_existing_entity_panel = lambda _entity_type, _name, **_kwargs: None
+    view._load_entity_item = lambda _entity_type, _name: {"Name": "No Media"}
+    view._preferred_entity_geometry = lambda _entity_type: {"width": 760, "height": 580}
+
+    def _capture(kind, title, state, *, geometry=None):
+        captured["kind"] = kind
+        captured["title"] = title
+        captured["state"] = state
+        captured["geometry"] = geometry
+        return "panel-new"
+
+    view._create_panel = _capture
+    monkeypatch.setattr(
+        gm_table_view_module, "entity_has_attachments", lambda _item: False
+    )
+    monkeypatch.setattr(
+        gm_table_view_module.messagebox,
+        "showinfo",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("normal entity opens must not show an attachment popup")
+        ),
+    )
+
+    GMTableView.open_entity_panel(view, "NPCs", "No Media")
+
+    assert captured["kind"] == "entity"
+    assert captured["title"] == "NPC: No Media"
+    assert captured["state"] == {"entity_type": "NPCs", "entity_name": "No Media"}
+    assert captured["geometry"] == {"width": 760, "height": 580}
+
+
+def test_open_entity_panel_sets_attachment_only_only_when_explicit_with_attachments(
+    monkeypatch,
+) -> None:
+    """Attachment-only state is opt-in and requires at least one linked attachment."""
+    created_states = []
+    view = GMTableView.__new__(GMTableView)
+    view.workspace = SimpleNamespace()
+    view._find_existing_entity_panel = lambda _entity_type, _name, **_kwargs: None
+    view._load_entity_item = lambda _entity_type, name: {"Name": name}
+    view._preferred_entity_geometry = lambda _entity_type: {"width": 760, "height": 580}
+    view._create_panel = (
+        lambda _kind, _title, state, *, geometry=None: created_states.append(state)
+        or f"panel-{len(created_states)}"
+    )
+
+    monkeypatch.setattr(
+        gm_table_view_module, "entity_has_attachments", lambda _item: True
+    )
+    GMTableView.open_entity_panel(view, "NPCs", "Has Media")
+
+    monkeypatch.setattr(
+        gm_table_view_module, "entity_has_attachments", lambda _item: False
+    )
+    GMTableView.open_entity_panel(
+        view, "NPCs", "Requested Missing Media", attachment_only=True
+    )
+
+    monkeypatch.setattr(
+        gm_table_view_module, "entity_has_attachments", lambda _item: True
+    )
+    GMTableView.open_entity_panel(
+        view, "NPCs", "Requested Has Media", attachment_only=True
+    )
+
+    assert created_states == [
+        {"entity_type": "NPCs", "entity_name": "Has Media"},
+        {"entity_type": "NPCs", "entity_name": "Requested Missing Media"},
+        {
+            "entity_type": "NPCs",
+            "entity_name": "Requested Has Media",
+            "attachment_only": True,
+        },
+    ]
+
+
 def test_build_entity_content_calls_detail_factory(monkeypatch) -> None:
     """Entity content should be built through the shared detail factory."""
     captured = {}


### PR DESCRIPTION
### Motivation
- Normal entity opens from the GM Table should always open an entity panel even when no attachments exist, and must not be blocked by a popup about missing attachments.
- Attachment-only behavior should be explicit and only enabled when the caller requests it and the entity actually has attachments.

### Description
- Updated `GMTableView.open_entity_panel` signature to accept `attachment_only: bool = False` and compute `has_attachments = entity_type != "Scenarios" and entity_has_attachments(item)` before deciding state.
- Removed the early `messagebox.showinfo(... "has no linked attachment")` and the early `return` so entity panels are always created after a successful load. (`modules/scenarios/gm_table_view.py`)
- Only set `state["attachment_only"] = True` when `has_attachments` is true and `attachment_only` was explicitly requested; otherwise create a normal entity panel state.
- Verified `_build_entity_content` renders entity details without requiring `attachment_only` by relying on `collect_entity_attachments` to show an attachment gallery when present and falling back to readable/detail rendering otherwise.

### Testing
- Ran `python -m pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and all tests passed (35 passed).
- Performed fast sanity checks with `python -m py_compile modules/scenarios/gm_table_view.py tests/scenarios/gm_table/test_gm_table_view.py` which succeeded.
- Added focused regression tests that assert normal attachmentless opens create entity panels without triggering the old popup and that `attachment_only` is only persisted when requested and attachments exist (`tests/scenarios/gm_table/test_gm_table_view.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d73c2a6a0832bb48194f5f70f0f45)