### PR TITLE
Fix fixed overlay tab column ordering

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -13,6 +13,8 @@ TABLE_PALETTE = {
 from .models import FixedOverlayItem, FixedOverlayState
 
 TAB_WIDTH = 28
+COLLAPSED_TAB_TEXT = "›"
+EXPANDED_TAB_TEXT = "‹"
 
 
 class FixedOverlayView(ctk.CTkFrame):
@@ -30,15 +32,16 @@ class FixedOverlayView(ctk.CTkFrame):
         self.apply_state(self._state)
 
     def _build_shell(self) -> None:
-        self.grid_columnconfigure(1, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=0)
         self.grid_columnconfigure(2, weight=0)
         self.grid_rowconfigure(0, weight=1)
-        self.tab_button = ctk.CTkButton(self, text="›", width=TAB_WIDTH, corner_radius=0, fg_color=TABLE_PALETTE["accent"], hover_color="#D97706", text_color="#111827", command=self.toggle_collapsed)
-        self.tab_button.grid(row=0, column=0, sticky="ns")
         self.content = ctk.CTkFrame(self, fg_color=TABLE_PALETTE["panel_bg"], corner_radius=0)
-        self.content.grid(row=0, column=1, sticky="nsew")
+        self.content.grid(row=0, column=0, sticky="nsew")
         self.resize_handle = ctk.CTkFrame(self, width=8, fg_color=TABLE_PALETTE["panel_focus"], cursor="sb_h_double_arrow")
-        self.resize_handle.grid(row=0, column=2, sticky="ns")
+        self.resize_handle.grid(row=0, column=1, sticky="ns")
+        self.tab_button = ctk.CTkButton(self, text=COLLAPSED_TAB_TEXT, width=TAB_WIDTH, corner_radius=0, fg_color=TABLE_PALETTE["accent"], hover_color="#D97706", text_color="#111827", command=self.toggle_collapsed)
+        self.tab_button.grid(row=0, column=2, sticky="ns")
         self.resize_handle.bind("<ButtonPress-1>", self._start_resize, add="+")
         self.resize_handle.bind("<B1-Motion>", self._drag_resize, add="+")
         self.resize_handle.bind("<ButtonRelease-1>", self._finish_resize, add="+")
@@ -69,9 +72,9 @@ class FixedOverlayView(ctk.CTkFrame):
         # anchors the overlay to the viewport edge and stretches it vertically.
         self.place(x=0, y=0, relheight=1.0)
         if self._state.collapsed:
-            self.content.grid_remove(); self.resize_handle.grid_remove(); self.tab_button.configure(text="›")
+            self.content.grid_remove(); self.resize_handle.grid_remove(); self.tab_button.configure(text=COLLAPSED_TAB_TEXT)
         else:
-            self.content.grid(); self.resize_handle.grid(); self.tab_button.configure(text="‹")
+            self.content.grid(); self.resize_handle.grid(); self.tab_button.configure(text=EXPANDED_TAB_TEXT)
         self.lift()
 
     def _refresh_items(self) -> None:

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -3,23 +3,36 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from modules.scenarios.gm_table.fixed_overlay.models import FixedOverlayState
-from modules.scenarios.gm_table.fixed_overlay.view import FixedOverlayView, TAB_WIDTH
+from modules.scenarios.gm_table.fixed_overlay import view as fixed_overlay_view
+from modules.scenarios.gm_table.fixed_overlay.view import (
+    COLLAPSED_TAB_TEXT,
+    EXPANDED_TAB_TEXT,
+    FixedOverlayView,
+    TAB_WIDTH,
+)
 
 
 class _FakeGridWidget:
     def __init__(self) -> None:
         self.removed = False
         self.shown = False
+        self.grid_options: dict[str, object] = {}
 
     def grid_remove(self) -> None:
         self.removed = True
 
-    def grid(self) -> None:
+    def grid(self, **kwargs: object) -> None:
         self.shown = True
+        self.removed = False
+        self.grid_options.update(kwargs)
+
+    def grid_info(self) -> dict[str, object]:
+        return dict(self.grid_options)
 
 
-class _FakeButton:
+class _FakeButton(_FakeGridWidget):
     def __init__(self) -> None:
+        super().__init__()
         self.options: dict[str, object] = {}
 
     def configure(self, **kwargs: object) -> None:
@@ -30,8 +43,11 @@ class _FakeFixedOverlay:
     def __init__(self) -> None:
         self._state = FixedOverlayState(width=420, collapsed=False, visible=True)
         self.content = _FakeGridWidget()
+        self.content.grid(row=0, column=0, sticky="nsew")
         self.resize_handle = _FakeGridWidget()
+        self.resize_handle.grid(row=0, column=1, sticky="ns")
         self.tab_button = _FakeButton()
+        self.tab_button.grid(row=0, column=2, sticky="ns")
         self.configured_width = None
         self.place_calls: list[dict[str, object]] = []
         self.hidden = False
@@ -61,7 +77,9 @@ def test_refresh_geometry_configures_width_without_place_dimensions() -> None:
     assert overlay.place_calls == [{"x": 0, "y": 0, "relheight": 1.0}]
     assert overlay.content.shown is True
     assert overlay.resize_handle.shown is True
-    assert overlay.tab_button.options["text"] == "‹"
+    assert overlay.tab_button.options["text"] == EXPANDED_TAB_TEXT
+    assert overlay.tab_button.grid_info()["column"] == 2
+    assert overlay.tab_button.removed is False
     assert overlay.lifted is True
 
 
@@ -75,7 +93,9 @@ def test_refresh_geometry_uses_tab_width_when_collapsed() -> None:
     assert overlay.place_calls == [{"x": 0, "y": 0, "relheight": 1.0}]
     assert overlay.content.removed is True
     assert overlay.resize_handle.removed is True
-    assert overlay.tab_button.options["text"] == "›"
+    assert overlay.tab_button.options["text"] == COLLAPSED_TAB_TEXT
+    assert overlay.tab_button.grid_info()["column"] == 2
+    assert overlay.tab_button.removed is False
 
 
 def test_refresh_geometry_hides_invisible_overlay() -> None:
@@ -86,3 +106,75 @@ def test_refresh_geometry_hides_invisible_overlay() -> None:
 
     assert overlay.hidden is True
     assert overlay.place_calls == []
+
+
+class _FakeCtkWidget(_FakeGridWidget):
+    def __init__(self, master=None, **kwargs: object) -> None:
+        super().__init__()
+        self.master = master
+        self.kwargs = kwargs
+        self.column_weights: dict[int, int] = {}
+        self.row_weights: dict[int, int] = {}
+        self.bindings: list[tuple[object, object, object]] = []
+        self.packed = False
+
+    def grid_columnconfigure(self, column: int, weight: int) -> None:
+        self.column_weights[column] = weight
+
+    def grid_rowconfigure(self, row: int, weight: int) -> None:
+        self.row_weights[row] = weight
+
+    def bind(self, sequence: object, callback: object, add: object = None) -> None:
+        self.bindings.append((sequence, callback, add))
+
+    def pack(self, **kwargs: object) -> None:
+        self.packed = True
+        self.pack_options = kwargs
+
+
+class _FakeCtkButton(_FakeCtkWidget):
+    pass
+
+
+class _FakeShell:
+    def __init__(self) -> None:
+        self.column_weights: dict[int, int] = {}
+        self.row_weights: dict[int, int] = {}
+
+    def grid_columnconfigure(self, column: int, weight: int) -> None:
+        self.column_weights[column] = weight
+
+    def grid_rowconfigure(self, row: int, weight: int) -> None:
+        self.row_weights[row] = weight
+
+    def toggle_collapsed(self) -> None:
+        pass
+
+    def collapse(self) -> None:
+        pass
+
+    def _start_resize(self, _event: object) -> str:
+        return "break"
+
+    def _drag_resize(self, _event: object) -> str:
+        return "break"
+
+    def _finish_resize(self, _event: object) -> str:
+        return "break"
+
+
+def test_build_shell_places_tab_in_rightmost_column(monkeypatch) -> None:
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkFrame", _FakeCtkWidget)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkScrollableFrame", _FakeCtkWidget)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkButton", _FakeCtkButton)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkLabel", _FakeCtkWidget)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkFont", lambda **kwargs: kwargs)
+    overlay = _FakeShell()
+
+    FixedOverlayView._build_shell(overlay)  # type: ignore[arg-type]
+
+    assert overlay.column_weights == {0: 1, 1: 0, 2: 0}
+    assert overlay.content.grid_info()["column"] == 0
+    assert overlay.resize_handle.grid_info()["column"] == 1
+    assert overlay.tab_button.grid_info()["column"] == 2
+    assert overlay.tab_button.kwargs["text"] == COLLAPSED_TAB_TEXT


