### PR TITLE
Fix GM Table book picker and fixed overlay

### DIFF
--- a/modules/generic/generic_list_selection_view.py
+++ b/modules/generic/generic_list_selection_view.py
@@ -43,11 +43,14 @@ class GenericListSelectionView(ctk.CTkFrame):
         self.filtered_items = self.items.copy()
         # Use the first field that is not "Portrait" as the unique field
         self.unique_field = next((f["name"] for f in self.template["fields"] if f["name"] != "Portrait"), None)
-        # Extra columns: all fields except "Portrait" and the unique field
+        # Extra columns: all compact fields except binary/large text payloads and the unique field.
+        # Book records can contain full extracted PDF text, and rendering that into
+        # a Treeview row makes the picker feel frozen before the list appears.
+        hidden_fields = {"Portrait", "ExtractedText", "ExtractedPages"}
         self.columns = [
             f["name"]
             for f in self.template["fields"]
-            if f["name"] not in ["Portrait", self.unique_field]
+            if f["name"] not in hidden_fields and f["name"] != self.unique_field
         ]
 
         # --- Create Search Bar ---
@@ -273,8 +276,9 @@ class GenericListSelectionView(ctk.CTkFrame):
 
     def _resolve_entity_name(self, item):
         """Resolve entity name."""
-        is_scenario = str(self.entity_type or "").strip().lower() == "scenarios"
-        primary_key, fallback_key = ("Title", "Name") if is_scenario else ("Name", "Title")
+        title_first_types = {"scenarios", "informations", "books"}
+        is_title_first = str(self.entity_type or "").strip().lower() in title_first_types
+        primary_key, fallback_key = ("Title", "Name") if is_title_first else ("Name", "Title")
         entity_name = str(item.get(primary_key) or item.get(fallback_key) or "").strip()
         return entity_name or "Unnamed"
 

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -64,7 +64,10 @@ class FixedOverlayView(ctk.CTkFrame):
             self.place_forget(); return
         width = TAB_WIDTH if self._state.collapsed else int(self._state.width)
         self.configure(width=width)
-        self.place(x=0, y=0, relheight=1.0)
+        # The overlay is placed in viewport coordinates, so explicitly update the
+        # place width; configure(width=...) alone leaves the previous requested
+        # size in effect on some Tk/CustomTkinter builds.
+        self.place(x=0, y=0, width=width, relheight=1.0)
         if self._state.collapsed:
             self.content.grid_remove(); self.resize_handle.grid_remove(); self.tab_button.configure(text="›")
         else:
@@ -86,9 +89,24 @@ class FixedOverlayView(ctk.CTkFrame):
             ctk.CTkLabel(frame, text=item.title, text_color=TABLE_PALETTE["text"], font=ctk.CTkFont(weight="bold"), anchor="w").grid(row=0, column=0, sticky="ew", padx=10, pady=(8, 4))
             body = ctk.CTkFrame(frame, fg_color="transparent")
             body.grid(row=1, column=0, sticky="nsew", padx=8, pady=(0, 8))
+            body.grid_rowconfigure(0, weight=1)
+            body.grid_columnconfigure(0, weight=1)
             frame.grid_rowconfigure(1, weight=1)
             payload = self._panel_builder(body, SimpleNamespace(panel_id=item.item_id, kind=item.kind, title=item.title, state=item.state))
+            self._mount_payload_widget(body, payload)
             self._payloads[item.item_id] = payload
+
+    @staticmethod
+    def _mount_payload_widget(host: ctk.CTkFrame, payload: object) -> None:
+        """Grid directly-returned widgets so fixed-table items render like panels."""
+        if not isinstance(payload, tk.Widget):
+            return
+        try:
+            if payload.master is not host or payload.winfo_manager():
+                return
+            payload.grid(row=0, column=0, sticky="nsew")
+        except Exception:
+            return
 
     def _start_resize(self, event) -> str:
         self._resize_start_x = int(event.x_root)


### PR DESCRIPTION
### Motivation
- The Books picker was slow and could hang because large extracted PDF fields were being rendered into each row of the selection view.
- Double-click selection for `Books` and some other title-first entity types could resolve the wrong field and fail to open the intended panel.
- The viewport-fixed overlay did not reliably resize or render pinned content like normal GM Table panels because the place geometry and payload mounting were incomplete.

### Description
- Updated `modules/generic/generic_list_selection_view.py` to exclude heavy binary/text fields (`ExtractedText`, `ExtractedPages`, and `Portrait`) from the Treeview columns and to prefer `Title` first for `Books` and `Informations` so selections resolve correctly.
- Updated `modules/scenarios/gm_table/fixed_overlay/view.py` to explicitly call `place(..., width=...)` when applying overlay geometry so resizing actually changes the viewport width, and added mounting logic to grid directly-returned widget payloads into pinned item bodies so pinned items render like regular panels.
- Added small grid configuration changes (`grid_rowconfigure`/`grid_columnconfigure`) inside fixed-overlay item bodies to allow hosted payloads to expand to the available space.

### Testing
- Ran `python -m pytest tests/scenarios/gm_table/test_layout_store.py tests/scenarios/gm_table/test_gm_table_view.py -q` and received `62 passed`.
- Ran `python -m pytest tests/generic/test_entity_detail_factory_window_focus.py tests/books/test_pdf_viewer_panel.py -q` and received `9 passed`.
- Ran Python byte-compile for the modified modules with `python -m compileall modules/generic/generic_list_selection_view.py modules/scenarios/gm_table/fixed_overlay/view.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a429b47cc08832b95f7101c76643d8e)