### PR TITLE
Fix fixed overlay launch geometry refresh

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/controller.py
+++ b/modules/scenarios/gm_table/fixed_overlay/controller.py
@@ -24,5 +24,10 @@ class FixedOverlayController:
         item = FixedOverlayItem(item_id=f"fixed_{uuid4().hex}", kind=kind, title=title, state=dict(state or {}))
         self.view.add_item(item)
         return item.item_id
+    def refresh_geometry(self) -> None:
+        """Refresh the fixed overlay placement after its anchor geometry changes."""
+        self.view._refresh_geometry()
+
     def lift(self) -> None:
-        self.view._refresh_geometry(); self.view.lift()
+        self.refresh_geometry()
+        self.view.lift()

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1391,6 +1391,7 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._map_tool_window_provider = map_tool_window_provider
         self._reveal_requested_callback = on_reveal_requested
         self._fixed_overlay_add_requested_callback = on_fixed_overlay_add_requested
+        self._fixed_overlay_surface_refresh_complete = False
         self._panels: dict[str, GMTablePanel] = {}
         self._definitions: dict[str, PanelDefinition] = {}
         self._panel_payloads: dict[str, object] = {}
@@ -1558,6 +1559,8 @@ class GMTableWorkspace(ctk.CTkFrame):
             on_changed=self._schedule_layout_changed,
             on_add_requested=self._request_fixed_overlay_add,
         )
+        self.after_idle(self._refresh_fixed_overlay_after_surface_map)
+        self.after(50, self._refresh_fixed_overlay_after_surface_map)
 
         self._empty_state = ctk.CTkLabel(
             self.surface,
@@ -1577,6 +1580,31 @@ class GMTableWorkspace(ctk.CTkFrame):
         """Forward fixed-overlay add requests to the owning table view."""
         if callable(self._fixed_overlay_add_requested_callback):
             self._fixed_overlay_add_requested_callback(source_widget)
+
+    def _refresh_fixed_overlay_after_surface_map(self) -> None:
+        """Refresh the fixed overlay once the table surface has real geometry."""
+        if self._disposed or self._fixed_overlay_surface_refresh_complete:
+            return
+        try:
+            is_ready = (
+                self.surface.winfo_ismapped()
+                and self.surface.winfo_width() > 1
+                and self.surface.winfo_height() > 1
+            )
+        except Exception:
+            is_ready = False
+
+        if not is_ready:
+            self.after(50, self._refresh_fixed_overlay_after_surface_map)
+            return
+
+        self._fixed_overlay_surface_refresh_complete = True
+        fixed_overlay = getattr(self, "fixed_overlay", None)
+        if fixed_overlay is not None:
+            try:
+                fixed_overlay.refresh_geometry()
+            except Exception:
+                pass
 
     def _schedule_layout_changed(self) -> None:
         """Debounce layout persistence."""


### PR DESCRIPTION
### Motivation
- The fixed overlay relied on the first pre-layout geometry pass and could be placed incorrectly at launch when the surface had not yet been mapped or had placeholder size values.
- The goal is to refresh overlay geometry once the surface has a real mapped size instead of depending on fragile pre-layout values.

### Description
- Add a public `FixedOverlayController.refresh_geometry()` wrapper that calls the view's geometry refresh so callers do not access private view internals. `lift()` now routes through this wrapper.
- Schedule a post-layout refresh in `GMTableWorkspace` immediately after creating `self.fixed_overlay` using `self.after_idle(...)` and a short delayed retry with `self.after(50, ...)`.
- Add `_refresh_fixed_overlay_after_surface_map()` which checks `self.surface.winfo_ismapped()`, `winfo_width()` and `winfo_height()`, reschedules itself with `self.after(50, ...)` until valid dimensions are available, then calls `fixed_overlay.refresh_geometry()` once and marks the refresh as complete via `_fixed_overlay_surface_refresh_complete`.
- Keep existing `<Configure>` handling as a runtime fallback and guard operations with `try/except` and a disposed check for safety.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table/workspace.py modules/scenarios/gm_table/fixed_overlay/controller.py` which succeeded. 
- Ran `git diff --check` which produced no issues. 
- Ran `pytest tests/scenarios/test_gm_table_middle_drag_hit_testing.py -q` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4686921a80832b8d01bb7f08537116)