### PR TITLE
Add GM Table Scenario Board bundle workflow

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/__init__.py
+++ b/modules/scenarios/gm_table/scenario_board/__init__.py
@@ -1,0 +1,25 @@
+"""Scenario board panel package for GM Table."""
+
+from modules.scenarios.gm_table.scenario_board.models import (
+    ScenarioBoardData,
+    ScenarioBoardScene,
+    build_scenario_board_data,
+    normalize_list_field,
+    split_scene_title,
+)
+from modules.scenarios.gm_table.scenario_board.bundle_service import (
+    ScenarioBundle,
+    resolve_scenario_bundle,
+)
+from modules.scenarios.gm_table.scenario_board.page import ScenarioBoardPanel
+
+__all__ = [
+    "ScenarioBoardData",
+    "ScenarioBundle",
+    "ScenarioBoardPanel",
+    "ScenarioBoardScene",
+    "build_scenario_board_data",
+    "normalize_list_field",
+    "resolve_scenario_bundle",
+    "split_scene_title",
+]

--- a/modules/scenarios/gm_table/scenario_board/bundle_service.py
+++ b/modules/scenarios/gm_table/scenario_board/bundle_service.py
@@ -1,0 +1,227 @@
+"""Scenario Board bundle resolution helpers.
+
+The board UI only knows about the scenario record and the selected scene.  This
+module turns those loose references into canonical campaign entity names using
+loaded wrappers and tolerant name matching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Mapping, Sequence
+
+_ENTITY_TYPES = ("NPCs", "Villains", "Places")
+_MAP_NAME_KEYS = ("Name", "Title", "Map", "MapName")
+_WORLD_MAP_KEYS = ("WorldMap", "World Map", "WorldMapName", "world_map", "worldMap")
+_SCENE_MAP_KEYS = ("Maps", "Map", "SceneMap", "Scene Map", "MapName", "map")
+
+
+@dataclass(frozen=True)
+class ScenarioBundle:
+    """Resolved launch bundle for the currently selected scene."""
+
+    scenario_title: str
+    scene_title: str
+    npcs: tuple[str, ...]
+    villains: tuple[str, ...]
+    places: tuple[str, ...]
+    maps: tuple[str, ...]
+    world_maps: tuple[str, ...]
+
+
+def resolve_scenario_bundle(
+    scenario_item: Mapping[str, Any] | None,
+    scene: object | None,
+    wrappers: Mapping[str, object] | None,
+    map_wrapper: object | None,
+) -> ScenarioBundle:
+    """Resolve scene/scenario references into canonical bundle candidates.
+
+    References can live on either the scenario record or the selected scene.
+    Matching is deliberately forgiving: exact case-insensitive aliases win, then
+    punctuation-insensitive aliases, then safe substring matches.
+    """
+
+    scenario = scenario_item if isinstance(scenario_item, Mapping) else {}
+    scene_title = str(getattr(scene, "title", "") or "").strip()
+    scenario_title = _label("Scenarios", scenario, fallback="Untitled Scenario")
+
+    wrapped = wrappers or {}
+    resolved: dict[str, tuple[str, ...]] = {}
+    for entity_type in _ENTITY_TYPES:
+        lookup = _build_lookup(entity_type, _safe_load_items(wrapped.get(entity_type)))
+        requested = [
+            *_coerce_names(scenario.get(entity_type)),
+            *_coerce_names(getattr(scene, entity_type.lower(), ())),
+        ]
+        resolved[entity_type] = _resolve_names(entity_type, requested, lookup)
+
+    map_lookup = _build_lookup(
+        "Maps", _safe_load_items(map_wrapper), name_keys=_MAP_NAME_KEYS
+    )
+    scenario_map_names: list[str] = []
+    for key in _SCENE_MAP_KEYS:
+        scenario_map_names.extend(_coerce_names(scenario.get(key)))
+    scene_map_names = list(_coerce_names(getattr(scene, "maps", ())))
+    maps = _resolve_names("Maps", [*scene_map_names, *scenario_map_names], map_lookup)
+
+    world_map_names: list[str] = []
+    for key in _WORLD_MAP_KEYS:
+        world_map_names.extend(_coerce_names(scenario.get(key)))
+    world_maps = _resolve_names("Maps", world_map_names, map_lookup)
+
+    if not world_maps:
+        world_maps = _infer_world_map_candidates(map_lookup.records)
+
+    return ScenarioBundle(
+        scenario_title=scenario_title,
+        scene_title=scene_title,
+        npcs=resolved["NPCs"],
+        villains=resolved["Villains"],
+        places=resolved["Places"],
+        maps=maps,
+        world_maps=world_maps,
+    )
+
+
+class _Lookup:
+    def __init__(
+        self,
+        entity_type: str,
+        records: Sequence[Mapping[str, Any]],
+        name_keys: Sequence[str] | None = None,
+    ) -> None:
+        self.entity_type = entity_type
+        self.records = tuple(records)
+        self.name_keys = tuple(name_keys or _entity_name_keys(entity_type))
+        self.by_alias: dict[str, Mapping[str, Any]] = {}
+        self.by_compact: dict[str, Mapping[str, Any]] = {}
+        for record in self.records:
+            fallback = _label(entity_type, record, fallback="")
+            for alias in _record_aliases(record, self.name_keys, fallback=fallback):
+                self.by_alias.setdefault(_normalize(alias), record)
+                self.by_compact.setdefault(_compact(alias), record)
+
+    def find(self, name: str) -> Mapping[str, Any] | None:
+        normalized = _normalize(name)
+        if not normalized:
+            return None
+        compact = _compact(name)
+        record = self.by_alias.get(normalized) or self.by_compact.get(compact)
+        if record is not None:
+            return record
+        if len(compact) < 4:
+            return None
+        matches = [
+            candidate
+            for alias, candidate in self.by_compact.items()
+            if compact in alias or alias in compact
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+
+def _safe_load_items(wrapper: object | None) -> list[dict[str, Any]]:
+    load_items = getattr(wrapper, "load_items", None)
+    if not callable(load_items):
+        return []
+    try:
+        items = load_items()
+    except Exception:
+        return []
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _build_lookup(
+    entity_type: str,
+    records: Sequence[Mapping[str, Any]],
+    name_keys: Sequence[str] | None = None,
+) -> _Lookup:
+    return _Lookup(entity_type, records, name_keys=name_keys)
+
+
+def _resolve_names(
+    entity_type: str, names: Sequence[str], lookup: _Lookup
+) -> tuple[str, ...]:
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        clean = str(name or "").strip()
+        if not clean:
+            continue
+        record = lookup.find(clean)
+        display = _label(entity_type, record, fallback=clean) if record else clean
+        key = _normalize(display)
+        if key and key not in seen:
+            seen.add(key)
+            resolved.append(display)
+    return tuple(resolved)
+
+
+def _infer_world_map_candidates(
+    records: Sequence[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    candidates: list[str] = []
+    for record in records:
+        text = " ".join(
+            str(record.get(key) or "") for key in ("Type", "Category", "Tags", "Kind")
+        )
+        if "world" in text.casefold():
+            candidates.append(_label("Maps", record, fallback=""))
+    return tuple(name for name in candidates if name)
+
+
+def _coerce_names(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, Mapping):
+        return tuple(
+            str(value.get(key) or "").strip()
+            for key in ("Name", "Title", "name", "title")
+            if str(value.get(key) or "").strip()
+        )
+    if isinstance(value, (list, tuple, set)):
+        names: list[str] = []
+        for item in value:
+            names.extend(_coerce_names(item))
+        return tuple(names)
+    text = str(value or "").strip()
+    if not text:
+        return ()
+    for delimiter in ("\n", ";", "|", ","):
+        if delimiter in text:
+            return tuple(part.strip() for part in text.split(delimiter) if part.strip())
+    return (text,)
+
+
+def _entity_name_keys(entity_type: str) -> tuple[str, ...]:
+    if entity_type in {"Scenarios", "Informations"}:
+        return ("Title", "Name", "title", "name")
+    return ("Name", "Title", "name", "title")
+
+
+def _label(entity_type: str, record: Mapping[str, Any] | None, *, fallback: str) -> str:
+    if isinstance(record, Mapping):
+        for key in _entity_name_keys(entity_type):
+            value = str(record.get(key) or "").strip()
+            if value:
+                return value
+    return str(fallback or "").strip()
+
+
+def _record_aliases(
+    record: Mapping[str, Any], keys: Sequence[str], *, fallback: str
+) -> set[str]:
+    aliases = {str(record.get(key) or "").strip() for key in keys}
+    aliases.add(str(fallback or "").strip())
+    return {alias for alias in aliases if alias}
+
+
+def _normalize(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip().casefold())
+
+
+def _compact(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "", _normalize(value))

--- a/modules/scenarios/gm_table/scenario_board/models.py
+++ b/modules/scenarios/gm_table/scenario_board/models.py
@@ -1,0 +1,288 @@
+"""Data preparation helpers for GM Table scenario board panels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Iterable, Mapping
+
+from modules.scenarios.widgets.scene_sections_parser import parse_scene_body_sections
+
+SCENARIO_BOARD_ENTITY_TYPES = (
+    "NPCs",
+    "PCs",
+    "Villains",
+    "Creatures",
+    "Places",
+    "Bases",
+    "Factions",
+    "Objects",
+    "Clues",
+    "Informations",
+    "Maps",
+    "Books",
+)
+
+
+@dataclass(frozen=True)
+class ScenarioBoardScene:
+    """One scene card prepared for the scenario board."""
+
+    index: int
+    title: str
+    body: str
+    intro_text: str
+    sections: tuple[dict[str, Any], ...]
+    npcs: tuple[str, ...] = ()
+    villains: tuple[str, ...] = ()
+    places: tuple[str, ...] = ()
+    maps: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ScenarioBoardData:
+    """Normalized scenario board payload consumed by the UI."""
+
+    title: str
+    status: str
+    summary: str
+    secrets: str
+    scenes: tuple[ScenarioBoardScene, ...]
+    linked_entities: dict[str, tuple[str, ...]]
+
+
+def _clean_text(value: Any) -> str:
+    """Return a display-safe string without leading or trailing whitespace."""
+    return str(value or "").strip()
+
+
+def _maybe_json_list(value: str) -> list[Any] | None:
+    """Return a parsed JSON list when a text field stores list data."""
+    text = value.strip()
+    if not text or text[0] not in '["':
+        return None
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return None
+    if isinstance(parsed, list):
+        return parsed
+    return None
+
+
+def normalize_list_field(value: Any) -> tuple[str, ...]:
+    """Normalize template list/list_longtext fields to a tuple of non-empty strings."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        parsed = _maybe_json_list(value)
+        if parsed is not None:
+            return normalize_list_field(parsed)
+        return tuple(
+            part.strip()
+            for part in value.replace("\r\n", "\n").split("\n")
+            if part.strip()
+        )
+    if isinstance(value, dict):
+        for key in ("Title", "Name", "title", "name"):
+            label = _clean_text(value.get(key))
+            if label:
+                return (label,)
+        return ()
+    if isinstance(value, Iterable):
+        items: list[str] = []
+        for entry in value:
+            if isinstance(entry, dict):
+                label = ""
+                for key in ("Title", "Name", "title", "name"):
+                    label = _clean_text(entry.get(key))
+                    if label:
+                        break
+            else:
+                label = _clean_text(entry)
+            if label:
+                items.append(label)
+        return tuple(items)
+    text = _clean_text(value)
+    return (text,) if text else ()
+
+
+def split_scene_title(scene_text: str, index: int) -> tuple[str, str]:
+    """Split a scene longtext block into a card title and body."""
+    text = _clean_text(scene_text)
+    if not text:
+        return f"Scene {index}", ""
+    lines = text.splitlines()
+    first_line = lines[0].strip()
+    if len(lines) > 1 and 0 < len(first_line) <= 90:
+        title = first_line.strip("#*: -") or f"Scene {index}"
+        return title, "\n".join(lines[1:]).strip()
+    for separator in (" — ", " – ", ": "):
+        if separator in first_line:
+            title, body = first_line.split(separator, 1)
+            if title.strip() and len(title.strip()) <= 90:
+                remaining = [body.strip(), *lines[1:]]
+                return (
+                    title.strip("#*: -"),
+                    "\n".join(part for part in remaining if part).strip(),
+                )
+    return f"Scene {index}", text
+
+
+SCENE_SOURCE_KEYS = ("Scenes", "Scene Flow", "SceneFlow", "scene_flow", "scenes")
+
+
+def _coerce_scene_entries(item: Mapping[str, Any]) -> list[Any]:
+    """Return scene entries from every supported scenario scene field."""
+    for key in SCENE_SOURCE_KEYS:
+        if key not in item:
+            continue
+        value = item.get(key)
+        if isinstance(value, dict):
+            nested = value.get("scenes") or value.get("Scenes")
+            if nested is not None:
+                value = nested
+            else:
+                sortable = []
+                for scene_key, scene_value in value.items():
+                    if isinstance(scene_value, (dict, list, tuple, str)):
+                        sortable.append((str(scene_key), scene_value))
+                return [
+                    entry for _key, entry in sorted(sortable, key=lambda pair: pair[0])
+                ]
+        if isinstance(value, list):
+            return list(value)
+        if isinstance(value, str):
+            parsed = _maybe_json_list(value)
+            if parsed is not None:
+                return list(parsed)
+            return list(normalize_list_field(value))
+    return []
+
+
+def _scene_field(entry: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in entry and entry.get(key) not in (None, ""):
+            return entry.get(key)
+    return None
+
+
+def _normalize_scene_entry(entry: Any, index: int) -> ScenarioBoardScene | None:
+    if isinstance(entry, Mapping):
+        title = _clean_text(
+            _scene_field(
+                entry,
+                (
+                    "Title",
+                    "title",
+                    "Name",
+                    "name",
+                    "Scene",
+                    "scene",
+                    "Heading",
+                    "heading",
+                ),
+            )
+        )
+        body_value = _scene_field(
+            entry,
+            (
+                "Description",
+                "description",
+                "Body",
+                "body",
+                "Text",
+                "text",
+                "Summary",
+                "summary",
+            ),
+        )
+        body = _clean_text(body_value)
+        if not title:
+            title, body = split_scene_title(body, index)
+        parsed = parse_scene_body_sections(body)
+        return ScenarioBoardScene(
+            index=index,
+            title=title or f"Scene {index}",
+            body=body,
+            intro_text=_clean_text(parsed.get("intro_text")),
+            sections=tuple(parsed.get("sections") or ()),
+            npcs=normalize_list_field(
+                _scene_field(
+                    entry,
+                    (
+                        "NPCs",
+                        "npcs",
+                        "SceneNPCs",
+                        "InvolvedNPCs",
+                        "Characters",
+                        "characters",
+                    ),
+                )
+            ),
+            villains=normalize_list_field(
+                _scene_field(
+                    entry, ("Villains", "villains", "Antagonists", "antagonists")
+                )
+            ),
+            places=normalize_list_field(
+                _scene_field(
+                    entry,
+                    (
+                        "Places",
+                        "places",
+                        "Locations",
+                        "locations",
+                        "Setting",
+                        "setting",
+                    ),
+                )
+            ),
+            maps=normalize_list_field(
+                _scene_field(
+                    entry, ("Maps", "maps", "Map", "map", "SceneMap", "Scene Map")
+                )
+            ),
+        )
+
+    scene_text = _clean_text(entry)
+    if not scene_text:
+        return None
+    title, body = split_scene_title(scene_text, index)
+    parsed = parse_scene_body_sections(body or scene_text)
+    return ScenarioBoardScene(
+        index=index,
+        title=title,
+        body=body or scene_text,
+        intro_text=_clean_text(parsed.get("intro_text")),
+        sections=tuple(parsed.get("sections") or ()),
+    )
+
+
+def build_scenario_board_data(
+    scenario_item: dict[str, Any] | None,
+) -> ScenarioBoardData:
+    """Build normalized display data for a scenario board panel."""
+    item = scenario_item if isinstance(scenario_item, dict) else {}
+    scenes: list[ScenarioBoardScene] = []
+    for index, entry in enumerate(_coerce_scene_entries(item), start=1):
+        scene = _normalize_scene_entry(entry, index)
+        if scene is not None:
+            scenes.append(scene)
+
+    linked_entities = {
+        entity_type: normalize_list_field(item.get(entity_type))
+        for entity_type in SCENARIO_BOARD_ENTITY_TYPES
+    }
+    linked_entities = {
+        entity_type: values for entity_type, values in linked_entities.items() if values
+    }
+
+    return ScenarioBoardData(
+        title=_clean_text(item.get("Title") or item.get("Name")) or "Untitled Scenario",
+        status=_clean_text(item.get("Status")),
+        summary=_clean_text(item.get("Summary")),
+        secrets=_clean_text(item.get("Secrets")),
+        scenes=tuple(scenes),
+        linked_entities=linked_entities,
+    )

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -1,0 +1,436 @@
+"""Scenario board page for the GM Table."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import customtkinter as ctk
+
+from modules.scenarios.gm_table.workspace import TABLE_PALETTE
+from modules.scenarios.gm_table.scenario_board.bundle_service import (
+    ScenarioBundle,
+    resolve_scenario_bundle,
+)
+from modules.scenarios.gm_table.scenario_board.models import (
+    ScenarioBoardData,
+    ScenarioBoardScene,
+    build_scenario_board_data,
+)
+
+OpenEntityCallback = Callable[[str, str], None]
+OpenMapCallback = Callable[[str | None], None]
+LaunchBundleCallback = Callable[[ScenarioBundle], None]
+StateChangedCallback = Callable[[], None]
+
+
+class ScenarioBoardPanel(ctk.CTkFrame):
+    """Compact live-session board built from one scenario record."""
+
+    def __init__(
+        self,
+        master,
+        *,
+        scenario_name: str,
+        scenario_item: dict[str, Any] | None,
+        open_entity_callback: OpenEntityCallback | None = None,
+        launch_bundle_callback: LaunchBundleCallback | None = None,
+        open_scene_map_callback: OpenMapCallback | None = None,
+        open_world_map_callback: OpenMapCallback | None = None,
+        wrappers: dict[str, object] | None = None,
+        map_wrapper: object | None = None,
+        initial_state: dict[str, Any] | None = None,
+        on_state_changed: StateChangedCallback | None = None,
+    ) -> None:
+        super().__init__(master, fg_color="transparent")
+        self.scenario_name = str(scenario_name or "").strip()
+        self._scenario_item = scenario_item if isinstance(scenario_item, dict) else {}
+        self._open_entity_callback = open_entity_callback
+        self._launch_bundle_callback = launch_bundle_callback
+        self._open_scene_map_callback = open_scene_map_callback
+        self._open_world_map_callback = open_world_map_callback
+        self._wrappers = wrappers or {}
+        self._map_wrapper = map_wrapper
+        self._on_state_changed = on_state_changed
+        self._data = build_scenario_board_data(scenario_item)
+        state = initial_state if isinstance(initial_state, dict) else {}
+        self._completed_scenes = {
+            int(value)
+            for value in state.get("completed_scenes", [])
+            if str(value).isdigit()
+        }
+        self._current_scene_index = self._coerce_scene_index(state.get("current_scene"))
+        if self._current_scene_index is None and self._data.scenes:
+            self._current_scene_index = self._data.scenes[0].index
+        self._scene_buttons: dict[int, ctk.CTkButton] = {}
+        self._scene_status_label: ctk.CTkLabel | None = None
+
+        self.grid_rowconfigure(1, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self._build_header()
+        self._build_scroll_body()
+        self._refresh_scene_selection()
+
+    def get_state(self) -> dict[str, Any]:
+        """Return persisted panel state."""
+        return {
+            "scenario_name": self.scenario_name or self._data.title,
+            "current_scene": self._current_scene_index,
+            "completed_scenes": sorted(self._completed_scenes),
+        }
+
+    def _build_header(self) -> None:
+        header = ctk.CTkFrame(
+            self,
+            fg_color=TABLE_PALETTE["panel_alt"],
+            corner_radius=16,
+            border_width=1,
+            border_color=TABLE_PALETTE["panel_border"],
+        )
+        header.grid(row=0, column=0, sticky="ew", pady=(0, 10))
+        header.grid_columnconfigure(0, weight=1)
+
+        title = self._data.title
+        if self._data.status:
+            title = f"{title}  •  {self._data.status}"
+        ctk.CTkLabel(
+            header,
+            text=title,
+            text_color=TABLE_PALETTE["text"],
+            font=ctk.CTkFont(size=18, weight="bold"),
+            anchor="w",
+        ).grid(row=0, column=0, sticky="ew", padx=14, pady=(10, 2))
+        self._scene_status_label = ctk.CTkLabel(
+            header,
+            text="Scenario Board",
+            text_color=TABLE_PALETTE["muted"],
+            font=ctk.CTkFont(size=12),
+            anchor="w",
+        )
+        self._scene_status_label.grid(
+            row=1, column=0, sticky="ew", padx=14, pady=(0, 8)
+        )
+
+        actions = ctk.CTkFrame(header, fg_color="transparent")
+        actions.grid(row=2, column=0, sticky="ew", padx=14, pady=(0, 12))
+        buttons = (
+            ("Launch Scenario Bundle", self._launch_current_bundle),
+            ("Open Scene Map", self._open_current_scene_map),
+            ("Open NPCs", lambda: self._open_entities("NPCs")),
+            ("Open Villain", lambda: self._open_entities("Villains")),
+            ("Open Places", lambda: self._open_entities("Places")),
+            ("Open World Map", self._open_world_map),
+            ("Mark Scene Done", self._mark_current_scene_done),
+        )
+        for text, command in buttons:
+            ctk.CTkButton(
+                actions,
+                text=text,
+                height=28,
+                fg_color=TABLE_PALETTE["table_chip"],
+                hover_color="#283146",
+                text_color=TABLE_PALETTE["text"],
+                corner_radius=14,
+                command=command,
+            ).pack(side="left", padx=(0, 6), pady=(0, 6))
+
+    def _build_scroll_body(self) -> None:
+        scroll = ctk.CTkScrollableFrame(
+            self,
+            fg_color="transparent",
+            scrollbar_button_color=TABLE_PALETTE["table_chip"],
+            scrollbar_button_hover_color=TABLE_PALETTE["accent"],
+        )
+        scroll.grid(row=1, column=0, sticky="nsew")
+        scroll.grid_columnconfigure(0, weight=1)
+        row = 0
+
+        row = self._add_text_card(scroll, row, "Summary", self._data.summary)
+        row = self._add_text_card(scroll, row, "Secrets", self._data.secrets)
+        row = self._add_entities_card(scroll, row, self._data)
+        row = self._add_scenes(scroll, row, self._data)
+
+        if row == 0:
+            ctk.CTkLabel(
+                scroll,
+                text="No scenario content found.",
+                text_color=TABLE_PALETTE["muted"],
+            ).grid(row=0, column=0, sticky="ew", padx=16, pady=16)
+
+    def _add_text_card(self, parent, row: int, title: str, text: str) -> int:
+        if not text:
+            return row
+        card = self._card(parent)
+        card.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        self._card_title(card, title).grid(
+            row=0, column=0, sticky="ew", padx=12, pady=(10, 4)
+        )
+        ctk.CTkLabel(
+            card,
+            text=text,
+            text_color=TABLE_PALETTE["text"],
+            justify="left",
+            wraplength=760,
+            anchor="w",
+        ).grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 12))
+        return row + 1
+
+    def _add_entities_card(self, parent, row: int, data: ScenarioBoardData) -> int:
+        if not data.linked_entities:
+            return row
+        card = self._card(parent)
+        card.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+        self._card_title(card, "Linked Entities").grid(
+            row=0, column=0, sticky="ew", padx=12, pady=(10, 4)
+        )
+        entity_row = 1
+        for entity_type, names in data.linked_entities.items():
+            ctk.CTkLabel(
+                card,
+                text=entity_type,
+                text_color=TABLE_PALETTE["muted"],
+                font=ctk.CTkFont(size=12, weight="bold"),
+                anchor="w",
+            ).grid(row=entity_row, column=0, sticky="ew", padx=12, pady=(6, 2))
+            entity_row += 1
+            chips = ctk.CTkFrame(card, fg_color="transparent")
+            chips.grid(row=entity_row, column=0, sticky="ew", padx=12, pady=(0, 2))
+            for name in names:
+                ctk.CTkButton(
+                    chips,
+                    text=name,
+                    height=26,
+                    fg_color=TABLE_PALETTE["table_chip"],
+                    hover_color="#283146",
+                    text_color=TABLE_PALETTE["text"],
+                    corner_radius=13,
+                    command=lambda et=entity_type, n=name: self._open_entity(et, n),
+                ).pack(side="left", padx=(0, 6), pady=(0, 6))
+            entity_row += 1
+        return row + 1
+
+    def _add_scenes(self, parent, row: int, data: ScenarioBoardData) -> int:
+        if not data.scenes:
+            return row
+        for scene in data.scenes:
+            card = self._card(parent)
+            card.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+            card.grid_columnconfigure(1, weight=1)
+            button = ctk.CTkButton(
+                card,
+                text=f"{scene.index}. {scene.title}",
+                height=30,
+                fg_color=TABLE_PALETTE["table_chip"],
+                hover_color="#283146",
+                text_color=TABLE_PALETTE["text"],
+                anchor="w",
+                command=lambda idx=scene.index: self._set_current_scene(idx),
+            )
+            button.grid(
+                row=0, column=0, sticky="ew", padx=12, pady=(10, 4), columnspan=2
+            )
+            self._scene_buttons[scene.index] = button
+            inner_row = 1
+            if scene.intro_text:
+                ctk.CTkLabel(
+                    card,
+                    text=scene.intro_text,
+                    text_color=TABLE_PALETTE["text"],
+                    justify="left",
+                    wraplength=760,
+                    anchor="w",
+                ).grid(
+                    row=inner_row,
+                    column=0,
+                    columnspan=2,
+                    sticky="ew",
+                    padx=12,
+                    pady=(0, 8),
+                )
+                inner_row += 1
+            inner_row = self._add_scene_entities(card, inner_row, scene)
+            for section in scene.sections:
+                inner_row = self._add_scene_section(card, inner_row, section)
+            row += 1
+        return row
+
+    def _add_scene_entities(self, parent, row: int, scene: ScenarioBoardScene) -> int:
+        parts = []
+        for label, values in (
+            ("NPCs", scene.npcs),
+            ("Villains", scene.villains),
+            ("Places", scene.places),
+            ("Maps", scene.maps),
+        ):
+            if values:
+                parts.append(f"{label}: {', '.join(values)}")
+        if not parts:
+            return row
+        ctk.CTkLabel(
+            parent,
+            text="  •  ".join(parts),
+            text_color=TABLE_PALETTE["muted"],
+            justify="left",
+            wraplength=760,
+            anchor="w",
+        ).grid(row=row, column=0, columnspan=2, sticky="ew", padx=12, pady=(0, 8))
+        return row + 1
+
+    def _add_scene_section(self, parent, row: int, section: dict[str, Any]) -> int:
+        title = f"{section.get('emoji', '')} {section.get('title', '')}".strip()
+        ctk.CTkLabel(
+            parent,
+            text=title,
+            text_color=TABLE_PALETTE["accent"],
+            font=ctk.CTkFont(size=12, weight="bold"),
+            anchor="w",
+        ).grid(row=row, column=0, columnspan=2, sticky="ew", padx=12, pady=(4, 2))
+        items = section.get("items") or []
+        text = (
+            "\n".join(f"• {item}" for item in items)
+            if items
+            else str(section.get("raw_text") or "").strip()
+        )
+        if text:
+            ctk.CTkLabel(
+                parent,
+                text=text,
+                text_color=TABLE_PALETTE["text"],
+                justify="left",
+                wraplength=760,
+                anchor="w",
+            ).grid(
+                row=row + 1, column=0, columnspan=2, sticky="ew", padx=18, pady=(0, 4)
+            )
+            return row + 2
+        return row + 1
+
+    def _current_scene(self) -> ScenarioBoardScene | None:
+        for scene in self._data.scenes:
+            if scene.index == self._current_scene_index:
+                return scene
+        return self._data.scenes[0] if self._data.scenes else None
+
+    def _current_bundle(self) -> ScenarioBundle:
+        return resolve_scenario_bundle(
+            self._scenario_item,
+            self._current_scene(),
+            self._wrappers,
+            self._map_wrapper,
+        )
+
+    def _set_current_scene(self, index: int) -> None:
+        self._current_scene_index = index
+        self._refresh_scene_selection()
+        self._notify_state_changed()
+
+    def _mark_current_scene_done(self) -> None:
+        if self._current_scene_index is None:
+            return
+        self._completed_scenes.add(self._current_scene_index)
+        next_scene = next(
+            (
+                scene.index
+                for scene in self._data.scenes
+                if scene.index not in self._completed_scenes
+            ),
+            None,
+        )
+        if next_scene is not None:
+            self._current_scene_index = next_scene
+        self._refresh_scene_selection()
+        self._notify_state_changed()
+
+    def _refresh_scene_selection(self) -> None:
+        for index, button in self._scene_buttons.items():
+            done = index in self._completed_scenes
+            current = index == self._current_scene_index
+            prefix = "✓ " if done else ("▶ " if current else "")
+            scene = next(
+                (
+                    candidate
+                    for candidate in self._data.scenes
+                    if candidate.index == index
+                ),
+                None,
+            )
+            if scene is not None:
+                button.configure(
+                    text=f"{prefix}{scene.index}. {scene.title}",
+                    fg_color=(
+                        TABLE_PALETTE["accent_soft"]
+                        if current
+                        else TABLE_PALETTE["table_chip"]
+                    ),
+                )
+        scene = self._current_scene()
+        if self._scene_status_label is not None:
+            if scene is None:
+                text = "Scenario Board"
+            else:
+                text = f"Current scene: {scene.index}. {scene.title}  •  Done: {len(self._completed_scenes)}/{len(self._data.scenes)}"
+            self._scene_status_label.configure(text=text)
+
+    def _launch_current_bundle(self) -> None:
+        if callable(self._launch_bundle_callback):
+            self._launch_bundle_callback(self._current_bundle())
+
+    def _open_current_scene_map(self) -> None:
+        bundle = self._current_bundle()
+        map_name = bundle.maps[0] if bundle.maps else None
+        if callable(self._open_scene_map_callback):
+            self._open_scene_map_callback(map_name)
+
+    def _open_world_map(self) -> None:
+        bundle = self._current_bundle()
+        map_name = bundle.world_maps[0] if bundle.world_maps else None
+        if callable(self._open_world_map_callback):
+            self._open_world_map_callback(map_name)
+
+    def _open_entities(self, entity_type: str) -> None:
+        bundle = self._current_bundle()
+        names = {
+            "NPCs": bundle.npcs,
+            "Villains": bundle.villains,
+            "Places": bundle.places,
+        }.get(entity_type, ())
+        for name in names:
+            self._open_entity(entity_type, name)
+
+    def _open_entity(self, entity_type: str, name: str) -> None:
+        if callable(self._open_entity_callback):
+            self._open_entity_callback(entity_type, name)
+
+    def _notify_state_changed(self) -> None:
+        if callable(self._on_state_changed):
+            self._on_state_changed()
+
+    @staticmethod
+    def _coerce_scene_index(value: Any) -> int | None:
+        try:
+            index = int(value)
+        except (TypeError, ValueError):
+            return None
+        return index if index > 0 else None
+
+    @staticmethod
+    def _card(parent) -> ctk.CTkFrame:
+        card = ctk.CTkFrame(
+            parent,
+            fg_color=TABLE_PALETTE["panel_alt"],
+            corner_radius=14,
+            border_width=1,
+            border_color=TABLE_PALETTE["panel_border"],
+        )
+        card.grid_columnconfigure(0, weight=1)
+        return card
+
+    @staticmethod
+    def _card_title(parent, text: str) -> ctk.CTkLabel:
+        return ctk.CTkLabel(
+            parent,
+            text=text,
+            text_color=TABLE_PALETTE["text"],
+            font=ctk.CTkFont(size=14, weight="bold"),
+            anchor="w",
+        )

