### PR TITLE
Add GM Table shared reveal actions and player-safe text reveals

### DIFF
--- a/modules/scenarios/gm_table/container_window.py
+++ b/modules/scenarios/gm_table/container_window.py
@@ -34,6 +34,7 @@ class GMTableContainerPage(ctk.CTkFrame):
         on_add_panel=None,
         panel_builder=None,
         on_layout_changed=None,
+        on_reveal_requested=None,
     ) -> None:
         super().__init__(master, fg_color="transparent")
         self.grid_rowconfigure(1, weight=1)
@@ -43,12 +44,14 @@ class GMTableContainerPage(ctk.CTkFrame):
         self._on_add_panel = on_add_panel
         self._panel_builder = panel_builder
         self._on_layout_changed = on_layout_changed
+        self._on_reveal_requested = on_reveal_requested
         self._add_menu = self._build_add_menu()
         self._build_toolbar()
         self.workspace = GMTableWorkspace(
             self,
             on_panel_build=self._mount_container_panel,
             on_layout_changed=self._handle_workspace_changed,
+            on_reveal_requested=self._handle_reveal_requested,
         )
         self.workspace.grid(row=1, column=0, sticky="nsew", pady=(8, 0))
         self.after_idle(self._restore_or_seed_layout)
@@ -171,6 +174,11 @@ class GMTableContainerPage(ctk.CTkFrame):
         """Bubble nested layout changes up to the outer GM Table."""
         if callable(self._on_layout_changed):
             self._on_layout_changed()
+
+    def _handle_reveal_requested(self, panel_id: str) -> None:
+        """Bubble nested reveal requests with the nested workspace context."""
+        if callable(self._on_reveal_requested):
+            self._on_reveal_requested(panel_id, self.workspace)
 
     def _create_internal_panel(
         self,

--- a/modules/scenarios/gm_table/handouts/page.py
+++ b/modules/scenarios/gm_table/handouts/page.py
@@ -9,11 +9,11 @@ import customtkinter as ctk
 from PIL import Image
 
 from modules.scenarios.gm_table.handouts.service import HandoutItem, collect_scenario_handouts
+from modules.scenarios.gm_table.reveal import reveal_handout
 from modules.ui.image_viewer import (
     DEFAULT_REVEAL_ANIMATION,
     REVEAL_ANIMATION_OPTIONS,
     normalize_reveal_animation,
-    show_portrait,
 )
 
 _CARD_WIDTH = 148
@@ -64,6 +64,7 @@ class GMTableHandoutsPage(ctk.CTkFrame):
         self._thumbnail_cache: dict[str, tuple[float, ctk.CTkImage]] = {}
         self._placeholder_thumb = self._build_placeholder_thumb()
         self._column_count = 1
+        self._card_menu = tk.Menu(self, tearoff=0)
 
         title = "Handouts"
         if self._scenario_name:
@@ -253,13 +254,44 @@ class GMTableHandoutsPage(ctk.CTkFrame):
             font=ctk.CTkFont(size=10),
         ).grid(row=3, column=0, sticky="ew", padx=7, pady=(0, 4))
 
+        ctk.CTkButton(
+            card,
+            text="Reveal",
+            width=70,
+            height=24,
+            fg_color="#1F6F86",
+            hover_color="#2589A4",
+            text_color="#F8FAFC",
+            corner_radius=8,
+            command=lambda item=handout: self._open_handout(item),
+        ).grid(row=4, column=0, sticky="w", padx=7, pady=(0, 7))
+
         self._bind_click_recursive(card, lambda _event, item=handout: self._open_handout(item))
+        self._bind_context_menu_recursive(card, handout)
         return card
 
     def _bind_click_recursive(self, widget, callback) -> None:
+        if isinstance(widget, ctk.CTkButton):
+            return
         widget.bind("<Button-1>", callback)
         for child in widget.winfo_children():
             self._bind_click_recursive(child, callback)
+
+    def _bind_context_menu_recursive(self, widget, handout: HandoutItem) -> None:
+        widget.bind("<Button-3>", lambda event, item=handout: self._show_handout_menu(event, item), add="+")
+        for child in widget.winfo_children():
+            self._bind_context_menu_recursive(child, handout)
+
+    def _show_handout_menu(self, event, handout: HandoutItem) -> str:
+        """Open a handout context menu with player reveal actions."""
+        menu = self._card_menu
+        menu.delete(0, "end")
+        menu.add_command(label="Reveal", command=lambda item=handout: self._open_handout(item))
+        try:
+            menu.tk_popup(event.x_root, event.y_root)
+        finally:
+            menu.grab_release()
+        return "break"
 
     def _get_thumbnail(self, resolved_path: str) -> tuple[ctk.CTkImage, bool]:
         candidate = Path(resolved_path)
@@ -312,11 +344,23 @@ class GMTableHandoutsPage(ctk.CTkFrame):
         self._selected_id = handout.id
         self._status_var.set("")
         self._highlight_selected()
