### PR TITLE
Books on GM Table + resizable fixed overlay and PDF viewer wheel/zoom

### DIFF
--- a/modules/books/pdf_viewer_panel.py
+++ b/modules/books/pdf_viewer_panel.py
@@ -52,6 +52,11 @@ class PDFViewerFrame(ctk.CTkFrame):
         ybar = ctk.CTkScrollbar(body, orientation="vertical", command=self.canvas.yview); ybar.grid(row=0, column=1, sticky="ns")
         xbar = ctk.CTkScrollbar(body, orientation="horizontal", command=self.canvas.xview); xbar.grid(row=1, column=0, sticky="ew")
         self.canvas.configure(yscrollcommand=ybar.set, xscrollcommand=xbar.set)
+        self.canvas.bind("<MouseWheel>", self._on_mousewheel, add="+")
+        self.canvas.bind("<Shift-MouseWheel>", self._on_shift_mousewheel, add="+")
+        self.canvas.bind("<Control-MouseWheel>", self._on_ctrl_mousewheel, add="+")
+        self.canvas.bind("<Button-4>", lambda _event: self.canvas.yview_scroll(-3, "units"), add="+")
+        self.canvas.bind("<Button-5>", lambda _event: self.canvas.yview_scroll(3, "units"), add="+")
         self.loading_label = ctk.CTkLabel(body, text="Loading page...")
 
     def open_pdf(self, pdf_path: str, *, initial_page: int = 1, zoom: float | None = None) -> None:
@@ -105,6 +110,20 @@ class PDFViewerFrame(ctk.CTkFrame):
         self._page_image = ImageTk.PhotoImage(image)
         self.canvas.delete("page"); self.canvas.create_image(0, 0, image=self._page_image, anchor="nw", tags="page")
         self.canvas.configure(scrollregion=(0, 0, image.width, image.height))
+    def _on_mousewheel(self, event) -> str:
+        direction = -1 if event.delta > 0 else 1
+        self.canvas.yview_scroll(direction * 3, "units")
+        return "break"
+
+    def _on_shift_mousewheel(self, event) -> str:
+        direction = -1 if event.delta > 0 else 1
+        self.canvas.xview_scroll(direction * 3, "units")
+        return "break"
+
+    def _on_ctrl_mousewheel(self, event) -> str:
+        self.adjust_zoom(0.1 if event.delta > 0 else -0.1)
+        return "break"
+
     def discard_stale_render_for_test(self, token: int) -> bool:
         return token != self._render_token
     def get_state(self) -> dict[str, Any]:

