### PR TITLE
Harden fixed overlay geometry timing

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
+++ b/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
@@ -35,6 +35,7 @@ class TransparentOverlayWindow:
         self.master = master
         self._width = 1
         self._visible = False
+        self._geometry_retry_id: str | None = None
         self._place_options: dict[str, object] = {}
         self.window = tk.Toplevel(master.winfo_toplevel())
         self.window.withdraw()
@@ -94,30 +95,62 @@ class TransparentOverlayWindow:
         self._place_options.update(kwargs)
         self._width = max(1, int(kwargs.get("width") or self._width))
         self._visible = True
-        self._apply_geometry()
-        self.window.deiconify()
+        if self._apply_geometry():
+            self.window.deiconify()
 
     def place(self, **kwargs: object) -> None:
         self.place_configure(**kwargs)
 
     def place_forget(self) -> None:
         self._visible = False
+        self._cancel_geometry_retry()
         self.window.withdraw()
 
-    def _apply_geometry(self) -> None:
+    def _cancel_geometry_retry(self) -> None:
+        if self._geometry_retry_id is None:
+            return
+        try:
+            self.master.after_cancel(self._geometry_retry_id)
+        except tk.TclError:
+            pass
+        self._geometry_retry_id = None
+
+    def _schedule_geometry_retry(self) -> None:
+        if not self._visible or self._geometry_retry_id is not None:
+            return
+        try:
+            self._geometry_retry_id = self.master.after(50, self._run_geometry_retry)
+        except tk.TclError:
+            self._geometry_retry_id = None
+
+    def _run_geometry_retry(self) -> None:
+        self._geometry_retry_id = None
+        if self._visible and self._apply_geometry():
+            self.window.deiconify()
+
+    def _apply_geometry(self) -> bool:
         try:
             self.master.update_idletasks()
+            mapped = bool(self.master.winfo_ismapped())
+            width = self.master.winfo_width()
+            height = self.master.winfo_height()
+            if not mapped or width <= 1 or height <= 1:
+                self._schedule_geometry_retry()
+                return False
             x = self.master.winfo_rootx() + int(self._place_options.get("x") or 0)
             y = self.master.winfo_rooty() + int(self._place_options.get("y") or 0)
-            height = max(1, self.master.winfo_height())
         except tk.TclError:
-            return
+            return False
+        self._cancel_geometry_retry()
         self.window.geometry(f"{self._width}x{height}+{x}+{y}")
+        return True
 
     def lift(self) -> None:
         self.window.lift()
 
     def destroy(self) -> None:
+        self._visible = False
+        self._cancel_geometry_retry()
         try:
             self.window.destroy()
         except tk.TclError:


### PR DESCRIPTION
### Motivation
- Prevent the overlay from being deiconified and placed with an invalid or placeholder geometry when its anchor/master widget is not yet mapped or has minimal dimensions.
- Avoid race conditions where the overlay appears at the wrong size/position during startup or rapid master resizes.

### Description
- Added a `_geometry_retry_id` field and helper methods `_cancel_geometry_retry`, `_schedule_geometry_retry`, and `_run_geometry_retry` to manage a single outstanding deferred geometry retry.
- Made `_apply_geometry` return a `bool` and inspect `self.master.winfo_ismapped()`, `self.master.winfo_width()`, and `self.master.winfo_height()` so it defers placement when the master is unmapped or has dimensions `<= 1`.
- Only call `self.window.deiconify()` after `_apply_geometry()` succeeds, and ensure deferred retries call `deiconify()` when they eventually succeed.
- Cancel pending retries when the overlay is hidden via `place_forget()` or when `destroy()` is called, and preserved the existing `<Configure>` binding so resize/reposition events still call `_apply_geometry()`.
- File changed: `modules/scenarios/gm_table/fixed_overlay/overlay_window.py`.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table/fixed_overlay/overlay_window.py`, which succeeded.
- Ran `git diff --check`, which reported no whitespace or diff issues for this change.
- Ran `pytest -q`, which failed during collection due to pre-existing test-environment issues unrelated to this change (duplicate test module basename import mismatch and mocked/placeholder `customtkinter` objects missing attributes like `CTkToplevel`/`CTkTextbox`), so no unit test failures attributable to this patch were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4688f96c28832bb46fe10fbfd70cf9)