### PR TITLE
Fix fixed overlay transparent shell

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
+++ b/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
@@ -42,11 +42,15 @@ class TransparentOverlayWindow:
         self.window.configure(background=TRANSPARENT_COLOR)
         self.window.transient(master.winfo_toplevel())
         self.support = self._configure_transparency()
+        # Keep the full-window host painted with Tk's transparent color.
+        # Opaque overlay chrome belongs on the controls/cards themselves; if the
+        # root shell uses the blended panel background it covers the entire
+        # Toplevel and defeats the transparent-color window configuration.
         self.shell = ctk.CTkFrame(
             self.window,
-            fg_color=background,
+            fg_color=TRANSPARENT_COLOR,
             corner_radius=0,
-            border_width=1,
+            border_width=0,
         )
         self.shell.place(x=0, y=0, relheight=1.0, relwidth=1.0)
         self._bind_anchor_events()
@@ -81,7 +85,10 @@ class TransparentOverlayWindow:
     def configure(self, **kwargs: object) -> None:
         if "width" in kwargs:
             self._width = max(1, int(kwargs["width"] or 1))
-        self.shell.configure(**{k: v for k, v in kwargs.items() if k != "width"})
+        shell_kwargs = {k: v for k, v in kwargs.items() if k != "width"}
+        if "fg_color" in shell_kwargs:
+            shell_kwargs["fg_color"] = TRANSPARENT_COLOR
+        self.shell.configure(**shell_kwargs)
 
     def place_configure(self, **kwargs: object) -> None:
         self._place_options.update(kwargs)

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -10,7 +10,7 @@ from modules.helpers import theme_manager
 from .models import FixedOverlayItem, FixedOverlayState
 from .style import OVERLAY_OPACITY, blend_hex_color
 from .theme import get_fixed_overlay_palette
-from .overlay_window import TransparentOverlayWindow
+from .overlay_window import TRANSPARENT_COLOR, TransparentOverlayWindow
 
 TAB_WIDTH = 28
 COLLAPSED_TAB_TEXT = "›"
