### PR TITLE
Fix fixed table overlay placement width

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -190,7 +190,15 @@ class FixedOverlayView(ctk.CTkFrame):
 
     def _place_with_width(self, width: int) -> None:
         """Place the overlay with an explicit width for reliable geometry."""
-        options = {"x": 0, "y": 0, "width": width, "relheight": 1.0}
+        options = {
+            "x": 0,
+            "y": 0,
+            "relx": 0,
+            "rely": 0,
+            "width": width,
+            "relwidth": 0,
+            "relheight": 1.0,
+        }
         place_configure = getattr(self, "place_configure", None)
         if callable(place_configure):
             place_configure(**options)

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -19,6 +19,20 @@ from modules.scenarios.gm_table.fixed_overlay.view import (
 )
 
 
+
+
+def _expected_place_options(width: int) -> dict[str, object]:
+    return {
+        "x": 0,
+        "y": 0,
+        "relx": 0,
+        "rely": 0,
+        "width": width,
+        "relwidth": 0,
+        "relheight": 1.0,
+    }
+
+
 class _FakeGridWidget:
     def __init__(
         self, name: str = "widget", call_order: list[str] | None = None
@@ -100,7 +114,7 @@ def test_refresh_geometry_places_expanded_width() -> None:
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
 
     assert overlay.configured_width == 420
-    assert overlay.place_calls == [{"x": 0, "y": 0, "width": 420, "relheight": 1.0}]
+    assert overlay.place_calls == [_expected_place_options(420)]
     assert overlay.content.shown is True
     assert overlay.resize_handle.shown is True
     assert overlay.tab_button.options["text"] == EXPANDED_TAB_TEXT
@@ -121,9 +135,7 @@ def test_refresh_geometry_uses_tab_width_when_collapsed() -> None:
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
 
     assert overlay.configured_width == TAB_WIDTH
-    assert overlay.place_calls == [
-        {"x": 0, "y": 0, "width": TAB_WIDTH, "relheight": 1.0}
-    ]
+    assert overlay.place_calls == [_expected_place_options(TAB_WIDTH)]
     assert overlay.content.removed is True
     assert overlay.resize_handle.removed is True
     assert overlay.tab_button.options["text"] == COLLAPSED_TAB_TEXT
@@ -147,7 +159,7 @@ def test_refresh_geometry_preserves_placed_width_across_toggles() -> None:
     overlay._state.collapsed = False
     FixedOverlayView._refresh_geometry(overlay)  # type: ignore[arg-type]
     assert overlay.configured_width == 420
-    assert overlay.place_calls[-1] == {"x": 0, "y": 0, "width": 420, "relheight": 1.0}
+    assert overlay.place_calls[-1] == _expected_place_options(420)
     assert overlay.call_order[-6:] == [
         "content.grid",
         "resize_handle.grid",


### PR DESCRIPTION
### Motivation
- Prevent the Fixed Table overlay from being inadvertently sized/positioned by stale relative placement values so an empty Fixed Table cannot cover the desk.
- Make tests assert the full placement contract (absolute + relative placement keys) to prevent regressions.

### Description
- Updated `FixedOverlayView._place_with_width` to pass explicit placement options including `relx`, `rely`, and `relwidth: 0` when calling `place_configure`/`place` so relative width is reset.
- Adjusted `tests/scenarios/gm_table/test_fixed_overlay_view.py` to assert the full placement dict (added `_expected_place_options` helper) for expanded, collapsed, and toggle scenarios.
- Kept behavior of preserving the last expanded width when toggling collapsed/expanded while ensuring placement uses the explicit, safe placement contract.

### Testing
- Ran `python -m compileall modules/scenarios/gm_table/fixed_overlay` which completed successfully.
- Ran `pytest tests/scenarios/gm_table/test_fixed_overlay_view.py -q` which passed: `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43df33da8c832b96eecb03dd33ce22)