### PR TITLE
Decode rich-text payloads and enable dynamic wrapping on Scenario Board

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/models.py
+++ b/modules/scenarios/gm_table/scenario_board/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import ast
 import json
 from typing import Any, Iterable, Mapping
 
@@ -51,9 +52,42 @@ class ScenarioBoardData:
     linked_entities: dict[str, tuple[str, ...]]
 
 
+def _parse_serialized_payload(value: str) -> Any | None:
+    """Decode JSON/Python literal rich-text payloads stored as strings."""
+    text = value.strip()
+    if not text or text[0] not in "[{":
+        return None
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(text)
+        except (ValueError, SyntaxError, TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, (dict, list, tuple)):
+            return parsed
+    return None
+
+
 def _clean_text(value: Any) -> str:
-    """Return a display-safe string without leading or trailing whitespace."""
-    return str(value or "").strip()
+    """Return display-safe plain text for raw and rich-text payloads."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        parsed = _parse_serialized_payload(value)
+        if parsed is not None:
+            return _clean_text(parsed)
+        return value.strip()
+    if isinstance(value, Mapping):
+        text_value = value.get("text")
+        if text_value is None:
+            text_value = value.get("Text")
+        if text_value is not None:
+            return _clean_text(text_value)
+        return ""
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        return "\n".join(
+            part for entry in value if (part := _clean_text(entry))
+        ).strip()
+    return str(value).strip()
 
 
 def _maybe_json_list(value: str) -> list[Any] | None:
@@ -84,7 +118,7 @@ def normalize_list_field(value: Any) -> tuple[str, ...]:
             if part.strip()
         )
     if isinstance(value, dict):
-        for key in ("Title", "Name", "title", "name"):
+        for key in ("Title", "Name", "title", "name", "text", "Text"):
             label = _clean_text(value.get(key))
             if label:
                 return (label,)
@@ -94,7 +128,7 @@ def normalize_list_field(value: Any) -> tuple[str, ...]:
         for entry in value:
             if isinstance(entry, dict):
                 label = ""
-                for key in ("Title", "Name", "title", "name"):
+                for key in ("Title", "Name", "title", "name", "text", "Text"):
                     label = _clean_text(entry.get(key))
                     if label:
                         break

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -165,14 +165,9 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         self._card_title(card, title).grid(
             row=0, column=0, sticky="ew", padx=12, pady=(10, 4)
         )
-        ctk.CTkLabel(
-            card,
-            text=text,
-            text_color=TABLE_PALETTE["text"],
-            justify="left",
-            wraplength=760,
-            anchor="w",
-        ).grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 12))
+        self._wrapped_label(card, text).grid(
+            row=1, column=0, sticky="ew", padx=12, pady=(0, 12)
+        )
         return row + 1
 
     def _add_entities_card(self, parent, row: int, data: ScenarioBoardData) -> int:
@@ -232,14 +227,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             self._scene_buttons[scene.index] = button
             inner_row = 1
             if scene.intro_text:
-                ctk.CTkLabel(
-                    card,
-                    text=scene.intro_text,
-                    text_color=TABLE_PALETTE["text"],
-                    justify="left",
-                    wraplength=760,
-                    anchor="w",
-                ).grid(
+                self._wrapped_label(card, scene.intro_text).grid(
                     row=inner_row,
                     column=0,
                     columnspan=2,
@@ -266,13 +254,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 parts.append(f"{label}: {', '.join(values)}")
         if not parts:
             return row
-        ctk.CTkLabel(
-            parent,
-            text="  •  ".join(parts),
-            text_color=TABLE_PALETTE["muted"],
-            justify="left",
-            wraplength=760,
-            anchor="w",
+        self._wrapped_label(
+            parent, "  •  ".join(parts), text_color=TABLE_PALETTE["muted"]
         ).grid(row=row, column=0, columnspan=2, sticky="ew", padx=12, pady=(0, 8))
         return row + 1
 
@@ -292,14 +275,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             else str(section.get("raw_text") or "").strip()
         )
         if text:
-            ctk.CTkLabel(
-                parent,
-                text=text,
-                text_color=TABLE_PALETTE["text"],
-                justify="left",
-                wraplength=760,
-                anchor="w",
-            ).grid(
+            self._wrapped_label(parent, text).grid(
                 row=row + 1, column=0, columnspan=2, sticky="ew", padx=18, pady=(0, 4)
             )
             return row + 2
@@ -412,6 +388,32 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         except (TypeError, ValueError):
             return None
         return index if index > 0 else None
+
+    @staticmethod
+    def _wrapped_label(
+        parent,
+        text: str,
+        *,
+        text_color: str | None = None,
+        horizontal_padding: int = 36,
+    ) -> ctk.CTkLabel:
+        """Create a label whose wrap length follows the available card width."""
+        label = ctk.CTkLabel(
+            parent,
+            text=text,
+            text_color=text_color or TABLE_PALETTE["text"],
+            justify="left",
+            wraplength=760,
+            anchor="w",
+        )
+
+        def update_wraplength(event=None) -> None:
+            width = getattr(event, "width", 0) or parent.winfo_width()
+            label.configure(wraplength=max(240, width - horizontal_padding))
+
+        parent.bind("<Configure>", update_wraplength, add="+")
+        label.after_idle(update_wraplength)
+        return label
 
     @staticmethod
     def _card(parent) -> ctk.CTkFrame:

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -60,6 +60,30 @@ def test_build_scenario_board_data_extracts_scenes_sections_and_links() -> None:
     assert data.linked_entities["Places"] == ("Docks",)
 
 
+def test_build_scenario_board_data_decodes_serialized_rich_text_payloads() -> None:
+    """Scenario Board should render rich-text payloads as readable plain text."""
+    data = build_scenario_board_data(
+        {
+            "Title": "Payload Run",
+            "Summary": "{'text': 'Readable summary.', 'formatting': {'bold': []}}",
+            "Secrets": {"text": "Readable secret.", "formatting": {"italic": []}},
+            "Scenes": [
+                {
+                    "Title": "Dict Scene",
+                    "Text": "{'text': 'Plain scene body.', 'formatting': {'bold': []}}",
+                },
+                r'{"text":"Inline Scene\nScene from JSON payload.","formatting":{"italic":[]}}',
+            ],
+        }
+    )
+
+    assert data.summary == "Readable summary."
+    assert data.secrets == "Readable secret."
+    assert data.scenes[0].body == "Plain scene body."
+    assert data.scenes[0].intro_text == "Plain scene body."
+    assert data.scenes[1].title == "Inline Scene"
+    assert data.scenes[1].body == "Scene from JSON payload."
+
 def test_scenario_board_has_dedicated_default_panel_size() -> None:
     """The scenario board should open as a large planning panel."""
     assert resolve_default_panel_size("scenario_board") == (900, 680)


### PR DESCRIPTION
### Motivation
- The Scenario Board was displaying serialized rich-text/dict-like payloads (e.g. `{'text': ..., 'formatting': ...}`) instead of readable plain text for Summary, Secrets and Scenes. 
- Text labels on the board used fixed wrap lengths, causing early mid-line wrapping instead of using available horizontal space.

### Description
- Add `_parse_serialized_payload` to decode JSON and Python-literal rich-text payloads and integrate it into `_clean_text` so string payloads, dicts with `text`/`Text` keys, and iterable content are normalized to plain text in `modules/scenarios/gm_table/scenario_board/models.py`.
- Extend `normalize_list_field` to extract readable labels from dict/list-rich entries (now checks `text`/`Text` keys) so linked entities render clean names.
- Replace fixed-length `CTkLabel` instances with a reusable `_wrapped_label` helper in `modules/scenarios/gm_table/scenario_board/page.py` that recalculates `wraplength` on resize so summary, scene intro, entity lists, and section text use available width.
- Add a regression test `test_build_scenario_board_data_decodes_serialized_rich_text_payloads` in `tests/scenarios/gm_table/test_scenario_board.py` to assert serialized Python-dict and JSON rich-text payloads are rendered as readable plain text.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/test_scene_text_payloads.py -q` which passed.
- Ran `python -m compileall modules/scenarios/gm_table/scenario_board tests/scenarios/gm_table/test_scenario_board.py` which succeeded.
- Ran broader checks `pytest -q tests/scenarios/gm_table -k 'not mount_payload_widget'` and `pytest -q tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/test_scene_text_payloads.py tests/test_text_helpers_mojibake.py` which passed; full `pytest -q tests/scenarios/gm_table` reports two GUI-only failures due to no X display in the CI/headless environment (`_tkinter.TclError: no display name and no $DISPLAY environment variable`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e90c5fbbc832b87b481b4d86e435b)