### PR TITLE
Add per-item header with Remove action to FixedOverlayView and tests

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -109,15 +109,41 @@ class FixedOverlayView(ctk.CTkFrame):
             frame = ctk.CTkFrame(self.items_host, fg_color=TABLE_PALETTE["panel_alt"], corner_radius=12)
             frame.pack(fill="both", expand=True, padx=4, pady=6)
             frame.grid_columnconfigure(0, weight=1)
-            ctk.CTkLabel(frame, text=item.title, text_color=TABLE_PALETTE["text"], font=ctk.CTkFont(weight="bold"), anchor="w").grid(row=0, column=0, sticky="ew", padx=10, pady=(8, 4))
+            frame.grid_columnconfigure(1, weight=0)
+
+            header = ctk.CTkFrame(frame, fg_color="transparent")
+            header.grid(row=0, column=0, sticky="ew", padx=10, pady=(8, 4), columnspan=2)
+            header.grid_columnconfigure(0, weight=1)
+            ctk.CTkLabel(header, text=item.title, text_color=TABLE_PALETTE["text"], font=ctk.CTkFont(weight="bold"), anchor="w").grid(row=0, column=0, sticky="ew")
+            actions = ctk.CTkFrame(header, fg_color="transparent")
+            actions.grid(row=0, column=1, sticky="e", padx=(8, 0))
+            ctk.CTkButton(
+                actions,
+                text="Remove",
+                width=72,
+                fg_color=TABLE_PALETTE["danger"],
+                hover_color="#DC2626",
+                text_color="#111827",
+                command=lambda item_id=item.item_id: self._remove_item(item_id),
+            ).grid(row=0, column=0, sticky="e")
+
             body = ctk.CTkFrame(frame, fg_color="transparent")
-            body.grid(row=1, column=0, sticky="nsew", padx=8, pady=(0, 8))
+            body.grid(row=1, column=0, sticky="nsew", padx=8, pady=(0, 8), columnspan=2)
             body.grid_rowconfigure(0, weight=1)
             body.grid_columnconfigure(0, weight=1)
             frame.grid_rowconfigure(1, weight=1)
             payload = self._panel_builder(body, SimpleNamespace(panel_id=item.item_id, kind=item.kind, title=item.title, state=item.state))
             self._mount_payload_widget(body, payload)
             self._payloads[item.item_id] = payload
+
+    def _remove_item(self, item_id: str) -> None:
+        before_count = len(self._state.items)
+        self._state.items = [item for item in self._state.items if item.item_id != item_id]
+        if len(self._state.items) == before_count:
+            return
+        self._payloads.pop(item_id, None)
+        self._refresh_items()
+        self._changed()
 
     @staticmethod
     def _mount_payload_widget(host: ctk.CTkFrame, payload: object) -> None:

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from modules.scenarios.gm_table.fixed_overlay.models import FixedOverlayState
+from modules.scenarios.gm_table.fixed_overlay.models import FixedOverlayItem, FixedOverlayState
 from modules.scenarios.gm_table.fixed_overlay import view as fixed_overlay_view
 from modules.scenarios.gm_table.fixed_overlay.view import (
     COLLAPSED_TAB_TEXT,
@@ -239,3 +239,40 @@ def test_request_add_calls_callback_with_add_button() -> None:
     FixedOverlayView._request_add(overlay)  # type: ignore[arg-type]
 
     assert calls == [overlay.add_button]
+
+
+def test_remove_item_deletes_item_and_persists_change() -> None:
+    changed_calls: list[str] = []
+    overlay = SimpleNamespace(
+        _state=FixedOverlayState(
+            items=[
+                FixedOverlayItem(item_id="keep", kind="note", title="Keep", state={"value": 1}),
+                FixedOverlayItem(item_id="remove", kind="note", title="Remove", state={"value": 2}),
+            ]
+        ),
+        _payloads={"keep": object(), "remove": object()},
+        _refresh_items=lambda: None,
+        _changed=lambda: changed_calls.append("changed"),
+    )
+
+    FixedOverlayView._remove_item(overlay, "remove")  # type: ignore[arg-type]
+
+    assert [item.item_id for item in overlay._state.items] == ["keep"]
+    assert "remove" not in overlay._payloads
+    assert changed_calls == ["changed"]
+    assert [item["item_id"] for item in FixedOverlayView.get_state(overlay)["items"]] == ["keep"]  # type: ignore[arg-type]
+
+
+def test_remove_item_ignores_unknown_item_without_change() -> None:
+    changed_calls: list[str] = []
+    overlay = SimpleNamespace(
+        _state=FixedOverlayState(items=[FixedOverlayItem(item_id="keep", kind="note", title="Keep")]),
+        _payloads={"keep": object()},
+        _refresh_items=lambda: None,
+        _changed=lambda: changed_calls.append("changed"),
+    )
+
+    FixedOverlayView._remove_item(overlay, "missing")  # type: ignore[arg-type]
+
+    assert [item.item_id for item in overlay._state.items] == ["keep"]
+    assert changed_calls == []


### PR DESCRIPTION
### Motivation
- Provide a small action area for each pinned/fixed overlay item so users can remove items from the overlay UI and persist layout state.
- Ensure removing an item updates the in-memory state and serialized state used for persistence.

### Description
- Added a per-item header/action area in `FixedOverlayView._refresh_items` that renders the item title and an actions frame. 
- Implemented a `Remove` button that calls a new `_remove_item(item_id: str)` method bound to the rendered item. 
- `_remove_item` filters the matching `FixedOverlayItem` out of `self._state.items`, clears the cached payload from `self._payloads`, calls `_refresh_items()` and then `_changed()` so persistence/layout updates occur. 
- Added unit tests in `tests/scenarios/gm_table/test_fixed_overlay_view.py` that verify removing an item deletes it from state, clears payloads, calls `_changed()`, and that removing an unknown id is a no-op.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_fixed_overlay_view.py`, which succeeded (tests for the fixed overlay view passed). 
- Ran full `pytest -q` which aborted during collection due to unrelated test-harness/environment issues (duplicate test module basename import mismatch and existing `customtkinter` SimpleNamespace stubs missing expected attributes), so the broader suite did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43691a8120832bac04ddac81aa94e6)