### PR TITLE
Fix GM Table fixed overlay expand handle visibility

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -195,7 +195,12 @@ class FixedOverlayView:
         if self._state.collapsed:
             self.content.grid_remove()
             self.resize_handle.grid_remove()
-            self.tab_button.grid(row=0, column=2, sticky="ns")
+            # When the overlay is narrowed to TAB_WIDTH, keep the expand handle
+            # in the first visible grid column. Leaving it in column 2 can push
+            # the button outside the clipped toplevel on some Tk/window-manager
+            # combinations, which makes the collapsed overlay look like it has
+            # no way to expand.
+            self.tab_button.grid(row=0, column=0, sticky="ns")
             self.tab_button.configure(text=COLLAPSED_TAB_TEXT)
         else:
             self.content.grid(row=0, column=0, sticky="nsew")

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -139,7 +139,7 @@ def test_refresh_geometry_uses_tab_width_when_collapsed() -> None:
     assert overlay.content.removed is True
     assert overlay.resize_handle.removed is True
     assert overlay.tab_button.options["text"] == COLLAPSED_TAB_TEXT
-    assert overlay.tab_button.grid_info()["column"] == 2
+    assert overlay.tab_button.grid_info()["column"] == 0
     assert overlay.tab_button.removed is False
 
 
@@ -154,6 +154,7 @@ def test_refresh_geometry_preserves_placed_width_across_toggles() -> None:
     assert overlay.configured_width == TAB_WIDTH
     assert overlay.content.removed is True
     assert overlay.resize_handle.removed is True
+    assert overlay.tab_button.grid_info()["column"] == 0
     assert overlay.tab_button.removed is False
 
     overlay._state.collapsed = False


### PR DESCRIPTION
### Motivation
- Ensure the fixed-overlay expand handle remains reachable when the GM Table overlay starts collapsed so users can expand it reliably at launch.

### Description
- In `modules/scenarios/gm_table/fixed_overlay/view.py` the collapsed-path in `_refresh_geometry` now grids the `tab_button` into column `0` (instead of column `2`) and includes a clarifying comment about clipped toplevels.
- Updated `tests/scenarios/gm_table/test_fixed_overlay_view.py` to assert the collapsed `tab_button` is placed in column `0` and to preserve the existing collapse/expand geometry assertions.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_fixed_overlay_view.py` and all tests passed (15 passed). 
- Ran `python -m py_compile modules/scenarios/gm_table/fixed_overlay/view.py tests/scenarios/gm_table/test_fixed_overlay_view.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43f363a134832b90ae9f04f128e729)