### PR TITLE
Persist GM Table desk annotations immediately

### DIFF
--- a/modules/scenarios/gm_table/annotation_persistence.py
+++ b/modules/scenarios/gm_table/annotation_persistence.py
@@ -1,0 +1,40 @@
+"""Persistence helpers for GM Table desk annotations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_ANNOTATION_TYPES = {"text", "stroke"}
+
+
+def serializable_desk_annotations(
+    annotations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return a JSON-safe copy of desk annotations for layout persistence."""
+    serialized: list[dict[str, Any]] = []
+    for annotation in annotations:
+        if not isinstance(annotation, dict):
+            continue
+        item_type = str(annotation.get("type") or "")
+        if item_type not in _ANNOTATION_TYPES:
+            continue
+        clean = dict(annotation)
+        if item_type == "stroke":
+            clean["points"] = _serializable_points(clean.get("points"))
+            if len(clean["points"]) < 2:
+                continue
+        serialized.append(clean)
+    return serialized
+
+
+def _serializable_points(points: Any) -> list[list[float]]:
+    """Normalize stroke points to JSON-friendly ``[x, y]`` pairs."""
+    normalized: list[list[float]] = []
+    for point in list(points or []):
+        try:
+            x, y = point
+            normalized.append([float(x), float(y)])
+        except (TypeError, ValueError):
+            continue
+    return normalized

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -43,6 +43,9 @@ from modules.scenarios.gm_table.organization.sticky_notes import (
     cluster_group_geometries,
     group_sticky_notes,
 )
+from modules.scenarios.gm_table.annotation_persistence import (
+    serializable_desk_annotations,
+)
 
 
 TABLE_PALETTE = {
@@ -1725,8 +1728,7 @@ class GMTableWorkspace(ctk.CTkFrame):
     def clear_desk_annotations(self) -> None:
         """Remove all writing and sketches drawn directly on the desk."""
         self._desk_annotations = []
-        self._redraw_desk_annotations()
-        self._schedule_layout_changed()
+        self._commit_desk_annotation_change()
 
     def _start_desk_annotation(self, event) -> str | None:
         """Begin drawing or place text on the desk texture."""
@@ -1748,8 +1750,7 @@ class GMTableWorkspace(ctk.CTkFrame):
                         "font_size": self._desk_annotation_styles["text"].get("font_size", 18),
                     }
                 )
-                self._redraw_desk_annotations()
-                self._schedule_layout_changed()
+                self._commit_desk_annotation_change()
             self.set_desk_annotation_tool(None)
             return "break"
         if self._desk_annotation_tool == "draw":
@@ -1778,10 +1779,28 @@ class GMTableWorkspace(ctk.CTkFrame):
                     "width": self._desk_annotation_styles["draw"].get("width", 3),
                 }
             )
-            self._schedule_layout_changed()
+            self._commit_desk_annotation_change()
         self._desk_draw_points = []
         self._redraw_desk_annotations()
         return "break"
+
+    def _commit_desk_annotation_change(self) -> None:
+        """Redraw desk annotations and persist them immediately.
+
+        Desk writing can be the only content on a GM Table, and users often close
+        or switch tables right after drawing. Persist synchronously here instead
+        of relying only on the regular debounced panel-layout callback.
+        """
+        self._desk_annotations = serializable_desk_annotations(self._desk_annotations)
+        self._redraw_desk_annotations()
+        if self._save_job is not None:
+            try:
+                self.after_cancel(self._save_job)
+            except Exception:
+                pass
+            self._save_job = None
+        if self._layout_changed_callback is not None and not self._disposed:
+            self._layout_changed_callback()
 
     def _project_world_point(self, point: tuple[float, float]) -> tuple[float, float]:
         """Project a world coordinate into desk canvas coordinates."""
@@ -3184,7 +3203,9 @@ class GMTableWorkspace(ctk.CTkFrame):
             "camera": self._camera_snapshot(),
             "home_camera": dict(getattr(self, "_home_camera", self._camera_snapshot())),
             "bookmarks": [dict(bookmark) for bookmark in getattr(self, "_bookmarks", [])],
-            "desk_annotations": list(getattr(self, "_desk_annotations", [])),
+            "desk_annotations": serializable_desk_annotations(
+                getattr(self, "_desk_annotations", [])
+            ),
             "panels": panels,
         }
 

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -1120,3 +1120,54 @@ def test_launch_scenario_bundle_opens_maps_and_entities() -> None:
         ("Villains", "Boss"),
         ("Places", "Docks"),
     ]
+
+
+def test_workspace_serializes_json_safe_desk_annotations() -> None:
+    """Desk drawings should be stored as JSON-safe coordinate lists."""
+    from modules.scenarios.gm_table.annotation_persistence import (
+        serializable_desk_annotations,
+    )
+
+    assert serializable_desk_annotations(
+        [
+            {
+                "type": "stroke",
+                "points": [(1, 2), ("3.5", "4.5")],
+                "fill": "#111827",
+                "width": 3,
+            },
+            {"type": "text", "x": 10, "y": 20, "text": "Saved note"},
+        ]
+    ) == [
+        {
+            "type": "stroke",
+            "points": [[1.0, 2.0], [3.5, 4.5]],
+            "fill": "#111827",
+            "width": 3,
+        },
+        {"type": "text", "x": 10, "y": 20, "text": "Saved note"},
+    ]
+
+
+def test_workspace_commits_desk_annotation_changes_immediately() -> None:
+    """Annotation-only desks should not wait for a debounced panel save."""
+    from modules.scenarios.gm_table.workspace import GMTableWorkspace
+
+    callbacks = []
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace._desk_annotations = [
+        {"type": "stroke", "points": [(1, 2), (3, 4)], "fill": "#111827"}
+    ]
+    workspace._save_job = None
+    workspace._disposed = False
+    workspace._layout_changed_callback = lambda: callbacks.append(
+        list(workspace._desk_annotations)
+    )
+    workspace._redraw_desk_annotations = lambda: callbacks.append("redraw")
+
+    GMTableWorkspace._commit_desk_annotation_change(workspace)
+
+    assert callbacks == [
+        "redraw",
+        [{"type": "stroke", "points": [[1.0, 2.0], [3.0, 4.0]], "fill": "#111827"}],
+    ]


### PR DESCRIPTION
### Motivation
- Desk drawings and text on the GM virtual table were not reliably saved when the desk contained only annotations, causing data loss when closing or switching tables.

### Description
- Added `modules/scenarios/gm_table/annotation_persistence.py` with `serializable_desk_annotations` to normalize/serialize desk `text` and `stroke` items and coerce stroke points to JSON-safe `[[x, y], ...]` lists.
- Introduced `_commit_desk_annotation_change` in `modules/scenarios/gm_table/workspace.py` and replaced debounced-only saves with immediate commits from `clear_desk_annotations`, the desk text entry path, and the draw finish path.
- Updated workspace `serialize` to use `serializable_desk_annotations` when writing layouts so persisted layouts are JSON-safe.
- Added regression tests in `tests/scenarios/gm_table/test_gm_table_view.py` to cover JSON-safe annotation serialization and immediate annotation commits.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table/workspace.py modules/scenarios/gm_table/annotation_persistence.py` and it succeeded.
- Ran `pytest -q tests/scenarios/gm_table/test_gm_table_view.py` which passed (`43 passed`).
- Ran the broader `pytest -q tests/scenarios/gm_table` where the suite largely passed but 2 tests failed due to the headless environment (Tkinter raised `no display name and no $DISPLAY`), indicating an environment limitation rather than a regression in these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee2092384832b9a7bf067a41007d9)