--- a/modules/scenarios/gm_table/scenario_board/panel.py
+++ b/modules/scenarios/gm_table/scenario_board/panel.py
@@ -1,0 +1,5 @@
+"""Compatibility import for the Scenario Board panel."""
+
+from modules.scenarios.gm_table.scenario_board.page import ScenarioBoardPanel
+
+__all__ = ["ScenarioBoardPanel"]

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -55,6 +55,7 @@ DEFAULT_PANEL_SIZES = {
     "campaign_dashboard": (780, 560),
     "world_map": (860, 620),
     "map_tool": (900, 640),
+    "scenario_board": (900, 680),
     "scene_flow": (860, 600),
     "image": (620, 520),
     "image_library": (860, 580),

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -34,6 +34,7 @@ from modules.scenarios.gm_table.attachments import (
     entity_has_attachments,
 )
 from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
+from modules.scenarios.gm_table.scenario_board import ScenarioBoardPanel, ScenarioBundle
 from modules.scenarios.gm_table.container_window import GMTableContainerPage
 from modules.scenarios.gm_table.pages import (
     GMTableAttachmentGallery,
@@ -144,6 +145,7 @@ class GMTableView(ctk.CTkFrame):
             "Campaign Dashboard",
             "World Map",
             "Map Tool",
+            "Scenario Board",
             "Scene Flow",
             "Image Library",
             "Image from Library",
@@ -854,6 +856,61 @@ class GMTableView(ctk.CTkFrame):
             self._panel_state(map_name=target_map),
         )
 
+    def open_or_focus_world_map(self, map_name: str | None = None) -> str | None:
+        """Public Scenario Board helper for opening or focusing the world map panel."""
+        return self._focus_or_open_world_map_panel(map_name)
+
+    def open_or_focus_map_panel(self, map_name: str | None = None) -> str | None:
+        """Public Scenario Board helper for opening or focusing a scene map panel."""
+        return self._focus_or_open_map_tool_panel(map_name)
+
+    def open_or_focus_entity_panel(self, entity_type: str, name: str) -> None:
+        """Public Scenario Board helper for deduplicated entity panels."""
+        self.open_entity_panel(entity_type, name)
+
+    def launch_scenario_bundle(self, bundle: ScenarioBundle) -> None:
+        """Open the active scene's resolved bundle onto the GM Table."""
+        if bundle.maps:
+            self.open_or_focus_map_panel(bundle.maps[0])
+        if bundle.world_maps:
+            self.open_or_focus_world_map(bundle.world_maps[0])
+        for entity_type, names in (
+            ("NPCs", bundle.npcs),
+            ("Villains", bundle.villains),
+            ("Places", bundle.places),
+        ):
+            for name in names:
+                self.open_or_focus_entity_panel(entity_type, name)
+
+    def open_or_focus_scenario_board(
+        self, scenario_name: str, *, workspace: GMTableWorkspace | None = None
+    ) -> str:
+        """Open one Scenario Board per scenario and focus it when already present."""
+        target_workspace = workspace or self.workspace
+        normalized = self._normalize_entity_name(scenario_name)
+        for panel in target_workspace.serialize().get("panels", []):
+            state = panel.get("state") or {}
+            if (
+                panel.get("kind") == "scenario_board"
+                and self._normalize_entity_name(state.get("scenario_name"))
+                == normalized
+            ):
+                panel_id = str(panel.get("panel_id"))
+                target_workspace.bring_to_front(panel_id)
+                width, height = resolve_default_panel_size("scenario_board")
+                target_workspace.ensure_panel_minimum_size(panel_id, width, height)
+                return panel_id
+
+        title = str(scenario_name or "").strip() or "Untitled Scenario"
+        width, height = resolve_default_panel_size("scenario_board")
+        return self._create_panel_in_workspace(
+            "scenario_board",
+            f"Scenario Board: {title}",
+            {"scenario_name": title},
+            geometry={"width": width, "height": height},
+            workspace=workspace,
+        )
+
     def _open_player_view_for_active_panel(self) -> None:
         """Open the player display for the active scene map."""
         panel_id, kind, payload = self._resolve_tabletop_context(prefer_world_map=True)
@@ -909,6 +966,15 @@ class GMTableView(ctk.CTkFrame):
         if option == "Map Tool":
             self._create_panel_in_workspace(
                 "map_tool", "Map Tool", {}, workspace=workspace
+            )
+            return
+        if option == "Scenario Board":
+            (
+                self._open_scenario_selection_for_panel("scenario_board")
+                if workspace is None
+                else self._open_scenario_selection_for_panel(
+                    "scenario_board", workspace=workspace
+                )
             )
             return
         if option == "Scene Flow":
@@ -1039,6 +1105,14 @@ class GMTableView(ctk.CTkFrame):
                             (getattr(payload, "current_map", None) or {}).get("Name")
                         )
                     ),
