### PR TITLE
Add '+ Add' button and on_add_requested callback to FixedOverlay and wire through GM Table

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/controller.py
+++ b/modules/scenarios/gm_table/fixed_overlay/controller.py
@@ -7,8 +7,13 @@ from .view import FixedOverlayView
 
 
 class FixedOverlayController:
-    def __init__(self, master, *, panel_builder, on_changed=None):
-        self.view = FixedOverlayView(master, panel_builder=panel_builder, on_changed=on_changed)
+    def __init__(self, master, *, panel_builder, on_changed=None, on_add_requested=None):
+        self.view = FixedOverlayView(
+            master,
+            panel_builder=panel_builder,
+            on_changed=on_changed,
+            on_add_requested=on_add_requested,
+        )
     def serialize(self) -> dict:
         return self.view.get_state()
     def restore(self, payload: dict | None) -> None:

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -20,10 +20,11 @@ EXPANDED_TAB_TEXT = "‹"
 class FixedOverlayView(ctk.CTkFrame):
     """Collapsible viewport overlay anchored to the left edge of the GM Table."""
 
-    def __init__(self, master, *, panel_builder, on_changed=None):
+    def __init__(self, master, *, panel_builder, on_changed=None, on_add_requested=None):
         super().__init__(master, width=TAB_WIDTH, fg_color=TABLE_PALETTE["panel_bg"], corner_radius=0, border_width=1, border_color=TABLE_PALETTE["panel_focus"])
         self._panel_builder = panel_builder
         self._on_changed = on_changed
+        self._on_add_requested = on_add_requested
         self._state = FixedOverlayState()
         self._payloads: dict[str, object] = {}
         self._resize_start_x = 0
@@ -51,7 +52,9 @@ class FixedOverlayView(ctk.CTkFrame):
         header.grid(row=0, column=0, sticky="ew")
         header.grid_columnconfigure(0, weight=1)
         ctk.CTkLabel(header, text="Fixed Table", text_color=TABLE_PALETTE["text"], font=ctk.CTkFont(size=13, weight="bold")).grid(row=0, column=0, sticky="w", padx=10, pady=8)
-        ctk.CTkButton(header, text="‹", width=32, command=self.collapse).grid(row=0, column=1, padx=8, pady=6)
+        self.add_button = ctk.CTkButton(header, text="+ Add", width=68, command=self._request_add)
+        self.add_button.grid(row=0, column=1, padx=(0, 6), pady=6)
+        ctk.CTkButton(header, text="‹", width=32, command=self.collapse).grid(row=0, column=2, padx=(0, 8), pady=6)
         self.items_host = ctk.CTkScrollableFrame(self.content, fg_color=TABLE_PALETTE["panel_bg"])
         self.items_host.grid(row=1, column=0, sticky="nsew", padx=8, pady=8)
         self.empty_label = ctk.CTkLabel(self.items_host, text="Pinned Table is empty. Use Add to Fixed Table.", text_color=TABLE_PALETTE["muted"], wraplength=300)
@@ -163,5 +166,10 @@ class FixedOverlayView(ctk.CTkFrame):
         return self._state.to_dict()
     @property
     def collapsed(self) -> bool: return self._state.collapsed
+    def _request_add(self) -> None:
+        """Ask the owning GM Table view to show fixed-overlay add actions."""
+        if callable(self._on_add_requested):
+            self._on_add_requested(self.add_button)
+
     def _changed(self) -> None:
         if callable(self._on_changed): self._on_changed()

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1383,12 +1383,14 @@ class GMTableWorkspace(ctk.CTkFrame):
         on_layout_changed: Callable[[], None] | None = None,
         map_tool_window_provider: Callable[[], object | None] | None = None,
         on_reveal_requested: Callable[[str], None] | None = None,
+        on_fixed_overlay_add_requested: Callable[[object], None] | None = None,
     ) -> None:
         super().__init__(master, fg_color=TABLE_PALETTE["table_bg"], corner_radius=28)
         self._build_panel = on_panel_build
         self._layout_changed_callback = on_layout_changed
         self._map_tool_window_provider = map_tool_window_provider
         self._reveal_requested_callback = on_reveal_requested
+        self._fixed_overlay_add_requested_callback = on_fixed_overlay_add_requested
         self._panels: dict[str, GMTablePanel] = {}
         self._definitions: dict[str, PanelDefinition] = {}
         self._panel_payloads: dict[str, object] = {}
@@ -1554,6 +1556,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             self.surface,
             panel_builder=self._build_panel,
             on_changed=self._schedule_layout_changed,
