### PR TITLE
Make GM Table attachments clickable and hide portrait spotlight when attachments present

### DIFF
--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -2244,6 +2244,7 @@ def create_entity_detail_frame(
     open_entity_callback=None,
     *,
     spotlight_only: bool = False,
+    show_spotlight: bool = True,
 ):
     """
     Routes Scenarios through our custom header/body and
@@ -2274,6 +2275,7 @@ def create_entity_detail_frame(
                 parent,
                 open_entity_callback,
                 spotlight_only=spotlight_only,
+                show_spotlight=show_spotlight,
             ),
         )
 
@@ -2371,25 +2373,34 @@ def create_entity_detail_frame(
             break
 
     spotlight_primary = entity_type in SPOTLIGHT_PRIMARY_ENTITY_TYPES
-    shell, main_column, side_column = create_detail_split_layout(
-        content_frame,
-        spotlight_primary=spotlight_primary,
-        single_column=spotlight_only,
-    )
+    if show_spotlight:
+        shell, main_column, side_column = create_detail_split_layout(
+            content_frame,
+            spotlight_primary=spotlight_primary,
+            single_column=spotlight_only,
+        )
+    else:
+        shell = ctk.CTkFrame(content_frame, fg_color="transparent")
+        shell.grid_columnconfigure(0, weight=1)
+        shell.grid_rowconfigure(0, weight=1)
+        main_column = ctk.CTkFrame(shell, fg_color="transparent")
+        main_column.grid(row=0, column=0, sticky="nsew")
+        side_column = main_column
     shell.pack(fill="both", expand=True, padx=10, pady=(0, 6))
 
     category_label = entity_type[:-1] if entity_type.endswith("s") else entity_type
     primary_type = _resolve_primary_type_chip(entity)
     spotlight_accent_lines = _build_spotlight_accent_lines(highlight_lines, primary_type)
 
-    create_spotlight_panel(
-        side_column,
-        title=str(entity_label),
-        portrait_builder=_make_spotlight_portrait if DEFAULT_PORTRAIT_PLACEMENT in {"spotlight", "both"} else None,
-        fallback_text=_spotlight_fallback(entity_type),
-        accent_lines=spotlight_accent_lines,
-        prominent=spotlight_primary,
-    )
+    if show_spotlight:
+        create_spotlight_panel(
+            side_column,
+            title=str(entity_label),
+            portrait_builder=_make_spotlight_portrait if DEFAULT_PORTRAIT_PLACEMENT in {"spotlight", "both"} else None,
+            fallback_text=_spotlight_fallback(entity_type),
+            accent_lines=spotlight_accent_lines,
+            prominent=spotlight_primary,
+        )
 
     if spotlight_only:
         return content_frame

--- a/modules/scenarios/gm_table/pages.py
+++ b/modules/scenarios/gm_table/pages.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import subprocess
+import sys
 from typing import Callable
 
 import customtkinter as ctk
 from PIL import Image
+from tkinter import messagebox
 
 from modules.helpers.config_helper import ConfigHelper
-from modules.helpers.logging_helper import log_exception, log_warning
+from modules.helpers.logging_helper import log_exception, log_info, log_warning
 from modules.helpers.portrait_helper import resolve_portrait_candidate
 from modules.image_assets import ImageAssetsService
 from modules.scenarios.gm_table.attachments import EntityAttachment
@@ -19,6 +23,46 @@ from modules.ui.image_library.result_card import ImageResult
 from modules.ui.image_library.toolbar import ToolbarState
 
 IMAGE_PANEL_SIZE = (520, 390)
+
+
+def open_attachment_file(attachment: EntityAttachment) -> bool:
+    """Open a GM Table attachment with the operating system default application."""
+    path = attachment.resolved_path or attachment.path
+    if not path:
+        messagebox.showwarning(
+            "Open Attachment",
+            "This attachment does not have an associated file.",
+        )
+        return False
+    resolved = Path(path).expanduser()
+    if not resolved.is_absolute():
+        resolved = Path(ConfigHelper.get_campaign_dir()) / resolved
+    resolved = resolved.resolve()
+    if not resolved.exists():
+        messagebox.showwarning(
+            "Open Attachment",
+            f"The attachment file could not be found:\n{resolved}",
+        )
+        return False
+    try:
+        if sys.platform.startswith("win"):
+            os.startfile(str(resolved))  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", str(resolved)])
+        else:
+            subprocess.Popen(["xdg-open", str(resolved)])
+        log_info(
+            f"Opened GM Table attachment '{resolved}'.",
+            func_name="gm_table.pages.open_attachment_file",
+        )
+        return True
+    except Exception as exc:
+        log_warning(
+            f"Failed to open GM Table attachment '{resolved}': {exc}",
+            func_name="gm_table.pages.open_attachment_file",
+        )
+        messagebox.showerror("Open Attachment", f"Failed to open the file:\n{exc}")
+        return False
 
 
 class GMTableHostedPage(ctk.CTkFrame):
@@ -188,9 +232,16 @@ class GMTableImagePage(ctk.CTkFrame):
 class GMTableAttachmentGallery(ctk.CTkFrame):
     """Compact gallery for entity attachments on the GM Table."""
 
-    def __init__(self, master, *, attachments: list[EntityAttachment]) -> None:
+    def __init__(
+        self,
+        master,
+        *,
+        attachments: list[EntityAttachment],
+        on_open: Callable[[EntityAttachment], bool] | None = None,
+    ) -> None:
         super().__init__(master, fg_color="transparent")
         self._images: list[ctk.CTkImage] = []
+        self._on_open = on_open or open_attachment_file
         self.grid_columnconfigure(0, weight=1)
         title = f"Attachments ({len(attachments)})"
         ctk.CTkLabel(
@@ -199,7 +250,7 @@ class GMTableAttachmentGallery(ctk.CTkFrame):
         body = ctk.CTkFrame(self, fg_color="transparent")
         body.grid(row=1, column=0, sticky="ew")
         for index, attachment in enumerate(attachments):
-            card = ctk.CTkFrame(body, corner_radius=12)
+            card = ctk.CTkFrame(body, corner_radius=12, cursor="hand2")
             card.grid(row=index // 2, column=index % 2, sticky="ew", padx=6, pady=6)
             card.grid_columnconfigure(0, weight=1)
             if attachment.is_image and attachment.resolved_path:
@@ -208,9 +259,26 @@ class GMTableAttachmentGallery(ctk.CTkFrame):
                 ctk.CTkLabel(card, text="📎", font=ctk.CTkFont(size=28)).grid(
                     row=0, column=0, pady=(10, 2)
                 )
-            ctk.CTkLabel(
-                card, text=attachment.label, wraplength=220, justify="center"
-            ).grid(row=1, column=0, padx=10, pady=(2, 10), sticky="ew")
+            label = ctk.CTkLabel(
+                card,
+                text=attachment.label,
+                wraplength=220,
+                justify="center",
+                cursor="hand2",
+            )
+            label.grid(row=1, column=0, padx=10, pady=(2, 10), sticky="ew")
+            self._bind_open(card, attachment)
+
+    def _bind_open(self, widget, attachment: EntityAttachment) -> None:
+        widget.bind(
+            "<Button-1>",
+            lambda _event=None, item=attachment: self._on_open(item),
+        )
+        for child in widget.winfo_children():
+            child.bind(
+                "<Button-1>",
+                lambda _event=None, item=attachment: self._on_open(item),
+            )
 
     def _add_image_preview(self, parent, attachment: EntityAttachment) -> None:
         try:

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1279,6 +1279,7 @@ class GMTableView(ctk.CTkFrame):
                 master=scrollable_host,
                 open_entity_callback=self.open_entity_panel,
                 spotlight_only=False,
+                show_spotlight=False,
             )
             detail_frame.pack(fill="both", expand=True, padx=8, pady=(0, 8))
             return scrollable_host

--- a/tests/scenarios/gm_table/test_entity_attachments.py
+++ b/tests/scenarios/gm_table/test_entity_attachments.py
@@ -56,3 +56,33 @@ def test_collect_entity_attachments_ignores_media_without_attachment_field(
         {"Portrait": "assets/portrait.png", "Image": "assets/portrait.png"},
         campaign_dir=str(tmp_path),
     )
+
+
+def test_open_attachment_file_uses_platform_launcher(monkeypatch, tmp_path: Path) -> None:
+    """Clicking an attachment card should open the linked file with the OS launcher."""
+    import modules.scenarios.gm_table.pages as pages
+    from modules.scenarios.gm_table.attachments import EntityAttachment
+
+    attachment_path = tmp_path / "docs" / "note.pdf"
+    _file(attachment_path)
+    launched = []
+
+    monkeypatch.setattr(pages.sys, "platform", "linux")
+    monkeypatch.setattr(
+        pages.subprocess,
+        "Popen",
+        lambda args: launched.append(args),
+    )
+
+    result = pages.open_attachment_file(
+        EntityAttachment(
+            field_name="Attachment",
+            path=str(attachment_path),
+            resolved_path=str(attachment_path),
+            label="note.pdf",
+            is_image=False,
+        )
+    )
+
+    assert result is True
+    assert launched == [["xdg-open", str(attachment_path.resolve())]]

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -338,6 +338,78 @@ def test_build_object_entity_content_uses_scrollable_full_detail(monkeypatch) ->
     assert frame.pack_calls == [{"fill": "both", "expand": True}]
 
 
+def test_build_entity_content_with_attachments_hides_portrait_spotlight(monkeypatch) -> None:
+    """Attachment-backed evidence cards should show attachments without an empty portrait panel."""
+    captured = {}
+
+    class _DummyWidget:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.setdefault("gallery_kwargs", kwargs)
+            self.pack_calls = []
+
+        def pack(self, **kwargs):
+            self.pack_calls.append(kwargs)
+
+    scroll_host = object()
+
+    def _fake_scroll_host(host):
+        captured["scroll_parent"] = host
+        return scroll_host
+
+    def _fake_factory(entity_type, item, *, master, open_entity_callback, **kwargs):
+        captured["entity_type"] = entity_type
+        captured["item"] = item
+        captured["master"] = master
+        captured["callback"] = open_entity_callback
+        captured["kwargs"] = kwargs
+        return _DummyWidget()
+
+    view = GMTableView.__new__(GMTableView)
+    expected_item = {
+        "Name": "Corporations Informations",
+        "Attachment": "assets/corp.png",
+    }
+    view._load_entity_item = lambda _entity_type, _name: expected_item
+
+    def callback(*args, **kwargs):
+        return None
+
+    view.open_entity_panel = callback
+    host = SimpleNamespace(
+        grid_rowconfigure=lambda *args, **kwargs: captured.setdefault(
+            "row", (args, kwargs)
+        ),
+        grid_columnconfigure=lambda *args, **kwargs: captured.setdefault(
+            "column", (args, kwargs)
+        ),
+    )
+
+    monkeypatch.setattr(gm_table_view_module, "build_scroll_host", _fake_scroll_host)
+    monkeypatch.setattr(gm_table_view_module, "GMTableAttachmentGallery", _DummyWidget)
+    attachment = object()
+    monkeypatch.setattr(
+        gm_table_view_module,
+        "collect_entity_attachments",
+        lambda _item: [attachment],
+    )
+    monkeypatch.setattr(
+        gm_table_view_module, "create_entity_detail_frame", _fake_factory
+    )
+
+    frame = GMTableView._build_entity_content(
+        view,
+        host,
+        {"entity_type": "Informations", "entity_name": "Corporations Informations"},
+    )
+
+    assert frame is scroll_host
+    assert captured["entity_type"] == "Informations"
+    assert captured["item"] is expected_item
+    assert captured["master"] is scroll_host
+    assert captured["callback"] is callback
+    assert captured["kwargs"] == {"spotlight_only": False, "show_spotlight": False}
+    assert captured["gallery_kwargs"] == {"attachments": [attachment]}
+
 def test_context_menu_handler_resolution_is_safe_without_gm_screen_api() -> None:
     """GM Table hosts without a context-menu API should not crash the detail factory."""
 


### PR DESCRIPTION
### Motivation
- Attachment-backed entity panels showed an empty portrait spotlight and did not let users open attached files directly. This change aims to present attachment-focused content without a blank portrait and to open attachments with the OS default application when clicked. 

### Description
- Add a `show_spotlight` parameter to `create_entity_detail_frame` to optionally suppress the portrait spotlight when embedding detail content (`modules/generic/entity_detail_factory.py`).
- Disable the portrait spotlight for GM Table entity pages that have explicit attachments by passing `show_spotlight=False` when building the detail frame (`modules/scenarios/gm_table_view.py`).
- Implement `open_attachment_file` to resolve attachment paths and launch them via the platform default (using `os.startfile`, `open`, or `xdg-open`), and wire attachment cards to call this opener when clicked (`modules/scenarios/gm_table/pages.py`).
- Make attachment cards clickable by adding click bindings and a hand cursor for both label and card, and keep existing image previews intact (`modules/scenarios/gm_table/pages.py`).
- Add regression tests covering opening attachments and rendering attachment-backed entity content without the empty spotlight (`tests/scenarios/gm_table/test_entity_attachments.py` and `tests/scenarios/gm_table/test_gm_table_view.py`).

### Testing
- Ran `pytest tests/scenarios/gm_table/test_entity_attachments.py tests/scenarios/gm_table/test_gm_table_view.py -q` and received `39 passed` (all tests succeeded). 
- Verified module syntax with `python -m py_compile modules/scenarios/gm_table/pages.py modules/generic/entity_detail_factory.py modules/scenarios/gm_table_view.py` which succeeded. 
- Ran `git diff --check` to ensure no trailing issues and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d813f8d88832b9f3ce8852a30c4fe)