### PR TITLE
Export and import GM virtual tables in campaign bundles

### DIFF
--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -29,7 +29,11 @@ from modules.generic.cross_campaign_asset_service import (
     list_sibling_campaigns,
     load_entities,
 )
-from modules.generic.github_gallery_client import GalleryBundleSummary, GithubGalleryClient
+from modules.generic.cross_campaign_gm_tables import load_gm_virtual_tables
+from modules.generic.github_gallery_client import (
+    GalleryBundleSummary,
+    GithubGalleryClient,
+)
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.checkbox_dialog import CheckboxDialog
 from modules.helpers.logging_helper import log_exception, log_info, log_warning
@@ -51,12 +55,21 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.focus_force()
 
         self.entity_definitions = load_entity_definitions()
-        self.entity_types = tuple(list_known_entities()) or tuple(sorted(self.entity_definitions.keys()))
+        self.entity_types = tuple(list_known_entities()) or tuple(
+            sorted(self.entity_definitions.keys())
+        )
+        if "gm_virtual_tables" not in self.entity_types:
+            self.entity_types = tuple(self.entity_types) + ("gm_virtual_tables",)
         if not self.entity_types:
             self.entity_types = ("npcs", "objects", "maps")
         for slug in self.entity_types:
-            self.entity_definitions.setdefault(slug, {"label": slug.replace("_", " ").title()})
-        self.entity_records: Dict[str, List[dict]] = {key: [] for key in self.entity_types}
+            self.entity_definitions.setdefault(
+                slug, {"label": slug.replace("_", " ").title()}
+            )
+        self.entity_definitions["gm_virtual_tables"] = {"label": "GM Virtual Tables"}
+        self.entity_records: Dict[str, List[dict]] = {
+            key: [] for key in self.entity_types
+        }
 
         self.gallery_client = GithubGalleryClient()
         self._online_dialog: Optional["OnlineGalleryDialog"] = None
@@ -78,19 +91,23 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.left_frame.grid(row=0, column=0, sticky="nsw", padx=10, pady=10)
         self.left_frame.grid_rowconfigure(1, weight=1)
 
-        ctk.CTkLabel(self.left_frame, text="Available Campaigns", font=("Segoe UI", 15, "bold")).grid(
-            row=0, column=0, columnspan=2, sticky="w", pady=(0, 6)
-        )
+        ctk.CTkLabel(
+            self.left_frame, text="Available Campaigns", font=("Segoe UI", 15, "bold")
+        ).grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 6))
 
         self.campaign_list = ctk.CTkScrollableFrame(self.left_frame, width=260)
         self.campaign_list.grid(row=1, column=0, columnspan=2, sticky="nsew")
 
         self.campaign_buttons: List[ctk.CTkButton] = []
 
-        browse_btn = ctk.CTkButton(self.left_frame, text="Browse…", command=self.browse_for_campaign)
+        browse_btn = ctk.CTkButton(
+            self.left_frame, text="Browse…", command=self.browse_for_campaign
+        )
         browse_btn.grid(row=2, column=0, sticky="ew", pady=(10, 0))
 
-        refresh_btn = ctk.CTkButton(self.left_frame, text="Refresh", command=self.refresh_campaign_list)
+        refresh_btn = ctk.CTkButton(
+            self.left_frame, text="Refresh", command=self.refresh_campaign_list
+        )
         refresh_btn.grid(row=2, column=1, sticky="ew", padx=(6, 0), pady=(10, 0))
 
         self.right_frame = ctk.CTkFrame(self)
@@ -108,18 +125,26 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
         for entity_type in self.entity_types:
             # Process each entity_type from entity_types.
-            label = self.entity_definitions.get(entity_type, {}).get("label") or entity_type.replace("_", " ").title()
+            label = (
+                self.entity_definitions.get(entity_type, {}).get("label")
+                or entity_type.replace("_", " ").title()
+            )
             tab = self.tabview.add(label)
             tab.grid_rowconfigure(0, weight=1)
             tab.grid_columnconfigure(0, weight=1)
             columns = ("name", "summary")
-            tree = ttk.Treeview(tab, columns=columns, show="headings", selectmode="extended", height=14)
+            tree = ttk.Treeview(
+                tab, columns=columns, show="headings", selectmode="extended", height=14
+            )
             tree.heading("name", text="Name")
             tree.heading("summary", text="Summary")
             tree.column("name", width=280, anchor="w", stretch=False)
             tree.column("summary", width=760, anchor="w", stretch=False)
             tree.grid(row=0, column=0, sticky="nsew")
-            tree.bind("<<TreeviewSelect>>", lambda _evt, et=entity_type: self.update_preview_from_tree(et))
+            tree.bind(
+                "<<TreeviewSelect>>",
+                lambda _evt, et=entity_type: self.update_preview_from_tree(et),
+            )
 
             yscroll = ttk.Scrollbar(tab, orient="vertical", command=tree.yview)
             xscroll = ttk.Scrollbar(tab, orient="horizontal", command=tree.xview)
@@ -133,10 +158,12 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.preview_frame.grid_rowconfigure(2, weight=1)
         self.preview_frame.grid_columnconfigure(0, weight=1)
 
