### PR TITLE
Seed lightweight secondary GM tables

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -25,6 +25,7 @@ from modules.scenarios.gm_screen import CampaignDashboardPanel
 from modules.scenarios.gm_table import GMTableLayoutStore, GMTableWorkspace
 from modules.scenarios.gm_table.table_name_labels import build_table_switch_labels
 from modules.scenarios.gm_table.table_registry import (
+    DEFAULT_GM_TABLE_ID,
     get_table_name,
     normalize_table_id,
 )
@@ -521,6 +522,21 @@ class GMTableView(ctk.CTkFrame):
 
     def _seed_default_panels(self) -> None:
         """Build the default table workspace without binding it to a scenario."""
+        table_id = normalize_table_id(getattr(self, "table_id", DEFAULT_GM_TABLE_ID))
+        if table_id != DEFAULT_GM_TABLE_ID:
+            self._create_panel(
+                "note",
+                f"{self.table_name} Notes",
+                {
+                    "text": (
+                        "Use this side table for notes, maps, handouts, "
+                        "or temporary planning."
+                    )
+                },
+                geometry={"x": 24, "y": 24, "width": 520, "height": 360},
+            )
+            return
+
         self._create_panel(
             "campaign_dashboard",
             "Campaign Dashboard",

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -520,9 +520,10 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
 
 
 def test_seed_default_panels_opens_table_level_panels() -> None:
-    """Starter tabletop should not bind the table identity to a scenario."""
+    """Starter tabletop should not bind the primary table identity to a scenario."""
     captured = []
     view = GMTableView.__new__(GMTableView)
+    view.table_id = "table_1"
     view.table_name = "Main"
     view._create_panel = lambda kind, title, state, *, geometry=None: captured.append(
         (kind, title, state, geometry)
@@ -542,6 +543,33 @@ def test_seed_default_panels_opens_table_level_panels() -> None:
             "Main Notes",
             {"text": ""},
             {"x": 948, "y": 24, "width": 520, "height": 520},
+        ),
+    ]
+
+
+def test_seed_default_panels_keeps_secondary_tables_lightweight() -> None:
+    """Secondary tables should not start with the campaign dashboard."""
+    captured = []
+    view = GMTableView.__new__(GMTableView)
+    view.table_id = "table_2"
+    view.table_name = "Table2"
+    view._create_panel = lambda kind, title, state, *, geometry=None: captured.append(
+        (kind, title, state, geometry)
+    )
+
+    GMTableView._seed_default_panels(view)
+
+    assert captured == [
+        (
+            "note",
+            "Table2 Notes",
+            {
+                "text": (
+                    "Use this side table for notes, maps, handouts, "
+                    "or temporary planning."
+                )
+            },
+            {"x": 24, "y": 24, "width": 520, "height": 360},
         ),
     ]
 


### PR DESCRIPTION
### Motivation
- Ensure the primary GM table (`table_1` / Main) continues to seed the full `Campaign Dashboard` starter layout while secondary tables get a lighter, less intrusive default. 
- Avoid hard-coded table-name checks by using the stable table registry constants and normalization to make seeding logic robust to ID formats. 

### Description
- Import and use `DEFAULT_GM_TABLE_ID` and `normalize_table_id` from `modules/scenarios/gm_table/table_registry.py` and normalize `self.table_id` before branching. 
- Change `_seed_default_panels` to seed a single helper `note` panel for non-default tables and keep the existing `campaign_dashboard` + `note` layout for the default table. 
- Preserve the manual add-path for `Campaign Dashboard` via `_handle_add_option`, leaving user-driven dashboard creation unchanged. 
- Add regression tests in `tests/scenarios/gm_table/test_gm_table_view.py` that assert the primary and secondary seeding behaviors. 
- Changes applied to `modules/scenarios/gm_table_view.py` and tests updated in `tests/scenarios/gm_table/test_gm_table_view.py` (commit `a5b4076`). 

### Testing
- Ran `python -m pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and the targeted tests passed. 
- Ran `pytest -q tests/scenarios/gm_table/test_gm_table_view.py -k "seed_default_panels or handle_add_option"` and the focused checks passed. 
- Ran `python -m py_compile modules/scenarios/gm_table_view.py tests/scenarios/gm_table/test_gm_table_view.py` and compilation succeeded. 
- Full `pytest -q tests/scenarios/gm_table` reported `128 passed, 2 failed` where the two failures are Tk UI tests failing with `TclError: no display name and no $DISPLAY environment variable` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e0c00ee2c832ba89feb2389135a10)