### PR TITLE
Restrict fixed-overlay add menu to requested entries

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -83,36 +83,24 @@ TITLE_KEY_ENTITY_TYPES = {"Scenarios", "Informations", "Books"}
 MAP_PANEL_KINDS = {"world_map", "map_tool"}
 
 FIXED_OVERLAY_ADD_OPTIONS = (
-    "Pin Active Panel",
-    "Campaign Dashboard",
-    "World Map",
-    "Map Tool",
-    "Image Library",
-    "Container Window",
+    "Image from Library",
+    "Handouts",
     "Loot Generator",
-    "Object Shelf",
-    "Whiteboard",
-    "Random Tables",
-    "Plot Twists",
-    "Puzzle Display",
     "Note Tab",
     "Sticky Note",
     "Character Graph",
     "Scenario Graph Editor",
+    "Random Tables",
+    "Plot Twists",
+    "Campaign Dashboard",
+    "Books",
 )
 
 FIXED_OVERLAY_DIRECT_PANEL_OPTIONS = {
     "Campaign Dashboard": ("campaign_dashboard", "Campaign Dashboard", {}),
-    "World Map": ("world_map", "World Map", {}),
-    "Map Tool": ("map_tool", "Map Tool", {}),
-    "Image Library": ("image_library", "Image Library", {}),
-    "Container Window": ("container_window", "Container Window", {}),
     "Loot Generator": ("loot_generator", "Loot Generator", {}),
-    "Object Shelf": ("object_shelf", "Object Shelf", {}),
-    "Whiteboard": ("whiteboard", "Whiteboard", {}),
     "Random Tables": ("random_tables", "Random Tables", {}),
     "Plot Twists": ("plot_twists", "Plot Twists", {}),
-    "Puzzle Display": ("puzzle_display", "Puzzle Display", {}),
     "Character Graph": ("character_graph", "Character Graph", {}),
     "Scenario Graph Editor": ("scenario_graph", "Scenario Graph", {}),
 }
@@ -890,6 +878,37 @@ class GMTableView(ctk.CTkFrame):
         )
         dialog.title("Add Image to GM Table")
 
