### PR TITLE
Fix GM Table book panel layout

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1836,8 +1836,11 @@ class GMTableView(ctk.CTkFrame):
         host.grid_columnconfigure(0, weight=2)
         host.grid_columnconfigure(1, weight=3)
 
-        details_host = build_scroll_host(host)
-        details_host.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        details_cell = ctk.CTkFrame(host, fg_color="transparent")
+        details_cell.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        details_cell.grid_rowconfigure(0, weight=1)
+        details_cell.grid_columnconfigure(0, weight=1)
+        details_host = build_scroll_host(details_cell)
         detail_frame = create_entity_detail_frame(
             "Books",
             item,


### PR DESCRIPTION
### Motivation
- Prevent a geometry-manager conflict that caused the GM Table book panel to fall back to an error/diagnostic view when a linked PDF viewer was shown beside the book details.

### Description
- Updated `_build_book_content` in `modules/scenarios/gm_table_view.py` to place the scrollable book details inside a dedicated grid-managed container (`details_cell`) and then mount the scroll host into that cell, keeping the PDF viewer in the adjacent grid column so `pack` and `grid` are not mixed in the same parent.

### Testing
- Ran `python3 -m py_compile modules/scenarios/gm_table_view.py` and the file compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a438ecfc850832ba57958d9654b5110)