### PR TITLE
Fix fixed overlay placement sizing

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -19,7 +19,7 @@ class FixedOverlayView(ctk.CTkFrame):
     """Collapsible viewport overlay anchored to the left edge of the GM Table."""
 
     def __init__(self, master, *, panel_builder, on_changed=None):
-        super().__init__(master, fg_color=TABLE_PALETTE["panel_bg"], corner_radius=0, border_width=1, border_color=TABLE_PALETTE["panel_focus"])
+        super().__init__(master, width=TAB_WIDTH, fg_color=TABLE_PALETTE["panel_bg"], corner_radius=0, border_width=1, border_color=TABLE_PALETTE["panel_focus"])
         self._panel_builder = panel_builder
         self._on_changed = on_changed
         self._state = FixedOverlayState()
@@ -56,7 +56,7 @@ class FixedOverlayView(ctk.CTkFrame):
             self.place_forget(); return
         width = TAB_WIDTH if self._state.collapsed else int(self._state.width)
         self.configure(width=width)
-        self.place(x=0, y=0, relheight=1.0, width=width)
+        self.place(x=0, y=0, relheight=1.0)
         if self._state.collapsed:
             self.content.grid_remove(); self.tab_button.configure(text="›")
         else:


### PR DESCRIPTION
### Motivation

- Prevent a runtime crash in the GM Table quick action caused by passing `width` to `place()` on a `customtkinter` widget, which requires sizing via the constructor or `configure()` instead.

### Description

- Initialize `FixedOverlayView` with an explicit `width=TAB_WIDTH` in the `ctk.CTkFrame` constructor so CustomTkinter owns the initial sizing. 
- Remove the invalid `width=...` argument from the `place(...)` call and keep runtime resizing via `self.configure(width=width)` in `_refresh_geometry()`.
- Change is localized to `modules/scenarios/gm_table/fixed_overlay/view.py` and preserves existing show/hide and layout behavior.

### Testing

- Ran a byte-compile check with `python -m py_compile modules/scenarios/gm_table/fixed_overlay/view.py modules/scenarios/gm_table/fixed_overlay/controller.py modules/scenarios/gm_table/fixed_overlay/models.py`, which succeeded. 
- Executed targeted test runs with `pytest -q tests/scenarios/gm_table/test_layout_store.py tests/scenarios/gm_table/test_workspace.py -q -k 'not mount_payload_widget'`, which passed.
- Full `pytest` run for those modules reported 60 passing tests and 2 failures that are unrelated to this change and are caused by the headless environment (`no display name and no $DISPLAY environment variable`) when tests instantiate `tk.Tk()`.
- Performed a static/AST scan to confirm no `width`/`height` are passed to `place()` in the fixed overlay view, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4294534580832b98d4a2bf3d134e09)