### PR TITLE
Improve GM table panel fallback diagnostics

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1588,15 +1588,60 @@ class GMTableView(ctk.CTkFrame):
                 f"Unable to build GM Table panel '{definition.title}': {exc}",
                 func_name="GMTableView._mount_panel_content",
             )
+            return self._build_panel_fallback(parent, definition, exc)
 
-        fallback = ctk.CTkLabel(
-            parent,
-            text=f"Panel unavailable: {definition.title}",
+        return self._build_panel_fallback(parent, definition)
+
+    def _build_panel_fallback(
+        self,
+        parent: ctk.CTkFrame,
+        definition: PanelDefinition,
+        exc: Exception | None = None,
+    ) -> ctk.CTkFrame:
+        """Render a concise diagnostic when a GM Table panel cannot load."""
+        fallback = ctk.CTkFrame(parent, fg_color=TABLE_PALETTE["panel_alt"])
+        fallback.grid_columnconfigure(0, weight=1)
+
+        lines = [
+            f"Panel: {definition.title}",
+            f"Kind: {definition.kind}",
+        ]
+        if exc is not None:
+            lines.append(f"Error: {self._sanitize_panel_error(exc)}")
+        if self._panel_needs_attachment_hint(definition):
+            lines.append(
+                "Hint: check the book Attachment path and the active campaign."
+            )
+
+        label = ctk.CTkLabel(
+            fallback,
+            text="\n".join(lines),
             text_color=TABLE_PALETTE["text"],
             justify="left",
+            anchor="w",
+            wraplength=520,
         )
+        label.grid(row=0, column=0, sticky="ew", padx=14, pady=14)
         fallback.grid(row=0, column=0, sticky="nsew")
         return fallback
+
+    @staticmethod
+    def _sanitize_panel_error(exc: Exception) -> str:
+        """Return a short, single-line error summary safe for panel UI."""
+        message = " ".join(str(exc).split())
+        if not message:
+            message = exc.__class__.__name__
+        max_length = 140
+        if len(message) > max_length:
+            message = f"{message[: max_length - 1].rstrip()}…"
+        return message
+
+    @staticmethod
+    def _panel_needs_attachment_hint(definition: PanelDefinition) -> bool:
+        """Return whether a failed panel likely depends on book/entity attachments."""
+        if definition.kind == "book":
+            return True
+        return definition.kind == "entity"
 
     def _handle_note_session_action(self) -> None:
         """Explain why scenario session actions are disabled on global notes."""

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -522,6 +522,74 @@ def test_mount_panel_content_builds_handouts_page(monkeypatch) -> None:
     }
 
 
+def test_mount_panel_content_renders_entity_fallback_with_diagnostics(monkeypatch) -> None:
+    """Entity panel build failures should show concise troubleshooting context."""
+    captured = {"labels": []}
+
+    class _DummyFrame:
+        def __init__(self, parent, **kwargs) -> None:
+            captured["frame_parent"] = parent
+            captured["frame_kwargs"] = kwargs
+
+        def grid_columnconfigure(self, *args, **kwargs) -> None:
+            captured["grid_columnconfigure"] = (args, kwargs)
+
+        def grid(self, **kwargs) -> None:
+            captured["frame_grid"] = kwargs
+
+    class _DummyLabel:
+        def __init__(self, parent, **kwargs) -> None:
+            captured["label_parent"] = parent
+            captured["labels"].append(kwargs)
+
+        def grid(self, **kwargs) -> None:
+            captured["label_grid"] = kwargs
+
+    class _EagerHostedPage:
+        def __init__(self, _parent, *, builder, **_kwargs) -> None:
+            builder(object())
+
+    monkeypatch.setattr(gm_table_view_module.ctk, "CTkFrame", _DummyFrame)
+    monkeypatch.setattr(gm_table_view_module.ctk, "CTkLabel", _DummyLabel)
+    monkeypatch.setattr(gm_table_view_module, "GMTableHostedPage", _EagerHostedPage)
+    monkeypatch.setattr(
+        gm_table_view_module, "log_warning", lambda *args, **kwargs: None
+    )
+
+    view = GMTableView.__new__(GMTableView)
+
+    def _raise_entity_content(_host, _state):
+        raise RuntimeError("Attachment path missing for /tmp/secret.pdf\nplease reload")
+
+    view._build_entity_content = _raise_entity_content
+    definition = gm_table_view_module.PanelDefinition(
+        panel_id="panel-entity",
+        kind="entity",
+        title="Book: Lost Archive",
+        state={"entity_type": "Books", "entity_name": "Lost Archive"},
+    )
+
+    fallback = GMTableView._mount_panel_content(view, object(), definition)
+
+    label_text = captured["labels"][0]["text"]
+    assert isinstance(fallback, _DummyFrame)
+    assert "Panel: Book: Lost Archive" in label_text
+    assert "Kind: entity" in label_text
+    assert "Attachment path missing for /tmp/secret.pdf please reload" in label_text
+    assert "check the book Attachment path and the active campaign" in label_text
+    assert not label_text.startswith("Panel unavailable:")
+
+
+def test_sanitize_panel_error_keeps_message_short_and_single_line() -> None:
+    """Fallback errors should avoid noisy multiline trace-style content."""
+    message = GMTableView._sanitize_panel_error(
+        RuntimeError("first line\n" + "x" * 200)
+    )
+
+    assert "\n" not in message
+    assert len(message) <= 140
+    assert message.endswith("…")
+
 def test_restore_or_seed_layout_restores_annotation_only_desks() -> None:
     """Saved desk text/drawings should restore even when no panels are present."""
     layout = {


### PR DESCRIPTION
### Motivation
- Replace the terse "Panel unavailable" fallback with a concise, actionable UI so users see why a panel failed to load.
- Preserve the existing warning log while surfacing a short, sanitized error and targeted troubleshooting for book/entity panels.
- Avoid exposing multiline or noisy trace-like messages in the UI and give a minimal hint about missing attachments/active campaign when relevant.

### Description
- Update `GMTableView._mount_panel_content` to call a new `self._build_panel_fallback(parent, definition, exc)` when panel construction raises, keeping the existing `log_warning` call.
- Add `_build_panel_fallback` that renders a framed fallback showing the panel title, kind, a sanitized single-line error summary when available, and a hint to check the book `Attachment` path and active campaign for book/entity failures.
- Add helper methods `_sanitize_panel_error` to collapse multiline/long messages into a safe single-line summary and `_panel_needs_attachment_hint` to detect when to show the attachment/campaign hint.
- Add focused tests in `tests/scenarios/gm_table/test_gm_table_view.py`: `test_mount_panel_content_renders_entity_fallback_with_diagnostics` and `test_sanitize_panel_error_keeps_message_short_and_single_line` which mock UI primitives and assert the fallback content.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_gm_table_view.py` and the tests passed: `53 passed`.
- The added tests specifically exercise entity panel fallback rendering and error sanitization and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a436ee73e38832b870d58bec0c847d3)