### PR TITLE
Fix world map token click/drag handling to keep inspector visible and allow movement

### DIFF
--- a/modules/maps/world_map_view.py
+++ b/modules/maps/world_map_view.py
@@ -194,6 +194,7 @@ class WorldMapPanel(ctk.CTkFrame):
         self._entity_tab_images: list[ctk.CTkImage] = []
         self._notes_textbox: ctk.CTkTextbox | None = None
         self._notes_status_label: ctk.CTkLabel | None = None
+        self._token_press_handled = False
 
         self.color_swatch_button: ctk.CTkButton | None = None
         self.zoom = 1.0
@@ -1548,23 +1549,25 @@ class WorldMapPanel(ctk.CTkFrame):
     # ------------------------------------------------------------------
     # Token interactions
     # ------------------------------------------------------------------
-    def _on_token_press(self, event, token: dict) -> None:
+    def _on_token_press(self, event, token: dict) -> str | None:
         """Handle token press."""
         if event is None:
-            return
+            return None
         if self.fog_mode:
             return "break"
+        self._token_press_handled = True
         self.selected_token = token
         token["drag_anchor"] = (event.x, event.y)
         if token.get("type") == "map":
             self._show_map_hint(token)
         else:
             self._show_entity_synthesis(token)
+        return "break"
 
-    def _on_token_drag(self, event, token: dict) -> None:
+    def _on_token_drag(self, event, token: dict) -> str | None:
         """Handle token drag."""
         if event is None or "drag_anchor" not in token or not self.render_params:
-            return
+            return None
         if self.fog_mode:
             return "break"
         scale, offset_x, offset_y, base_w, base_h = self.render_params
@@ -1574,18 +1577,21 @@ class WorldMapPanel(ctk.CTkFrame):
         dx = x - token["drag_anchor"][0]
         dy = y - token["drag_anchor"][1]
         if abs(dx) < 1 and abs(dy) < 1:
-            return
+            return "break"
         token["drag_anchor"] = (x, y)
         for cid in token.get("canvas_ids", []):
             self.canvas.move(cid, dx, dy)
         token["x_norm"] = (x - offset_x) / (base_w * scale)
         token["y_norm"] = (y - offset_y) / (base_h * scale)
-    def _on_token_release(self, _event, token: dict) -> None:
+        return "break"
+
+    def _on_token_release(self, _event, token: dict) -> str:
         """Handle token release."""
         if self.fog_mode:
             return "break"
         token.pop("drag_anchor", None)
         self._persist_tokens()
+        return "break"
 
     def _on_token_double_click(self, _event, token: dict) -> None:
         """Handle token double click."""
@@ -1779,6 +1785,9 @@ class WorldMapPanel(ctk.CTkFrame):
 
     def _on_canvas_press(self, event) -> str | None:
         """Handle canvas press."""
+        if getattr(self, "_token_press_handled", False):
+            self._token_press_handled = False
+            return "break"
         if self.measure_mode:
             self._measurement_start_world = self._event_to_world_pixels(event)
             self._clear_measurement_preview()


### PR DESCRIPTION
### Motivation
- Clicking a token immediately opened the right inspector but the canvas background handler then cleared it, preventing subsequent drags from moving the entity. 
- Token drag/release handlers should consume pointer events so dragging continues to work after selection. 
- A small event-guard is needed to stop the token press from bubbling into the canvas press handler.

### Description
- Added a boolean guard `self._token_press_handled` initialized to `False` and used it to prevent token press events from being interpreted by the canvas background handler. 
- Updated `_on_token_press` to set the guard, select the token, open the inspector (map hint or entity synthesis) and return `"break"` so the event is consumed. 
- Updated `_on_token_drag` and `_on_token_release` to return `"break"` when handling drags/releases and to keep the drag-anchor and coordinate update behavior intact so tokens remain movable. 
- Added an early check in `_on_canvas_press` to clear the guard and return `"break"` when a token press was just handled, preventing the inspector from being immediately hidden.

### Testing
- Compiled the modified module with `python3 -m py_compile modules/maps/world_map_view.py` and it succeeded. 
- Ran `git diff --check` to validate whitespace/format issues and it reported no problems. 
- Executed a focused pytest run: `python3 -m pytest tests/maps/test_marker_types.py tests/maps/test_measurement_templates.py tests/maps/test_floating_toolbar_compact_controls.py` where `tests/maps/test_measurement_templates.py` passed and two tests failed in other files (`test_marker_type_icons_have_distinct_glyph_shapes` and `test_world_map_canvas_tools_moved_to_floating_palette`); those failures appear unrelated to the event-handling changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa3254e90832b81e56f1e456fc075)