+    def _add_image_to_fixed_overlay_from_library_result(self, image_result) -> None:
+        """Create a fixed-overlay image item from an image-library selection."""
+        image_path = str(getattr(image_result, "path", "") or "").strip()
+        if not image_path:
+            messagebox.showerror("GM Table", "The selected image has no usable path.")
+            return
+        image_title = str(getattr(image_result, "name", "") or "").strip() or "Image"
+        self.workspace.add_to_fixed_overlay(
+            "image",
+            image_title,
+            {"image_path": image_path, "image_title": image_title},
+        )
+
+    def _open_image_library_for_fixed_overlay_image(self) -> None:
+        """Open the image library and add the selected image to the fixed overlay."""
+        try:
+            from modules.ui.image_library.dialogs.library_browser_dialog import (
+                ImageLibraryBrowserDialog,
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                "Image Library", f"Image library is unavailable: {exc}"
+            )
+            return
+
+        dialog = ImageLibraryBrowserDialog(
+            self.winfo_toplevel(),
+            on_attach_to_entity=self._add_image_to_fixed_overlay_from_library_result,
+        )
+        dialog.title("Add Image to Fixed Table")
+
     def _preferred_entity_geometry(self, entity_type: str) -> dict[str, int]:
         """Return the default geometry for an entity panel."""
         width, height = resolve_default_panel_size(
@@ -1337,6 +1356,15 @@ class GMTableView(ctk.CTkFrame):
 
     def _handle_fixed_overlay_add_option(self, option: str) -> None:
         """Create supported panel payloads directly inside the fixed overlay."""
+        if option == "Image from Library":
+            self._open_image_library_for_fixed_overlay_image()
+            return
+        if option == "Handouts":
+            self._open_handouts_selection_for_fixed_overlay()
+            return
+        if option == "Books":
+            self._open_entity_selection_for_fixed_overlay("Books")
+            return
         if option == "Note Tab":
             existing_notes = [
                 item
@@ -2024,6 +2052,73 @@ class GMTableView(ctk.CTkFrame):
 
         view = GenericListSelectionView(
             popup, "Scenarios", wrapper, template, _open_selected
+        )
+        view.pack(fill="both", expand=True)
+
+    def _open_handouts_selection_for_fixed_overlay(self) -> None:
+        """Ask which scenario should power a fixed-overlay handouts item."""
+        wrapper = self.wrappers.get("Scenarios")
+        template = self._templates.get("Scenarios")
+        if wrapper is None or template is None:
+            messagebox.showerror("GM Table", "Scenarios are not available.")
+            return
+
+        popup = ctk.CTkToplevel(self)
+        popup.title("Select Scenario")
+        popup.geometry("1200x800")
+        popup.transient(self.winfo_toplevel())
+        popup.grab_set()
+        popup.focus_force()
+
+        def _open_selected(
+            selected_type: str, selected_name: str, item: dict | None = None
+        ) -> None:
+            del selected_type
+            popup.destroy()
+            scenario_title = self._entity_label(
+                "Scenarios", item, fallback=selected_name
+            )
+            self.workspace.add_to_fixed_overlay(
+                "handouts",
+                f"Handouts: {scenario_title}",
+                {"scenario_name": scenario_title},
+            )
+
+        view = GenericListSelectionView(
+            popup, "Scenarios", wrapper, template, _open_selected
+        )
+        view.pack(fill="both", expand=True)
+
+    def _open_entity_selection_for_fixed_overlay(self, entity_type: str) -> None:
+        """Open the generic picker for fixed-overlay entity-backed items."""
+        wrapper = self.wrappers.get(entity_type)
+        template = self._templates.get(entity_type)
+        if wrapper is None or template is None:
+            messagebox.showerror("GM Table", f"{entity_type} is not available.")
+            return
+        popup = ctk.CTkToplevel(self)
+        popup.title(f"Select {entity_type}")
+        popup.geometry("1200x800")
+        popup.transient(self.winfo_toplevel())
+        popup.grab_set()
+        popup.focus_force()
+
+        def _open_selected(
+            selected_type: str, selected_name: str, item: dict | None = None
+        ) -> None:
+            popup.destroy()
+            label = self._entity_label(selected_type, item, fallback=selected_name)
+            singular = (
+                selected_type[:-1] if selected_type.endswith("s") else selected_type
+            )
+            self.workspace.add_to_fixed_overlay(
+                "entity",
+                f"{singular}: {label}",
+                {"entity_type": selected_type, "entity_name": label},
+            )
+
+        view = GenericListSelectionView(
+            popup, entity_type, wrapper, template, _open_selected
         )
         view.pack(fill="both", expand=True)
 

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -1217,6 +1217,48 @@ def test_add_menu_options_include_pdf_viewer_static() -> None:
     assert '"Open PDF"' in text
 
 
+def test_fixed_overlay_add_options_match_requested_menu() -> None:
+    assert gm_table_view_module.FIXED_OVERLAY_ADD_OPTIONS == (
+        "Image from Library",
+        "Handouts",
+        "Loot Generator",
+        "Note Tab",
+        "Sticky Note",
+        "Character Graph",
+        "Scenario Graph Editor",
+        "Random Tables",
+        "Plot Twists",
+        "Campaign Dashboard",
+        "Books",
+    )
+
+
+def test_handle_fixed_overlay_add_option_routes_picker_items(monkeypatch) -> None:
+    view = GMTableView.__new__(GMTableView)
+    calls = []
+    monkeypatch.setattr(
+        view,
+        "_open_image_library_for_fixed_overlay_image",
+        lambda: calls.append("image"),
+    )
+    monkeypatch.setattr(
+        view,
+        "_open_handouts_selection_for_fixed_overlay",
+        lambda: calls.append("handouts"),
+    )
+    monkeypatch.setattr(
+        view,
+        "_open_entity_selection_for_fixed_overlay",
+        lambda entity_type: calls.append(entity_type),
+    )
+
+    GMTableView._handle_fixed_overlay_add_option(view, "Image from Library")
+    GMTableView._handle_fixed_overlay_add_option(view, "Handouts")
+    GMTableView._handle_fixed_overlay_add_option(view, "Books")
+
+    assert calls == ["image", "handouts", "Books"]
+
+
 def test_handle_add_option_routes_fixed_table_toggle() -> None:
     view = GMTableView.__new__(GMTableView)
     calls = []


### PR DESCRIPTION
### Motivation
- Reduce the fixed-overlay "Add" menu to the explicit set of entries requested so the overlay shows only the intended quick-add options.
- Ensure picker-backed entries (images, handouts, Books) route correctly into the fixed overlay instead of opening full panels.
- Keep the fixed-overlay direct panel mapping minimal and consistent with the visible menu.

### Description
- Updated `FIXED_OVERLAY_ADD_OPTIONS` in `modules/scenarios/gm_table_view.py` to the requested list: `"Image from Library", "Handouts", "Loot Generator", "Note Tab", "Sticky Note", "Character Graph", "Scenario Graph Editor", "Random Tables", "Plot Twists", "Campaign Dashboard", "Books"`.
- Removed several previously-exposed fixed-overlay direct entries and trimmed `FIXED_OVERLAY_DIRECT_PANEL_OPTIONS` to the remaining direct panel mappings.
- Added routing and helper flows to add picker-driven items into the fixed overlay: `_open_image_library_for_fixed_overlay_image`, `_add_image_to_fixed_overlay_from_library_result`, `_open_handouts_selection_for_fixed_overlay`, and `_open_entity_selection_for_fixed_overlay` in `modules/scenarios/gm_table_view.py`.
- Added regression tests in `tests/scenarios/gm_table/test_gm_table_view.py` verifying the fixed-overlay menu contents and that picker-based options route to the new helper methods.

### Testing
- Compiled the modified module with `python -m py_compile modules/scenarios/gm_table_view.py` and it succeeded.
- Ran the scenario GM Table tests with `python -m pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and all tests passed (`51 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a436ca6a8d8832bb968a46abaaf310b)