### PR TITLE
Set fixed overlay transparency to 80%

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
+++ b/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
@@ -61,7 +61,7 @@ class TransparentOverlayWindow:
             return TransparencySupport("transparentcolor", True)
         except tk.TclError as exc:
             try:
-                self.window.attributes("-alpha", 0.98)
+                self.window.attributes("-alpha", 0.80)
                 return TransparencySupport("alpha", True, str(exc))
             except tk.TclError as alpha_exc:
                 return TransparencySupport("fallback", False, str(alpha_exc))

--- a/modules/scenarios/gm_table/fixed_overlay/style.py
+++ b/modules/scenarios/gm_table/fixed_overlay/style.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-OVERLAY_OPACITY = 0.90
+OVERLAY_OPACITY = 0.80
 
 
 def blend_hex_color(

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -54,13 +54,13 @@ class FixedOverlayView:
         self.apply_state(self._state)
 
     def _overlay_surface_color(self) -> str:
-        """Return the fixed overlay surface color blended at 90% opacity."""
+        """Return the fixed overlay surface color blended at 80% opacity."""
         return blend_hex_color(
             self._palette["panel_bg"], self._palette["table_bg"], OVERLAY_OPACITY
         )
 
     def _overlay_item_color(self) -> str:
-        """Return fixed item chrome blended at 90% opacity."""
+        """Return fixed item chrome blended at 80% opacity."""
         return blend_hex_color(
             self._palette["panel_alt"], self._palette["table_bg"], OVERLAY_OPACITY
         )

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -258,9 +258,9 @@ class _FakeShell:
         return "break"
 
 
-def test_fixed_overlay_style_blends_at_ninety_percent_opacity() -> None:
-    assert OVERLAY_OPACITY == 0.90
-    assert blend_hex_color("#000000", "#FFFFFF", OVERLAY_OPACITY) == "#191919"
+def test_fixed_overlay_style_blends_at_eighty_percent_opacity() -> None:
+    assert OVERLAY_OPACITY == 0.80
+    assert blend_hex_color("#000000", "#FFFFFF", OVERLAY_OPACITY) == "#333333"
 
 
 def test_build_shell_places_tab_in_rightmost_column(monkeypatch) -> None:
@@ -408,7 +408,7 @@ def test_transparent_overlay_window_reports_graceful_fallback() -> None:
     assert support.true_transparency is False
     assert fake.window.calls == [
         ("-transparentcolor", "#010203"),
-        ("-alpha", 0.98),
+        ("-alpha", 0.80),
     ]
 
 


### PR DESCRIPTION
### Motivation
- The fixed GM Table overlay should render with a lower blend and fallback alpha to achieve a slightly less translucent appearance (request: make transparency 80%).

### Description
- Lower the blended overlay opacity constant from `0.90` to `0.80` in `modules/scenarios/gm_table/fixed_overlay/style.py` by changing `OVERLAY_OPACITY`.
- Update docstrings in `modules/scenarios/gm_table/fixed_overlay/view.py` to reflect the new 80% blend used by `_overlay_surface_color` and `_overlay_item_color`.
- Reduce the transparent-window alpha fallback from `0.98` to `0.80` in `modules/scenarios/gm_table/fixed_overlay/overlay_window.py` so the window-level alpha matches the new intent.
- Adjust `tests/scenarios/gm_table/test_fixed_overlay_view.py` expectations to assert the updated `OVERLAY_OPACITY` and fallback alpha values.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_fixed_overlay_view.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e8f100b8832b95bbc27c6c07ebb7)