-        ctk.CTkLabel(self.preview_frame, text="Preview", font=("Segoe UI", 15, "bold")).grid(
-            row=0, column=0, sticky="nw"
+        ctk.CTkLabel(
+            self.preview_frame, text="Preview", font=("Segoe UI", 15, "bold")
+        ).grid(row=0, column=0, sticky="nw")
+        self.preview_name = ctk.CTkLabel(
+            self.preview_frame, text="", font=("Segoe UI", 14, "bold")
         )
-        self.preview_name = ctk.CTkLabel(self.preview_frame, text="", font=("Segoe UI", 14, "bold"))
         self.preview_name.grid(row=1, column=0, sticky="nw", pady=(4, 4))
 
         self.preview_image_label = ctk.CTkLabel(self.preview_frame, text="", image=None)
@@ -147,11 +174,15 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.preview_text.configure(state="disabled")
 
         button_row = ctk.CTkFrame(self)
-        button_row.grid(row=1, column=0, columnspan=2, sticky="ew", padx=10, pady=(0, 10))
+        button_row.grid(
+            row=1, column=0, columnspan=2, sticky="ew", padx=10, pady=(0, 10)
+        )
         for column_index in range(9):
             button_row.grid_columnconfigure(column_index, weight=1)
 
-        self.export_btn = ctk.CTkButton(button_row, text="Export Selected…", command=self.export_selected)
+        self.export_btn = ctk.CTkButton(
+            button_row, text="Export Selected…", command=self.export_selected
+        )
         self.export_btn.grid(row=0, column=0, padx=6, pady=6, sticky="ew")
         self.copy_btn = ctk.CTkButton(
             button_row,
@@ -159,7 +190,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             command=self.copy_selected_to_current_campaign,
         )
         self.copy_btn.grid(row=0, column=1, padx=6, pady=6, sticky="ew")
-        self.import_btn = ctk.CTkButton(button_row, text="Import Bundle…", command=self.import_bundle)
+        self.import_btn = ctk.CTkButton(
+            button_row, text="Import Bundle…", command=self.import_bundle
+        )
         self.import_btn.grid(row=0, column=2, padx=6, pady=6, sticky="ew")
         self.import_image_library_btn = ctk.CTkButton(
             button_row,
@@ -167,7 +200,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             command=self.import_image_library_bundle,
         )
         self.import_image_library_btn.grid(row=0, column=3, padx=6, pady=6, sticky="ew")
-        self.reload_btn = ctk.CTkButton(button_row, text="Refresh Source", command=self.reload_source)
+        self.reload_btn = ctk.CTkButton(
+            button_row, text="Refresh Source", command=self.reload_source
+        )
         self.reload_btn.grid(row=0, column=4, padx=6, pady=6, sticky="ew")
         self.publish_btn = ctk.CTkButton(
             button_row,
@@ -180,7 +215,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             text="Publish Image Library…",
             command=self.publish_image_library_to_github,
         )
-        self.publish_image_library_btn.grid(row=0, column=6, padx=6, pady=6, sticky="ew")
+        self.publish_image_library_btn.grid(
+            row=0, column=6, padx=6, pady=6, sticky="ew"
+        )
         self.gallery_btn = ctk.CTkButton(
             button_row,
             text="Browse Online Gallery…",
@@ -205,7 +242,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.campaign_buttons.clear()
 
         self.source_campaigns = list_sibling_campaigns(include_current=True)
-        active_db_path = self.active_campaign.db_path.resolve() if self.active_campaign else None
+        active_db_path = (
+            self.active_campaign.db_path.resolve() if self.active_campaign else None
+        )
         for index, campaign in enumerate(self.source_campaigns):
             # Process each (index, campaign) from enumerate(source_campaigns).
             label = campaign.name
@@ -242,7 +281,12 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             self.select_campaign(candidates[0])
             return
 
-        dialog = SelectionDialog(self, "Select Database", "Choose a campaign database:", [c.name for c in candidates])
+        dialog = SelectionDialog(
+            self,
+            "Select Database",
+            "Choose a campaign database:",
+            [c.name for c in candidates],
+        )
         self.wait_window(dialog)
         if dialog.result is None:
             return
@@ -269,7 +313,14 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             try:
                 # Keep reload source resilient if this step fails.
                 for entity_type in self.entity_types:
-                    self.entity_records[entity_type] = load_entities(entity_type, self.selected_campaign.db_path)
+                    if entity_type == "gm_virtual_tables":
+                        self.entity_records[entity_type] = load_gm_virtual_tables(
+                            self.selected_campaign.root
+                        )
+                    else:
+                        self.entity_records[entity_type] = load_entities(
+                            entity_type, self.selected_campaign.db_path
+                        )
             except Exception as exc:
                 log_exception(
                     f"Failed to load entities from {self.selected_campaign.db_path}: {exc}",
@@ -303,7 +354,14 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 # Process each (idx, record) from enumerate(records).
                 name = record.get("Name") or record.get("Title") or "<Unnamed>"
                 summary = None
-                for field in ("Description", "Summary", "Information", "Notes", "Background", "Secret"):
+                for field in (
+                    "Description",
+                    "Summary",
+                    "Information",
+                    "Notes",
+                    "Background",
+                    "Secret",
+                ):
                     # Process each field while updating populate lists.
                     value = record.get(field)
                     if value:
@@ -312,7 +370,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 if summary is None:
                     summary = ""
                 summary_text = " ".join(str(summary).split())[:140]
-                tree.insert("", END, iid=f"{entity_type}:{idx}", values=(name, summary_text))
+                tree.insert(
+                    "", END, iid=f"{entity_type}:{idx}", values=(name, summary_text)
+                )
         self._set_preview(None, None)
 
     # ------------------------------------------------------------- Preview
@@ -354,7 +414,14 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.preview_name.configure(text=name)
 
         description = ""
-        for field in ("Description", "Summary", "Information", "Notes", "Background", "Secret"):
+        for field in (
+            "Description",
+            "Summary",
+            "Information",
+            "Notes",
+            "Background",
+            "Secret",
+        ):
             # Process each field while updating preview.
             value = record.get(field)
             if value:
@@ -391,7 +458,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                     # Keep preview resilient if this step fails.
                     pil_image = Image.open(resolved)
                     pil_image.thumbnail((360, 360))
-                    self._preview_image = ctk.CTkImage(light_image=pil_image, dark_image=pil_image, size=pil_image.size)
+                    self._preview_image = ctk.CTkImage(
+                        light_image=pil_image, dark_image=pil_image, size=pil_image.size
+                    )
                     self._update_preview_image_label(self._preview_image, "")
                     return
                 except Exception as exc:
@@ -467,7 +536,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             return
         include_random_tables = random_tables_dialog.result
 
-        default_name = f"asset_bundle_{self.selected_campaign.name.replace(' ', '_')}.zip"
+        default_name = (
+            f"asset_bundle_{self.selected_campaign.name.replace(' ', '_')}.zip"
+        )
         destination = filedialog.asksaveasfilename(
             title="Export Asset Bundle",
             defaultextension=".zip",
@@ -476,6 +547,8 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         )
         if not destination:
             return
+
+        gm_virtual_tables = selections.pop("gm_virtual_tables", [])
 
         def worker(callback):
             """Handle worker."""
@@ -486,6 +559,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 include_database=False,
                 include_systems=include_systems,
                 include_random_tables=include_random_tables,
+                gm_virtual_tables=gm_virtual_tables,
                 progress_callback=callback,
             )
 
@@ -497,9 +571,14 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             systems_meta = manifest.get("systems")
             if isinstance(systems_meta, dict):
                 lines.append(f"Systems: {systems_meta.get('count', 0)}")
+            gm_tables_meta = manifest.get("gm_virtual_tables")
+            if isinstance(gm_tables_meta, dict):
+                lines.append(f"GM Virtual Tables: {gm_tables_meta.get('count', 0)}")
             return "\n".join(lines)
 
-        self._run_progress_task("Exporting Assets", worker, "Asset bundle created successfully.", detail)
+        self._run_progress_task(
+            "Exporting Assets", worker, "Asset bundle created successfully.", detail
+        )
 
     def publish_selected_to_github(self):
         """Handle publish selected to github."""
@@ -542,7 +621,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             return
         title = title.strip()
         if not title:
-            messagebox.showwarning("Invalid Title", "Enter a non-empty title for the bundle.")
+            messagebox.showwarning(
+                "Invalid Title", "Enter a non-empty title for the bundle."
+            )
             return
 
         description = simpledialog.askstring(
@@ -610,7 +691,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             return
         title = title.strip()
         if not title:
-            messagebox.showwarning("Invalid Title", "Enter a non-empty title for the bundle.")
+            messagebox.showwarning(
+                "Invalid Title", "Enter a non-empty title for the bundle."
+            )
             return
 
         description = simpledialog.askstring(
@@ -651,6 +734,8 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             slug = slug[:48]
         archive_path = temp_dir / f"{slug}.zip"
 
+        gm_virtual_tables = selections.pop("gm_virtual_tables", [])
+
         def worker(callback):
             """Handle worker."""
             try:
@@ -662,6 +747,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                     include_database=include_database,
                     include_systems=True,
                     include_random_tables=include_random_tables,
+                    gm_virtual_tables=gm_virtual_tables,
                     progress_callback=callback,
                 )
                 return self.gallery_client.publish_bundle(
@@ -694,7 +780,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             messagebox.showinfo("Bundle Published", message)
             self._refresh_online_dialog()
 
-        self._run_progress_task(progress_title, worker, None, None, on_success=on_success)
+        self._run_progress_task(
+            progress_title, worker, None, None, on_success=on_success
+        )
 
     def copy_selected_to_current_campaign(self):
         """Copy selected to current campaign."""
@@ -706,6 +794,15 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         if not selections:
             messagebox.showinfo("No Selection", "Select at least one asset to copy.")
             return
+
+        gm_virtual_tables = selections.pop("gm_virtual_tables", [])
+        if gm_virtual_tables:
+            messagebox.showinfo(
+                "GM Virtual Tables",
+                "GM virtual tables can be moved with Export Selected… and Import Bundle…",
+            )
+            if not selections:
+                return
 
         duplicates = detect_duplicates(selections, self.active_campaign)
         if duplicates:
@@ -793,7 +890,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             ),
         )
 
-    def _start_import_from_bundle(self, bundle_path: Path, *, cleanup: Optional[Callable[[], None]] = None):
+    def _start_import_from_bundle(
+        self, bundle_path: Path, *, cleanup: Optional[Callable[[], None]] = None
+    ):
         """Start import from bundle."""
         target_campaign = self.active_campaign
 
@@ -834,7 +933,12 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 """Import worker."""
                 try:
                     # Keep worker resilient if this step fails.
-                    return apply_import(analysis, target_campaign, overwrite=overwrite, progress_callback=callback)
+                    return apply_import(
+                        analysis,
+                        target_campaign,
+                        overwrite=overwrite,
+                        progress_callback=callback,
+                    )
                 except Exception:
                     cleanup_analysis(analysis)
                     if cleanup:
@@ -849,7 +953,10 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                     f"Skipped: {summary.get('skipped', 0)}\n"
                     f"Systems imported: {summary.get('systems_imported', 0)}\n"
                     f"Systems updated: {summary.get('systems_updated', 0)}\n"
-                    f"Systems skipped: {summary.get('systems_skipped', 0)}"
+                    f"Systems skipped: {summary.get('systems_skipped', 0)}\n"
+                    f"GM tables imported: {summary.get('gm_virtual_tables_imported', 0)}\n"
+                    f"GM tables updated: {summary.get('gm_virtual_tables_updated', 0)}\n"
+                    f"GM tables skipped: {summary.get('gm_virtual_tables_skipped', 0)}"
                 )
 
             def finalize(result):
@@ -870,7 +977,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 on_success=finalize,
             )
 
-        self._run_progress_task("Analyzing Bundle", analyze_worker, None, None, on_success=after_analysis)
+        self._run_progress_task(
+            "Analyzing Bundle", analyze_worker, None, None, on_success=after_analysis
+        )
 
     def _post_image_library_import(self, summary: dict, overwrite: bool):
         """Internal helper for image-library-only import completion."""
@@ -978,7 +1087,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 on_success=finalize,
             )
 
-        self._run_progress_task("Analyzing Bundle", analyze_worker, None, None, on_success=after_analysis)
+        self._run_progress_task(
+            "Analyzing Bundle", analyze_worker, None, None, on_success=after_analysis
+        )
 
     def open_online_gallery(self):
         """Open online gallery."""
@@ -1001,7 +1112,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
     def configure_github_token(self):
         """Handle configure github token."""
-        raw_value = (ConfigHelper.get("Gallery", "github_token", fallback="") or "").strip()
+        raw_value = (
+            ConfigHelper.get("Gallery", "github_token", fallback="") or ""
+        ).strip()
         existing_token = decrypt_secret(raw_value)
 
         prompt_lines = [
@@ -1023,7 +1136,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         if not token:
             ConfigHelper.set("Gallery", "github_token", "")
             self.gallery_client.set_token(None)
-            messagebox.showinfo("GitHub Token", "The stored GitHub token has been cleared.")
+            messagebox.showinfo(
+                "GitHub Token", "The stored GitHub token has been cleared."
+            )
             self._update_publish_button_state()
             return
 
@@ -1038,12 +1153,18 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
         ConfigHelper.set("Gallery", "github_token", encrypted_value)
         self.gallery_client.set_token(token)
-        messagebox.showinfo("GitHub Token", "Your GitHub token has been saved securely.")
+        messagebox.showinfo(
+            "GitHub Token", "Your GitHub token has been saved securely."
+        )
         self._update_publish_button_state()
 
     def _github_token_button_label(self) -> str:
         """Internal helper for github token button label."""
-        return "Set GitHub Token…" if not self.gallery_client.can_publish else "Update GitHub Token…"
+        return (
+            "Set GitHub Token…"
+            if not self.gallery_client.can_publish
+            else "Update GitHub Token…"
+        )
 
     def _update_publish_button_state(self):
         """Update publish button state."""
@@ -1089,7 +1210,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         def worker(callback):
             """Handle worker."""
             try:
-                return self.gallery_client.download_bundle(bundle, archive_path, progress_callback=callback)
+                return self.gallery_client.download_bundle(
+                    bundle, archive_path, progress_callback=callback
+                )
             except Exception:
                 shutil.rmtree(temp_dir, ignore_errors=True)
                 raise
@@ -1105,7 +1228,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 return
             self._start_import_from_bundle(path, cleanup=cleanup)
 
-        self._run_progress_task("Downloading Bundle", worker, None, None, on_success=handle_success)
+        self._run_progress_task(
+            "Downloading Bundle", worker, None, None, on_success=handle_success
+        )
 
     def _download_and_import_image_library_bundle(self, bundle: GalleryBundleSummary):
         """Download a gallery bundle and import only image library entities."""
@@ -1119,7 +1244,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         cleanup: Optional[Callable[[], None]] = None,
     ) -> None:
         """Internal helper for install full campaign from archive."""
-        default_name = bundle.source_campaign or bundle.display_title or Path(archive_path).stem
+        default_name = (
+            bundle.source_campaign or bundle.display_title or Path(archive_path).stem
+        )
         folder_name = simpledialog.askstring(
             "Install Campaign",
             "Enter a folder name for the downloaded campaign:",
@@ -1135,7 +1262,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         folder_name = folder_name.strip()
         if not folder_name:
             # Handle the branch where folder name is unavailable.
-            messagebox.showwarning("Invalid Name", "Enter a non-empty folder name for the campaign.")
+            messagebox.showwarning(
+                "Invalid Name", "Enter a non-empty folder name for the campaign."
+            )
             if cleanup:
                 cleanup()
             return
@@ -1179,7 +1308,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             """Handle worker."""
             try:
                 # Keep worker resilient if this step fails.
-                return install_full_campaign_bundle(archive_path, target_dir, progress_callback=callback)
+                return install_full_campaign_bundle(
+                    archive_path, target_dir, progress_callback=callback
+                )
             finally:
                 if cleanup:
                     cleanup()
@@ -1209,6 +1340,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
     def _delete_gallery_bundle(self, bundle: GalleryBundleSummary):
         """Delete gallery bundle."""
+
         def worker(callback):
             """Handle worker."""
             return self.gallery_client.delete_bundle(bundle, progress_callback=callback)
@@ -1221,7 +1353,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             )
             self._refresh_online_dialog()
 
-        self._run_progress_task("Deleting Bundle", worker, None, None, on_success=handle_success)
+        self._run_progress_task(
+            "Deleting Bundle", worker, None, None, on_success=handle_success
+        )
 
     def _post_copy(self, summary: dict):
         """Internal helper for post copy."""
@@ -1277,7 +1411,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         return {"image_assets": [copy.deepcopy(record) for record in records]}
 
     # ------------------------------------------------------- Busy handling
