### PR TITLE
Improve GM desk annotation UX and persistence

### DIFF
--- a/modules/scenarios/gm_table/annotations/__init__.py
+++ b/modules/scenarios/gm_table/annotations/__init__.py
@@ -1,5 +1,6 @@
 """Desk annotation helpers for GM Table workspaces."""
 
 from .style_dialog import ask_desk_annotation_style
+from .toolbar import DeskAnnotationToolbar
 
-__all__ = ["ask_desk_annotation_style"]
+__all__ = ["ask_desk_annotation_style", "DeskAnnotationToolbar"]

--- a/modules/scenarios/gm_table/annotations/style_dialog.py
+++ b/modules/scenarios/gm_table/annotations/style_dialog.py
@@ -83,7 +83,7 @@ class DeskAnnotationStyleDialog(ctk.CTkToplevel):
         ).grid(row=0, column=0, padx=(14, 10), pady=(14, 8), sticky="w")
         self.color_preview = ctk.CTkButton(
             container,
-            text=self.color_var.get(),
+            text="Selected",
             width=132,
             height=30,
             fg_color=self.color_var.get(),
@@ -163,7 +163,7 @@ class DeskAnnotationStyleDialog(ctk.CTkToplevel):
         if color:
             normalized = _normalize_hex_color(color, self.color_var.get())
             self.color_var.set(normalized)
-            self.color_preview.configure(text=normalized, fg_color=normalized, hover_color=normalized)
+            self.color_preview.configure(text="Selected", fg_color=normalized, hover_color=normalized)
 
     def _apply(self) -> None:
         self.result = {"fill": self.color_var.get()}

--- a/modules/scenarios/gm_table/annotations/toolbar.py
+++ b/modules/scenarios/gm_table/annotations/toolbar.py
@@ -1,0 +1,215 @@
+"""Inline annotation controls for GM Table desks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import tkinter as tk
+
+import customtkinter as ctk
+
+
+COLOR_SWATCHES: tuple[tuple[str, str], ...] = (
+    ("Ink", "#1F2937"),
+    ("Sepia", "#241A10"),
+    ("Ruby", "#DC2626"),
+    ("Amber", "#D97706"),
+    ("Emerald", "#059669"),
+    ("Sky", "#0284C7"),
+    ("Violet", "#7C3AED"),
+    ("Chalk", "#F8FAFC"),
+)
+TEXT_SIZE_OPTIONS = (12, 14, 16, 18, 20, 24, 28, 32, 36, 42, 48, 56, 64)
+STROKE_WIDTH_OPTIONS = (2, 3, 4, 5, 6, 8, 10, 12)
+DEFAULT_STYLES: dict[str, dict[str, object]] = {
+    "draw": {"fill": "#1F2937", "width": 3},
+    "text": {"fill": "#241A10", "font_size": 18},
+}
+
+
+class DeskAnnotationToolbar(ctk.CTkFrame):
+    """Compact inline desk annotation toolbar with swatches and size controls."""
+
+    def __init__(
+        self,
+        master,
+        *,
+        palette: dict[str, str],
+        on_tool_selected: Callable[[str], None],
+        on_style_changed: Callable[[str, dict[str, object]], None],
+        on_clear: Callable[[], None],
+    ) -> None:
+        super().__init__(
+            master,
+            fg_color=palette["table_chip"],
+            corner_radius=16,
+            border_width=1,
+            border_color=palette["table_line"],
+        )
+        self._palette = palette
+        self._on_tool_selected = on_tool_selected
+        self._on_style_changed = on_style_changed
+        self._on_clear = on_clear
+        self._active_tool = "draw"
+        self._styles = {tool: dict(style) for tool, style in DEFAULT_STYLES.items()}
+        self._swatch_buttons: dict[str, ctk.CTkButton] = {}
+        self._tool_buttons: dict[str, ctk.CTkButton] = {}
+        self._text_size_var = tk.StringVar(value=str(DEFAULT_STYLES["text"]["font_size"]))
+        self._stroke_width_var = tk.StringVar(value=str(DEFAULT_STYLES["draw"]["width"]))
+
+        self._build()
+        self._refresh_controls()
+
+    def style_for_tool(self, tool: str) -> dict[str, object]:
+        """Return a copy of the current style for a desk annotation tool."""
+        normalized = "text" if str(tool).lower() == "text" else "draw"
+        return dict(self._styles[normalized])
+
+    def set_active_tool(self, tool: str) -> None:
+        """Refresh the toolbar selection without invoking callbacks."""
+        normalized = "text" if str(tool).lower() == "text" else "draw"
+        self._active_tool = normalized
+        self._refresh_controls()
+
+    def _build(self) -> None:
+        label = ctk.CTkLabel(
+            self,
+            text="Marks",
+            text_color=self._palette["muted"],
+            font=ctk.CTkFont(size=11, weight="bold"),
+        )
+        label.pack(side="left", padx=(10, 6))
+
+        self._tool_buttons["draw"] = ctk.CTkButton(
+            self,
+            text="Draw",
+            width=54,
+            height=26,
+            corner_radius=13,
+            command=lambda: self._select_tool("draw"),
+        )
+        self._tool_buttons["draw"].pack(side="left", padx=(0, 4))
+
+        self._tool_buttons["text"] = ctk.CTkButton(
+            self,
+            text="Text",
+            width=52,
+            height=26,
+            corner_radius=13,
+            command=lambda: self._select_tool("text"),
+        )
+        self._tool_buttons["text"].pack(side="left", padx=(0, 8))
+
+        for name, color in COLOR_SWATCHES:
+            button = ctk.CTkButton(
+                self,
+                text="",
+                width=22,
+                height=22,
+                corner_radius=11,
+                fg_color=color,
+                hover_color=color,
+                border_width=1,
+                border_color=self._palette["table_line"],
+                command=lambda value=color: self._select_color(value),
+            )
+            button.pack(side="left", padx=(0, 4))
+            self._swatch_buttons[color.upper()] = button
+
+        self._stroke_menu = ctk.CTkOptionMenu(
+            self,
+            values=[str(width) for width in STROKE_WIDTH_OPTIONS],
+            variable=self._stroke_width_var,
+            width=58,
+            height=26,
+            fg_color=self._palette["table_alt"],
+            button_color=self._palette["accent"],
+            button_hover_color="#D97706",
+            dropdown_fg_color=self._palette["table_alt"],
+            dropdown_hover_color="#283146",
+            text_color=self._palette["text"],
+            dropdown_text_color=self._palette["text"],
+            command=lambda _value: self._update_size(),
+        )
+        self._stroke_menu.pack(side="left", padx=(4, 0))
+
+        self._text_menu = ctk.CTkOptionMenu(
+            self,
+            values=[str(size) for size in TEXT_SIZE_OPTIONS],
+            variable=self._text_size_var,
+            width=64,
+            height=26,
+            fg_color=self._palette["table_alt"],
+            button_color=self._palette["accent"],
+            button_hover_color="#D97706",
+            dropdown_fg_color=self._palette["table_alt"],
+            dropdown_hover_color="#283146",
+            text_color=self._palette["text"],
+            dropdown_text_color=self._palette["text"],
+            command=lambda _value: self._update_size(),
+        )
+        self._text_menu.pack(side="left", padx=(4, 0))
+
+        ctk.CTkButton(
+            self,
+            text="Clear",
+            width=56,
+            height=26,
+            fg_color="#2B1C23",
+            hover_color="#40222B",
+            text_color=self._palette["text"],
+            corner_radius=13,
+            command=self._on_clear,
+        ).pack(side="left", padx=(6, 8))
+
+    def _select_tool(self, tool: str) -> None:
+        self.set_active_tool(tool)
+        self._on_tool_selected(self._active_tool)
+
+    def _select_color(self, color: str) -> None:
+        self._styles[self._active_tool]["fill"] = color.upper()
+        self._emit_style_change()
+        self._refresh_controls()
+
+    def _update_size(self) -> None:
+        if self._active_tool == "text":
+            self._styles["text"]["font_size"] = _coerce_option(
+                self._text_size_var.get(), TEXT_SIZE_OPTIONS, int(DEFAULT_STYLES["text"]["font_size"])
+            )
+        else:
+            self._styles["draw"]["width"] = _coerce_option(
+                self._stroke_width_var.get(), STROKE_WIDTH_OPTIONS, int(DEFAULT_STYLES["draw"]["width"])
+            )
+        self._emit_style_change()
+
+    def _emit_style_change(self) -> None:
+        self._on_style_changed(self._active_tool, self.style_for_tool(self._active_tool))
+
+    def _refresh_controls(self) -> None:
+        active_color = str(self._styles[self._active_tool].get("fill") or "").upper()
+        for color, button in self._swatch_buttons.items():
+            button.configure(
+                border_width=3 if color == active_color else 1,
+                border_color=self._palette["panel_focus"] if color == active_color else self._palette["table_line"],
+            )
+        for tool, button in self._tool_buttons.items():
+            is_active = tool == self._active_tool
+            button.configure(
+                fg_color=self._palette["accent"] if is_active else self._palette["table_alt"],
+                hover_color="#D97706" if is_active else "#283146",
+                text_color="#10131B" if is_active else self._palette["text"],
+            )
+        if self._active_tool == "text":
+            self._text_menu.configure(state="normal")
+            self._stroke_menu.configure(state="disabled")
+        else:
+            self._text_menu.configure(state="disabled")
+            self._stroke_menu.configure(state="normal")
+
+
+def _coerce_option(value, options: tuple[int, ...], fallback: int) -> int:
+    """Coerce a menu value to a supported option."""
+    try:
+        numeric = int(value)
+    except Exception:
+        return fallback
+    return numeric if numeric in options else fallback

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1708,11 +1708,11 @@ class GMTableWorkspace(ctk.CTkFrame):
             pass
 
     def set_desk_annotation_tool(self, tool: str | None, style: dict | None = None) -> None:
-        """Activate a one-shot desk annotation tool with optional style choices."""
+        """Activate a desk annotation tool with optional style choices."""
         normalized = str(tool or "").strip().lower()
         self._desk_annotation_tool = normalized if normalized in {"draw", "text"} else None
         if self._desk_annotation_tool and isinstance(style, dict):
-            self._desk_annotation_styles[self._desk_annotation_tool].update(style)
+            self.configure_desk_annotation_style(self._desk_annotation_tool, style)
         try:
             if self._desk_annotation_tool == "draw":
                 cursor = "pencil"
@@ -1724,6 +1724,14 @@ class GMTableWorkspace(ctk.CTkFrame):
             self._desk_texture_canvas.configure(cursor=cursor)
         except Exception:
             pass
+
+
+    def configure_desk_annotation_style(self, tool: str, style: dict | None) -> None:
+        """Update saved style choices for a desk annotation tool."""
+        normalized = str(tool or "").strip().lower()
+        if normalized not in {"draw", "text"} or not isinstance(style, dict):
+            return
+        self._desk_annotation_styles[normalized].update(style)
 
     def clear_desk_annotations(self) -> None:
         """Remove all writing and sketches drawn directly on the desk."""
@@ -3224,11 +3232,13 @@ class GMTableWorkspace(ctk.CTkFrame):
             for bookmark in list(payload.get("bookmarks") or [])
             if isinstance(bookmark, dict)
         ]
-        self._desk_annotations = [
-            dict(annotation)
-            for annotation in list(payload.get("desk_annotations") or [])
-            if isinstance(annotation, dict)
-        ]
+        self._desk_annotations = serializable_desk_annotations(
+            [
+                dict(annotation)
+                for annotation in list(payload.get("desk_annotations") or [])
+                if isinstance(annotation, dict)
+            ]
+        )
         panels = [item for item in list(payload.get("panels") or []) if isinstance(item, dict)]
         panels.sort(key=lambda item: int((item.get("state") or {}).get("z", 0)))
         for item in panels:
@@ -3286,3 +3296,5 @@ class GMTableWorkspace(ctk.CTkFrame):
                 )
                 panel._refresh_window_controls()
         self.clamp_panels()
+        self.after_idle(self._refresh_desk_texture)
+        self.after_idle(self._redraw_desk_annotations)

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -30,7 +30,7 @@ from modules.scenarios.gm_table.table_registry import (
     get_table_name,
     normalize_table_id,
 )
-from modules.scenarios.gm_table.annotations import ask_desk_annotation_style
+from modules.scenarios.gm_table.annotations import DeskAnnotationToolbar
 from modules.scenarios.gm_table.attachments import (
     collect_entity_attachments,
     entity_has_attachments,
@@ -112,6 +112,7 @@ class GMTableView(ctk.CTkFrame):
         self.layout_store = layout_store or GMTableLayoutStore()
         self._layout_settle_scheduler = LayoutSettleScheduler(self)
         self._workspace_loaded = False
+        self._save_feedback_job: str | None = None
         self._templates = {
             "Campaigns": load_entity_template("campaigns"),
             "Scenarios": load_entity_template("scenarios"),
@@ -245,6 +246,7 @@ class GMTableView(ctk.CTkFrame):
         title_frame = ctk.CTkFrame(bar, fg_color="transparent")
         title_frame.grid(row=0, column=0, padx=18, pady=8, sticky="ew")
         title_frame.grid_columnconfigure(0, weight=1)
+        title_frame.grid_columnconfigure(1, weight=0)
 
         self.title_label = ctk.CTkLabel(
             title_frame,
@@ -254,6 +256,15 @@ class GMTableView(ctk.CTkFrame):
             anchor="w",
         )
         self.title_label.grid(row=0, column=0, sticky="ew")
+
+        self.save_feedback_label = ctk.CTkLabel(
+            title_frame,
+            text="",
+            text_color=TABLE_PALETTE["danger"],
+            font=ctk.CTkFont(size=12, weight="bold"),
+            anchor="e",
+        )
+        self.save_feedback_label.grid(row=0, column=1, padx=(10, 0), sticky="e")
 
         ctk.CTkButton(
             title_frame,
@@ -265,7 +276,7 @@ class GMTableView(ctk.CTkFrame):
             text_color=TABLE_PALETTE["text"],
             corner_radius=14,
             command=self._open_rename_dialog,
-        ).grid(row=0, column=1, padx=(10, 0), sticky="e")
+        ).grid(row=0, column=2, padx=(10, 0), sticky="e")
 
         actions = ctk.CTkFrame(bar, fg_color="transparent")
         actions.grid(row=0, column=1, padx=12, pady=8, sticky="e")
@@ -356,29 +367,14 @@ class GMTableView(ctk.CTkFrame):
             command=self._open_panel_search,
         ).pack(side="left", padx=(0, 10))
 
-        ctk.CTkButton(
+        self.annotation_toolbar = DeskAnnotationToolbar(
             actions,
-            text="Draw",
-            width=78,
-            height=30,
-            fg_color=TABLE_PALETTE["table_chip"],
-            hover_color="#283146",
-            text_color=TABLE_PALETTE["text"],
-            corner_radius=14,
-            command=lambda: self._activate_desk_annotation_tool("draw"),
-        ).pack(side="left", padx=(0, 10))
-
-        ctk.CTkButton(
-            actions,
-            text="Desk Text",
-            width=104,
-            height=30,
-            fg_color=TABLE_PALETTE["table_chip"],
-            hover_color="#283146",
-            text_color=TABLE_PALETTE["text"],
-            corner_radius=14,
-            command=lambda: self._activate_desk_annotation_tool("text"),
-        ).pack(side="left", padx=(0, 10))
+            palette=TABLE_PALETTE,
+            on_tool_selected=self._activate_desk_annotation_tool,
+            on_style_changed=self._update_desk_annotation_style,
+            on_clear=lambda: self.workspace.clear_desk_annotations(),
+        )
+        self.annotation_toolbar.pack(side="left", padx=(0, 10))
 
         ctk.CTkButton(
             actions,
@@ -406,16 +402,21 @@ class GMTableView(ctk.CTkFrame):
 
 
     def _activate_desk_annotation_tool(self, tool: str) -> None:
-        """Ask for annotation styling before arming a desk drawing tool."""
-        current_styles = getattr(self.workspace, "_desk_annotation_styles", {})
-        style = ask_desk_annotation_style(
-            self,
-            tool=tool,
-            initial_style=current_styles.get(tool, {}) if isinstance(current_styles, dict) else {},
-        )
-        if style is None:
-            return
+        """Arm a desk annotation tool immediately using inline toolbar styling."""
+        toolbar = getattr(self, "annotation_toolbar", None)
+        if toolbar is not None:
+            toolbar.set_active_tool(tool)
+            style = toolbar.style_for_tool(tool)
+        else:
+            style = None
         self.workspace.set_desk_annotation_tool(tool, style)
+
+    def _update_desk_annotation_style(self, tool: str, style: dict[str, object]) -> None:
+        """Apply inline annotation style changes without interrupting the active tool."""
+        workspace = getattr(self, "workspace", None)
+        if workspace is None:
+            return
+        workspace.configure_desk_annotation_style(tool, style)
 
     def _build_table_switch_options(
         self,
@@ -647,22 +648,39 @@ class GMTableView(ctk.CTkFrame):
             "gm_table_layout", self._save_layout_snapshot
         )
 
-    def _save_layout_snapshot(self) -> None:
+    def _save_layout_snapshot(self) -> bool:
         """Write the latest workspace snapshot to storage."""
         try:
             self.layout_store.save_table_layout(
                 self.table_id, self.workspace.serialize()
             )
+            return True
         except Exception as exc:
             log_warning(
                 f"Unable to save GM Table layout: {exc}",
                 func_name="GMTableView._save_layout_snapshot",
             )
+            return False
 
     def save_layout_now(self) -> None:
-        """Persist immediately and notify the user."""
-        self._save_layout_snapshot()
-        messagebox.showinfo("GM Table", f"Layout saved for '{self.table_name}'.")
+        """Persist immediately and show inline save feedback."""
+        if self._save_layout_snapshot():
+            self._show_save_feedback(f"Saved {self.table_name}")
+        else:
+            self._show_save_feedback("Save failed")
+
+    def _show_save_feedback(self, message: str) -> None:
+        """Display compact save confirmation beside the table title."""
+        label = getattr(self, "save_feedback_label", None)
+        if label is None:
+            return
+        label.configure(text=message)
+        if hasattr(self, "_save_feedback_job") and self._save_feedback_job is not None:
+            try:
+                self.after_cancel(self._save_feedback_job)
+            except Exception:
+                pass
+        self._save_feedback_job = self.after(2200, lambda: label.configure(text=""))
 
     def reset_table(self) -> None:
         """Reset the table workspace to the starter layout."""

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -1171,3 +1171,31 @@ def test_workspace_commits_desk_annotation_changes_immediately() -> None:
         "redraw",
         [{"type": "stroke", "points": [[1.0, 2.0], [3.0, 4.0]], "fill": "#111827"}],
     ]
+
+
+def test_save_layout_now_reports_failed_save_feedback() -> None:
+    """Manual save feedback should not claim success when persistence fails."""
+    view = GMTableView.__new__(GMTableView)
+    view.table_name = "Main Desk"
+    view._save_layout_snapshot = lambda: False
+
+    messages = []
+    view._show_save_feedback = messages.append
+
+    GMTableView.save_layout_now(view)
+
+    assert messages == ["Save failed"]
+
+
+def test_save_layout_now_reports_successful_save_feedback() -> None:
+    """Manual save feedback should confirm the named table only after success."""
+    view = GMTableView.__new__(GMTableView)
+    view.table_name = "Main Desk"
+    view._save_layout_snapshot = lambda: True
+
+    messages = []
+    view._show_save_feedback = messages.append
+
+    GMTableView.save_layout_now(view)
+
+    assert messages == ["Saved Main Desk"]


### PR DESCRIPTION
### Motivation

- Replace the blocking save confirmation popup with a subtle inline status so saves are less disruptive to GM workflow.  
- Modernize the Draw and Desk Text tool activation so users can start annotating immediately and adjust styles inline.  
- Ensure desk annotations persist and are visible on app relaunch without requiring tool reactivation.

### Description

- Added a modular inline `DeskAnnotationToolbar` under `modules/scenarios/gm_table/annotations/` that exposes immediate `Draw`/`Text` activation, visual-only color swatches, stroke width and text size selectors, an active-tool indicator, and a `Clear` action (`modules/scenarios/gm_table/annotations/toolbar.py`).  
- Replaced the save popup with an inline red status label placed next to the table title and wired `save_layout_now()` to show `Saved <TableName>` or `Save failed`, clearing after a short delay (`modules/scenarios/gm_table_view.py`).  
- Stopped requiring the modal `ask_desk_annotation_style(...)` prior to arming annotation tools and wired the inline toolbar to call `workspace.set_desk_annotation_tool(...)` and `workspace.configure_desk_annotation_style(...)` for immediate activation and live updates (`modules/scenarios/gm_table_view.py`, `modules/scenarios/gm_table/workspace.py`).  
- Kept hex color values internally for rendering but removed any visible hex text from UI controls and the fallback style dialog (swatches/buttons show only color or the word "Selected" rather than `#HEX`) (`modules/scenarios/gm_table/annotations/style_dialog.py`, `modules/scenarios/gm_table/annotations/toolbar.py`).  
- Fixed restoration of persisted desk annotations by normalizing/serializing incoming annotations into `GMTableWorkspace._desk_annotations` and scheduling redraws after the desk texture and surface are ready so saved text and strokes appear immediately after restore (`modules/scenarios/gm_table/workspace.py`, `modules/scenarios/gm_table/annotation_persistence.py`).

### Testing

- Ran byte-compile checks with `python -m py_compile` on the modified modules and they completed with no errors.  
- Ran the GM Table view test suite with `python -m pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and it passed (`45 passed`).  
- Executed a focused set of annotation and save tests (several `tests/scenarios/gm_table` unit tests) and they passed (specific annotation and save-related tests passed).  
- Ran the full workspace tests with `python -m pytest tests/scenarios/gm_table/test_workspace.py -q` which reported the logic tests passing but two UI tests failed due to the CI environment lacking a display (`_tkinter.TclError: no display name and no $DISPLAY`), which is an environment limitation rather than a regression in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f896be9b4832baa466340db05a0f8)