--- a/modules/scenarios/gm_table/fixed_overlay/models.py
+++ b/modules/scenarios/gm_table/fixed_overlay/models.py
@@ -43,7 +43,7 @@ class FixedOverlayState:
         return {
             "visible": bool(self.visible),
             "collapsed": bool(self.collapsed),
-            "width": max(260, min(720, int(self.width or 360))),
+            "width": max(260, min(1100, int(self.width or 360))),
             "anchor": self.anchor if self.anchor in {"left"} else "left",
             "selected_item_ids": [str(value) for value in self.selected_item_ids],
             "items": [item.to_dict() for item in self.items],
@@ -56,7 +56,7 @@ class FixedOverlayState:
         return cls(
             visible=bool(source.get("visible", True)),
             collapsed=bool(source.get("collapsed", True)),
-            width=max(260, min(720, int(source.get("width") or 360))),
+            width=max(260, min(1100, int(source.get("width") or 360))),
             anchor="left",
             selected_item_ids=[str(value) for value in list(source.get("selected_item_ids") or [])],
             items=[item for item in items if item.item_id],

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -24,16 +24,24 @@ class FixedOverlayView(ctk.CTkFrame):
         self._on_changed = on_changed
         self._state = FixedOverlayState()
         self._payloads: dict[str, object] = {}
+        self._resize_start_x = 0
+        self._resize_start_width = 0
         self._build_shell()
         self.apply_state(self._state)
 
     def _build_shell(self) -> None:
         self.grid_columnconfigure(1, weight=1)
+        self.grid_columnconfigure(2, weight=0)
         self.grid_rowconfigure(0, weight=1)
         self.tab_button = ctk.CTkButton(self, text="›", width=TAB_WIDTH, corner_radius=0, fg_color=TABLE_PALETTE["accent"], hover_color="#D97706", text_color="#111827", command=self.toggle_collapsed)
         self.tab_button.grid(row=0, column=0, sticky="ns")
         self.content = ctk.CTkFrame(self, fg_color=TABLE_PALETTE["panel_bg"], corner_radius=0)
         self.content.grid(row=0, column=1, sticky="nsew")
+        self.resize_handle = ctk.CTkFrame(self, width=8, fg_color=TABLE_PALETTE["panel_focus"], cursor="sb_h_double_arrow")
+        self.resize_handle.grid(row=0, column=2, sticky="ns")
+        self.resize_handle.bind("<ButtonPress-1>", self._start_resize, add="+")
+        self.resize_handle.bind("<B1-Motion>", self._drag_resize, add="+")
+        self.resize_handle.bind("<ButtonRelease-1>", self._finish_resize, add="+")
         self.content.grid_rowconfigure(1, weight=1)
         self.content.grid_columnconfigure(0, weight=1)
         header = ctk.CTkFrame(self.content, fg_color=TABLE_PALETTE["table_alt"], corner_radius=0)
@@ -58,9 +66,9 @@ class FixedOverlayView(ctk.CTkFrame):
         self.configure(width=width)
         self.place(x=0, y=0, relheight=1.0)
         if self._state.collapsed:
-            self.content.grid_remove(); self.tab_button.configure(text="›")
+            self.content.grid_remove(); self.resize_handle.grid_remove(); self.tab_button.configure(text="›")
         else:
-            self.content.grid(); self.tab_button.configure(text="‹")
+            self.content.grid(); self.resize_handle.grid(); self.tab_button.configure(text="‹")
         self.lift()
 
     def _refresh_items(self) -> None:
@@ -81,6 +89,21 @@ class FixedOverlayView(ctk.CTkFrame):
             frame.grid_rowconfigure(1, weight=1)
             payload = self._panel_builder(body, SimpleNamespace(panel_id=item.item_id, kind=item.kind, title=item.title, state=item.state))
             self._payloads[item.item_id] = payload
+
+    def _start_resize(self, event) -> str:
+        self._resize_start_x = int(event.x_root)
+        self._resize_start_width = int(self._state.width)
+        return "break"
+
+    def _drag_resize(self, event) -> str:
+        delta = int(event.x_root) - self._resize_start_x
+        self._state.width = max(280, min(1100, self._resize_start_width + delta))
+        self._refresh_geometry()
+        return "break"
+
+    def _finish_resize(self, _event) -> str:
+        self._changed()
+        return "break"
 
     def expand(self) -> None:
         self._state.collapsed = False; self._refresh_geometry(); self._changed()

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -197,6 +197,8 @@ def resolve_default_panel_size(kind: str, state: dict | None = None) -> tuple[in
         return 760, 580
     if entity_type == "Objects":
         return 960, 700
+    if entity_type == "Books":
+        return 1100, 760
     if entity_type == "Creatures":
         return 680, 480
     return 680, 560

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -76,9 +76,10 @@ ENTITY_TYPES = (
     "Clues",
     "Informations",
     "Puzzles",
+    "Books",
 )
 
-TITLE_KEY_ENTITY_TYPES = {"Scenarios", "Informations"}
+TITLE_KEY_ENTITY_TYPES = {"Scenarios", "Informations", "Books"}
 MAP_PANEL_KINDS = {"world_map", "map_tool"}
 
 
@@ -128,6 +129,7 @@ class GMTableView(ctk.CTkFrame):
             "Informations": load_entity_template("informations"),
             "Puzzles": load_entity_template("puzzles"),
             "Objects": load_entity_template("objects"),
+            "Books": load_entity_template("books"),
             "Maps": load_entity_template("maps"),
         }
         self.wrappers = {
@@ -144,6 +146,7 @@ class GMTableView(ctk.CTkFrame):
             "Informations": GenericModelWrapper("informations"),
             "Puzzles": GenericModelWrapper("puzzles"),
             "Objects": GenericModelWrapper("objects"),
+            "Books": GenericModelWrapper("books"),
         }
         self.map_wrapper = GenericModelWrapper("maps")
 
@@ -158,8 +161,6 @@ class GMTableView(ctk.CTkFrame):
             "Handouts",
             "Fixed Table",
             "Toggle Fixed Table",
-            "PDF Viewer",
-            "Open PDF",
             "Add to Fixed Table",
             "Container Window",
             "Loot Generator",
@@ -1603,6 +1604,9 @@ class GMTableView(ctk.CTkFrame):
             )
         attachments = collect_entity_attachments(item)
 
+        if entity_type == "Books":
+            return self._build_book_content(host, item)
+
         if attachments:
             host.grid_rowconfigure(0, weight=1)
             host.grid_columnconfigure(0, weight=1)
@@ -1644,6 +1648,48 @@ class GMTableView(ctk.CTkFrame):
         )
         frame.grid(row=0, column=0, sticky="nsew")
         return frame