-        show_portrait(
-            resolved_path,
-            title=handout.title,
-            subtitle=handout.subtitle,
-            animation=self._selected_animation(),
+        reveal_handout(handout, animation=self._selected_animation())
+
+    def reveal(self) -> None:
+        """Reveal the selected handout from the workspace panel action."""
+        handout = self._selected_handout()
+        if handout is None:
+            self._status_var.set("Select a handout to reveal first.")
+            return
+        self._open_handout(handout)
+
+    def _selected_handout(self) -> HandoutItem | None:
+        """Return the currently selected handout, if it still exists."""
+        if not self._selected_id:
+            return None
+        return next(
+            (handout for handout in self._handouts if handout.id == self._selected_id),
+            None,
         )
 
     def _highlight_selected(self) -> None:

--- a/modules/scenarios/gm_table/pages.py
+++ b/modules/scenarios/gm_table/pages.py
@@ -17,6 +17,7 @@ from modules.helpers.logging_helper import log_exception, log_info, log_warning
 from modules.helpers.portrait_helper import resolve_portrait_candidate
 from modules.image_assets import ImageAssetsService
 from modules.scenarios.gm_table.attachments import EntityAttachment
+from modules.scenarios.gm_table.reveal import reveal_image
 from modules.scenarios.session_notes import SessionControls, SessionControlsCallbacks
 from modules.ui.image_library.browser_panel import ImageBrowserPanel
 from modules.ui.image_library.result_card import ImageResult
@@ -180,12 +181,23 @@ class GMTableImagePage(ctk.CTkFrame):
         self._ctk_image: ctk.CTkImage | None = None
         self._source_image: Image.Image | None = None
 
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.grid(row=0, column=0, sticky="ew", pady=(0, 8))
+        header.grid_columnconfigure(0, weight=1)
+
         ctk.CTkLabel(
-            self,
+            header,
             text=self._title,
             font=ctk.CTkFont(size=16, weight="bold"),
             anchor="w",
-        ).grid(row=0, column=0, sticky="ew", pady=(0, 8))
+        ).grid(row=0, column=0, sticky="ew")
+        ctk.CTkButton(
+            header,
+            text="Reveal",
+            width=82,
+            height=28,
+            command=self.reveal,
+        ).grid(row=0, column=1, sticky="e", padx=(8, 0))
 
         self.image_label = ctk.CTkLabel(self, text="Loading image…", anchor="center")
         self.image_label.grid(row=1, column=0, sticky="nsew")
@@ -227,6 +239,10 @@ class GMTableImagePage(ctk.CTkFrame):
 
     def get_state(self) -> dict:
         return {"image_path": self._image_path, "image_title": self._title}
+
+    def reveal(self):
+        """Reveal this image to the player-facing display."""
+        return reveal_image(self._image_path, title=self._title)
 
 
 class GMTableAttachmentGallery(ctk.CTkFrame):

--- a/modules/scenarios/gm_table/reveal/__init__.py
+++ b/modules/scenarios/gm_table/reveal/__init__.py
@@ -1,0 +1,19 @@
+"""Reveal helpers for GM Table player-facing displays."""
+
+from .service import (
+    RevealResult,
+    is_reveal_supported,
+    reveal_entity,
+    reveal_handout,
+    reveal_image,
+    reveal_map_payload,
+)
+
+__all__ = [
+    "RevealResult",
+    "is_reveal_supported",
+    "reveal_entity",
+    "reveal_handout",
+    "reveal_image",
+    "reveal_map_payload",
+]