+                )
+            if kind == "scenario_board":
+                return GMTableHostedPage(
+                    parent,
+                    builder=lambda host: self._build_scenario_board_content(
+                        host, definition.state
+                    ),
+                    state_getter=lambda payload: payload.get_state(),
                 )
             if kind == "scene_flow":
                 return GMTableHostedPage(
@@ -1237,6 +1311,26 @@ class GMTableView(ctk.CTkFrame):
         widget = create_scene_flow_frame(
             host,
             scenario_title=state.get("scenario_title") or "",
+        )
+        widget.grid(row=0, column=0, sticky="nsew")
+        return widget
+
+    def _build_scenario_board_content(self, host, state: dict):
+        """Build the scenario board page."""
+        scenario_name = str(state.get("scenario_name") or "").strip()
+        scenario_item = self._load_scenario_item(scenario_name) if scenario_name else {}
+        widget = ScenarioBoardPanel(
+            host,
+            scenario_name=scenario_name,
+            scenario_item=scenario_item,
+            open_entity_callback=self.open_or_focus_entity_panel,
+            launch_bundle_callback=self.launch_scenario_bundle,
+            open_scene_map_callback=self.open_or_focus_map_panel,
+            open_world_map_callback=self.open_or_focus_world_map,
+            wrappers=self.wrappers,
+            map_wrapper=self.map_wrapper,
+            initial_state=state,
+            on_state_changed=self._persist_layout,
         )
         widget.grid(row=0, column=0, sticky="nsew")
         return widget
@@ -1530,6 +1624,9 @@ class GMTableView(ctk.CTkFrame):
                     {"scenario_title": scenario_title},
                     workspace=workspace,
                 )