+
+
+    def _build_book_content(self, host, item: dict):
+        """Build a readable book panel with the linked PDF beside its details."""
+        host.grid_rowconfigure(0, weight=1)
+        host.grid_columnconfigure(0, weight=2)
+        host.grid_columnconfigure(1, weight=3)
+
+        details_host = build_scroll_host(host)
+        details_host.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        detail_frame = create_entity_detail_frame(
+            "Books",
+            item,
+            master=details_host,
+            open_entity_callback=self.open_entity_panel,
+            spotlight_only=False,
+            show_spotlight=False,
+        )
+        detail_frame.pack(fill="both", expand=True, padx=8, pady=8)
+
+        attachment = str(item.get("Attachment") or "").strip()
+        if attachment:
+            viewer = PDFViewerFrame(
+                host,
+                pdf_path=attachment,
+                attachment_path=attachment,
+                title=self._entity_label("Books", item, fallback="Book"),
+                initial_state={"current_page": 1, "zoom": 1.25},
+                on_state_changed=self._persist_layout,
+            )
+            viewer.grid(row=0, column=1, sticky="nsew")
+            return viewer
+
+        missing = ctk.CTkFrame(host, fg_color=TABLE_PALETTE["panel_alt"], corner_radius=14)
+        missing.grid(row=0, column=1, sticky="nsew")
+        ctk.CTkLabel(
+            missing,
+            text="No linked PDF attachment for this book.",
+            text_color=TABLE_PALETTE["muted"],
+            wraplength=360,
+        ).pack(expand=True, padx=24, pady=24)
+        return missing
 
     def _build_unavailable_entity_content(
         self, host, *, entity_type: str | None, entity_name: str | None


### PR DESCRIPTION
### Motivation
- Allow the GM to resize the viewport-fixed overlay with the mouse so the overlay acts like a virtual desk for pinned windows.
- Make `Books` usable directly on the GM Table so a book's details and its linked PDF can be shown side-by-side in a panel.
- Replace the stand-alone PDF add-menu choices with integrated book viewing inside the entity panel workflow.
- Improve PDF reading UX by adding mouse-wheel scrolling and Ctrl+wheel zoom alongside the existing +/- controls.

### Description
- Added `Books` to the GM Table entity list and model wrappers and removed the standalone `PDF Viewer`/`Open PDF` entries from the GM Table add-menu in `modules/scenarios/gm_table_view.py` and related wiring.
- Implemented `GMTableView._build_book_content` which displays the book detail frame plus a `PDFViewerFrame` (if the book has an `Attachment`) so books appear as readable panels on the virtual desk in `modules/scenarios/gm_table_view.py`.
- Enhanced the reusable PDF viewer `PDFViewerFrame` to bind mouse wheel events for vertical scroll, `Shift`+wheel for horizontal scroll, and `Ctrl`+wheel for zooming in/out, preserving the existing `+`/`-` and `Reset Zoom` controls in `modules/books/pdf_viewer_panel.py`.
- Added a draggable resize handle to the fixed overlay UI with `ButtonPress`/`B1-Motion`/`ButtonRelease` handlers and expanded the persisted overlay width limit to `1100`px in `modules/scenarios/gm_table/fixed_overlay/view.py` and `modules/scenarios/gm_table/fixed_overlay/models.py`.
- Increased the preferred default panel size for `Books` so the detail + PDF layout opens with adequate space in `modules/scenarios/gm_table/workspace.py`.

### Testing
- Ran Python byte-compile on modified modules with `python -m compileall modules/scenarios/gm_table_view.py modules/books/pdf_viewer_panel.py modules/scenarios/gm_table/fixed_overlay/view.py modules/scenarios/gm_table/fixed_overlay/models.py` and on workspace with `python -m compileall modules/scenarios/gm_table/workspace.py`, which completed successfully.
- Ran `pytest tests/scenarios/gm_table/test_gm_table_view.py` which passed (`49 passed`).
- Attempted `pytest tests/test_main_window_launch_defaults.py tests/test_main_window_shortcuts.py` but collection failed due to an environment dependency error: `ModuleNotFoundError: No module named 'docx.shared'; 'docx' is not a package`, which blocks full app-level test collection in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42972029b4832bb067554b353571bb)