-    def _run_progress_task(self, title, worker, success_message, detail_builder, on_success=None):
+    def _run_progress_task(
+        self, title, worker, success_message, detail_builder, on_success=None
+    ):
         """Run progress task."""
         progress_win = ctk.CTkToplevel(self)
         progress_win.title(title)
@@ -1287,7 +1423,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         progress_win.grab_set()
         progress_win.lift()
 
-        label = ctk.CTkLabel(progress_win, text="Starting...", wraplength=360, justify="center")
+        label = ctk.CTkLabel(
+            progress_win, text="Starting...", wraplength=360, justify="center"
+        )
         label.pack(fill="x", padx=20, pady=(20, 10))
         bar = ctk.CTkProgressBar(progress_win, mode="determinate")
         bar.pack(fill="x", padx=20, pady=(0, 20))
@@ -1295,6 +1433,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
         def update(message: str, fraction: float):
             """Update the operation."""
+
             def apply():
                 """Apply the operation."""
                 label.configure(text=message)
@@ -1323,7 +1462,9 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 return
             if success_message:
                 detail = detail_builder(result) if detail_builder else None
-                message = success_message if not detail else f"{success_message}\n\n{detail}"
+                message = (
+                    success_message if not detail else f"{success_message}\n\n{detail}"
+                )
                 messagebox.showinfo("Success", message)
 
         def handle_error(exc: Exception):
@@ -1370,7 +1511,12 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
 
 class OnlineGalleryDialog(ctk.CTkToplevel):
-    def __init__(self, master, client: GithubGalleryClient, parent_window: CrossCampaignAssetLibraryWindow):
+    def __init__(
+        self,
+        master,
+        client: GithubGalleryClient,
+        parent_window: CrossCampaignAssetLibraryWindow,
+    ):
         """Initialize the OnlineGalleryDialog instance."""
         super().__init__(master)
         self.client = client
@@ -1418,28 +1564,44 @@ class OnlineGalleryDialog(ctk.CTkToplevel):
         self.detail_text.configure(state="disabled")
 
         button_bar = ctk.CTkFrame(self)
-        button_bar.grid(row=1, column=0, columnspan=3, sticky="ew", padx=10, pady=(10, 10))
+        button_bar.grid(
+            row=1, column=0, columnspan=3, sticky="ew", padx=10, pady=(10, 10)
+        )
         button_bar.grid_columnconfigure((0, 1, 2, 3, 4), weight=1)
 
-        self.refresh_btn = ctk.CTkButton(button_bar, text="Refresh", command=self.refresh)
+        self.refresh_btn = ctk.CTkButton(
+            button_bar, text="Refresh", command=self.refresh
+        )
         self.refresh_btn.grid(row=0, column=0, padx=6, pady=6, sticky="ew")
-        self.download_btn = ctk.CTkButton(button_bar, text="Download & Import…", command=self._download_selected)
+        self.download_btn = ctk.CTkButton(
+            button_bar, text="Download & Import…", command=self._download_selected
+        )
         self.download_btn.grid(row=0, column=1, padx=6, pady=6, sticky="ew")
         self.download_image_library_btn = ctk.CTkButton(
             button_bar,
             text="Import Image Library…",
             command=self._download_image_library_selected,
         )
-        self.download_image_library_btn.grid(row=0, column=2, padx=6, pady=6, sticky="ew")
-        self.install_btn = ctk.CTkButton(button_bar, text="Download & Install Campaign…", command=self._install_selected)
+        self.download_image_library_btn.grid(
+            row=0, column=2, padx=6, pady=6, sticky="ew"
+        )
+        self.install_btn = ctk.CTkButton(
+            button_bar,
+            text="Download & Install Campaign…",
+            command=self._install_selected,
+        )
         self.install_btn.grid(row=0, column=3, padx=6, pady=6, sticky="ew")
-        self.delete_btn = ctk.CTkButton(button_bar, text="Delete from GitHub…", command=self._delete_selected)
+        self.delete_btn = ctk.CTkButton(
+            button_bar, text="Delete from GitHub…", command=self._delete_selected
+        )
         self.delete_btn.grid(row=0, column=4, padx=6, pady=6, sticky="ew")
         if not self.client.can_publish:
             self.delete_btn.configure(state="disabled")
 
         self.status_label = ctk.CTkLabel(self, text="", anchor="w")
-        self.status_label.grid(row=2, column=0, columnspan=3, sticky="ew", padx=10, pady=(0, 10))
+        self.status_label.grid(
+            row=2, column=0, columnspan=3, sticky="ew", padx=10, pady=(0, 10)
+        )
 
         self.tree.bind("<<TreeviewSelect>>", self._on_select)
         self._bundle_map: Dict[str, GalleryBundleSummary] = {}
@@ -1494,12 +1656,19 @@ class OnlineGalleryDialog(ctk.CTkToplevel):
             else:
                 date_text = "—"
             author_text = bundle.author or "—"
-            self.tree.insert("", END, iid=iid, values=(bundle.display_title, size_text, date_text, author_text))
+            self.tree.insert(
+                "",
+                END,
+                iid=iid,
+                values=(bundle.display_title, size_text, date_text, author_text),
+            )
 
     def _handle_error(self, exc: Exception):
         """Internal helper for handle error."""
         self.status_label.configure(text=f"Failed to load bundles: {exc}")
-        messagebox.showerror("Gallery Error", f"Unable to fetch GitHub releases.\n{exc}")
+        messagebox.showerror(
+            "Gallery Error", f"Unable to fetch GitHub releases.\n{exc}"
+        )
 
     def _on_select(self, _event):
         """Handle select."""
@@ -1528,7 +1697,9 @@ class OnlineGalleryDialog(ctk.CTkToplevel):
             published = bundle.published_at
             if published.tzinfo:
                 published = published.astimezone()
-            lines.append(f"Published: {published.strftime('%Y-%m-%d %H:%M:%S %Z').strip()}")
+            lines.append(
+                f"Published: {published.strftime('%Y-%m-%d %H:%M:%S %Z').strip()}"
+            )
         if bundle.asset_download_count:
             lines.append(f"Downloads: {bundle.asset_download_count}")
         if bundle.source_campaign:
@@ -1574,7 +1745,9 @@ class OnlineGalleryDialog(ctk.CTkToplevel):
     def _delete_selected(self):
         """Delete selected."""
         if not self.client.can_publish:
-            messagebox.showerror("Unavailable", "Configure a GitHub token to delete bundles.")
+            messagebox.showerror(
+                "Unavailable", "Configure a GitHub token to delete bundles."
+            )
             return
         bundle = self._current_selection()
         if not bundle:

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -22,10 +22,20 @@ from modules.generic.ambiance_wallpaper_bundle import (
     load_wallpaper_manifest,
     merge_wallpaper_bundle,
 )
