### PR TITLE
Refactor fixed GM table overlay to transparent Toplevel

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
+++ b/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
@@ -1,0 +1,120 @@
+"""Platform-aware transparent window host for the fixed GM Table overlay."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from dataclasses import dataclass
+
+import customtkinter as ctk
+
+
+TRANSPARENT_COLOR = "#010203"
+
+
+@dataclass(frozen=True)
+class TransparencySupport:
+    """Describes the transparency mode selected for an overlay window."""
+
+    mode: str
+    true_transparency: bool
+    reason: str = ""
+
+
+class TransparentOverlayWindow:
+    """A toplevel layer anchored over a master widget.
+
+    Tk's regular child widgets cannot be truly translucent on every platform. This
+    host keeps the fixed-overlay controls in a dedicated borderless ``Toplevel``
+    positioned over the GM table, then uses the best transparency option Tk offers
+    on the current windowing system. If true transparent colors are unavailable,
+    it gracefully falls back to an opaque toplevel whose child widgets still use
+    the pre-blended overlay colors from ``style.py``.
+    """
+
+    def __init__(self, master: tk.Widget, *, background: str) -> None:
+        self.master = master
+        self._width = 1
+        self._visible = False
+        self._place_options: dict[str, object] = {}
+        self.window = tk.Toplevel(master.winfo_toplevel())
+        self.window.withdraw()
+        self.window.overrideredirect(True)
+        self.window.configure(background=TRANSPARENT_COLOR)
+        self.window.transient(master.winfo_toplevel())
+        self.support = self._configure_transparency()
+        self.shell = ctk.CTkFrame(
+            self.window,
+            fg_color=background,
+            corner_radius=0,
+            border_width=1,
+        )
+        self.shell.place(x=0, y=0, relheight=1.0, relwidth=1.0)
+        self._bind_anchor_events()
+
+    def _configure_transparency(self) -> TransparencySupport:
+        try:
+            self.window.attributes("-transparentcolor", TRANSPARENT_COLOR)
+            return TransparencySupport("transparentcolor", True)
+        except tk.TclError as exc:
+            try:
+                self.window.attributes("-alpha", 0.98)
+                return TransparencySupport("alpha", True, str(exc))
+            except tk.TclError as alpha_exc:
+                return TransparencySupport("fallback", False, str(alpha_exc))
+
+    def _bind_anchor_events(self) -> None:
+        for widget in {self.master, self.master.winfo_toplevel()}:
+            try:
+                widget.bind("<Configure>", self._on_anchor_configure, add="+")
+                widget.bind("<Destroy>", self._on_anchor_destroy, add="+")
+            except tk.TclError:
+                pass
+
+    def _on_anchor_configure(self, _event: object = None) -> None:
+        if self._visible:
+            self._apply_geometry()
+
+    def _on_anchor_destroy(self, event: object = None) -> None:
+        if event is not None and getattr(event, "widget", None) is self.master:
+            self.destroy()
+
+    def configure(self, **kwargs: object) -> None:
+        if "width" in kwargs:
+            self._width = max(1, int(kwargs["width"] or 1))
+        self.shell.configure(**{k: v for k, v in kwargs.items() if k != "width"})
+
+    def place_configure(self, **kwargs: object) -> None:
+        self._place_options.update(kwargs)
+        self._width = max(1, int(kwargs.get("width") or self._width))
+        self._visible = True
+        self._apply_geometry()
+        self.window.deiconify()
+
+    def place(self, **kwargs: object) -> None:
+        self.place_configure(**kwargs)
+
+    def place_forget(self) -> None:
+        self._visible = False
+        self.window.withdraw()
+
+    def _apply_geometry(self) -> None:
+        try:
+            self.master.update_idletasks()
+            x = self.master.winfo_rootx() + int(self._place_options.get("x") or 0)
+            y = self.master.winfo_rooty() + int(self._place_options.get("y") or 0)
+            height = max(1, self.master.winfo_height())
+        except tk.TclError:
+            return
+        self.window.geometry(f"{self._width}x{height}+{x}+{y}")
+
+    def lift(self) -> None:
+        self.window.lift()
+
+    def destroy(self) -> None:
+        try:
+            self.window.destroy()
+        except tk.TclError:
+            pass
+
+    def update_idletasks(self) -> None:
+        self.window.update_idletasks()

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -10,6 +10,7 @@ from modules.helpers import theme_manager
 from .models import FixedOverlayItem, FixedOverlayState
 from .style import OVERLAY_OPACITY, blend_hex_color
 from .theme import get_fixed_overlay_palette
+from .overlay_window import TransparentOverlayWindow
 
 TAB_WIDTH = 28
 COLLAPSED_TAB_TEXT = "›"
@@ -24,21 +25,18 @@ MIN_ITEM_HEIGHT = 140
 ITEM_CHROME_WIDTH = 48
 
 
-class FixedOverlayView(ctk.CTkFrame):
+class FixedOverlayView:
     """Collapsible viewport overlay anchored to the left edge of the GM Table."""
 
     def __init__(
         self, master, *, panel_builder, on_changed=None, on_add_requested=None
     ):
         self._palette = get_fixed_overlay_palette()
-        super().__init__(
-            master,
-            width=TAB_WIDTH,
-            fg_color=self._overlay_surface_color(),
-            corner_radius=0,
-            border_width=1,
-            border_color=self._palette["panel_focus"],
+        self._overlay_layer = TransparentOverlayWindow(
+            master, background=self._overlay_surface_color()
         )
+        self._shell = self._overlay_layer.shell
+        self._shell.configure(border_color=self._palette["panel_focus"])
         self._panel_builder = panel_builder
         self._on_changed = on_changed
         self._on_add_requested = on_add_requested
@@ -68,23 +66,24 @@ class FixedOverlayView(ctk.CTkFrame):
         )
 
     def _build_shell(self) -> None:
-        self.grid_columnconfigure(0, weight=1)
-        self.grid_columnconfigure(1, weight=0)
-        self.grid_columnconfigure(2, weight=0)
-        self.grid_rowconfigure(0, weight=1)
+        host = getattr(self, "_shell", self)
+        host.grid_columnconfigure(0, weight=1)
+        host.grid_columnconfigure(1, weight=0)
+        host.grid_columnconfigure(2, weight=0)
+        host.grid_rowconfigure(0, weight=1)
         self.content = ctk.CTkFrame(
-            self, fg_color=self._overlay_surface_color(), corner_radius=0
+            host, fg_color=self._overlay_surface_color(), corner_radius=0
         )
         self.content.grid(row=0, column=0, sticky="nsew")
         self.resize_handle = ctk.CTkFrame(
-            self,
+            host,
             width=8,
             fg_color=self._palette["panel_focus"],
             cursor="sb_h_double_arrow",
         )
         self.resize_handle.grid(row=0, column=1, sticky="ns")
         self.tab_button = ctk.CTkButton(
-            self,
+            host,
             text=COLLAPSED_TAB_TEXT,
             width=TAB_WIDTH,
             corner_radius=0,
@@ -153,7 +152,29 @@ class FixedOverlayView(ctk.CTkFrame):
         if self._theme_unsub is not None:
             self._theme_unsub()
             self._theme_unsub = None
-        super().destroy()
+        self._overlay_layer.destroy()
+
+    def configure(self, **kwargs: object) -> None:
+        self._overlay_layer.configure(**kwargs)
+
+    def place_configure(self, **kwargs: object) -> None:
+        self._overlay_layer.place_configure(**kwargs)
+
+    def place(self, **kwargs: object) -> None:
+        self._overlay_layer.place(**kwargs)
+
+    def place_forget(self) -> None:
+        self._overlay_layer.place_forget()
+
+    def lift(self) -> None:
+        self._overlay_layer.lift()
+
+    def update_idletasks(self) -> None:
+        self._overlay_layer.update_idletasks()
+
+    @property
+    def transparency_support(self):
+        return self._overlay_layer.support
 
     def apply_state(self, state: FixedOverlayState) -> None:
         self._state = state

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -336,3 +336,77 @@ def test_remove_item_ignores_unknown_item_without_change() -> None:
 
     assert [item.item_id for item in overlay._state.items] == ["keep"]
     assert changed_calls == []
+
+
+def test_fixed_overlay_state_serializes_geometry_and_items() -> None:
+    state = FixedOverlayState(
+        visible=True,
+        collapsed=False,
+        width=9999,
+        selected_item_ids=["item-a"],
+        items=[
+            FixedOverlayItem(
+                item_id="item-a",
+                kind="note",
+                title="Pinned Note",
+                state={"fixed_overlay_width": 512, "fixed_overlay_height": 384},
+            )
+        ],
+    )
+
+    payload = state.to_dict()
+
+    assert payload["collapsed"] is False
+    assert payload["width"] == 1100
+    assert payload["items"] == [
+        {
+            "item_id": "item-a",
+            "kind": "note",
+            "title": "Pinned Note",
+            "state": {"fixed_overlay_width": 512, "fixed_overlay_height": 384},
+        }
+    ]
+
+
+def test_item_dimensions_clamp_collapsed_and_expanded_geometry() -> None:
+    tiny = FixedOverlayItem(
+        item_id="tiny",
+        kind="note",
+        title="Tiny",
+        state={"fixed_overlay_width": 1, "fixed_overlay_height": 1},
+    )
+    huge = FixedOverlayItem(
+        item_id="huge",
+        kind="note",
+        title="Huge",
+        state={"fixed_overlay_width": 5000, "fixed_overlay_height": 900},
+    )
+
+    assert FixedOverlayView._item_dimensions(tiny) == (240, 140)
+    assert FixedOverlayView._item_dimensions(huge) == (1052, 900)
+
+
+class _AttributesFailWindow:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def attributes(self, *args: object) -> None:
+        self.calls.append(args)
+        raise fixed_overlay_view.tk.TclError("unsupported")
+
+
+def test_transparent_overlay_window_reports_graceful_fallback() -> None:
+    from modules.scenarios.gm_table.fixed_overlay.overlay_window import (
+        TransparentOverlayWindow,
+    )
+
+    fake = SimpleNamespace(window=_AttributesFailWindow())
+
+    support = TransparentOverlayWindow._configure_transparency(fake)  # type: ignore[arg-type]
+
+    assert support.mode == "fallback"
+    assert support.true_transparency is False
+    assert fake.window.calls == [
+        ("-transparentcolor", "#010203"),
+        ("-alpha", 0.98),
+    ]


### PR DESCRIPTION
### Motivation
- Replace the previous CTkFrame-based overlay with a platform-aware overlay that can provide true transparency and better z-ordering for the GM table surface. 
- Keep the existing controller-facing API and behavior so workspace code can continue to create/restore/toggle the overlay via `FixedOverlayController`.
- Provide a graceful fallback path when the OS/windowing system does not support true transparent colors.

### Description
- Introduces `TransparentOverlayWindow` (`modules/scenarios/gm_table/fixed_overlay/overlay_window.py`), a borderless `tk.Toplevel` host anchored over the GM table that attempts `-transparentcolor`, then `-alpha`, and falls back to an opaque host if needed. 
- Refactors `FixedOverlayView` (`modules/scenarios/gm_table/fixed_overlay/view.py`) to host its CTk controls inside the new overlay shell instead of subclassing `ctk.CTkFrame`, and adds proxy methods (`configure`, `place`, `place_forget`, `lift`, `update_idletasks`) so the controller API is preserved. 
- Preserves `FixedOverlayController` behavior and API in `modules/scenarios/gm_table/fixed_overlay/controller.py` so `modules/scenarios/gm_table/workspace.py` continues to create/restore/toggle the overlay through `FixedOverlayController`. 
- Adds tests exercising serialization/clamping of overlay geometry and items and the transparency fallback behavior in `tests/scenarios/gm_table/test_fixed_overlay_view.py`.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_fixed_overlay_view.py` and all fixed-overlay tests passed (`12 passed`).
- Compiled the overlay package with `python -m compileall modules/scenarios/gm_table/fixed_overlay` with no errors.
- Running the workspace-related Tk tests together in this headless CI environment (`tests/scenarios/gm_table/test_workspace.py`) produced failures due to the absence of a display (`no $DISPLAY`), not due to the overlay refactor; fixed-overlay specific tests passed locally in the test runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e34a7348832b8ca448b7c781b486)