### PR TITLE
Persist annotation-only GM table desks

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -564,11 +564,24 @@ class GMTableView(ctk.CTkFrame):
         """Restore saved workspace or create a starter tabletop."""
         layout = self.layout_store.get_table_layout(self.table_id)
         layout = self._filter_attachmentless_entity_panels(layout)
-        if layout.get("panels"):
+        if self._has_saved_workspace_content(layout):
             self.workspace.restore(layout)
         else:
             self._seed_default_panels()
         self._workspace_loaded = True
+
+    @staticmethod
+    def _has_saved_workspace_content(layout: dict) -> bool:
+        """Return whether a saved desk has any restorable panels or annotations."""
+        if not isinstance(layout, dict):
+            return False
+        for key in ("panels", "desk_annotations", "bookmarks"):
+            value = layout.get(key)
+            if isinstance(value, list) and value:
+                return True
+        return isinstance(layout.get("camera"), dict) or isinstance(
+            layout.get("home_camera"), dict
+        )
 
     def _filter_attachmentless_entity_panels(self, layout: dict) -> dict:
         """Drop only saved attachment-gallery panels that no longer have attachments."""

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -522,6 +522,43 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
     }
 
 
+def test_restore_or_seed_layout_restores_annotation_only_desks() -> None:
+    """Saved desk text/drawings should restore even when no panels are present."""
+    layout = {
+        "desk_annotations": [
+            {"type": "text", "x": 20, "y": 40, "text": "Clue here"},
+            {"type": "stroke", "points": [(1, 2), (3, 4)]},
+        ],
+        "panels": [],
+    }
+    restored = []
+    seeded = []
+    view = GMTableView.__new__(GMTableView)
+    view.table_id = "table_1"
+    view.layout_store = SimpleNamespace(get_table_layout=lambda _table_id: layout)
+    view._filter_attachmentless_entity_panels = lambda saved_layout: saved_layout
+    view.workspace = SimpleNamespace(
+        restore=lambda saved_layout: restored.append(saved_layout)
+    )
+    view._seed_default_panels = lambda: seeded.append(True)
+
+    GMTableView._restore_or_seed_layout(view)
+
+    assert restored == [layout]
+    assert seeded == []
+    assert view._workspace_loaded is True
+
+
+def test_has_saved_workspace_content_includes_desk_annotations() -> None:
+    """Annotation-only layouts should count as restorable table content."""
+    assert GMTableView._has_saved_workspace_content(
+        {"desk_annotations": [{"type": "text"}]}
+    )
+    assert not GMTableView._has_saved_workspace_content(
+        {"desk_annotations": [], "panels": []}
+    )
+
+
 def test_seed_default_panels_opens_table_level_panels() -> None:
     """Starter tabletop should not bind the primary table identity to a scenario."""
     captured = []


### PR DESCRIPTION
### Motivation

- Ensure desk-level annotations (drawings and text), bookmarks, or camera state are preserved when a GM table is saved and restored, even if the saved layout has no floating panels.

### Description

- Replace the previous `if layout.get("panels"):` check with a more accurate predicate by adding `@staticmethod def _has_saved_workspace_content(layout: dict) -> bool` in `modules/scenarios/gm_table_view.py` and using it in `_restore_or_seed_layout` to decide whether to restore or seed defaults.
- The new `_has_saved_workspace_content` returns true when `panels`, `desk_annotations`, or `bookmarks` lists are non-empty or when `camera`/`home_camera` state is present.
- Add regression tests in `tests/scenarios/gm_table/test_gm_table_view.py` that verify annotation-only desks restore correctly and that `_has_saved_workspace_content` treats annotation-only layouts as restorable.

### Testing

- Ran `pytest tests/scenarios/gm_table/test_gm_table_view.py -q` which passed (41 passed).
- Ran `python -m py_compile modules/scenarios/gm_table_view.py tests/scenarios/gm_table/test_gm_table_view.py` to validate syntax and compilation which succeeded.
- Ran `pytest tests/scenarios/gm_table/test_gm_table_view.py tests/scenarios/gm_table/test_workspace.py -q` and observed the two failing tests are GUI/Tk-dependent failures caused by the headless environment lacking `$DISPLAY` (tests unrelated to the new logic); functional tests for the changed behavior passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3edfdb2364832ba69af457e44a255d)