### PR DESCRIPTION
### Motivation
- Ensure the overlay shell places the main content first and the tab last so the tab remains the rightmost element and visible when collapsed or expanded.
- Make only the content column expand so the overlay resizes predictably while the tab and resize handle stay fixed.
- Clarify tab semantics by using explicit collapsed/expanded text constants to indicate open/close direction.

### Description
- Reordered shell columns in `FixedOverlayView._build_shell` so `self.content` is column `0`, `self.resize_handle` is column `1`, and `self.tab_button` is column `2`, and configured column weights with only column `0` expanding via `grid_columnconfigure(0, weight=1)`.
- Added `COLLAPSED_TAB_TEXT` and `EXPANDED_TAB_TEXT` constants and updated `_refresh_geometry` to use them, preserving `TAB_WIDTH` when collapsed and `state.width` when expanded.
- Kept the tab button as the last/rightmost column in both collapsed and expanded states by leaving it in column `2` and hiding/showing the other widgets instead of reordering.
- Updated and added tests in `tests/scenarios/gm_table/test_fixed_overlay_view.py` to assert column weights, that the tab is in the rightmost column (`column == 2`), and that the tab remains visible with correct text in both collapsed and expanded states.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_fixed_overlay_view.py -q` and all tests passed.
- Test summary: `4 passed in 0.33s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a435b1e5b9c832b90ef6ba90fc9d65c)