@@ -72,7 +72,7 @@ class FixedOverlayView:
         host.grid_columnconfigure(2, weight=0)
         host.grid_rowconfigure(0, weight=1)
         self.content = ctk.CTkFrame(
-            host, fg_color=self._overlay_surface_color(), corner_radius=0
+            host, fg_color=TRANSPARENT_COLOR, corner_radius=0
         )
         self.content.grid(row=0, column=0, sticky="nsew")
         self.resize_handle = ctk.CTkFrame(
@@ -99,7 +99,7 @@ class FixedOverlayView:
         self.content.grid_rowconfigure(1, weight=1)
         self.content.grid_columnconfigure(0, weight=1)
         self.header = ctk.CTkFrame(
-            self.content, fg_color=self._overlay_surface_color(), corner_radius=0
+            self.content, fg_color=TRANSPARENT_COLOR, corner_radius=0
         )
         header = self.header
         header.grid(row=0, column=0, sticky="ew")
@@ -118,7 +118,7 @@ class FixedOverlayView:
             row=0, column=2, padx=(0, 8), pady=6
         )
         self.items_host = ctk.CTkScrollableFrame(
-            self.content, fg_color=self._overlay_surface_color()
+            self.content, fg_color=TRANSPARENT_COLOR
         )
         self.items_host.grid(row=1, column=0, sticky="nsew", padx=8, pady=8)
         self.empty_label = ctk.CTkLabel(
@@ -133,12 +133,12 @@ class FixedOverlayView:
         """Refresh fixed-overlay chrome colors after the global theme changes."""
         self._palette = get_fixed_overlay_palette(theme)
         self.configure(
-            fg_color=self._overlay_surface_color(),
+            fg_color=TRANSPARENT_COLOR,
             border_color=self._palette["panel_focus"],
         )
-        self.content.configure(fg_color=self._overlay_surface_color())
-        self.header.configure(fg_color=self._overlay_surface_color())
-        self.items_host.configure(fg_color=self._overlay_surface_color())
+        self.content.configure(fg_color=TRANSPARENT_COLOR)
+        self.header.configure(fg_color=TRANSPARENT_COLOR)
+        self.items_host.configure(fg_color=TRANSPARENT_COLOR)
         self.resize_handle.configure(fg_color=self._palette["panel_focus"])
         self.tab_button.configure(
             fg_color=self._palette["accent"],

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -410,3 +410,73 @@ def test_transparent_overlay_window_reports_graceful_fallback() -> None:
         ("-transparentcolor", "#010203"),
         ("-alpha", 0.98),
     ]
+
+
+def test_transparent_overlay_window_shell_uses_transparent_color(monkeypatch) -> None:
+    from modules.scenarios.gm_table.fixed_overlay import overlay_window
+
+    created_frames: list[object] = []
+
+    class FakeToplevel:
+        def withdraw(self) -> None:
+            pass
+
+        def overrideredirect(self, _value: bool) -> None:
+            pass
+
+        def configure(self, **kwargs: object) -> None:
+            self.configured = kwargs
+
+        def transient(self, _master: object) -> None:
+            pass
+
+        def attributes(self, *_args: object) -> None:
+            pass
+
+    class FakeMaster:
+        def winfo_toplevel(self) -> object:
+            return self
+
+        def bind(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class FakeFrame:
+        def __init__(self, master: object, **kwargs: object) -> None:
+            self.master = master
+            self.kwargs = kwargs
+            self.configure_calls: list[dict[str, object]] = []
+            created_frames.append(self)
+
+        def place(self, **kwargs: object) -> None:
+            self.place_options = kwargs
+
+        def configure(self, **kwargs: object) -> None:
+            self.configure_calls.append(kwargs)
+
+    monkeypatch.setattr(overlay_window.tk, "Toplevel", lambda _master: FakeToplevel())
+    monkeypatch.setattr(overlay_window.ctk, "CTkFrame", FakeFrame)
+
+    window = overlay_window.TransparentOverlayWindow(FakeMaster(), background="#ABCDEF")
+    window.configure(fg_color="#ABCDEF", border_color="#123456")
+
+    assert created_frames[0].kwargs["fg_color"] == overlay_window.TRANSPARENT_COLOR
+    assert created_frames[0].kwargs["border_width"] == 0
+    assert created_frames[0].configure_calls[-1]["fg_color"] == overlay_window.TRANSPARENT_COLOR
+    assert created_frames[0].configure_calls[-1]["border_color"] == "#123456"
+
+
+def test_build_shell_keeps_full_area_hosts_transparent(monkeypatch) -> None:
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkFrame", _FakeCtkWidget)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkScrollableFrame", _FakeCtkWidget)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkButton", _FakeCtkButton)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkLabel", _FakeCtkWidget)
+    monkeypatch.setattr(fixed_overlay_view.ctk, "CTkFont", lambda **kwargs: kwargs)
+    overlay = _FakeShell()
+
+    FixedOverlayView._build_shell(overlay)  # type: ignore[arg-type]
+
+    assert overlay.content.kwargs["fg_color"] == fixed_overlay_view.TRANSPARENT_COLOR
+    assert overlay.header.kwargs["fg_color"] == fixed_overlay_view.TRANSPARENT_COLOR
+    assert overlay.items_host.kwargs["fg_color"] == fixed_overlay_view.TRANSPARENT_COLOR
+    assert overlay.resize_handle.kwargs["fg_color"] == overlay._palette["panel_focus"]
+    assert overlay.tab_button.kwargs["fg_color"] == overlay._palette["accent"]


### PR DESCRIPTION
### Motivation
- Prevent the overlay Toplevel from being covered by a full-area opaque frame so platform transparency (`-transparentcolor`) remains effective. 
- Ensure only the overlay chrome and item cards draw opaque/semi-opaque backgrounds while the rest of the overlay remains visually and click-through transparent.

### Description
- In `TransparentOverlayWindow.__init__` keep the root shell `CTkFrame` painted with `TRANSPARENT_COLOR` and remove the full-area border so it does not block the Toplevel transparency; also set `border_width=0` for the shell. 
- In `TransparentOverlayWindow.configure` guard `fg_color` updates so callers cannot replace the shell’s transparent color with an opaque full-area color. 
- In `FixedOverlayView._build_shell` change the main `content`, `header`, and `items_host` frames to use `TRANSPARENT_COLOR` so only controls/cards render opaque chrome; preserve explicit opaque colors for `resize_handle`, `tab_button`, and individual item frames. 
- Add regression/visual-smoke tests: `test_transparent_overlay_window_shell_uses_transparent_color` to assert the shell is created with `TRANSPARENT_COLOR` and `test_build_shell_keeps_full_area_hosts_transparent` to assert `content/header/items_host` remain transparent.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_fixed_overlay_view.py` which includes the new regression tests and existing coverage, and all tests passed (`14 passed`).
- The new tests exercise `TransparentOverlayWindow` construction and `FixedOverlayView._build_shell` behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e68dbd54832b8249a35268b0c8a1)