### PR TITLE
Fix fixed overlay CustomTkinter placement

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -64,10 +64,10 @@ class FixedOverlayView(ctk.CTkFrame):
             self.place_forget(); return
         width = TAB_WIDTH if self._state.collapsed else int(self._state.width)
         self.configure(width=width)
-        # The overlay is placed in viewport coordinates, so explicitly update the
-        # place width; configure(width=...) alone leaves the previous requested
-        # size in effect on some Tk/CustomTkinter builds.
-        self.place(x=0, y=0, width=width, relheight=1.0)
+        # CustomTkinter requires fixed dimensions to be configured on the
+        # widget itself instead of supplied to place().  The place manager only
+        # anchors the overlay to the viewport edge and stretches it vertically.
+        self.place(x=0, y=0, relheight=1.0)
         if self._state.collapsed:
             self.content.grid_remove(); self.resize_handle.grid_remove(); self.tab_button.configure(text="›")
         else:

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from modules.scenarios.gm_table.fixed_overlay.models import FixedOverlayState
+from modules.scenarios.gm_table.fixed_overlay.view import FixedOverlayView, TAB_WIDTH
+
+
+class _FakeGridWidget:
+    def __init__(self) -> None:
+        self.removed = False
+        self.shown = False
+
+    def grid_remove(self) -> None:
+        self.removed = True
+
+    def grid(self) -> None:
+        self.shown = True
+
+
+class _FakeButton:
+    def __init__(self) -> None:
+        self.options: dict[str, object] = {}
+
+    def configure(self, **kwargs: object) -> None:
+        self.options.update(kwargs)
+
+
+class _FakeFixedOverlay:
+    def __init__(self) -> None:
+        self._state = FixedOverlayState(width=420, collapsed=False, visible=True)
+        self.content = _FakeGridWidget()
+        self.resize_handle = _FakeGridWidget()
+        self.tab_button = _FakeButton()
+        self.configured_width = None
+        self.place_calls: list[dict[str, object]] = []
+        self.hidden = False
+        self.lifted = False
+
+    def configure(self, **kwargs: object) -> None:
+        self.configured_width = kwargs.get("width")
+
+    def place(self, **kwargs: object) -> None:
+        if "width" in kwargs or "height" in kwargs:
+            raise AssertionError("FixedOverlayView.place() must not receive width/height")
+        self.place_calls.append(kwargs)
+
+    def place_forget(self) -> None:
+        self.hidden = True
+
+    def lift(self) -> None:
+        self.lifted = True
+
+
+def test_refresh_geometry_configures_width_without_place_dimensions() -> None:
+    overlay = _FakeFixedOverlay()
+
+    FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
+
+    assert overlay.configured_width == 420
+    assert overlay.place_calls == [{"x": 0, "y": 0, "relheight": 1.0}]
+    assert overlay.content.shown is True
+    assert overlay.resize_handle.shown is True
+    assert overlay.tab_button.options["text"] == "‹"
+    assert overlay.lifted is True
+
+
+def test_refresh_geometry_uses_tab_width_when_collapsed() -> None:
+    overlay = _FakeFixedOverlay()
+    overlay._state = FixedOverlayState(width=420, collapsed=True, visible=True)
+
+    FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
+
+    assert overlay.configured_width == TAB_WIDTH
+    assert overlay.place_calls == [{"x": 0, "y": 0, "relheight": 1.0}]
+    assert overlay.content.removed is True
+    assert overlay.resize_handle.removed is True
+    assert overlay.tab_button.options["text"] == "›"
+
+
+def test_refresh_geometry_hides_invisible_overlay() -> None:
+    overlay = _FakeFixedOverlay()
+    overlay._state = SimpleNamespace(visible=False)
+
+    FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
+
+    assert overlay.hidden is True
+    assert overlay.place_calls == []


### PR DESCRIPTION
### Motivation
- CustomTkinter raises `ValueError` when `width`/`height` are passed to `place()` because those must be set at widget construction/configuration, causing runtime crashes in `_refresh_geometry`.
- Ensure the fixed overlay uses viewport anchoring without passing size to the place manager so it behaves on multiple Tk/CustomTkinter builds.

### Description
- Change `FixedOverlayView._refresh_geometry` to configure the widget width via `configure(width=...)` and call `place(x=0, y=0, relheight=1.0)` without `width`/`height` arguments.
- Update explanatory comment in `modules/scenarios/gm_table/fixed_overlay/view.py` to reflect the new placement approach.
- Add unit tests `tests/scenarios/gm_table/test_fixed_overlay_view.py` that assert expanded, collapsed, and hidden geometry behavior and guard that `place()` does not receive `width`/`height`.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_fixed_overlay_view.py` and the new overlay geometry tests passed (`3 passed`).
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py tests/scenarios/gm_table/test_fixed_overlay_view.py` and two preexisting `tkinter` tests failed with `_tkinter.TclError: no display name and no $DISPLAY` in this headless environment, indicating environment limitations rather than regressions from this change.
- Overall combined run showed the new tests passing and failures limited to tests requiring a graphical display.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a1020c28832bb40d7e435e7790ea)