+            on_add_requested=self._request_fixed_overlay_add,
         )
 
         self._empty_state = ctk.CTkLabel(
@@ -1569,6 +1572,11 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._refresh_desk_texture()
         self._refresh_minimap()
         self._refresh_minimized_tray()
+
+    def _request_fixed_overlay_add(self, source_widget: object) -> None:
+        """Forward fixed-overlay add requests to the owning table view."""
+        if callable(self._fixed_overlay_add_requested_callback):
+            self._fixed_overlay_add_requested_callback(source_widget)
 
     def _schedule_layout_changed(self) -> None:
         """Debounce layout persistence."""

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -82,6 +82,41 @@ ENTITY_TYPES = (
 TITLE_KEY_ENTITY_TYPES = {"Scenarios", "Informations", "Books"}
 MAP_PANEL_KINDS = {"world_map", "map_tool"}
 
+FIXED_OVERLAY_ADD_OPTIONS = (
+    "Pin Active Panel",
+    "Campaign Dashboard",
+    "World Map",
+    "Map Tool",
+    "Image Library",
+    "Container Window",
+    "Loot Generator",
+    "Object Shelf",
+    "Whiteboard",
+    "Random Tables",
+    "Plot Twists",
+    "Puzzle Display",
+    "Note Tab",
+    "Sticky Note",
+    "Character Graph",
+    "Scenario Graph Editor",
+)
+
+FIXED_OVERLAY_DIRECT_PANEL_OPTIONS = {
+    "Campaign Dashboard": ("campaign_dashboard", "Campaign Dashboard", {}),
+    "World Map": ("world_map", "World Map", {}),
+    "Map Tool": ("map_tool", "Map Tool", {}),
+    "Image Library": ("image_library", "Image Library", {}),
+    "Container Window": ("container_window", "Container Window", {}),
+    "Loot Generator": ("loot_generator", "Loot Generator", {}),
+    "Object Shelf": ("object_shelf", "Object Shelf", {}),
+    "Whiteboard": ("whiteboard", "Whiteboard", {}),
+    "Random Tables": ("random_tables", "Random Tables", {}),
+    "Plot Twists": ("plot_twists", "Plot Twists", {}),
+    "Puzzle Display": ("puzzle_display", "Puzzle Display", {}),
+    "Character Graph": ("character_graph", "Character Graph", {}),
+    "Scenario Graph Editor": ("scenario_graph", "Scenario Graph", {}),
+}
+
 
 class GMTableView(ctk.CTkFrame):
     """Freeform GM workspace with draggable panels."""
@@ -219,6 +254,7 @@ class GMTableView(ctk.CTkFrame):
         ]
         self._add_menu = self._build_add_menu()
         self._layout_tools_menu = self._build_layout_tools_menu()
+        self._fixed_overlay_add_menu = self._build_fixed_overlay_add_menu()
         self._build_toolbar()
         self.workspace = GMTableWorkspace(
             self,
@@ -226,6 +262,7 @@ class GMTableView(ctk.CTkFrame):
             on_layout_changed=self._persist_layout,
             map_tool_window_provider=self._get_map_tool_window,
             on_reveal_requested=self._reveal_panel,
+            on_fixed_overlay_add_requested=self._show_fixed_overlay_add_menu,
         )
         self.workspace.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 18))
 
@@ -541,6 +578,24 @@ class GMTableView(ctk.CTkFrame):
         return menu
 
 
+    def _build_fixed_overlay_add_menu(self) -> tk.Menu:
+        """Build the fixed overlay add menu from supported GM desk panel options."""
+        menu = tk.Menu(self, tearoff=0)
+        for option in FIXED_OVERLAY_ADD_OPTIONS:
+            if option == "Pin Active Panel":
+                menu.add_command(
+                    label="Pin Active Panel",
+                    command=self._add_active_panel_to_fixed_table,
+                )
+                menu.add_separator()
+                continue
+            menu.add_command(
+                label=option,
+                command=lambda value=option: self._handle_fixed_overlay_add_option(value),
+            )
+        return menu
+
+
     def _build_layout_tools_menu(self) -> tk.Menu:
         """Build the desk arrangement menu kept separate from Add Panel."""
         menu = tk.Menu(self, tearoff=0)
@@ -558,6 +613,20 @@ class GMTableView(ctk.CTkFrame):
             self._layout_tools_menu.tk_popup(x, y)
         finally:
             self._layout_tools_menu.grab_release()
+
+    def _show_fixed_overlay_add_menu(self, source_widget: object) -> None:
+        """Open the fixed-overlay add menu beside the overlay's internal add button."""
+        try:
+            x = source_widget.winfo_rootx()
+            y = source_widget.winfo_rooty() + source_widget.winfo_height()
+        except Exception:
+            x = self.winfo_rootx()
+            y = self.winfo_rooty()
+        try:
+            self._fixed_overlay_add_menu.tk_popup(x, y)
+        finally:
+            self._fixed_overlay_add_menu.grab_release()
+
 
     def _show_add_menu(self) -> None:
         """Open the add menu under the toolbar button."""
