### PR TITLE
GM Table: add annotation style dialog, toolbar tweaks, and topmost focus fix

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1441,7 +1441,7 @@ class MainWindow(ctk.CTk):
 
         try:
             window.attributes("-topmost", True)
-            window.after_idle(lambda: window.attributes("-topmost", False))
+            window.after(1200, lambda: window.attributes("-topmost", False))
         except Exception as exc:
             log_warning(
                 f"Unable to toggle detached window topmost state: {exc}",
@@ -3032,7 +3032,7 @@ class MainWindow(ctk.CTk):
             self._focus_detached_window(window)
             try:
                 window.attributes("-topmost", True)
-                window.after(800, lambda: window.attributes("-topmost", False))
+                window.after(1200, lambda: window.attributes("-topmost", False))
             except Exception:
                 pass
 

--- a/modules/scenarios/gm_table/annotations/__init__.py
+++ b/modules/scenarios/gm_table/annotations/__init__.py
@@ -1,0 +1,5 @@
+"""Desk annotation helpers for GM Table workspaces."""
+
+from .style_dialog import ask_desk_annotation_style
+
+__all__ = ["ask_desk_annotation_style"]

--- a/modules/scenarios/gm_table/annotations/style_dialog.py
+++ b/modules/scenarios/gm_table/annotations/style_dialog.py
@@ -1,0 +1,195 @@
+"""Dialogs for GM Table desk annotation styling."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import colorchooser
+
+import customtkinter as ctk
+
+from modules.scenarios.gm_table.workspace import TABLE_PALETTE
+
+
+DEFAULT_DRAW_COLOR = "#1F2937"
+DEFAULT_TEXT_COLOR = "#241A10"
+DEFAULT_TEXT_SIZE = 18
+DEFAULT_STROKE_WIDTH = 3
+TEXT_SIZE_OPTIONS = (12, 14, 16, 18, 20, 24, 28, 32, 36, 42, 48, 56, 64)
+STROKE_WIDTH_OPTIONS = (2, 3, 4, 5, 6, 8, 10, 12)
+
+
+def _normalize_hex_color(value: str | None, fallback: str) -> str:
+    """Return a Tk-compatible hex color value."""
+    candidate = str(value or "").strip()
+    if len(candidate) == 7 and candidate.startswith("#"):
+        try:
+            int(candidate[1:], 16)
+            return candidate.upper()
+        except ValueError:
+            return fallback
+    return fallback
+
+
+def _coerce_option(value, options: tuple[int, ...], fallback: int) -> int:
+    """Coerce a numeric option to one of the allowed values."""
+    try:
+        numeric = int(value)
+    except Exception:
+        return fallback
+    return numeric if numeric in options else fallback
+
+
+class DeskAnnotationStyleDialog(ctk.CTkToplevel):
+    """Collect color and size choices for GM Table desk annotations."""
+
+    def __init__(self, master, *, tool: str, initial_style: dict | None = None) -> None:
+        super().__init__(master)
+        self.tool = "text" if str(tool).lower() == "text" else "draw"
+        style = initial_style or {}
+        self.result: dict | None = None
+        self.title("Desk Text Style" if self.tool == "text" else "Draw Style")
+        self.transient(master.winfo_toplevel())
+        self.grab_set()
+        self.resizable(False, False)
+        self.grid_columnconfigure(0, weight=1)
+
+        default_color = DEFAULT_TEXT_COLOR if self.tool == "text" else DEFAULT_DRAW_COLOR
+        self.color_var = tk.StringVar(
+            value=_normalize_hex_color(style.get("fill"), default_color)
+        )
+        self.text_size_var = tk.StringVar(
+            value=str(_coerce_option(style.get("font_size"), TEXT_SIZE_OPTIONS, DEFAULT_TEXT_SIZE))
+        )
+        self.stroke_width_var = tk.StringVar(
+            value=str(_coerce_option(style.get("width"), STROKE_WIDTH_OPTIONS, DEFAULT_STROKE_WIDTH))
+        )
+
+        self._build_body()
+        self.protocol("WM_DELETE_WINDOW", self._cancel)
+        self.bind("<Escape>", lambda _event: self._cancel())
+        self.bind("<Return>", lambda _event: self._apply())
+        self.after_idle(self._bring_to_front)
+
+    def _build_body(self) -> None:
+        container = ctk.CTkFrame(self, fg_color=TABLE_PALETTE["table_alt"], corner_radius=18)
+        container.grid(row=0, column=0, padx=16, pady=16, sticky="nsew")
+        container.grid_columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(
+            container,
+            text="Color",
+            text_color=TABLE_PALETTE["text"],
+            font=ctk.CTkFont(size=13, weight="bold"),
+        ).grid(row=0, column=0, padx=(14, 10), pady=(14, 8), sticky="w")
+        self.color_preview = ctk.CTkButton(
+            container,
+            text=self.color_var.get(),
+            width=132,
+            height=30,
+            fg_color=self.color_var.get(),
+            hover_color=self.color_var.get(),
+            text_color="#FFFFFF",
+            command=self._choose_color,
+        )
+        self.color_preview.grid(row=0, column=1, padx=(0, 14), pady=(14, 8), sticky="ew")
+
+        if self.tool == "text":
+            ctk.CTkLabel(
+                container,
+                text="Text size",
+                text_color=TABLE_PALETTE["text"],
+                font=ctk.CTkFont(size=13, weight="bold"),
+            ).grid(row=1, column=0, padx=(14, 10), pady=8, sticky="w")
+            ctk.CTkOptionMenu(
+                container,
+                values=[str(size) for size in TEXT_SIZE_OPTIONS],
+                variable=self.text_size_var,
+                width=132,
+                fg_color=TABLE_PALETTE["table_chip"],
+                button_color=TABLE_PALETTE["accent"],
+                button_hover_color="#D97706",
+                dropdown_fg_color=TABLE_PALETTE["table_alt"],
+                dropdown_hover_color="#283146",
+                text_color=TABLE_PALETTE["text"],
+                dropdown_text_color=TABLE_PALETTE["text"],
+            ).grid(row=1, column=1, padx=(0, 14), pady=8, sticky="ew")
+        else:
+            ctk.CTkLabel(
+                container,
+                text="Line size",
+                text_color=TABLE_PALETTE["text"],
+                font=ctk.CTkFont(size=13, weight="bold"),
+            ).grid(row=1, column=0, padx=(14, 10), pady=8, sticky="w")
+            ctk.CTkOptionMenu(
+                container,
+                values=[str(width) for width in STROKE_WIDTH_OPTIONS],
+                variable=self.stroke_width_var,
+                width=132,
+                fg_color=TABLE_PALETTE["table_chip"],
+                button_color=TABLE_PALETTE["accent"],
+                button_hover_color="#D97706",
+                dropdown_fg_color=TABLE_PALETTE["table_alt"],
+                dropdown_hover_color="#283146",
+                text_color=TABLE_PALETTE["text"],
+                dropdown_text_color=TABLE_PALETTE["text"],
+            ).grid(row=1, column=1, padx=(0, 14), pady=8, sticky="ew")
+
+        actions = ctk.CTkFrame(container, fg_color="transparent")
+        actions.grid(row=2, column=0, columnspan=2, padx=14, pady=(12, 14), sticky="e")
+        ctk.CTkButton(
+            actions,
+            text="Cancel",
+            width=86,
+            fg_color=TABLE_PALETTE["table_chip"],
+            hover_color="#283146",
+            command=self._cancel,
+        ).pack(side="left", padx=(0, 8))
+        ctk.CTkButton(
+            actions,
+            text="Use Tool",
+            width=98,
+            fg_color=TABLE_PALETTE["accent"],
+            hover_color="#D97706",
+            text_color="#10131B",
+            command=self._apply,
+        ).pack(side="left")
+
+    def _choose_color(self) -> None:
+        color = colorchooser.askcolor(
+            color=self.color_var.get(),
+            title="Choose desk annotation color",
+            parent=self,
+        )[1]
+        if color:
+            normalized = _normalize_hex_color(color, self.color_var.get())
+            self.color_var.set(normalized)
+            self.color_preview.configure(text=normalized, fg_color=normalized, hover_color=normalized)
+
+    def _apply(self) -> None:
+        self.result = {"fill": self.color_var.get()}
+        if self.tool == "text":
+            self.result["font_size"] = _coerce_option(
+                self.text_size_var.get(), TEXT_SIZE_OPTIONS, DEFAULT_TEXT_SIZE
+            )
+        else:
+            self.result["width"] = _coerce_option(
+                self.stroke_width_var.get(), STROKE_WIDTH_OPTIONS, DEFAULT_STROKE_WIDTH
+            )
+        self.destroy()
+
+    def _cancel(self) -> None:
+        self.result = None
+        self.destroy()
+
+    def _bring_to_front(self) -> None:
+        self.lift()
+        self.focus_force()
+        self.attributes("-topmost", True)
+        self.after(250, lambda: self.attributes("-topmost", False))
+
+
+def ask_desk_annotation_style(master, *, tool: str, initial_style: dict | None = None) -> dict | None:
+    """Open a modal style dialog and return the chosen annotation style."""
+    dialog = DeskAnnotationStyleDialog(master, tool=tool, initial_style=initial_style)
+    master.wait_window(dialog)
+    return dialog.result

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1401,6 +1401,10 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._desk_annotation_tool: str | None = None
         self._desk_annotations: list[dict[str, object]] = []
         self._desk_draw_points: list[tuple[float, float]] = []
+        self._desk_annotation_styles = {
+            "draw": {"fill": "#1F2937", "width": 3},
+            "text": {"fill": "#241A10", "font_size": 18},
+        }
         self._drag_controller = GMTableDragController(
             should_block_middle_drag=self._pointer_is_inside_map_tool
         )
@@ -1700,10 +1704,12 @@ class GMTableWorkspace(ctk.CTkFrame):
         except Exception:
             pass
 
-    def set_desk_annotation_tool(self, tool: str | None) -> None:
-        """Activate a one-shot desk annotation tool."""
+    def set_desk_annotation_tool(self, tool: str | None, style: dict | None = None) -> None:
+        """Activate a one-shot desk annotation tool with optional style choices."""
         normalized = str(tool or "").strip().lower()
         self._desk_annotation_tool = normalized if normalized in {"draw", "text"} else None
+        if self._desk_annotation_tool and isinstance(style, dict):
+            self._desk_annotation_styles[self._desk_annotation_tool].update(style)
         try:
             if self._desk_annotation_tool == "draw":
                 cursor = "pencil"
@@ -1738,7 +1744,8 @@ class GMTableWorkspace(ctk.CTkFrame):
                         "x": world_x,
                         "y": world_y,
                         "text": text,
-                        "fill": "#241A10",
+                        "fill": self._desk_annotation_styles["text"].get("fill", "#241A10"),
+                        "font_size": self._desk_annotation_styles["text"].get("font_size", 18),
                     }
                 )
                 self._redraw_desk_annotations()
@@ -1767,8 +1774,8 @@ class GMTableWorkspace(ctk.CTkFrame):
                 {
                     "type": "stroke",
                     "points": list(self._desk_draw_points),
-                    "fill": "#1F2937",
-                    "width": 3,
+                    "fill": self._desk_annotation_styles["draw"].get("fill", "#1F2937"),
+                    "width": self._desk_annotation_styles["draw"].get("width", 3),
                 }
             )
             self._schedule_layout_changed()
@@ -1802,7 +1809,11 @@ class GMTableWorkspace(ctk.CTkFrame):
                     text=str(item.get("text") or ""),
                     fill=str(item.get("fill") or "#241A10"),
                     anchor="nw",
-                    font=("Comic Sans MS", max(12, int(18 * zoom)), "bold"),
+                    font=(
+                        "Comic Sans MS",
+                        max(8, int(_coerce_float(item.get("font_size"), 18) * zoom)),
+                        "bold",
+                    ),
                     tags=("desk_annotation",),
                 )
             elif item.get("type") == "stroke":
@@ -1829,8 +1840,8 @@ class GMTableWorkspace(ctk.CTkFrame):
             if len(coords) >= 4:
                 canvas.create_line(
                     *coords,
-                    fill="#111827",
-                    width=max(1, int(3 * zoom)),
+                    fill=str(self._desk_annotation_styles["draw"].get("fill", "#111827")),
+                    width=max(1, int(_coerce_float(self._desk_annotation_styles["draw"].get("width"), 3) * zoom)),
                     smooth=True,
                     capstyle="round",
                     joinstyle="round",

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -30,6 +30,7 @@ from modules.scenarios.gm_table.table_registry import (
     get_table_name,
     normalize_table_id,
 )
+from modules.scenarios.gm_table.annotations import ask_desk_annotation_style
 from modules.scenarios.gm_table.attachments import (
     collect_entity_attachments,
     entity_has_attachments,
@@ -306,6 +307,19 @@ class GMTableView(ctk.CTkFrame):
         )
         self.add_button.pack(side="left", padx=(0, 10))
 
+        self.layout_tools_button = ctk.CTkButton(
+            actions,
+            text="Arrange Desk",
+            width=122,
+            height=30,
+            fg_color=TABLE_PALETTE["accent"],
+            hover_color="#D97706",
+            text_color="#10131B",
+            corner_radius=14,
+            command=self._show_layout_tools_menu,
+        )
+        self.layout_tools_button.pack(side="left", padx=(0, 10))
+
         ctk.CTkButton(
             actions,
             text="Map Tool",
@@ -320,7 +334,7 @@ class GMTableView(ctk.CTkFrame):
 
         ctk.CTkButton(
             actions,
-            text="Player View",
+            text="WorldMap",
             width=116,
             height=30,
             fg_color=TABLE_PALETTE["table_chip"],
@@ -342,19 +356,6 @@ class GMTableView(ctk.CTkFrame):
             command=self._open_panel_search,
         ).pack(side="left", padx=(0, 10))
 
-        self.layout_tools_button = ctk.CTkButton(
-            actions,
-            text="Arrange Desk",
-            width=122,
-            height=30,
-            fg_color=TABLE_PALETTE["table_chip"],
-            hover_color="#283146",
-            text_color=TABLE_PALETTE["text"],
-            corner_radius=14,
-            command=self._show_layout_tools_menu,
-        )
-        self.layout_tools_button.pack(side="left", padx=(0, 10))
-
         ctk.CTkButton(
             actions,
             text="Draw",
@@ -364,7 +365,7 @@ class GMTableView(ctk.CTkFrame):
             hover_color="#283146",
             text_color=TABLE_PALETTE["text"],
             corner_radius=14,
-            command=lambda: self.workspace.set_desk_annotation_tool("draw"),
+            command=lambda: self._activate_desk_annotation_tool("draw"),
         ).pack(side="left", padx=(0, 10))
 
         ctk.CTkButton(
@@ -376,7 +377,7 @@ class GMTableView(ctk.CTkFrame):
             hover_color="#283146",
             text_color=TABLE_PALETTE["text"],
             corner_radius=14,
-            command=lambda: self.workspace.set_desk_annotation_tool("text"),
+            command=lambda: self._activate_desk_annotation_tool("text"),
         ).pack(side="left", padx=(0, 10))
 
         ctk.CTkButton(
@@ -402,6 +403,19 @@ class GMTableView(ctk.CTkFrame):
             corner_radius=14,
             command=self.reset_table,
         ).pack(side="left")
+
+
+    def _activate_desk_annotation_tool(self, tool: str) -> None:
+        """Ask for annotation styling before arming a desk drawing tool."""
+        current_styles = getattr(self.workspace, "_desk_annotation_styles", {})
+        style = ask_desk_annotation_style(
+            self,
+            tool=tool,
+            initial_style=current_styles.get(tool, {}) if isinstance(current_styles, dict) else {},
+        )
+        if style is None:
+            return
+        self.workspace.set_desk_annotation_tool(tool, style)
 
     def _build_table_switch_options(
         self,


### PR DESCRIPTION
### Motivation
- Allow GMs to choose color and size when adding desk text or freehand drawing on the virtual table.  
- Make the toolbar ergonomics match the requested layout: move `Arrange Desk` next to `+ Add Panel` and use the same accent styling, and rename `Player View` to `WorldMap`.  
- Ensure GM Table windows appear on top briefly when opened or focused so they reliably surface to the user.

### Description
- Added a small annotation style UI under `modules/scenarios/gm_table/annotations/` (`style_dialog.py` and `__init__.py`) that exposes color picking and size options for text and line-width options for draw.  
- Wired toolbar Draw and Desk Text buttons in `modules/scenarios/gm_table_view.py` to open the style dialog first (`_activate_desk_annotation_tool`) and then arm `GMTableWorkspace` with the chosen style.  
- Persisted desk annotation style metadata in `modules/scenarios/gm_table/workspace.py` (`_desk_annotation_styles`) and updated annotation creation and rendering to use the chosen `fill`, `font_size`, and `width`.  
- Moved and restyled the `Arrange Desk` button to sit next to `+ Add Panel` and switched its `fg_color` to the accent color; renamed the `Player View` toolbar button text to `WorldMap`.  
- Extended detached-window focus handling in `main_window.py` so detached GM windows are set `-topmost` for a short timeout (1200ms) when opened or focused.

### Testing
- Compiled modified modules with `python -m compileall modules/scenarios/gm_table/workspace.py modules/scenarios/gm_table_view.py modules/scenarios/gm_table/annotations/style_dialog.py main_window.py` and `python -m compileall modules/scenarios/gm_table/annotations/__init__.py modules/scenarios/gm_table/annotations/style_dialog.py`; compilation succeeded.  
- Ran unit tests `pytest tests/test_generic_list_selection_view.py -q` and `pytest tests/test_scenario_secrets.py -q`; the test runs that executed passed (`4 passed` / `1 passed` as shown in the environment runs).  
- Performed `git diff --check` and confirmed no diff-check issues.  
- Note: a direct import smoke-check of `GMTableView` in the live interpreter failed in this environment due to the absence of `customtkinter`, but bytecode compilation and the automated tests above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3edb6960d4832b88b069c148a8eb77)