--- a/modules/scenarios/gm_table/reveal/service.py
+++ b/modules/scenarios/gm_table/reveal/service.py
@@ -1,0 +1,341 @@
+"""Shared reveal actions for GM Table player-facing displays."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import tkinter as tk
+from tkinter import messagebox
+from typing import Any, Iterable
+
+import customtkinter as ctk
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.logging_helper import log_info, log_warning
+from modules.helpers.portrait_helper import resolve_portrait_candidate
+from modules.helpers.text_helpers import (
+    deserialize_possible_json,
+    format_multiline_text,
+)
+from modules.ui.image_viewer import show_portrait, _get_monitors
+
+_IMAGE_PANEL_KINDS = {"image"}
+_MAP_PANEL_KINDS = {"world_map", "map_tool"}
+_SUPPORTED_PANEL_KINDS = {*_IMAGE_PANEL_KINDS, *_MAP_PANEL_KINDS, "entity"}
+_TITLE_KEYS = ("Name", "Title", "Scenario", "Heading")
+_GM_ONLY_TOKENS = (
+    "gm",
+    "dm",
+    "secret",
+    "secrets",
+    "private",
+    "hidden",
+    "spoiler",
+    "solution",
+    "answer",
+    "notes",
+    "internal",
+)
+_SKIP_EXACT_KEYS = {
+    "id",
+    "uuid",
+    "created",
+    "created_at",
+    "updated",
+    "updated_at",
+    "tags",
+    "portrait",
+    "portraits",
+    "image",
+    "images",
+    "image_path",
+    "fogmaskpath",
+    "tokens",
+}
+
+
+@dataclass(slots=True)
+class RevealResult:
+    """Outcome of a reveal attempt."""
+
+    ok: bool
+    message: str = ""
+
+
+def is_reveal_supported(kind: str, state: dict | None = None) -> bool:
+    """Return whether a GM Table panel kind can offer a Reveal action."""
+    _ = state
+    normalized = str(kind or "").strip()
+    if normalized in _SUPPORTED_PANEL_KINDS:
+        return True
+    if normalized == "handouts":
+        return True
+    return False
+
+
+def reveal_image(
+    path: str,
+    *,
+    title: str | None = None,
+    subtitle: str | None = None,
+    animation: str | None = None,
+    quiet: bool = False,
+) -> RevealResult:
+    """Reveal image-like content via the existing full-screen image reveal utility."""
+    resolved = resolve_portrait_candidate(path, ConfigHelper.get_campaign_dir())
+    if not resolved:
+        message = "No revealable image was found for this panel."
+        if not quiet:
+            messagebox.showwarning("Reveal", message)
+        return RevealResult(False, message)
+    window = show_portrait(resolved, title=title, subtitle=subtitle, animation=animation)
+    if window is None:
+        message = "The image reveal could not be opened."
+        return RevealResult(False, message)
+    log_info(f"Revealed image '{resolved}'.", func_name="gm_table.reveal.reveal_image")
+    return RevealResult(True)
+
+
+def reveal_handout(handout: Any, *, animation: str | None = None) -> RevealResult:
+    """Reveal a collected handout item."""
+    path = str(getattr(handout, "path", "") or "").strip()
+    title = str(getattr(handout, "title", "") or "").strip() or Path(path).name
+    subtitle = str(getattr(handout, "subtitle", "") or "").strip() or None
+    return reveal_image(path, title=title, subtitle=subtitle, animation=animation)
+
+
+def reveal_map_payload(payload: object, *, title: str | None = None) -> RevealResult:
+    """Reveal a map-capable payload, preferring its native player display."""
+    if payload is None:
+        message = "No map panel is available to reveal."
+        messagebox.showinfo("Reveal", message)
+        return RevealResult(False, message)
+
+    opener = getattr(payload, "open_player_display", None)
+    if callable(opener):
+        before = _current_toplevel(payload)
+        opener()
+        after = _current_toplevel(payload)
+        if after is not None or before is not None:
+            log_info("Revealed map via native player display.", func_name="gm_table.reveal.reveal_map_payload")
+            return RevealResult(True)
+        message = "The map player display is not available for the current map."
+        messagebox.showinfo("Reveal", message)
+        return RevealResult(False, message)
+
+    current_map = getattr(payload, "current_map", None)
+    if isinstance(current_map, dict):
+        image_path = str(current_map.get("Image") or current_map.get("image") or "").strip()
+        map_title = str(current_map.get("Name") or title or "Map").strip()
+        if image_path:
+            return reveal_image(image_path, title=map_title, subtitle="Map")
+
+    message = "This map panel does not expose a player display."
+    messagebox.showinfo("Reveal", message)
+    return RevealResult(False, message)
+
+
+def reveal_entity(entity_type: str, item: dict, *, title: str | None = None) -> RevealResult:
+    """Reveal player-safe text for an entity, clue, or information record."""
+    if not isinstance(item, dict) or not item:
+        message = "No entity content is available to reveal."
+        _show_reveal_info(message)
+        return RevealResult(False, message)
+
+    display_title = str(title or _entity_title(item) or entity_type or "Reveal").strip()
+    sections = list(_player_safe_sections(item))
+    if not sections:
+        message = "No player-safe fields were found to reveal."
+        _show_reveal_info(message)
+        return RevealResult(False, message)
+
+    window = _show_text_reveal(display_title, str(entity_type or "").strip(), sections)
+    if window is None:
+        message = "No player display is available for this reveal."
+        _show_reveal_info(message)
+        return RevealResult(False, message)
+    log_info(f"Revealed text entity '{display_title}'.", func_name="gm_table.reveal.reveal_entity")
+    return RevealResult(True)
+
+
+def _show_reveal_info(message: str) -> None:
+    """Show a reveal info dialog when Tk is available."""
+    try:
+        messagebox.showinfo("Reveal", message)
+    except tk.TclError as exc:
+        log_warning(
+            f"Unable to show reveal dialog: {exc}",
+            func_name="gm_table.reveal._show_reveal_info",
+        )
+
+
+def _current_toplevel(payload: object):
+    for attr in ("_player_view_window", "player_display_window", "player_window"):
+        candidate = getattr(payload, attr, None)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _entity_title(item: dict) -> str:
+    for key in _TITLE_KEYS:
+        value = str(item.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _is_gm_only_key(key: str) -> bool:
+    normalized = str(key or "").strip().casefold().replace(" ", "_").replace("-", "_")
+    if normalized in _SKIP_EXACT_KEYS:
+        return True
+    return any(token in normalized for token in _GM_ONLY_TOKENS)
+
+
+def _player_safe_sections(item: dict) -> Iterable[tuple[str, str]]:
+    for key, value in item.items():
+        label = str(key or "").strip()
+        if not label or _is_gm_only_key(label):
+            continue
+        text = _format_reveal_value(value)
+        if not text:
+            continue
+        yield label, text
+
+
+def _format_reveal_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return ""
+        decoded = deserialize_possible_json(stripped)
+        if decoded != stripped:
+            return _format_reveal_value(decoded)
+        return stripped
+    if isinstance(value, dict):
+        if "text" in value or "formatting" in value:
+            return format_multiline_text(value).strip()
+        parts = []
+        for child_key, child_value in value.items():
+            if _is_gm_only_key(str(child_key)):
+                continue
+            child_text = _format_reveal_value(child_value)
+            if child_text:
+                parts.append(f"{child_key}: {child_text}")
+        return "\n".join(parts).strip()
+    if isinstance(value, (list, tuple, set)):
+        parts = [_format_reveal_value(part) for part in value]
+        return "\n".join(part for part in parts if part).strip()
+    return str(value).strip()
+
+
+def _show_text_reveal(title: str, subtitle: str, sections: list[tuple[str, str]]):
+    try:
+        monitors = _get_monitors()
+    except tk.TclError as exc:
+        log_warning(
+            f"Unable to detect monitors for text reveal: {exc}",
+            func_name="gm_table.reveal._show_text_reveal",
+        )
+        return None
+    if not monitors:
+        log_warning("No monitors detected for text reveal", func_name="gm_table.reveal._show_text_reveal")
+        return None
+    monitor_x, monitor_y, monitor_width, monitor_height = monitors[1] if len(monitors) > 1 else monitors[0]
+
+    win = None
+    try:
+        win = ctk.CTkToplevel()
+        win.title(title or "Reveal")
+        win.geometry(f"{monitor_width}x{monitor_height}+{monitor_x}+{monitor_y}")
+        try:
+            win.configure(fg_color="#F8FAFC")
+        except Exception:
+            pass
+
+        root = tk.Frame(win, bg="#F8FAFC")
+        root.pack(fill="both", expand=True)
+        header = tk.Frame(root, bg="#0F172A")
+        header.pack(fill="x")
+        if subtitle:
+            tk.Label(
+                header,
+                text=subtitle.upper(),
+                font=("Segoe UI", 16, "bold"),
+                fg="#FBBF24",
+                bg="#0F172A",
+            ).pack(anchor="w", padx=48, pady=(30, 0))
+        tk.Label(
+            header,
+            text=title,
+            font=("Segoe UI", 34, "bold"),
+            fg="#F8FAFC",
+            bg="#0F172A",
+            justify="left",
+            wraplength=max(480, monitor_width - 120),
+        ).pack(anchor="w", padx=48, pady=(6, 30))
+
+        body_container = tk.Frame(root, bg="#F8FAFC")
+        body_container.pack(fill="both", expand=True, padx=42, pady=28)
+        canvas = tk.Canvas(body_container, bg="#F8FAFC", highlightthickness=0)
+        scrollbar = tk.Scrollbar(body_container, orient="vertical", command=canvas.yview)
+        canvas.configure(yscrollcommand=scrollbar.set)
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+        body = tk.Frame(canvas, bg="#F8FAFC")
+        window_id = canvas.create_window((0, 0), window=body, anchor="nw")
+
+        def _update_scroll(_event=None):
+            canvas.configure(scrollregion=canvas.bbox("all"))
+
+        def _resize(event):
+            canvas.itemconfig(window_id, width=event.width)
+
+        body.bind("<Configure>", _update_scroll)
+        canvas.bind("<Configure>", _resize)
+
+        for label, text in sections:
+            section = tk.Frame(body, bg="#F8FAFC")
+            section.pack(fill="x", anchor="w", pady=(0, 20))
+            tk.Label(
+                section,
+                text=label,
+                font=("Segoe UI", 20, "bold"),
+                fg="#0F172A",
+                bg="#F8FAFC",
+            ).pack(anchor="w")
+            tk.Label(
+                section,
+                text=text,
+                font=("Segoe UI", 17),
+                fg="#1E293B",
+                bg="#F8FAFC",
+                justify="left",
+                wraplength=max(420, monitor_width - 140),
+            ).pack(anchor="w", pady=(4, 0))
+
+        def _close(_event=None):
+            win.destroy()
+            return "break"
+
+        for sequence in ("<Escape>", "<Button-1>"):
+            win.bind(sequence, _close)
+        try:
+            win.lift()
+            win.focus_force()
+        except Exception:
+            pass
+        return win
+    except tk.TclError as exc:
+        log_warning(
+            f"Unable to create text reveal window: {exc}",
+            func_name="gm_table.reveal._show_text_reveal",
+        )
+        if win is not None:
+            try:
+                win.destroy()
+            except tk.TclError:
+                pass
+        return None

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -31,6 +31,7 @@ from modules.scenarios.gm_table.panel_depth_styles import (
     PanelDepthStyle,
     resolve_panel_depth_style,
 )
+from modules.scenarios.gm_table.reveal import is_reveal_supported
 
 
 TABLE_PALETTE = {
@@ -540,6 +541,7 @@ class GMTablePanel(ctk.CTkFrame):
         on_snap_preview_changed: Callable[[str, str | None], None],
         on_toggle_maximize: Callable[[str], None],
         on_window_action: Callable[[str, str], None],
+        on_reveal_requested: Callable[[str], None] | None = None,
     ) -> None:
         self._skin = resolve_panel_skin(definition.kind, definition.state)
         self._skin_name = self._skin.name
@@ -574,6 +576,7 @@ class GMTablePanel(ctk.CTkFrame):
         self._on_snap_preview_changed = on_snap_preview_changed
         self._on_toggle_maximize = on_toggle_maximize
         self._on_window_action = on_window_action
+        self._on_reveal_requested = on_reveal_requested
         self._drag_origin: tuple[int, int, int, int] | None = None
         self._resize_origin: tuple[int, int, dict[str, int], str] | None = None
         self._restore_geometry: dict[str, int] | None = None
@@ -1145,6 +1148,9 @@ class GMTablePanel(ctk.CTkFrame):
         self._on_focus(self.definition.panel_id)
         menu = self._actions_menu
         menu.delete(0, "end")
+        if is_reveal_supported(self.definition.kind, self.definition.state):
+            menu.add_command(label="Reveal", command=self._dispatch_reveal)
+            menu.add_separator()
         menu.add_command(label="Restore", command=lambda: self._dispatch_window_action("restore"))
         menu.add_command(label="Minimize", command=lambda: self._dispatch_window_action("minimize"))
         maximize_label = "Restore Size" if self._layout_mode in SNAP_LAYOUT_MODES else "Maximize"
@@ -1163,6 +1169,12 @@ class GMTablePanel(ctk.CTkFrame):
             menu.tk_popup(x, y)
         finally:
             menu.grab_release()
+
+    def _dispatch_reveal(self) -> None:
+        """Forward a player reveal request to the workspace owner."""
+        self._on_focus(self.definition.panel_id)
+        if self._on_reveal_requested is not None:
+            self._on_reveal_requested(self.definition.panel_id)
 
     def _refresh_window_controls(self) -> None:
         """Refresh control labels for the current layout mode."""
@@ -1331,11 +1343,13 @@ class GMTableWorkspace(ctk.CTkFrame):
         on_panel_build: Callable[[ctk.CTkFrame, PanelDefinition], object],
         on_layout_changed: Callable[[], None] | None = None,
         map_tool_window_provider: Callable[[], object | None] | None = None,
+        on_reveal_requested: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(master, fg_color=TABLE_PALETTE["table_bg"], corner_radius=28)
         self._build_panel = on_panel_build
         self._layout_changed_callback = on_layout_changed
         self._map_tool_window_provider = map_tool_window_provider
+        self._reveal_requested_callback = on_reveal_requested
         self._panels: dict[str, GMTablePanel] = {}
         self._definitions: dict[str, PanelDefinition] = {}
         self._panel_payloads: dict[str, object] = {}
@@ -2347,6 +2361,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             on_snap_preview_changed=self.preview_snap_target,
             on_toggle_maximize=self.toggle_panel_maximize,
             on_window_action=self.handle_window_action,
+            on_reveal_requested=self._handle_reveal_requested,
         )
         panel.attach_depth_layers(self._create_panel_depth_layers(panel))
         self._apply_floating_geometry(panel, world_geometry)
@@ -2406,6 +2421,11 @@ class GMTableWorkspace(ctk.CTkFrame):
         if action == "restore_all":
             self.restore_all_panels()
             return
+
+    def _handle_reveal_requested(self, panel_id: str) -> None:
+        """Dispatch a reveal request for one panel payload."""
+        if self._reveal_requested_callback is not None:
+            self._reveal_requested_callback(panel_id)
 
     def preview_snap_target(self, panel_id: str, mode: str | None) -> None:
         """Show a restrained preview rectangle for the requested snap target."""

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -43,6 +43,7 @@ from modules.scenarios.gm_table.pages import (
     GMTableImagePage,
     GMTableNotePage,
 )
+from modules.scenarios.gm_table.reveal import reveal_entity, reveal_image, reveal_map_payload
 from modules.scenarios.session_notes import SessionControlsCallbacks
 from modules.scenarios.gm_table.workspace import (
     PanelDefinition,
@@ -177,6 +178,7 @@ class GMTableView(ctk.CTkFrame):
             on_panel_build=self._mount_panel_content,
             on_layout_changed=self._persist_layout,
             map_tool_window_provider=self._get_map_tool_window,
+            on_reveal_requested=self._reveal_panel,
         )
         self.workspace.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 18))
 
@@ -927,6 +929,55 @@ class GMTableView(ctk.CTkFrame):
         if kind == "world_map" and hasattr(payload, "open_player_display"):
             payload.open_player_display()
 
+    def _reveal_panel(
+        self,
+        panel_id: str,
+        workspace: GMTableWorkspace | None = None,
+    ) -> None:
+        """Reveal the requested GM Table panel to the player-facing display."""
+        target_workspace = workspace or self.workspace
+        definition = target_workspace.get_panel_definition(panel_id)
+        if definition is None:
+            messagebox.showinfo("Reveal", "This panel is no longer available.")
+            return
+
+        payload = self._unwrap_hosted_payload(target_workspace.get_panel_payload(panel_id))
+        kind = definition.kind
+        state = definition.state if isinstance(definition.state, dict) else {}
+
+        if kind == "image":
+            path = str(state.get("image_path") or "").strip()
+            title = str(state.get("image_title") or definition.title or "Image").strip()
+            reveal_image(path, title=title)
+            return
+
+        if kind in MAP_PANEL_KINDS:
+            reveal_map_payload(payload, title=definition.title)
+            return
+
+        if kind == "entity":
+            entity_type = str(state.get("entity_type") or "").strip()
+            entity_name = str(state.get("entity_name") or definition.title or "").strip()
+            try:
+                item = self._load_entity_item(entity_type, entity_name)
+            except Exception as exc:
+                messagebox.showwarning("Reveal", f"Unable to load entity for reveal:\n{exc}")
+                return
+            reveal_entity(entity_type, item, title=self._entity_label(entity_type, item, fallback=entity_name))
+            return
+
+        if hasattr(payload, "reveal") and callable(payload.reveal):
+            payload.reveal()
+            return
+
+        messagebox.showinfo("Reveal", "This panel does not support player reveal.")
+
+    @staticmethod
+    def _unwrap_hosted_payload(payload: object) -> object:
+        """Return the inner widget/controller for hosted GM Table pages."""
+        inner = getattr(payload, "_payload", None)
+        return inner if inner is not None else payload
+
     def _apply_fog_action(self, action: str) -> None:
         """Route fog controls to the active map-capable tabletop panel."""
         _panel_id, _kind, payload = self._resolve_tabletop_context()
@@ -1159,6 +1210,7 @@ class GMTableView(ctk.CTkFrame):
                     ),
                     panel_builder=self._mount_panel_content,
                     on_layout_changed=self._persist_layout,
+                    on_reveal_requested=self._reveal_panel,
                 )
             if kind == "loot_generator":
                 return GMTableHostedPage(

--- a/modules/scenarios/scenario_builder_wizard.py
+++ b/modules/scenarios/scenario_builder_wizard.py
@@ -2071,7 +2071,16 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
     def _set_navigation_enabled(self, enabled: bool):  # pragma: no cover - UI interaction
         """Set navigation enabled."""
         state = "normal" if enabled else "disabled"
-        for btn in (self.back_btn, self.next_btn, self.finish_btn, self.cancel_btn, self.story_forge_btn):
+        button_names = (
+            "back_btn",
+            "next_btn",
+            "finish_btn",
+            "cancel_btn",
+            "story_forge_btn",
+        )
+        for btn in (getattr(self, name, None) for name in button_names):
+            if btn is None:
+                continue
             try:
                 # Keep navigation enabled resilient if this step fails.
                 if btn.winfo_exists():
@@ -2176,21 +2185,26 @@ class ScenarioBuilderWizard(ctk.CTkToplevel):
             payload[field] = list(dict.fromkeys(self.wizard_state.get(field, [])))
         sync_graph = bool(self.wizard_state.get("ScenarioCharacterGraphSync"))
 
+        button_names = (
+            "back_btn",
+            "next_btn",
+            "finish_btn",
+            "cancel_btn",
+            "story_forge_btn",
+        )
         buttons = {
-            self.back_btn: self.back_btn.cget("state"),
-            self.next_btn: self.next_btn.cget("state"),
-            self.finish_btn: self.finish_btn.cget("state"),
-            self.cancel_btn: self.cancel_btn.cget("state"),
-            self.story_forge_btn: self.story_forge_btn.cget("state"),
+            btn: btn.cget("state")
+            for btn in (getattr(self, name, None) for name in button_names)
+            if btn is not None
         }
         for btn in buttons:
             btn.configure(state="disabled")
 
         try:
             # Keep finish resilient if this step fails.
-            if self.mode == "embedded":
+            if getattr(self, "mode", "standalone") == "embedded":
                 # Handle the branch where mode == 'embedded'.
-                if self.persist_on_finish:
+                if getattr(self, "persist_on_finish", False):
                     # Continue with this path when persist on finish is set.
                     persisted, _ = self._persist_scenario_payload(title, payload)
                     if not persisted:

--- a/tests/scenarios/gm_table/handouts/test_page.py
+++ b/tests/scenarios/gm_table/handouts/test_page.py
@@ -85,7 +85,7 @@ def test_open_handout_shows_warning_without_blocking_when_file_is_missing() -> N
     assert triggered == ["render"]
 
 
-def test_open_handout_uses_image_viewer_for_existing_file(monkeypatch) -> None:
+def test_open_handout_reveals_existing_file_with_expected_metadata(monkeypatch) -> None:
     real_path = Path("handouts") / "existing.png"
     handout = _build_item(str(real_path))
 
@@ -96,11 +96,10 @@ def test_open_handout_uses_image_viewer_for_existing_file(monkeypatch) -> None:
     view._animation_var = _StringVarStub("Curtain")
     view._highlight_selected = lambda: calls.append("highlight")
 
-    monkeypatch.setattr(
-        page_module,
-        "show_portrait",
-        lambda path, title=None, subtitle=None, animation=None: calls.append((path, title, subtitle, animation)),
-    )
+    def _fake_reveal(revealed_handout, *, animation=None):
+        calls.append((revealed_handout.path, revealed_handout.title, revealed_handout.subtitle, animation))
+
+    monkeypatch.setattr(page_module, "reveal_handout", _fake_reveal)
 
     original_exists = page_module.Path.exists
     page_module.Path.exists = lambda self: True
@@ -111,7 +110,7 @@ def test_open_handout_uses_image_viewer_for_existing_file(monkeypatch) -> None:
 
     assert view._selected_id == handout.id
     assert calls[0] == "highlight"
-    assert calls[1] == (str(Path(real_path).resolve()), "Kara Voss", "NPC", "curtain")
+    assert calls[1] == (str(real_path), "Kara Voss", "NPC", "curtain")
 
 
 def test_get_state_includes_selected_animation() -> None:

--- a/tests/scenarios/gm_table/test_gm_table_handouts_page.py
+++ b/tests/scenarios/gm_table/test_gm_table_handouts_page.py
@@ -35,7 +35,7 @@ class _Widget:
     def grid_propagate(self, _flag: bool) -> None:
         return None
 
-    def bind(self, event, callback) -> None:
+    def bind(self, event, callback, **_kwargs) -> None:
         self.bindings[event] = callback
 
     def winfo_children(self):
@@ -134,7 +134,7 @@ def test_render_grid_builds_compact_cards_for_collected_handouts() -> None:
     assert set(view._visible_cards.keys()) == {"one", "two", "three"}
 
 
-def test_clicking_card_opens_portrait_with_expected_path_title_and_subtitle(monkeypatch) -> None:
+def test_clicking_card_reveals_handout_with_expected_path_title_subtitle_and_animation(monkeypatch) -> None:
     image_path = Path("handouts") / "kara.png"
     handout = _item(str(image_path), title="Kara Voss")
 
@@ -143,11 +143,11 @@ def test_clicking_card_opens_portrait_with_expected_path_title_and_subtitle(monk
     monkeypatch.setattr(page_module.ctk, "CTkFont", lambda **_kwargs: object())
 
     shown = []
-    monkeypatch.setattr(
-        page_module,
-        "show_portrait",
-        lambda path, title=None, subtitle=None, animation=None: shown.append((path, title, subtitle, animation)),
-    )
+
+    def _fake_reveal(revealed_handout, *, animation=None):
+        shown.append((revealed_handout.path, revealed_handout.title, revealed_handout.subtitle, animation))
+
+    monkeypatch.setattr(page_module, "reveal_handout", _fake_reveal)
     monkeypatch.setattr(page_module.Path, "exists", lambda self: True)
 
     view = page_module.GMTableHandoutsPage.__new__(page_module.GMTableHandoutsPage)
@@ -160,7 +160,7 @@ def test_clicking_card_opens_portrait_with_expected_path_title_and_subtitle(monk
     card = page_module.GMTableHandoutsPage._build_card(view, _GridFrame(), replace(handout))
     card.bindings["<Button-1>"](None)
 
-    assert shown == [(str(Path(image_path).resolve()), "Kara Voss", "NPC", "drift_up")]
+    assert shown == [(str(image_path), "Kara Voss", "NPC", "drift_up")]
     assert view._selected_id == handout.id
 
 

--- a/tests/scenarios/test_gm_table_reveal_service.py
+++ b/tests/scenarios/test_gm_table_reveal_service.py
@@ -1,0 +1,63 @@
+"""Tests for GM Table reveal helpers."""
+
+import tkinter as tk
+
+from modules.scenarios.gm_table.reveal import service
+from modules.scenarios.gm_table.reveal.service import (
+    _format_reveal_value,
+    _player_safe_sections,
+    reveal_entity,
+)
+
+
+def test_player_safe_sections_omit_nested_gm_only_fields():
+    item = {
+        "Name": "Public Name",
+        "Description": "Visible description",
+        "GM Notes": "Do not reveal",
+        "Details": {
+            "Public clue": "A silver key",
+            "Secret Answer": "Behind the statue",
+        },
+    }
+
+    sections = dict(_player_safe_sections(item))
+
+    assert sections == {
+        "Name": "Public Name",
+        "Description": "Visible description",
+        "Details": "Public clue: A silver key",
+    }
+
+
+def test_format_reveal_value_handles_python_literal_rich_text_strings():
+    payload = "{'text': 'Intro line\\nSecond line', 'formatting': {'bold': []}}"
+
+    assert _format_reveal_value(payload) == "Intro line\nSecond line"
+
+
+def test_reveal_entity_returns_failure_when_monitor_detection_needs_display(monkeypatch):
+    def raise_tcl_error():
+        raise tk.TclError("no display name and no $DISPLAY environment variable")
+
+    monkeypatch.setattr(service, "_get_monitors", raise_tcl_error)
+    monkeypatch.setattr(service.messagebox, "showinfo", lambda *_args, **_kwargs: raise_tcl_error())
+
+    result = reveal_entity("npc", {"Name": "Ada", "Description": "Visible"})
+
+    assert result.ok is False
+    assert result.message == "No player display is available for this reveal."
+
+
+def test_reveal_entity_returns_failure_when_text_window_creation_needs_display(monkeypatch):
+    def raise_tcl_error(*_args, **_kwargs):
+        raise tk.TclError("couldn't connect to display")
+
+    monkeypatch.setattr(service, "_get_monitors", lambda: [(0, 0, 1280, 720)])
+    monkeypatch.setattr(service.ctk, "CTkToplevel", raise_tcl_error)
+    monkeypatch.setattr(service.messagebox, "showinfo", lambda *_args, **_kwargs: None)
+
+    result = reveal_entity("npc", {"Name": "Ada", "Description": "Visible"})
+
+    assert result.ok is False
+    assert result.message == "No player display is available for this reveal."


### PR DESCRIPTION
### Motivation

- Provide a single, reusable reveal action for GM Table panels so GMs can push images, handouts, maps, and text to a player-facing display.  
- Reuse existing image/second-screen utilities for image-like content and add a player-safe text renderer for entities/clues that omits GM-only fields.  
- Make the reveal action optional and fail gracefully when no player display/second-screen is available or when running headless.

### Description

- Introduce a new reveal helper package `modules/scenarios/gm_table/reveal` exposing `RevealResult` and functions `is_reveal_supported`, `reveal_image`, `reveal_handout`, `reveal_map_payload`, and `reveal_entity`.  
- Route image reveals to the existing image viewer (`show_portrait`) and reuse it for handouts and map-image fallbacks.  
- Implement player-safe text reveals that filter GM-only keys (nested and top-level) via `_player_safe_sections`/`_format_reveal_value` and render a formatted, scrollable player window via `_show_text_reveal`.  
- Harden text reveal and informational dialogs to catch `tk.TclError` and return `RevealResult(False, ...)` instead of raising, so behavior is graceful in headless/no-`$DISPLAY` environments.  
- Add UI integrations: a `Reveal` button on `GMTableImagePage`, handout card `Reveal` buttons and a context menu, workspace panel action-menu `Reveal` entries, and a workspace-level dispatch `_reveal_panel` in `modules/scenarios/gm_table_view.py` that routes image/map/entity/handout reveals (including nested container workspaces).  
- Update tests to cover player-safe filtering, headless/TclError failure paths, and the handout reveal contract; adjust handout tests to patch `reveal_handout` instead of the removed `show_portrait` helper.

### Testing

- Syntax/compile checks and AST parsing were run via `python -m py_compile` and an AST check across `modules`/`tests` with no syntax errors.  
- Targeted unit tests for the reveal service were run with and without `DISPLAY` and passed: `pytest tests/scenarios/test_gm_table_reveal_service.py` and `env -u DISPLAY pytest tests/scenarios/test_gm_table_reveal_service.py` (both green).  
- Handouts and GM Table integration tests were updated and run: `pytest tests/scenarios/gm_table/test_gm_table_handouts_service.py tests/scenarios/gm_table/test_gm_table_handouts_page.py tests/scenarios/gm_table/handouts/test_page.py` (green).  
- Larger GM Table/GM screen suites including routing checks were executed (`pytest tests/scenarios/gm_table/test_gm_table_view.py tests/campaigns/ui/test_gm_screen_router.py tests/scenarios/test_gm_table_reveal_service.py`) and passed; environment limitation noted that no real X/Tk server is available here but the code is guarded and tests exercise headless paths via mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e9ebd07c8832bb4a6d2f8d7b03966)