### PR TITLE
Fix fixed overlay placement width handling

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -67,9 +67,9 @@ class FixedOverlayView(ctk.CTkFrame):
             self.place_forget(); return
         width = TAB_WIDTH if self._state.collapsed else int(self._state.width)
         self.configure(width=width)
-        # Keep CustomTkinter's configured width in sync, but make the place
-        # manager's explicit width the source of truth for visible geometry.
-        self.place(x=0, y=0, width=width, relheight=1.0)
+        # CustomTkinter widgets reject explicit width/height values in place();
+        # set the requested width on the widget itself and let place use it.
+        self.place(x=0, y=0, relheight=1.0)
         if self._state.collapsed:
             self.content.grid_remove()
             self.resize_handle.grid_remove()

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -72,7 +72,7 @@ def test_refresh_geometry_places_expanded_width() -> None:
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
 
     assert overlay.configured_width == 420
-    assert overlay.place_calls == [{"x": 0, "y": 0, "width": 420, "relheight": 1.0}]
+    assert overlay.place_calls == [{"x": 0, "y": 0, "relheight": 1.0}]
     assert overlay.content.shown is True
     assert overlay.resize_handle.shown is True
     assert overlay.tab_button.options["text"] == EXPANDED_TAB_TEXT
@@ -88,7 +88,7 @@ def test_refresh_geometry_uses_tab_width_when_collapsed() -> None:
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
 
     assert overlay.configured_width == TAB_WIDTH
-    assert overlay.place_calls == [{"x": 0, "y": 0, "width": TAB_WIDTH, "relheight": 1.0}]
+    assert overlay.place_calls == [{"x": 0, "y": 0, "relheight": 1.0}]
     assert overlay.content.removed is True
     assert overlay.resize_handle.removed is True
     assert overlay.tab_button.options["text"] == COLLAPSED_TAB_TEXT
@@ -100,18 +100,18 @@ def test_refresh_geometry_preserves_placed_width_across_toggles() -> None:
     overlay = _FakeFixedOverlay()
 
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
-    assert overlay.place_calls[-1]["width"] == 420
+    assert overlay.configured_width == 420
 
     overlay._state.collapsed = True
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
-    assert overlay.place_calls[-1]["width"] == TAB_WIDTH
+    assert overlay.configured_width == TAB_WIDTH
     assert overlay.content.removed is True
     assert overlay.resize_handle.removed is True
     assert overlay.tab_button.removed is False
 
     overlay._state.collapsed = False
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
-    assert overlay.place_calls[-1]["width"] == 420
+    assert overlay.configured_width == 420
     assert overlay.content.grid_info() == {"row": 0, "column": 0, "sticky": "nsew"}
     assert overlay.resize_handle.grid_info() == {"row": 0, "column": 1, "sticky": "ns"}
     assert overlay.tab_button.grid_info() == {"row": 0, "column": 2, "sticky": "ns"}


### PR DESCRIPTION
### Motivation
- CustomTkinter raises a `ValueError` when `width`/`height` are passed to `place()`, so the overlay must set its requested width via `configure()` and call `place()` without unsupported geometry arguments to avoid crashes.

### Description
- Replace `self.place(x=0, y=0, width=width, relheight=1.0)` with `self.configure(width=width)` followed by `self.place(x=0, y=0, relheight=1.0)` in `modules/scenarios/gm_table/fixed_overlay/view.py`, and update `tests/scenarios/gm_table/test_fixed_overlay_view.py` to assert the configured width (`configured_width`) and that `place()` does not receive `width`.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_fixed_overlay_view.py -q`, which passed (`5 passed`).
- Ran `pytest tests/scenarios/gm_table/test_workspace.py tests/scenarios/gm_table/test_fixed_overlay_view.py -q`, which failed due to the container being headless (`no display name and no $DISPLAY`), and `xvfb-run` is not available in the environment to run those GUI-dependent tests.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a435d217b74832bb077f758afe24b3e)