-from modules.generic.cross_campaign_bundle_extras import collect_full_campaign_extra_files
+from modules.generic.cross_campaign_bundle_extras import (
+    collect_full_campaign_extra_files,
+)
+from modules.generic.cross_campaign_gm_tables import (
+    export_gm_virtual_tables,
+    load_bundled_gm_virtual_tables,
+    merge_gm_virtual_tables,
+)
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.helpers.config_helper import ConfigHelper
-from modules.helpers.portrait_helper import parse_portrait_value, serialize_portrait_value
+from modules.helpers.portrait_helper import (
+    parse_portrait_value,
+    serialize_portrait_value,
+)
 from modules.helpers.logging_helper import (
     log_exception,
     log_module_import,
@@ -38,7 +48,16 @@ log_module_import(__name__)
 BUNDLE_VERSION = 1
 
 
-PORTRAIT_ENTITY_TYPES = {"npcs", "objects", "pcs", "creatures", "places", "clues", "factions", "villains"}
+PORTRAIT_ENTITY_TYPES = {
+    "npcs",
+    "objects",
+    "pcs",
+    "creatures",
+    "places",
+    "clues",
+    "factions",
+    "villains",
+}
 AUDIO_ENTITY_TYPES = {"npcs", "pcs", "creatures", "places", "villains"}
 ATTACHMENT_FIELDS = {
     "clues": "Attachment",
@@ -79,11 +98,15 @@ class BundleAnalysis:
     world_maps: Optional[Dict[str, dict]] = None
     systems: Optional[List[dict]] = None
     ambiance_wallpapers: Optional[List[dict]] = None
+    gm_virtual_tables: Optional[dict] = None
 
 
 def _resolve_active_campaign() -> CampaignDatabase:
     """Resolve active campaign."""
-    db_path_value = ConfigHelper.get("Database", "path", fallback="default_campaign.db") or "default_campaign.db"
+    db_path_value = (
+        ConfigHelper.get("Database", "path", fallback="default_campaign.db")
+        or "default_campaign.db"
+    )
     db_path = Path(db_path_value)
     if not db_path.is_absolute():
         db_path = (Path(ConfigHelper.get_campaign_dir()) / db_path).resolve()
@@ -117,7 +140,11 @@ def list_sibling_campaigns(include_current: bool = False) -> List[CampaignDataba
             if db_path.resolve() == active.db_path.resolve():
                 continue
             candidates.append(
-                CampaignDatabase(name=f"{entry.name} ({db_path.name})", root=entry.resolve(), db_path=db_path.resolve())
+                CampaignDatabase(
+                    name=f"{entry.name} ({db_path.name})",
+                    root=entry.resolve(),
+                    db_path=db_path.resolve(),
+                )
             )
 
     if include_current:
@@ -131,7 +158,13 @@ def discover_databases_in_directory(directory: Path) -> List[CampaignDatabase]:
     db_files = list(directory.glob("*.db"))
     results: List[CampaignDatabase] = []
     for db_path in db_files:
-        results.append(CampaignDatabase(name=f"{directory.name} ({db_path.name})", root=directory, db_path=db_path.resolve()))
+        results.append(
+            CampaignDatabase(
+                name=f"{directory.name} ({db_path.name})",
+                root=directory,
+                db_path=db_path.resolve(),
+            )
+        )
     return results
 
 
@@ -156,13 +189,17 @@ def load_entities(entity_type: str, db_path: Path) -> List[dict]:
         raise
 
 
-def save_entities(entity_type: str, db_path: Path, items: List[dict], *, replace: bool = True) -> None:
+def save_entities(
+    entity_type: str, db_path: Path, items: List[dict], *, replace: bool = True
+) -> None:
     """Save entities."""
     wrapper = GenericModelWrapper(entity_type, db_path=str(db_path))
     wrapper.save_items(items, replace=replace)
 
 
-def _load_full_campaign_records(source_campaign: CampaignDatabase, selected_for_bundle: dict) -> None:
+def _load_full_campaign_records(
+    source_campaign: CampaignDatabase, selected_for_bundle: dict
+) -> None:
     """Backfill all known entity records for full-campaign exports.
 
     Explicit selections are authoritative: if a type is already present in
@@ -172,7 +209,9 @@ def _load_full_campaign_records(source_campaign: CampaignDatabase, selected_for_
         if entity_type in selected_for_bundle:
             continue
         try:
-            selected_for_bundle[entity_type] = load_entities(entity_type, source_campaign.db_path)
+            selected_for_bundle[entity_type] = load_entities(
+                entity_type, source_campaign.db_path
+            )
         except sqlite3.OperationalError as exc:
             if not _is_missing_table_error(exc):
                 raise
@@ -184,8 +223,7 @@ def _load_full_campaign_records(source_campaign: CampaignDatabase, selected_for_
 
 def _ensure_campaign_systems_table(conn: sqlite3.Connection) -> None:
     """Ensure campaign systems table."""
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS campaign_systems (
             slug TEXT PRIMARY KEY,
             label TEXT NOT NULL,
@@ -193,8 +231,7 @@ def _ensure_campaign_systems_table(conn: sqlite3.Connection) -> None:
             supported_faces_json TEXT,
             analyzer_config_json TEXT
         )
-        """
-    )
+        """)
 
 
 def _load_campaign_systems(db_path: Path) -> List[dict]:
@@ -205,13 +242,11 @@ def _load_campaign_systems(db_path: Path) -> List[dict]:
     conn.row_factory = sqlite3.Row
     try:
         # Keep campaign systems resilient if this step fails.
-        cursor = conn.execute(
-            """
+        cursor = conn.execute("""
             SELECT slug, label, default_formula, supported_faces_json, analyzer_config_json
             FROM campaign_systems
             ORDER BY slug
-            """
-        )
+            """)
         return [dict(row) for row in cursor.fetchall()]
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc).lower():
@@ -235,7 +270,9 @@ def _determine_record_key(record: dict) -> str:
     return str(record.get("rowid") or record.get("_id") or id(record))
 
 
-def _collect_portraits(entity_type: str, record: dict, campaign_dir: Path) -> List[AssetReference]:
+def _collect_portraits(
+    entity_type: str, record: dict, campaign_dir: Path
+) -> List[AssetReference]:
     """Collect portraits."""
     portraits = parse_portrait_value(record.get("Portrait"))
     collected: List[AssetReference] = []
@@ -262,7 +299,9 @@ def _collect_portraits(entity_type: str, record: dict, campaign_dir: Path) -> Li
     return collected
 
 
-def _collect_audio_asset(entity_type: str, record: dict, campaign_dir: Path) -> Optional[AssetReference]:
+def _collect_audio_asset(
+    entity_type: str, record: dict, campaign_dir: Path
+) -> Optional[AssetReference]:
     """Collect audio asset."""
     raw_value = record.get("Audio")
     normalized = normalize_audio_reference(raw_value)
@@ -320,7 +359,9 @@ def _collect_attachment_asset(
     )
 
 
-def _collect_image_library_assets(entity_type: str, record: dict, campaign_dir: Path) -> List[AssetReference]:
+def _collect_image_library_assets(
+    entity_type: str, record: dict, campaign_dir: Path
+) -> List[AssetReference]:
     """Collect image-library assets."""
     collected: List[AssetReference] = []
     seen_absolute_paths: set[str] = set()
@@ -409,7 +450,9 @@ def save_world_map_store(campaign_dir: Optional[Path], maps: Dict[str, dict]) ->
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = {"maps": maps}
-        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
     except Exception as exc:
         log_warning(
             f"Failed to save world map store at {path}: {exc}",
@@ -417,7 +460,9 @@ def save_world_map_store(campaign_dir: Optional[Path], maps: Dict[str, dict]) ->
         )
 
 
-def _collect_world_map_entries(records: Iterable[dict], campaign_dir: Path) -> Dict[str, dict]:
+def _collect_world_map_entries(
+    records: Iterable[dict], campaign_dir: Path
+) -> Dict[str, dict]:
     """Collect world map entries."""
     store = load_world_map_store(campaign_dir)
     if not store:
@@ -454,7 +499,12 @@ def _rewrite_world_map_entries(
                 # Process each token from tokens.
                 if not isinstance(token, dict):
                     continue
-                for field in ("portrait_path", "image_path", "token_image", "video_path"):
+                for field in (
+                    "portrait_path",
+                    "image_path",
+                    "token_image",
+                    "video_path",
+                ):
                     # Process each field while updating rewrite world map entries.
                     value = token.get(field)
                     if isinstance(value, str) and value in replacements:
@@ -560,7 +610,10 @@ def _collect_token_assets(record: dict, campaign_dir: Path) -> Iterable[AssetRef
         # Process each token from tokens.
         if not isinstance(token, dict):
             continue
-        for field, asset_type in ("image_path", "token_image"), ("video_path", "token_video"):
+        for field, asset_type in ("image_path", "token_image"), (
+            "video_path",
+            "token_video",
+        ):
             # Process each (field, asset_type) while updating token assets.
             path_value = token.get(field)
             if not path_value:
@@ -584,7 +637,9 @@ def _collect_token_assets(record: dict, campaign_dir: Path) -> Iterable[AssetRef
     return assets
 
 
-def collect_assets(entity_type: str, records: Iterable[dict], campaign_dir: Path) -> List[AssetReference]:
+def collect_assets(
+    entity_type: str, records: Iterable[dict], campaign_dir: Path
+) -> List[AssetReference]:
     """Collect assets."""
     collected: List[AssetReference] = []
     if entity_type == "maps":
@@ -596,7 +651,9 @@ def collect_assets(entity_type: str, records: Iterable[dict], campaign_dir: Path
     if entity_type in IMAGE_LIBRARY_ENTITY_TYPES:
         # Handle the branch where entity_type is in IMAGE_LIBRARY_ENTITY_TYPES.
         for record in records:
-            collected.extend(_collect_image_library_assets(entity_type, record, campaign_dir))
+            collected.extend(
+                _collect_image_library_assets(entity_type, record, campaign_dir)
+            )
         return collected
 
     attachment_field = ATTACHMENT_FIELDS.get(entity_type)
@@ -611,7 +668,9 @@ def collect_assets(entity_type: str, records: Iterable[dict], campaign_dir: Path
                 collected.append(audio)
         if attachment_field:
             # Continue with this path when attachment field is set.
-            attachment = _collect_attachment_asset(entity_type, record, campaign_dir, attachment_field)
+            attachment = _collect_attachment_asset(
+                entity_type, record, campaign_dir, attachment_field
+            )
             if attachment:
                 collected.append(attachment)
     return collected
@@ -644,6 +703,7 @@ def export_bundle(
     include_database: bool = False,
     include_systems: bool = True,
     include_random_tables: bool = False,
+    gm_virtual_tables: Optional[List[dict]] = None,
     progress_callback=None,
 ) -> dict:
     """Export bundle."""
@@ -655,7 +715,9 @@ def export_bundle(
     if include_database and not source_campaign.db_path.exists():
         raise FileNotFoundError(source_campaign.db_path)
 
-    selected_for_bundle = {entity: list(records) for entity, records in selected_records.items()}
+    selected_for_bundle = {
+        entity: list(records) for entity, records in selected_records.items()
+    }
     if include_database:
         _load_full_campaign_records(source_campaign, selected_for_bundle)
 
@@ -720,7 +782,9 @@ def export_bundle(
                 )
 
             if entity_type == "maps":
-                bundled_world_maps.update(_collect_world_map_entries(records, source_campaign.root))
+                bundled_world_maps.update(
+                    _collect_world_map_entries(records, source_campaign.root)
+                )
 
         if include_database or include_random_tables:
             extra_files = collect_full_campaign_extra_files(source_campaign.root)
@@ -745,6 +809,10 @@ def export_bundle(
                     }
                 )
 
+        export_gm_virtual_tables(
+            source_campaign.root, gm_virtual_tables or [], temp_root, manifest
+        )
+
         if include_systems:
             # Continue with this path when include systems is set.
             systems = _load_campaign_systems(source_campaign.db_path)
@@ -760,7 +828,9 @@ def export_bundle(
             # Continue with this path when bundled world maps is set.
             world_map_path = temp_root / "data" / "world_maps.json"
             with world_map_path.open("w", encoding="utf-8") as fh:
-                json.dump({"maps": bundled_world_maps}, fh, indent=2, ensure_ascii=False)
+                json.dump(
+                    {"maps": bundled_world_maps}, fh, indent=2, ensure_ascii=False
+                )
             manifest["world_maps"] = {
                 "count": len(bundled_world_maps),
                 "data_path": "data/world_maps.json",
@@ -784,7 +854,8 @@ def export_bundle(
                     "file_name": source_campaign.db_path.name,
                     "relative_path": f"database/{source_campaign.db_path.name}",
                     "size": int(stat.st_size),
-                    "modified_at": datetime.utcfromtimestamp(stat.st_mtime).isoformat() + "Z",
+                    "modified_at": datetime.utcfromtimestamp(stat.st_mtime).isoformat()
+                    + "Z",
                 }
             except Exception as exc:
                 log_exception(
@@ -794,7 +865,9 @@ def export_bundle(
                 raise
         _call_progress(progress_callback, "Writing bundle archive...", 0.8)
         archive_path = temp_root / "manifest.json"
-        archive_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8")
+        archive_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
 
         with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as zf:
             for file_path in temp_root.rglob("*"):
@@ -918,7 +991,9 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
         world_maps: Dict[str, dict] = {}
         if isinstance(world_maps_manifest, dict):
             # Handle the branch where isinstance(world_maps_manifest, dict).
-            data_file = world_maps_manifest.get("data_path") or world_maps_manifest.get("path")
+            data_file = world_maps_manifest.get("data_path") or world_maps_manifest.get(
+                "path"
+            )
             if data_file:
                 # Continue with this path when data file is set.
                 file_path = temp_dir / data_file
@@ -926,7 +1001,11 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
                     try:
                         # Keep analyze bundle resilient if this step fails.
                         payload = json.loads(file_path.read_text(encoding="utf-8"))
-                        maps = payload.get("maps") if isinstance(payload, dict) else payload
+                        maps = (
+                            payload.get("maps")
+                            if isinstance(payload, dict)
+                            else payload
+                        )
                         if isinstance(maps, dict):
                             world_maps = maps
                     except json.JSONDecodeError as exc:
@@ -939,7 +1018,9 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
         systems: Optional[List[dict]] = None
         if isinstance(systems_manifest, dict):
             # Handle the branch where isinstance(systems_manifest, dict).
-            data_file = systems_manifest.get("data_path") or systems_manifest.get("path")
+            data_file = systems_manifest.get("data_path") or systems_manifest.get(
+                "path"
+            )
             if data_file:
                 # Continue with this path when data file is set.
                 file_path = temp_dir / data_file
@@ -956,6 +1037,7 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
                         )
 
         ambiance_wallpapers = load_wallpaper_manifest(temp_dir, manifest)
+        gm_virtual_tables = load_bundled_gm_virtual_tables(temp_dir, manifest)
 
         return BundleAnalysis(
             manifest=manifest,
@@ -967,13 +1049,16 @@ def analyze_bundle(bundle_path: Path, target_db: Path) -> BundleAnalysis:
             world_maps=world_maps or None,
             systems=systems,
             ambiance_wallpapers=ambiance_wallpapers or None,
+            gm_virtual_tables=gm_virtual_tables,
         )
     except Exception:
         shutil.rmtree(temp_dir, ignore_errors=True)
         raise
 
 
-def _determine_target_path(asset_type: str, original_path: str, campaign_dir: Path) -> Tuple[Path, str]:
+def _determine_target_path(
+    asset_type: str, original_path: str, campaign_dir: Path
+) -> Tuple[Path, str]:
     """Internal helper for determine target path."""
     original = (original_path or "").replace("\\", "/")
     name = Path(original).name or "asset"
@@ -1083,6 +1168,9 @@ def apply_import_for_entity_types(
             "ambiance_wallpapers_imported": 0,
             "ambiance_wallpapers_updated": 0,
             "ambiance_wallpapers_skipped": 0,
+            "gm_virtual_tables_imported": 0,
+            "gm_virtual_tables_updated": 0,
+            "gm_virtual_tables_skipped": 0,
         }
 
     filtered_data = {
@@ -1096,7 +1184,9 @@ def apply_import_for_entity_types(
         if entity_type in selected_types
     }
     filtered_assets = [
-        asset for asset in analysis.assets if str(asset.get("entity_type") or "") in selected_types
+        asset
+        for asset in analysis.assets
+        if str(asset.get("entity_type") or "") in selected_types
     ]
     filtered_world_maps = analysis.world_maps if "maps" in selected_types else None
 
@@ -1110,6 +1200,7 @@ def apply_import_for_entity_types(
         world_maps=filtered_world_maps,
         systems=None,
         ambiance_wallpapers=analysis.ambiance_wallpapers,
+        gm_virtual_tables=None,
     )
     return apply_import(
         filtered_analysis,
@@ -1156,7 +1247,9 @@ def apply_import(
                 )
                 continue
             target_path, relative = _determine_target_path(
-                asset.get("asset_type", ""), asset.get("original_path", ""), target_campaign.root
+                asset.get("asset_type", ""),
+                asset.get("original_path", ""),
+                target_campaign.root,
             )
             try:
                 shutil.copy2(source, target_path)
@@ -1166,7 +1259,11 @@ def apply_import(
                     f"Failed to copy asset {source}: {exc}",
                     func_name="modules.generic.cross_campaign_asset_service.apply_import",
                 )
-            _call_progress(progress_callback, f"Copying assets ({index}/{total_assets})", index / total_assets)
+            _call_progress(
+                progress_callback,
+                f"Copying assets ({index}/{total_assets})",
+                index / total_assets,
+            )
 
         for entity_type, records in analysis.data_by_type.items():
             # Process each (entity_type, records) from analysis.data_by_type.items().
@@ -1196,12 +1293,19 @@ def apply_import(
                     merged[key] = updated_record
                     summary["imported"] += 1
 
-            save_entities(entity_type, target_campaign.db_path, list(merged.values()), replace=False)
+            save_entities(
+                entity_type,
+                target_campaign.db_path,
+                list(merged.values()),
+                replace=False,
+            )
 
         imported_extra_files = 0
         skipped_extra_files = 0
         for extra_entry in analysis.manifest.get("extra_files") or []:
-            relative_path = str(extra_entry.get("relative_path") or "").replace("\\", "/").strip()
+            relative_path = (
+                str(extra_entry.get("relative_path") or "").replace("\\", "/").strip()
+            )
             bundle_rel = str(extra_entry.get("bundle_path") or "").strip()
             if not relative_path or not bundle_rel:
                 continue
@@ -1250,7 +1354,9 @@ def apply_import(
                 conn.row_factory = sqlite3.Row
                 existing_slugs = {
                     row["slug"]
-                    for row in conn.execute("SELECT slug FROM campaign_systems").fetchall()
+                    for row in conn.execute(
+                        "SELECT slug FROM campaign_systems"
+                    ).fetchall()
                     if row["slug"]
                 }
                 for system in analysis.systems:
@@ -1273,7 +1379,13 @@ def apply_import(
                             SET label = ?, default_formula = ?, supported_faces_json = ?, analyzer_config_json = ?
                             WHERE slug = ?
                             """,
-                            (label, default_formula, supported_faces_json, analyzer_config_json, slug),
+                            (
+                                label,
+                                default_formula,
+                                supported_faces_json,
+                                analyzer_config_json,
+                                slug,
+                            ),
                         )
                         summary["systems_updated"] += 1
                     else:
@@ -1283,7 +1395,13 @@ def apply_import(
                                 slug, label, default_formula, supported_faces_json, analyzer_config_json
                             ) VALUES (?, ?, ?, ?, ?)
                             """,
-                            (slug, label, default_formula, supported_faces_json, analyzer_config_json),
+                            (
+                                slug,
+                                label,
+                                default_formula,
+                                supported_faces_json,
+                                analyzer_config_json,
+                            ),
                         )
                         summary["systems_imported"] += 1
                 conn.commit()
@@ -1291,7 +1409,9 @@ def apply_import(
                 conn.close()
 
         if analysis.world_maps:
-            rewritten_world_maps = _rewrite_world_map_entries(analysis.world_maps, replacements)
+            rewritten_world_maps = _rewrite_world_map_entries(
+                analysis.world_maps, replacements
+            )
             _merge_world_map_entries(target_campaign.root, rewritten_world_maps)
 
         wallpaper_summary = merge_wallpaper_bundle(
@@ -1301,6 +1421,13 @@ def apply_import(
             overwrite=overwrite,
         )
         summary.update(wallpaper_summary)
+
+        gm_table_summary = merge_gm_virtual_tables(
+            target_campaign.root,
+            analysis.gm_virtual_tables,
+            overwrite=overwrite,
+        )
+        summary.update(gm_table_summary)
     finally:
         shutil.rmtree(analysis.temp_dir, ignore_errors=True)
 
@@ -1338,7 +1465,9 @@ def install_full_campaign_bundle(
 
         relative_path = str(database_entry.get("relative_path") or "").strip()
         if not relative_path:
-            relative_path = database_entry.get("path") or database_entry.get("file_name") or ""
+            relative_path = (
+                database_entry.get("path") or database_entry.get("file_name") or ""
+            )
         if not relative_path:
             raise ValueError("Bundle database entry is missing a path")
 
@@ -1346,7 +1475,9 @@ def install_full_campaign_bundle(
         if not db_source.exists():
             raise FileNotFoundError(db_source)
 
-        db_name = str(database_entry.get("file_name") or Path(relative_path).name or "campaign.db")
+        db_name = str(
+            database_entry.get("file_name") or Path(relative_path).name or "campaign.db"
+        )
 
         if not target_dir.exists():
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -1374,9 +1505,17 @@ def install_full_campaign_bundle(
                 )
                 continue
 
-            original_path = str(asset.get("original_path") or "").replace("\\", "/").strip()
-            relative_parts = [part for part in Path(original_path).parts if part not in ("", ".", "..")]
-            relative = Path(*relative_parts) if relative_parts else Path(source_asset.name)
+            original_path = (
+                str(asset.get("original_path") or "").replace("\\", "/").strip()
+            )
+            relative_parts = [
+                part
+                for part in Path(original_path).parts
+                if part not in ("", ".", "..")
+            ]
+            relative = (
+                Path(*relative_parts) if relative_parts else Path(source_asset.name)
+            )
             destination = (target_root / relative).resolve()
             if not str(destination).startswith(str(target_root)):
                 destination = target_root / source_asset.name
@@ -1400,7 +1539,9 @@ def install_full_campaign_bundle(
         extra_offset = len(assets)
         for index, extra_entry in enumerate(extra_files, start=1):
             bundle_rel = str(extra_entry.get("bundle_path") or "").strip()
-            relative_path = str(extra_entry.get("relative_path") or "").replace("\\", "/").strip()
+            relative_path = (
+                str(extra_entry.get("relative_path") or "").replace("\\", "/").strip()
+            )
             if not bundle_rel or not relative_path:
                 continue
             source_extra = (temp_dir / bundle_rel).resolve()
@@ -1434,8 +1575,12 @@ def install_full_campaign_bundle(
 
         install_wallpaper_bundle(temp_dir, target_root, manifest)
 
-        campaign_name = str(manifest.get("source_campaign", {}).get("name") or target_dir.name)
-        return CampaignDatabase(name=campaign_name, root=target_dir, db_path=db_destination)
+        campaign_name = str(
+            manifest.get("source_campaign", {}).get("name") or target_dir.name
+        )
+        return CampaignDatabase(
+            name=campaign_name, root=target_dir, db_path=db_destination
+        )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
@@ -1459,14 +1604,20 @@ def apply_direct_copy(
     world_map_entries: Dict[str, dict] = {}
     map_records = selected_records.get("maps")
     if map_records:
-        world_map_entries = _collect_world_map_entries(map_records, source_campaign.root)
+        world_map_entries = _collect_world_map_entries(
+            map_records, source_campaign.root
+        )
 
     total_assets = len(asset_refs) or 1
     for index, asset in enumerate(asset_refs, start=1):
         # Process each (index, asset) from enumerate(asset_refs, start=1).
         original = asset.original_path
         if original in replacements:
-            _call_progress(progress_callback, f"Copying assets ({index}/{total_assets})", index / total_assets)
+            _call_progress(
+                progress_callback,
+                f"Copying assets ({index}/{total_assets})",
+                index / total_assets,
+            )
             continue
         target_path, relative = _determine_target_path(
             asset.asset_type, asset.original_path, target_campaign.root
@@ -1480,7 +1631,11 @@ def apply_direct_copy(
                 f"Failed to copy asset {asset.absolute_path}: {exc}",
                 func_name="modules.generic.cross_campaign_asset_service.apply_direct_copy",
             )
-        _call_progress(progress_callback, f"Copying assets ({index}/{total_assets})", index / total_assets)
+        _call_progress(
+            progress_callback,
+            f"Copying assets ({index}/{total_assets})",
+            index / total_assets,
+        )
 
     for entity_type, records in selected_records.items():
         # Process each (entity_type, records) from selected_records.items().
@@ -1510,10 +1665,14 @@ def apply_direct_copy(
                 merged[key] = updated_record
                 summary["imported"] += 1
 
-        save_entities(entity_type, target_campaign.db_path, list(merged.values()), replace=False)
+        save_entities(
+            entity_type, target_campaign.db_path, list(merged.values()), replace=False
+        )
 
     if world_map_entries:
-        rewritten_world_maps = _rewrite_world_map_entries(world_map_entries, replacements)
+        rewritten_world_maps = _rewrite_world_map_entries(
+            world_map_entries, replacements
+        )
         _merge_world_map_entries(target_campaign.root, rewritten_world_maps)
 
     _call_progress(progress_callback, "Copy complete", 1.0)
@@ -1589,7 +1748,11 @@ def _rewrite_record_paths(
         if replacement:
             relative_replacement = str(Path(replacement).as_posix())
             updated["RelativePath"] = relative_replacement
-            campaign_root = target_campaign_root.resolve() if target_campaign_root else _resolve_campaign_dir(None)
+            campaign_root = (
+                target_campaign_root.resolve()
+                if target_campaign_root
+                else _resolve_campaign_dir(None)
+            )
             updated["Path"] = str((campaign_root / relative_replacement).resolve())
             updated["SourceRoot"] = str(campaign_root)
 

--- a/modules/generic/cross_campaign_bundle_extras.py
+++ b/modules/generic/cross_campaign_bundle_extras.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Tuple
 
-
 _RANDOM_TABLE_FILE = Path("static/data/random_tables.json")
 _RANDOM_TABLE_DIR = Path("static/data/random_tables")
 _CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE = Path("campaign_custom_tables.json")
-_INTERNAL_RANDOM_TABLE_CUSTOM_FILE = Path("_internal/static/data/random_tables/campaign_custom_tables.json")
+_INTERNAL_RANDOM_TABLE_CUSTOM_FILE = Path(
+    "_internal/static/data/random_tables/campaign_custom_tables.json"
+)
 _GM_LAYOUTS_FILE = Path("gm_layouts.json")
+_GM_VIRTUAL_TABLES_FILE = Path("gm_table_layouts.json")
 _GM_TABLE_MARKS_FILES = (
     Path("data/save/clue_positions.json"),
     Path("data/save/clue_links.json"),
@@ -42,15 +44,23 @@ def collect_full_campaign_extra_files(campaign_root: Path) -> List[Tuple[Path, s
 
     campaign_custom_tables = (root / _CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE).resolve()
     if campaign_custom_tables.exists() and campaign_custom_tables.is_file():
-        collected.append((campaign_custom_tables, _CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE.as_posix()))
+        collected.append(
+            (campaign_custom_tables, _CAMPAIGN_CUSTOM_RANDOM_TABLE_FILE.as_posix())
+        )
 
     internal_custom_tables = (root / _INTERNAL_RANDOM_TABLE_CUSTOM_FILE).resolve()
     if internal_custom_tables.exists() and internal_custom_tables.is_file():
-        collected.append((internal_custom_tables, _INTERNAL_RANDOM_TABLE_CUSTOM_FILE.as_posix()))
+        collected.append(
+            (internal_custom_tables, _INTERNAL_RANDOM_TABLE_CUSTOM_FILE.as_posix())
+        )
 
     gm_layouts_file = (root / _GM_LAYOUTS_FILE).resolve()
     if gm_layouts_file.exists() and gm_layouts_file.is_file():
         collected.append((gm_layouts_file, _GM_LAYOUTS_FILE.as_posix()))
+
+    gm_virtual_tables_file = (root / _GM_VIRTUAL_TABLES_FILE).resolve()
+    if gm_virtual_tables_file.exists() and gm_virtual_tables_file.is_file():
+        collected.append((gm_virtual_tables_file, _GM_VIRTUAL_TABLES_FILE.as_posix()))
 
     for relative in _GM_TABLE_MARKS_FILES:
         marks_file = (root / relative).resolve()

--- a/modules/generic/cross_campaign_gm_tables.py
+++ b/modules/generic/cross_campaign_gm_tables.py
@@ -1,0 +1,180 @@
+"""Helpers for cross-campaign GM virtual table bundle data."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from modules.helpers.logging_helper import log_warning
+from modules.scenarios.gm_table.layout_store import GMTableLayoutStore
+from modules.scenarios.gm_table.table_registry import get_table_name, normalize_table_id
+
+MANIFEST_KEY = "gm_virtual_tables"
+
+
+def _store_path(campaign_root: Path) -> Path:
+    return Path(campaign_root).resolve() / GMTableLayoutStore.FILE_NAME
+
+
+def _read_store(campaign_root: Path) -> dict[str, Any]:
+    path = _store_path(campaign_root)
+    if not path.exists() or not path.is_file():
+        return {"tables": {}, "global": {}}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        log_warning(
+            f"Unable to load GM virtual tables from {path}: {exc}",
+            func_name="cross_campaign_gm_tables._read_store",
+        )
+        return {"tables": {}, "global": {}}
+    return payload if isinstance(payload, dict) else {"tables": {}, "global": {}}
+
+
+def _write_store(campaign_root: Path, payload: dict[str, Any]) -> None:
+    path = _store_path(campaign_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _table_names(payload: dict[str, Any]) -> dict[str, str]:
+    global_settings = payload.get("global")
+    if not isinstance(global_settings, dict):
+        return {}
+    names = global_settings.get("table_names")
+    if not isinstance(names, dict):
+        return {}
+    return {
+        normalize_table_id(key): str(value)
+        for key, value in names.items()
+        if str(value).strip()
+    }
+
+
+def load_gm_virtual_tables(campaign_root: Path) -> List[dict[str, Any]]:
+    """Return GM table layouts as selectable records for the asset library."""
+    payload = _read_store(campaign_root)
+    tables = payload.get("tables")
+    if not isinstance(tables, dict):
+        return []
+    names = _table_names(payload)
+    records: List[dict[str, Any]] = []
+    for table_id, layout in sorted(tables.items()):
+        normalized_id = normalize_table_id(table_id)
+        if not isinstance(layout, dict):
+            continue
+        panel_count = (
+            len(layout.get("panels") or [])
+            if isinstance(layout.get("panels"), list)
+            else 0
+        )
+        records.append(
+            {
+                "TableId": normalized_id,
+                "Name": names.get(normalized_id) or get_table_name(normalized_id),
+                "Summary": f"{panel_count} panel(s)",
+                "Layout": copy.deepcopy(layout),
+            }
+        )
+    return records
+
+
+def export_gm_virtual_tables(
+    campaign_root: Path, records: List[dict[str, Any]], temp_root: Path, manifest: dict
+) -> None:
+    """Write selected GM virtual table records to a bundle manifest."""
+    if not records:
+        return
+    payload = {"tables": {}, "global": {"table_names": {}}}
+    for record in records:
+        table_id = normalize_table_id(
+            record.get("TableId") or record.get("Name") or "table"
+        )
+        layout = record.get("Layout") if isinstance(record.get("Layout"), dict) else {}
+        payload["tables"][table_id] = copy.deepcopy(layout)
+        name = str(record.get("Name") or "").strip()
+        if name and name != get_table_name(table_id):
+            payload["global"]["table_names"][table_id] = name
+    data_path = temp_root / "data" / "gm_virtual_tables.json"
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    manifest[MANIFEST_KEY] = {
+        "count": len(payload["tables"]),
+        "data_path": "data/gm_virtual_tables.json",
+    }
+
+
+def load_bundled_gm_virtual_tables(
+    temp_root: Path, manifest: dict
+) -> dict[str, Any] | None:
+    section = manifest.get(MANIFEST_KEY)
+    if not isinstance(section, dict):
+        return None
+    data_path = str(section.get("data_path") or "").strip()
+    if not data_path:
+        return None
+    file_path = temp_root / data_path
+    if not file_path.exists():
+        return None
+    try:
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        log_warning(
+            f"Unable to parse bundled GM virtual tables {data_path}: {exc}",
+            func_name="cross_campaign_gm_tables.load_bundled_gm_virtual_tables",
+        )
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def merge_gm_virtual_tables(
+    campaign_root: Path, bundled: dict[str, Any] | None, *, overwrite: bool
+) -> dict[str, int]:
+    summary = {
+        "gm_virtual_tables_imported": 0,
+        "gm_virtual_tables_updated": 0,
+        "gm_virtual_tables_skipped": 0,
+    }
+    if not bundled:
+        return summary
+    incoming_tables = bundled.get("tables")
+    if not isinstance(incoming_tables, dict):
+        return summary
+    current = _read_store(campaign_root)
+    current_tables = current.setdefault("tables", {})
+    if not isinstance(current_tables, dict):
+        current_tables = {}
+        current["tables"] = current_tables
+    current_global = current.setdefault("global", {})
+    if not isinstance(current_global, dict):
+        current_global = {}
+        current["global"] = current_global
+    current_names = current_global.setdefault("table_names", {})
+    if not isinstance(current_names, dict):
+        current_names = {}
+        current_global["table_names"] = current_names
+    incoming_names = _table_names(bundled)
+    changed = False
+    for raw_table_id, layout in incoming_tables.items():
+        table_id = normalize_table_id(raw_table_id)
+        if not isinstance(layout, dict):
+            continue
+        exists = table_id in current_tables
+        if exists and not overwrite:
+            summary["gm_virtual_tables_skipped"] += 1
+            continue
+        current_tables[table_id] = copy.deepcopy(layout)
+        if table_id in incoming_names:
+            current_names[table_id] = incoming_names[table_id]
+        if exists:
+            summary["gm_virtual_tables_updated"] += 1
+        else:
+            summary["gm_virtual_tables_imported"] += 1
+        changed = True
+    if changed:
+        _write_store(campaign_root, current)
+    return summary

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -1,5 +1,6 @@
 """Regression tests for cross campaign asset service."""
 
+import json
 import shutil
 import sqlite3
 import sys
@@ -48,7 +49,9 @@ def test_analyze_bundle_rejects_unsafe_zip_member_path(tmp_path):
     assert not (tmp_path / "escape.txt").exists()
 
 
-def test_analyze_bundle_ignores_unsafe_or_malformed_ambiance_wallpaper_entries(tmp_path):
+def test_analyze_bundle_ignores_unsafe_or_malformed_ambiance_wallpaper_entries(
+    tmp_path,
+):
     """Wallpaper bundle metadata should sanitize relative paths and tolerate malformed numbers."""
     bundle_path = tmp_path / "wallpapers.zip"
     with zipfile.ZipFile(bundle_path, "w") as zf:
@@ -63,7 +66,7 @@ def test_analyze_bundle_ignores_unsafe_or_malformed_ambiance_wallpaper_entries(t
                 '{"id": "safe", "relative_path": "nested/sky.png", "filename": "sky.png", '
                 '"created_at": "not-a-float"},'
                 '{"id": "unsafe", "relative_path": "../escape.png", "filename": "escape.png"}'
-                ']}'
+                "]}"
             ),
         )
 
@@ -189,7 +192,9 @@ def test_rewrite_record_paths_updates_image_library_fields(tmp_path):
     assert updated["SourceRoot"] == str(target_campaign_root)
 
 
-def test_export_bundle_full_campaign_includes_image_assets_even_without_selection(tmp_path, monkeypatch):
+def test_export_bundle_full_campaign_includes_image_assets_even_without_selection(
+    tmp_path, monkeypatch
+):
     """Full campaign exports should still include image library records/assets."""
     campaign_root = tmp_path / "source_campaign"
     campaign_root.mkdir(parents=True, exist_ok=True)
@@ -199,20 +204,33 @@ def test_export_bundle_full_campaign_includes_image_assets_even_without_selectio
     image_file.parent.mkdir(parents=True, exist_ok=True)
     image_file.write_bytes(b"forest-bytes")
 
-    source_campaign = CampaignDatabase(name="Source", root=campaign_root, db_path=db_path)
+    source_campaign = CampaignDatabase(
+        name="Source", root=campaign_root, db_path=db_path
+    )
     destination = tmp_path / "bundle.zip"
 
     def fake_load_entities(entity_type, _db_path):
         if entity_type == "image_assets":
-            return [{"Name": "Forest Tile", "RelativePath": "assets/image_library/tiles/forest.png"}]
+            return [
+                {
+                    "Name": "Forest Tile",
+                    "RelativePath": "assets/image_library/tiles/forest.png",
+                }
+            ]
         return []
 
-    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities
+    )
 
