### PR TITLE
Default FixedOverlay to expanded; update tab label and tests

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/models.py
+++ b/modules/scenarios/gm_table/fixed_overlay/models.py
@@ -37,7 +37,7 @@ class FixedOverlayItem:
 class FixedOverlayState:
     """Viewport-fixed overlay state; no Tk objects or world coordinates."""
     visible: bool = True
-    collapsed: bool = True
+    collapsed: bool = False
     width: int = 360
     anchor: str = "left"
     selected_item_ids: list[str] = field(default_factory=list)
@@ -59,7 +59,7 @@ class FixedOverlayState:
         items = [FixedOverlayItem.from_dict(item) for item in list(source.get("items") or []) if isinstance(item, dict)]
         return cls(
             visible=bool(source.get("visible", True)),
-            collapsed=bool(source.get("collapsed", True)),
+            collapsed=bool(source.get("collapsed", False)),
             width=max(MIN_OVERLAY_WIDTH, min(MAX_OVERLAY_WIDTH, int(source.get("width") or DEFAULT_OVERLAY_WIDTH))),
             anchor="left",
             selected_item_ids=[str(value) for value in list(source.get("selected_item_ids") or [])],

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -84,7 +84,7 @@ class FixedOverlayView:
         self.resize_handle.grid(row=0, column=1, sticky="ns")
         self.tab_button = ctk.CTkButton(
             host,
-            text=COLLAPSED_TAB_TEXT,
+            text=EXPANDED_TAB_TEXT,
             width=TAB_WIDTH,
             corner_radius=0,
             fg_color=self._palette["accent"],

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -263,6 +263,13 @@ def test_fixed_overlay_style_blends_at_eighty_percent_opacity() -> None:
     assert blend_hex_color("#000000", "#FFFFFF", OVERLAY_OPACITY) == "#333333"
 
 
+def test_fixed_overlay_default_state_starts_expanded() -> None:
+    state = FixedOverlayState.from_dict(None)
+
+    assert state.visible is True
+    assert state.collapsed is False
+
+
 def test_build_shell_places_tab_in_rightmost_column(monkeypatch) -> None:
     monkeypatch.setattr(fixed_overlay_view.ctk, "CTkFrame", _FakeCtkWidget)
     monkeypatch.setattr(fixed_overlay_view.ctk, "CTkScrollableFrame", _FakeCtkWidget)
@@ -277,7 +284,7 @@ def test_build_shell_places_tab_in_rightmost_column(monkeypatch) -> None:
     assert overlay.content.grid_info()["column"] == 0
     assert overlay.resize_handle.grid_info()["column"] == 1
     assert overlay.tab_button.grid_info()["column"] == 2
-    assert overlay.tab_button.kwargs["text"] == COLLAPSED_TAB_TEXT
+    assert overlay.tab_button.kwargs["text"] == EXPANDED_TAB_TEXT
     assert overlay.add_button.grid_info()["column"] == 1
     assert overlay.add_button.kwargs["text"] == "+ Add"
     assert overlay.add_button.kwargs["command"] == overlay._request_add


### PR DESCRIPTION
### Motivation
- The fixed overlay should start expanded by default rather than collapsed to improve initial visibility of pinned items.

### Description
- Set `FixedOverlayState.collapsed` default to `False` in the dataclass.
- Update `FixedOverlayState.from_dict` to treat a missing `collapsed` value as `False`.
- Change the tab button text in `FixedOverlayView._build_shell` from `COLLAPSED_TAB_TEXT` to `EXPANDED_TAB_TEXT` to match the new default state.
- Add `test_fixed_overlay_default_state_starts_expanded` and update `test_build_shell` expectations to reflect the expanded default and tab label change.

### Testing
- Ran unit tests in `tests/scenarios/gm_table/test_fixed_overlay_view.py` including the new `test_fixed_overlay_default_state_starts_expanded`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ee76acb4832baeefbc8531b22d31)