@@ -1222,7 +1291,15 @@ class GMTableView(ctk.CTkFrame):
             self._create_panel_in_workspace(
                 "sticky_note",
                 "Sticky Note",
-                {"title": "", "body": "", "text": "", "color": "Yellow", "tags": [], "vote_marker": "", "pinned": False},
+                {
+                    "title": "",
+                    "body": "",
+                    "text": "",
+                    "color": "Yellow",
+                    "tags": [],
+                    "vote_marker": "",
+                    "pinned": False,
+                },
                 workspace=workspace,
             )
             return
@@ -1256,6 +1333,40 @@ class GMTableView(ctk.CTkFrame):
                 else self._open_entity_selection(option, workspace=workspace)
             )
             return
+
+
+    def _handle_fixed_overlay_add_option(self, option: str) -> None:
+        """Create supported panel payloads directly inside the fixed overlay."""
+        if option == "Note Tab":
+            existing_notes = [
+                item
+                for item in self.workspace.fixed_overlay.serialize().get("items", [])
+                if item.get("kind") == "note"
+            ]
+            self.workspace.add_to_fixed_overlay(
+                "note", f"Note {len(existing_notes) + 1}", {"text": ""}
+            )
+            return
+        if option == "Sticky Note":
+            self.workspace.add_to_fixed_overlay(
+                "sticky_note",
+                "Sticky Note",
+                {
+                    "title": "",
+                    "body": "",
+                    "text": "",
+                    "color": "Yellow",
+                    "tags": [],
+                    "vote_marker": "",
+                    "pinned": False,
+                },
+            )
+            return
+        panel = FIXED_OVERLAY_DIRECT_PANEL_OPTIONS.get(option)
+        if panel is None:
+            return
+        kind, title, state = panel
+        self.workspace.add_to_fixed_overlay(kind, title, dict(state))
 
 
     def _open_pdf_for_table(self, *, workspace: GMTableWorkspace | None = None) -> None:

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -196,6 +196,9 @@ class _FakeShell:
     def collapse(self) -> None:
         pass
 
+    def _request_add(self) -> None:
+        pass
+
     def _start_resize(self, _event: object) -> str:
         return "break"
 
@@ -221,3 +224,18 @@ def test_build_shell_places_tab_in_rightmost_column(monkeypatch) -> None:
     assert overlay.resize_handle.grid_info()["column"] == 1
     assert overlay.tab_button.grid_info()["column"] == 2
     assert overlay.tab_button.kwargs["text"] == COLLAPSED_TAB_TEXT
+    assert overlay.add_button.grid_info()["column"] == 1
+    assert overlay.add_button.kwargs["text"] == "+ Add"
+    assert overlay.add_button.kwargs["command"] == overlay._request_add
+
+
+def test_request_add_calls_callback_with_add_button() -> None:
+    calls: list[object] = []
+    overlay = SimpleNamespace(
+        _on_add_requested=lambda source: calls.append(source),
+        add_button=object(),
+    )
+
+    FixedOverlayView._request_add(overlay)  # type: ignore[arg-type]
+
+    assert calls == [overlay.add_button]


### PR DESCRIPTION
### Motivation
- Make the fixed-overlay self-sufficient so it can offer an internal Add control without importing GM Table menu logic. 
- Provide a clean callback path so overlay UI events forward to the owning GM Table view to create or pin supported panel types.

### Description
- Added an optional `on_add_requested` parameter to `FixedOverlayView.__init__` and stored it as `_on_add_requested`, and added a header `+ Add` button that calls a new `FixedOverlayView._request_add` method. 
- Passed the callback through `FixedOverlayController` by adding `on_add_requested` to its constructor and forwarding it to the view. 
- Extended `GMTableWorkspace` to accept `on_fixed_overlay_add_requested`, forward it into the `FixedOverlayController`, and expose `_request_fixed_overlay_add` to call the workspace owner. 
- Implemented a `FIXED_OVERLAY` add menu and wiring in `GMTableView` so the overlay can trigger the same panel creation/pinning flows (reuses existing add flow and preserves existing "Add to Fixed Table" behavior). 
- Added a focused unit test to `tests/scenarios/gm_table/test_fixed_overlay_view.py` that verifies the overlay calls the callback with its internal add button.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_fixed_overlay_view.py` and targeted `GMTableView` add-menu tests and they passed (focused tests covering the new path succeeded). 
- Compiled modified modules with `python -m compileall` to verify syntax and module loadability and it succeeded. 
- Ran the broader GM Table test suite where 96 tests passed and 2 tests failed; the two failures are Tk display-dependent `tests/scenarios/gm_table/test_workspace.py` cases failing in the headless CI environment due to `TclError: no display name and no $DISPLAY` rather than regressions in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4366ee0cc0832baf145674cc5e0413)