-    manifest = export_bundle(destination, source_campaign, selected_records={}, include_database=True)
+    manifest = export_bundle(
+        destination, source_campaign, selected_records={}, include_database=True
+    )
 
     assert manifest["entities"]["image_assets"]["count"] == 1
-    assert any(asset.get("asset_type") == "image_library" for asset in manifest["assets"])
+    assert any(
+        asset.get("asset_type") == "image_library" for asset in manifest["assets"]
+    )
 
 
 def test_export_bundle_full_campaign_keeps_explicit_selections(tmp_path, monkeypatch):
@@ -237,7 +255,9 @@ def test_export_bundle_full_campaign_keeps_explicit_selections(tmp_path, monkeyp
         "modules.generic.cross_campaign_asset_service.list_known_entities",
         lambda: ["villains", "campaigns"],
     )
-    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities
+    )
 
     manifest = export_bundle(
         tmp_path / "bundle.zip",
@@ -256,7 +276,9 @@ def test_export_bundle_full_campaign_keeps_explicit_selections(tmp_path, monkeyp
     assert "Database Villain" not in villains
 
 
-def test_export_bundle_full_campaign_skips_missing_backfill_tables(tmp_path, monkeypatch):
+def test_export_bundle_full_campaign_skips_missing_backfill_tables(
+    tmp_path, monkeypatch
+):
     """Missing tables during full-campaign backfill should not stop later entity types."""
     campaign_root = tmp_path / "source_campaign"
     campaign_root.mkdir(parents=True, exist_ok=True)
@@ -277,7 +299,9 @@ def test_export_bundle_full_campaign_skips_missing_backfill_tables(tmp_path, mon
         "modules.generic.cross_campaign_asset_service.list_known_entities",
         lambda: ["missing_entities", "campaigns"],
     )
-    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities
+    )
 
     manifest = export_bundle(
         tmp_path / "bundle.zip",
@@ -291,7 +315,9 @@ def test_export_bundle_full_campaign_skips_missing_backfill_tables(tmp_path, mon
     assert manifest["entities"]["campaigns"]["count"] == 1
 
 
-def test_export_bundle_full_campaign_loads_all_known_entities_and_villain_media(tmp_path, monkeypatch):
+def test_export_bundle_full_campaign_loads_all_known_entities_and_villain_media(
+    tmp_path, monkeypatch
+):
     """Full campaign exports should backfill every known entity type and villain media."""
     campaign_root = tmp_path / "source_campaign"
     campaign_root.mkdir(parents=True, exist_ok=True)
@@ -319,7 +345,12 @@ def test_export_bundle_full_campaign_loads_all_known_entities_and_villain_media(
         ],
         "campaigns": [{"Name": "Embers of Dusk"}],
         "scenarios": [{"Name": "The First Spark"}],
-        "image_assets": [{"Name": "Forest Tile", "RelativePath": "assets/image_library/tiles/forest.png"}],
+        "image_assets": [
+            {
+                "Name": "Forest Tile",
+                "RelativePath": "assets/image_library/tiles/forest.png",
+            }
+        ],
         "maps": [{"Name": "Cavern"}],
     }
 
@@ -330,7 +361,9 @@ def test_export_bundle_full_campaign_loads_all_known_entities_and_villain_media(
         "modules.generic.cross_campaign_asset_service.list_known_entities",
         lambda: ["villains", "campaigns", "scenarios", "image_assets", "maps"],
     )
-    monkeypatch.setattr("modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities)
+    monkeypatch.setattr(
+        "modules.generic.cross_campaign_asset_service.load_entities", fake_load_entities
+    )
 
     manifest = export_bundle(
         tmp_path / "bundle.zip",
@@ -345,7 +378,8 @@ def test_export_bundle_full_campaign_loads_all_known_entities_and_villain_media(
     villain_assets = {
         asset["asset_type"]: asset
         for asset in manifest["assets"]
-        if asset["entity_type"] == "villains" and asset["record_key"] == "The Ashen Lich"
+        if asset["entity_type"] == "villains"
+        and asset["record_key"] == "The Ashen Lich"
     }
     assert villain_assets["portrait"]["original_path"] == "portraits/villains/lich.png"
     assert villain_assets["audio"]["original_path"] == "audio/villains/lich_theme.mp3"
@@ -362,23 +396,31 @@ def test_install_full_campaign_bundle_restores_random_tables_files(tmp_path):
     source_root.mkdir(parents=True, exist_ok=True)
     db_path = source_root / "campaign.db"
     sqlite3.connect(db_path).close()
-    random_tables_file = source_root / "static" / "data" / "random_tables" / "encounters.json"
+    random_tables_file = (
+        source_root / "static" / "data" / "random_tables" / "encounters.json"
+    )
     random_tables_file.parent.mkdir(parents=True, exist_ok=True)
     random_tables_file.write_text('{"categories": []}', encoding="utf-8")
 
     source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
     bundle_path = tmp_path / "full_bundle.zip"
-    export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+    export_bundle(
+        bundle_path, source_campaign, selected_records={}, include_database=True
+    )
 
     target_root = tmp_path / "installed_campaign"
     installed = install_full_campaign_bundle(bundle_path, target_root)
 
-    restored_random_table = installed.root / "static" / "data" / "random_tables" / "encounters.json"
+    restored_random_table = (
+        installed.root / "static" / "data" / "random_tables" / "encounters.json"
+    )
     assert restored_random_table.exists()
     assert restored_random_table.read_text(encoding="utf-8") == '{"categories": []}'
 
 
-def test_install_full_campaign_bundle_restores_campaign_custom_random_tables_file(tmp_path):
+def test_install_full_campaign_bundle_restores_campaign_custom_random_tables_file(
+    tmp_path,
+):
     """Installing a full campaign bundle should restore campaign custom random tables JSON."""
     source_root = tmp_path / "source"
     source_root.mkdir(parents=True, exist_ok=True)
@@ -390,9 +432,14 @@ def test_install_full_campaign_bundle_restores_campaign_custom_random_tables_fil
 
     source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
     bundle_path = tmp_path / "full_bundle.zip"
-    manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+    manifest = export_bundle(
+        bundle_path, source_campaign, selected_records={}, include_database=True
+    )
     extra_files = manifest.get("extra_files") or []
-    assert any(entry.get("relative_path") == "campaign_custom_tables.json" for entry in extra_files)
+    assert any(
+        entry.get("relative_path") == "campaign_custom_tables.json"
+        for entry in extra_files
+    )
 
     target_root = tmp_path / "installed_campaign"
     installed = install_full_campaign_bundle(bundle_path, target_root)
@@ -418,8 +465,12 @@ def test_install_full_campaign_bundle_restores_custom_templates(tmp_path):
 
     source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
     bundle_path = tmp_path / "full_bundle.zip"
-    manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
-    extra_paths = {entry.get("relative_path") for entry in manifest.get("extra_files") or []}
+    manifest = export_bundle(
+        bundle_path, source_campaign, selected_records={}, include_database=True
+    )
+    extra_paths = {
+        entry.get("relative_path") for entry in manifest.get("extra_files") or []
+    }
 
     assert "templates/custom_entities.json" in extra_paths
     assert "templates/rivals_template.json" in extra_paths
@@ -430,9 +481,15 @@ def test_install_full_campaign_bundle_restores_custom_templates(tmp_path):
     restored_custom_entities = installed.root / "templates" / "custom_entities.json"
     restored_rivals_template = installed.root / "templates" / "rivals_template.json"
     assert restored_custom_entities.exists()
-    assert restored_custom_entities.read_text(encoding="utf-8") == '{"entities": ["rivals"]}'
+    assert (
+        restored_custom_entities.read_text(encoding="utf-8")
+        == '{"entities": ["rivals"]}'
+    )
     assert restored_rivals_template.exists()
-    assert restored_rivals_template.read_text(encoding="utf-8") == '{"name": "Rivals", "fields": []}'
+    assert (
+        restored_rivals_template.read_text(encoding="utf-8")
+        == '{"name": "Rivals", "fields": []}'
+    )
 
 
 def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_path):
@@ -458,7 +515,9 @@ def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_p
 
     source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
     bundle_path = tmp_path / "full_bundle.zip"
-    export_bundle(bundle_path, source_campaign, selected_records={}, include_database=True)
+    export_bundle(
+        bundle_path, source_campaign, selected_records={}, include_database=True
+    )
 
     target_root = tmp_path / "installed_campaign"
     installed = install_full_campaign_bundle(bundle_path, target_root)
@@ -469,13 +528,25 @@ def test_install_full_campaign_bundle_restores_maptools_and_gm_table_files(tmp_p
     restored_world_map_data = installed.root / "world_maps" / "world_map_data.json"
 
     assert restored_gm_layouts.exists()
-    assert restored_gm_layouts.read_text(encoding="utf-8") == '{"layouts": {"Default": {"tabs": []}}}'
+    assert (
+        restored_gm_layouts.read_text(encoding="utf-8")
+        == '{"layouts": {"Default": {"tabs": []}}}'
+    )
     assert restored_clue_positions.exists()
-    assert restored_clue_positions.read_text(encoding="utf-8") == '{"Clue A": {"x": 10, "y": 20}}'
+    assert (
+        restored_clue_positions.read_text(encoding="utf-8")
+        == '{"Clue A": {"x": 10, "y": 20}}'
+    )
     assert restored_clue_links.exists()
-    assert restored_clue_links.read_text(encoding="utf-8") == '[{"source": "A", "target": "B"}]'
+    assert (
+        restored_clue_links.read_text(encoding="utf-8")
+        == '[{"source": "A", "target": "B"}]'
+    )
     assert restored_world_map_data.exists()
-    assert restored_world_map_data.read_text(encoding="utf-8") == '{"maps": {"City": {"tokens": []}}}'
+    assert (
+        restored_world_map_data.read_text(encoding="utf-8")
+        == '{"maps": {"City": {"tokens": []}}}'
+    )
 
 
 def test_export_bundle_asset_mode_can_include_random_tables_files(tmp_path):
@@ -485,7 +556,9 @@ def test_export_bundle_asset_mode_can_include_random_tables_files(tmp_path):
     db_path = source_root / "campaign.db"
     sqlite3.connect(db_path).close()
 
-    random_tables_file = source_root / "static" / "data" / "random_tables" / "encounters.json"
+    random_tables_file = (
+        source_root / "static" / "data" / "random_tables" / "encounters.json"
+    )
     random_tables_file.parent.mkdir(parents=True, exist_ok=True)
     random_tables_file.write_text('{"categories": []}', encoding="utf-8")
 
@@ -500,7 +573,10 @@ def test_export_bundle_asset_mode_can_include_random_tables_files(tmp_path):
     )
 
     extra_files = manifest.get("extra_files") or []
-    assert any(entry.get("relative_path") == "static/data/random_tables/encounters.json" for entry in extra_files)
+    assert any(
+        entry.get("relative_path") == "static/data/random_tables/encounters.json"
+        for entry in extra_files
+    )
 
 
 def test_apply_import_restores_extra_files_for_asset_bundle(tmp_path):
@@ -510,7 +586,9 @@ def test_apply_import_restores_extra_files_for_asset_bundle(tmp_path):
     db_path = source_root / "campaign.db"
     sqlite3.connect(db_path).close()
 
-    random_tables_file = source_root / "static" / "data" / "random_tables" / "encounters.json"
+    random_tables_file = (
+        source_root / "static" / "data" / "random_tables" / "encounters.json"
+    )
     random_tables_file.parent.mkdir(parents=True, exist_ok=True)
     random_tables_file.write_text('{"categories": []}', encoding="utf-8")
 
@@ -528,7 +606,9 @@ def test_apply_import_restores_extra_files_for_asset_bundle(tmp_path):
     target_root.mkdir(parents=True, exist_ok=True)
     target_db = target_root / "campaign.db"
     sqlite3.connect(target_db).close()
-    target_campaign = CampaignDatabase(name="Target", root=target_root, db_path=target_db)
+    target_campaign = CampaignDatabase(
+        name="Target", root=target_root, db_path=target_db
+    )
 
     analysis = analyze_bundle(bundle_path, target_campaign.db_path)
     summary = apply_import(analysis, target_campaign, overwrite=True)
@@ -570,7 +650,9 @@ def test_export_bundle_includes_ambiance_wallpaper_files_and_metadata(tmp_path):
     source_campaign = CampaignDatabase(name="Source", root=source_root, db_path=db_path)
     bundle_path = tmp_path / "wallpapers.zip"
 
-    manifest = export_bundle(bundle_path, source_campaign, selected_records={}, include_database=False)
+    manifest = export_bundle(
+        bundle_path, source_campaign, selected_records={}, include_database=False
+    )
 
     section = manifest["ambiance_wallpapers"]
     assert section["count"] == 1
@@ -590,7 +672,12 @@ def test_apply_import_restores_ambiance_wallpaper_media_and_index(tmp_path):
     sqlite3.connect(db_path).close()
     item, _media = _write_wallpaper(source_root)
     bundle_path = tmp_path / "wallpapers.zip"
-    export_bundle(bundle_path, CampaignDatabase("Source", source_root, db_path), {}, include_database=False)
+    export_bundle(
+        bundle_path,
+        CampaignDatabase("Source", source_root, db_path),
+        {},
+        include_database=False,
+    )
 
     target_root = tmp_path / "target"
     target_root.mkdir(parents=True, exist_ok=True)
@@ -619,7 +706,12 @@ def test_apply_import_skips_or_overwrites_existing_ambiance_wallpapers(tmp_path)
     sqlite3.connect(db_path).close()
     item, _media = _write_wallpaper(source_root, content=b"new")
     bundle_path = tmp_path / "wallpapers.zip"
-    export_bundle(bundle_path, CampaignDatabase("Source", source_root, db_path), {}, include_database=False)
+    export_bundle(
+        bundle_path,
+        CampaignDatabase("Source", source_root, db_path),
+        {},
+        include_database=False,
+    )
 
     target_root = tmp_path / "target"
     target_root.mkdir(parents=True, exist_ok=True)
@@ -629,27 +721,33 @@ def test_apply_import_skips_or_overwrites_existing_ambiance_wallpapers(tmp_path)
     existing_media = target_store.wallpapers_dir / item.relative_path
     existing_media.parent.mkdir(parents=True, exist_ok=True)
     existing_media.write_bytes(b"old")
-    target_store.save([
-        WallpaperLibraryItem(
-            id="existing-id",
-            relative_path=item.relative_path,
-            filename=item.filename,
-            media_type="image",
-            width=100,
-            height=100,
-            filesize=3,
-            created_at=1.0,
-            tags=("old",),
-        )
-    ])
+    target_store.save(
+        [
+            WallpaperLibraryItem(
+                id="existing-id",
+                relative_path=item.relative_path,
+                filename=item.filename,
+                media_type="image",
+                width=100,
+                height=100,
+                filesize=3,
+                created_at=1.0,
+                tags=("old",),
+            )
+        ]
+    )
     target_campaign = CampaignDatabase("Target", target_root, target_db)
 
-    skip_summary = apply_import(analyze_bundle(bundle_path, target_db), target_campaign, overwrite=False)
+    skip_summary = apply_import(
+        analyze_bundle(bundle_path, target_db), target_campaign, overwrite=False
+    )
     assert existing_media.read_bytes() == b"old"
     assert target_store.load()[0].id == "existing-id"
     assert skip_summary["ambiance_wallpapers_skipped"] == 1
 
-    overwrite_summary = apply_import(analyze_bundle(bundle_path, target_db), target_campaign, overwrite=True)
+    overwrite_summary = apply_import(
+        analyze_bundle(bundle_path, target_db), target_campaign, overwrite=True
+    )
     loaded = target_store.load()
     assert existing_media.read_bytes() == b"new"
     assert len(loaded) == 1
@@ -666,10 +764,93 @@ def test_install_full_campaign_bundle_restores_ambiance_wallpapers(tmp_path):
     sqlite3.connect(db_path).close()
     item, _media = _write_wallpaper(source_root)
     bundle_path = tmp_path / "full_wallpapers.zip"
-    export_bundle(bundle_path, CampaignDatabase("Source", source_root, db_path), {}, include_database=True)
+    export_bundle(
+        bundle_path,
+        CampaignDatabase("Source", source_root, db_path),
+        {},
+        include_database=True,
+    )
 
     installed = install_full_campaign_bundle(bundle_path, tmp_path / "installed")
 
     store = CampaignWallpaperIndexStore(str(installed.root))
     assert (store.wallpapers_dir / item.relative_path).read_bytes() == b"sky"
     assert store.load()[0].id == item.id
+
+
+def test_export_bundle_full_campaign_restores_gm_virtual_table_layouts(tmp_path):
+    """Full campaign bundles should carry GM virtual table layout persistence."""
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True, exist_ok=True)
+    db_path = source_root / "campaign.db"
+    sqlite3.connect(db_path).close()
+    gm_tables = source_root / "gm_table_layouts.json"
+    gm_tables.write_text(
+        '{"tables": {"table_1": {"panels": [{"panel_id": "notes"}]}}, "global": {"table_names": {"table_1": "War Room"}}}',
+        encoding="utf-8",
+    )
+
+    bundle_path = tmp_path / "full_bundle.zip"
+    manifest = export_bundle(
+        bundle_path,
+        CampaignDatabase(name="Source", root=source_root, db_path=db_path),
+        selected_records={},
+        include_database=True,
+    )
+
+    assert any(
+        entry.get("relative_path") == "gm_table_layouts.json"
+        for entry in manifest.get("extra_files") or []
+    )
+
+    target_root = tmp_path / "installed_campaign"
+    installed = install_full_campaign_bundle(bundle_path, target_root)
+
+    restored = installed.root / "gm_table_layouts.json"
+    assert restored.exists()
+    assert '"War Room"' in restored.read_text(encoding="utf-8")
+
+
+def test_export_and_import_selected_gm_virtual_tables(tmp_path):
+    """Selected GM virtual tables should export/import independently from entity rows."""
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "target"
+    source_root.mkdir(parents=True, exist_ok=True)
+    target_root.mkdir(parents=True, exist_ok=True)
+    source_db = source_root / "campaign.db"
+    target_db = target_root / "campaign.db"
+    sqlite3.connect(source_db).close()
+    sqlite3.connect(target_db).close()
+
+    bundle_path = tmp_path / "gm_tables.zip"
+    manifest = export_bundle(
+        bundle_path,
+        CampaignDatabase(name="Source", root=source_root, db_path=source_db),
+        selected_records={},
+        include_database=False,
+        gm_virtual_tables=[
+            {
+                "TableId": "table_1",
+                "Name": "War Room",
+                "Layout": {"panels": [{"panel_id": "notes", "kind": "note"}]},
+            }
+        ],
+    )
+
+    assert manifest["gm_virtual_tables"]["count"] == 1
+    with zipfile.ZipFile(bundle_path, "r") as zf:
+        assert "data/gm_virtual_tables.json" in zf.namelist()
+
+    analysis = analyze_bundle(bundle_path, target_db)
+    summary = apply_import(
+        analysis,
+        CampaignDatabase(name="Target", root=target_root, db_path=target_db),
+        overwrite=True,
+    )
+
+    restored = json.loads(
+        (target_root / "gm_table_layouts.json").read_text(encoding="utf-8")
+    )
+    assert restored["tables"]["table_1"]["panels"][0]["panel_id"] == "notes"
+    assert restored["global"]["table_names"]["table_1"] == "War Room"
+    assert summary["gm_virtual_tables_imported"] == 1


### PR DESCRIPTION
### Motivation
- Support exporting and importing GM virtual table layouts when creating full-campaign or asset bundles so GM tabletop layouts travel with campaign data. 
- Offer the same export/import UX for GM virtual tables as for other asset types in the Cross-campaign Asset Library.

### Description
- Added a new helper module `modules/generic/cross_campaign_gm_tables.py` implementing `load_gm_virtual_tables`, `export_gm_virtual_tables`, `load_bundled_gm_virtual_tables`, and `merge_gm_virtual_tables` to serialize, bundle, and merge `gm_table_layouts.json` payloads. 
- Integrated GM table handling into the bundle service by adding a `gm_virtual_tables` parameter to `export_bundle`, loading bundled GM tables in `analyze_bundle`, and merging them in `apply_import` via `merge_gm_virtual_tables`, and extended `BundleAnalysis` with `gm_virtual_tables`. 
- Exposed `GM Virtual Tables` as a selectable tab in the `CrossCampaignAssetLibraryWindow`, loadable via `load_gm_virtual_tables`, and ensured selected tables are passed through export/publish flows (`export_bundle`/gallery publish) and reported in export/import summaries. 
- Included `gm_table_layouts.json` in the list of full-campaign extra files by updating `collect_full_campaign_extra_files`, and added tests that cover full-campaign restoration and selected GM table export/import. 

### Testing
- Ran static checks and byte-compile: `python -m py_compile` on modified modules succeeded. 
- Formatted code with `black` on modified files with no errors. 
- Executed unit tests: `pytest -q tests/test_cross_campaign_asset_service.py tests/scenarios/gm_table/test_layout_store.py` which completed successfully with `32 passed` (and warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fdcef2e80832b914130a569b5a460)