### PR TITLE
Fix fixed table expand bar spacing

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/models.py
+++ b/modules/scenarios/gm_table/fixed_overlay/models.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+MIN_OVERLAY_WIDTH = 180
+MAX_OVERLAY_WIDTH = 1100
+DEFAULT_OVERLAY_WIDTH = 360
+
 
 def _json_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
@@ -43,7 +47,7 @@ class FixedOverlayState:
         return {
             "visible": bool(self.visible),
             "collapsed": bool(self.collapsed),
-            "width": max(260, min(1100, int(self.width or 360))),
+            "width": max(MIN_OVERLAY_WIDTH, min(MAX_OVERLAY_WIDTH, int(self.width or DEFAULT_OVERLAY_WIDTH))),
             "anchor": self.anchor if self.anchor in {"left"} else "left",
             "selected_item_ids": [str(value) for value in self.selected_item_ids],
             "items": [item.to_dict() for item in self.items],
@@ -56,7 +60,7 @@ class FixedOverlayState:
         return cls(
             visible=bool(source.get("visible", True)),
             collapsed=bool(source.get("collapsed", True)),
-            width=max(260, min(1100, int(source.get("width") or 360))),
+            width=max(MIN_OVERLAY_WIDTH, min(MAX_OVERLAY_WIDTH, int(source.get("width") or DEFAULT_OVERLAY_WIDTH))),
             anchor="left",
             selected_item_ids=[str(value) for value in list(source.get("selected_item_ids") or [])],
             items=[item for item in items if item.item_id],

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -12,8 +12,9 @@ from .theme import get_fixed_overlay_palette
 TAB_WIDTH = 28
 COLLAPSED_TAB_TEXT = "›"
 EXPANDED_TAB_TEXT = "‹"
-MIN_OVERLAY_WIDTH = 280
+MIN_OVERLAY_WIDTH = 180
 MAX_OVERLAY_WIDTH = 1100
+EMPTY_OVERLAY_WIDTH = 180
 DEFAULT_ITEM_WIDTH = 340
 DEFAULT_ITEM_HEIGHT = 260
 MIN_ITEM_WIDTH = 240
@@ -220,6 +221,8 @@ class FixedOverlayView(ctk.CTkFrame):
             return
 
     def _preferred_overlay_width(self) -> int:
+        if not self._state.items:
+            return EMPTY_OVERLAY_WIDTH
         item_widths = [self._item_dimensions(item)[0] + ITEM_CHROME_WIDTH for item in self._state.items]
         preferred = max([int(self._state.width or 360), *item_widths] or [360])
         return max(MIN_OVERLAY_WIDTH, min(MAX_OVERLAY_WIDTH, preferred))


### PR DESCRIPTION
### Motivation
- The fixed-overlay (pinned GM Table) reserved a large minimum width which left the expand/collapse tab far from the GM table left edge and created unnecessary blank space when the overlay was empty.
- Persisted layouts could restore the old wider minimum because width bounds were hard-coded in the persistence logic.

### Description
- Reduced the overlay minimum width from `280` to `180` in `modules/scenarios/gm_table/fixed_overlay/view.py` so the expand/collapse tab sits closer to the GM table edge.
- Added `EMPTY_OVERLAY_WIDTH` and return the compact width when the overlay has no items to avoid reserving empty space in `fixed_overlay/view.py`.
- Introduced shared constants `MIN_OVERLAY_WIDTH`, `MAX_OVERLAY_WIDTH`, and `DEFAULT_OVERLAY_WIDTH` in `modules/scenarios/gm_table/fixed_overlay/models.py` and used them when serializing/restoring `FixedOverlayState` so persisted layouts respect the new bounds.

### Testing
- Compiled modified modules with `python -m py_compile modules/scenarios/gm_table/fixed_overlay/view.py modules/scenarios/gm_table/fixed_overlay/models.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cf6f6ee8832bb323ebceb18c58a2)