+                return
+            if panel_kind == "scenario_board":
+                self.open_or_focus_scenario_board(scenario_title, workspace=workspace)
                 return
             if panel_kind == "handouts":
                 self._create_panel_in_selection_workspace(

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -338,7 +338,9 @@ def test_build_object_entity_content_uses_scrollable_full_detail(monkeypatch) ->
     assert frame.pack_calls == [{"fill": "both", "expand": True}]
 
 
-def test_build_entity_content_with_attachments_hides_portrait_spotlight(monkeypatch) -> None:
+def test_build_entity_content_with_attachments_hides_portrait_spotlight(
+    monkeypatch,
+) -> None:
     """Attachment-backed evidence cards should show attachments without an empty portrait panel."""
     captured = {}
 
@@ -409,6 +411,7 @@ def test_build_entity_content_with_attachments_hides_portrait_spotlight(monkeypa
     assert captured["callback"] is callback
     assert captured["kwargs"] == {"spotlight_only": False, "show_spotlight": False}
     assert captured["gallery_kwargs"] == {"attachments": [attachment]}
+
 
 def test_context_menu_handler_resolution_is_safe_without_gm_screen_api() -> None:
     """GM Table hosts without a context-menu API should not crash the detail factory."""
@@ -1023,3 +1026,60 @@ def test_mount_panel_content_builds_container_window(monkeypatch) -> None:
     assert isinstance(mounted, _DummyContainerPage)
     assert captured["kwargs"]["initial_state"] == {"container_layout": {"panels": []}}
     assert captured["kwargs"]["on_layout_changed"] == view._persist_layout
+
+
+def test_open_or_focus_scenario_board_reuses_existing_panel() -> None:
+    """Scenario Board helper should avoid duplicate panels for the same scenario."""
+    calls = []
+    workspace = SimpleNamespace(
+        serialize=lambda: {
+            "panels": [
+                {
+                    "panel_id": "board-1",
+                    "kind": "scenario_board",
+                    "state": {"scenario_name": "Night Run"},
+                }
+            ]
+        },
+        bring_to_front=lambda panel_id: calls.append(("front", panel_id)),
+        ensure_panel_minimum_size=lambda panel_id, width, height: calls.append(
+            ("ensure", panel_id, width, height)
+        ),
+    )
+    view = GMTableView.__new__(GMTableView)
+    view.workspace = workspace
+
+    panel_id = GMTableView.open_or_focus_scenario_board(view, "night run")
+
+    assert panel_id == "board-1"
+    assert calls == [("front", "board-1"), ("ensure", "board-1", 900, 680)]
+
+
+def test_launch_scenario_bundle_opens_maps_and_entities() -> None:
+    """Launching a resolved bundle should route through deduplicating helpers."""
+    calls = []
+    view = GMTableView.__new__(GMTableView)
+    view.open_or_focus_map_panel = lambda name=None: calls.append(("map", name))
+    view.open_or_focus_world_map = lambda name=None: calls.append(("world", name))
+    view.open_or_focus_entity_panel = lambda entity_type, name: calls.append(
+        (entity_type, name)
+    )
+    bundle = gm_table_view_module.ScenarioBundle(
+        scenario_title="Night Run",
+        scene_title="Cold Open",
+        npcs=("Fixer",),
+        villains=("Boss",),
+        places=("Docks",),
+        maps=("Docks Map",),
+        world_maps=("City Map",),
+    )
+
+    GMTableView.launch_scenario_bundle(view, bundle)
+
+    assert calls == [
+        ("map", "Docks Map"),
+        ("world", "City Map"),
+        ("NPCs", "Fixer"),
+        ("Villains", "Boss"),
+        ("Places", "Docks"),
+    ]

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -1,0 +1,210 @@
+"""Tests for GM Table scenario board data and integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from modules.scenarios.gm_table.scenario_board import (
+    build_scenario_board_data,
+    normalize_list_field,
+    resolve_scenario_bundle,
+    split_scene_title,
+)
+from modules.scenarios.gm_table.workspace import resolve_default_panel_size
+from modules.scenarios.gm_table_view import GMTableView
+
+
+def test_normalize_list_field_accepts_json_lines_and_dicts() -> None:
+    """Scenario board fields can come from templates, JSON, or hydrated records."""
+    assert normalize_list_field('["A", "B"]') == ("A", "B")
+    assert normalize_list_field("A\n\nB") == ("A", "B")
+    assert normalize_list_field([{"Title": "Scene NPC"}, {"Name": "Legacy NPC"}]) == (
+        "Scene NPC",
+        "Legacy NPC",
+    )
+
+
+def test_split_scene_title_uses_first_short_line_as_card_title() -> None:
+    """Scene cards should get a readable title without losing body text."""
+    title, body = split_scene_title("Warehouse Ambush\nKey beats:\n- Alarm", 2)
+
+    assert title == "Warehouse Ambush"
+    assert body == "Key beats:\n- Alarm"
+
+
+def test_build_scenario_board_data_extracts_scenes_sections_and_links() -> None:
+    """Board data should normalize scenario metadata for UI rendering."""
+    data = build_scenario_board_data(
+        {
+            "Title": "Night Run",
+            "Status": "Ready",
+            "Summary": "A chase through the docks.",
+            "Secrets": "The patron is lying.",
+            "Scenes": [
+                "Cold Open\nKey beats:\n- Meet the fixer\nClues/hooks:\n- Blue ticket",
+                "Finale: Fight on the ferry",
+            ],
+            "NPCs": ["Fixer", "Captain"],
+            "Places": '["Docks"]',
+        }
+    )
+
+    assert data.title == "Night Run"
+    assert data.status == "Ready"
+    assert data.summary == "A chase through the docks."
+    assert data.secrets == "The patron is lying."
+    assert [scene.title for scene in data.scenes] == ["Cold Open", "Finale"]
+    assert data.scenes[0].sections[0]["title"] == "Key beats"
+    assert data.scenes[0].sections[0]["items"] == ["Meet the fixer"]
+    assert data.linked_entities["NPCs"] == ("Fixer", "Captain")
+    assert data.linked_entities["Places"] == ("Docks",)
+
+
+def test_scenario_board_has_dedicated_default_panel_size() -> None:
+    """The scenario board should open as a large planning panel."""
+    assert resolve_default_panel_size("scenario_board") == (900, 680)
+
+
+def test_handle_add_option_routes_scenario_board_to_scenario_picker() -> None:
+    """The GM Table add menu should request a scenario before opening the board."""
+    captured = []
+    view = GMTableView.__new__(GMTableView)
+    view._open_scenario_selection_for_panel = (
+        lambda panel_kind, **kwargs: captured.append((panel_kind, kwargs))
+    )
+
+    GMTableView._handle_add_option(view, "Scenario Board")
+
+    assert captured == [("scenario_board", {})]
+
+
+def test_scenario_selection_creates_scenario_board_panel() -> None:
+    """Selected scenarios should create persisted scenario_board panels."""
+    captured = []
+    view = GMTableView.__new__(GMTableView)
+    view.wrappers = {"Scenarios": SimpleNamespace()}
+    view._templates = {"Scenarios": {}}
+    view.winfo_toplevel = lambda: None
+    view._entity_label = lambda _entity_type, item, fallback="": item.get(
+        "Title", fallback
+    )
+    view.open_or_focus_scenario_board = (
+        lambda scenario_title, **kwargs: captured.append(
+            ("scenario_board", scenario_title, kwargs)
+        )
+    )
+
+    class _Popup:
+        def title(self, _value):
+            pass
+
+        def geometry(self, _value):
+            pass
+
+        def transient(self, _value):
+            pass
+
+        def grab_set(self):
+            pass
+
+        def focus_force(self):
+            pass
+
+        def destroy(self):
+            captured.append(("destroy",))
+
+    class _SelectionView:
+        def __init__(self, _popup, entity_type, _wrapper, _template, callback):
+            assert entity_type == "Scenarios"
+            callback("Scenarios", "Fallback", {"Title": "Night Run"})
+
+        def pack(self, **_kwargs):
+            pass
+
+    import modules.scenarios.gm_table_view as gm_table_view_module
+
+    original_toplevel = gm_table_view_module.ctk.CTkToplevel
+    original_selection = gm_table_view_module.GenericListSelectionView
+    try:
+        gm_table_view_module.ctk.CTkToplevel = lambda _master: _Popup()
+        gm_table_view_module.GenericListSelectionView = _SelectionView
+        GMTableView._open_scenario_selection_for_panel(view, "scenario_board")
+    finally:
+        gm_table_view_module.ctk.CTkToplevel = original_toplevel
+        gm_table_view_module.GenericListSelectionView = original_selection
+
+    assert captured == [
+        ("destroy",),
+        ("scenario_board", "Night Run", {"workspace": None}),
+    ]
+
+
+def test_build_scenario_board_data_extracts_scene_flow_dict_entities() -> None:
+    """Scenario Board accepts scene-flow variants and structured scene references."""
+    data = build_scenario_board_data(
+        {
+            "Title": "Museum Job",
+            "SceneFlow": {
+                "002": {
+                    "title": "Gallery Chase",
+                    "description": "Run through the exhibits.",
+                    "NPCs": ["Curator"],
+                    "Villains": "The Fox",
+                    "Places": [{"Name": "Grand Gallery"}],
+                    "Maps": "Gallery Map",
+                }
+            },
+        }
+    )
+
+    assert [scene.title for scene in data.scenes] == ["Gallery Chase"]
+    scene = data.scenes[0]
+    assert scene.body == "Run through the exhibits."
+    assert scene.npcs == ("Curator",)
+    assert scene.villains == ("The Fox",)
+    assert scene.places == ("Grand Gallery",)
+    assert scene.maps == ("Gallery Map",)
+
+
+def test_resolve_scenario_bundle_uses_scene_and_tolerant_wrapper_matches() -> None:
+    """Bundle service resolves scene/scenario candidates using forgiving aliases."""
+    scene = build_scenario_board_data(
+        {
+            "Title": "Museum Job",
+            "Scenes": [
+                {
+                    "Title": "Gallery Chase",
+                    "NPCs": ["curator vale"],
+                    "Villains": ["THE FOX"],
+                    "Places": ["Grand-Gallery"],
+                    "Maps": ["gallerymap"],
+                }
+            ],
+        }
+    ).scenes[0]
+    wrappers = {
+        "NPCs": SimpleNamespace(load_items=lambda: [{"Name": "Curator Vale"}]),
+        "Villains": SimpleNamespace(load_items=lambda: [{"Name": "The Fox"}]),
+        "Places": SimpleNamespace(load_items=lambda: [{"Name": "Grand Gallery"}]),
+    }
+    map_wrapper = SimpleNamespace(
+        load_items=lambda: [
+            {"Name": "Gallery Map"},
+            {"Name": "Campaign World", "Type": "World Map"},
+        ]
+    )
+
+    bundle = resolve_scenario_bundle(
+        {"Title": "Museum Job", "NPCs": ["Spare Contact"]},
+        scene,
+        wrappers,
+        map_wrapper,
+    )
+
+    assert bundle.scenario_title == "Museum Job"
+    assert bundle.scene_title == "Gallery Chase"
+    assert bundle.npcs == ("Spare Contact", "Curator Vale")
+    assert bundle.villains == ("The Fox",)
+    assert bundle.places == ("Grand Gallery",)
+    assert bundle.maps == ("Gallery Map",)
+    assert bundle.world_maps == ("Campaign World",)


### PR DESCRIPTION
### Motivation
- The GM Table needs a live-session “Scenario Board” so a GM can pick a scenario and open a pre-arranged set of helpful panels for running (not editing) that scenario.
- The feature should present scenario details and scene navigation, let the GM mark scenes done, and launch a resolved bundle of maps/entities into predefined panel geometry to avoid manual window arranging.
- Implement this as a compact page + a small bundle resolution service that reuses existing panel creation and entity/map helpers to keep the change non-invasive and robust.

### Description
- Added a new Scenario Board package under `modules/scenarios/gm_table/scenario_board/` with `models.py`, `bundle_service.py`, `page.py` and a small compatibility `panel.py` plus package `__init__.py` to expose the API; `models.py` normalizes scenario/scene data and supports many scene-source formats and fields. 
- Implemented `bundle_service.py` which builds a `ScenarioBundle` by resolving scenario- and scene-level NPCs, villains, places, maps and world-map candidates using wrapper-backed tolerant matching (case/punctuation-insensitive, compact substring fallback). 
- Implemented the Scenario Board UI in `page.py` (`ScenarioBoardPanel`) providing scene list/navigation, current-scene tracking, completed-scene persistence, and action buttons: `Launch Scenario Bundle`, `Open Scene Map`, `Open NPCs`, `Open Villain`, `Open Places`, `Open World Map`, and `Mark Scene Done`. The panel exposes `get_state()` so workspace serialization persists `scenario_name`, `current_scene`, and `completed_scenes`. 
- Integrated into GM Table: added `Scenario Board` to the Add menu, mounted board pages via the existing hosted-page mechanism, added public helpers on `GMTableView` (`open_or_focus_scenario_board`, `launch_scenario_bundle`, `open_or_focus_map_panel`, `open_or_focus_world_map`, `open_or_focus_entity_panel`) and ensured single-board-per-scenario deduping and use of predefined default geometry. 
- Added a default panel size for `scenario_board` in `modules/scenarios/gm_table/workspace.py` (900×680) and ensured bundle launch reuses existing map/entity panel open/focus logic rather than duplicating panel creation.
- Tests and small stubs were added to cover normalization, structured scene extraction, bundle resolution, add-menu routing, deduped scenario-board opening, and bundle launch routing.

### Testing
- Ran the targeted integration/unit test suite with `pytest -q tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/gm_table/test_gm_table_view.py`, and the tests passed (targeted suite green).
- Verified module import/bytecode sanity with `python -m compileall modules/scenarios/gm_table/scenario_board modules/scenarios/gm_table_view.py` which succeeded.
- Verified the new `scenario_board` default size with `resolve_default_panel_size` tests and exercised the GM Table open/focus and launch helpers via unit tests; those checks passed in the CI-like test runs.
- A full `pytest -q` of the whole repository was not fully green in this environment due to pre-existing unrelated issues (headless/Tk display constraints for some UI tests and an unrelated missing third-party import in a separate smoke test), but they are unrelated to the Scenario Board changes and the Scenario Board/GM Table targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3414b2cc832b8a25e64d770e39e7)