### PR TITLE
Restore fixed overlay z-order after handout reveal

### DIFF
--- a/modules/scenarios/gm_table/handouts/page.py
+++ b/modules/scenarios/gm_table/handouts/page.py
@@ -43,6 +43,7 @@ class GMTableHandoutsPage(ctk.CTkFrame):
         wrappers: dict[str, object],
         map_wrapper: object,
         initial_state: dict | None = None,
+        on_reveal_complete=None,
     ) -> None:
         super().__init__(master, fg_color="transparent")
         self.grid_rowconfigure(3, weight=1)
@@ -53,6 +54,7 @@ class GMTableHandoutsPage(ctk.CTkFrame):
         self._scenario_item = scenario_item if isinstance(scenario_item, dict) else {}
         self._wrappers = wrappers
         self._map_wrapper = map_wrapper
+        self._on_reveal_complete = on_reveal_complete
 
         self._query_var = tk.StringVar(value=str(state.get("query") or ""))
         self._status_var = tk.StringVar(value="")
@@ -344,7 +346,21 @@ class GMTableHandoutsPage(ctk.CTkFrame):
         self._selected_id = handout.id
         self._status_var.set("")
         self._highlight_selected()
-        reveal_handout(handout, animation=self._selected_animation())
+        try:
+            reveal_handout(handout, animation=self._selected_animation())
+        finally:
+            self._notify_reveal_complete()
+
+    def _notify_reveal_complete(self) -> None:
+        """Let the owner restore overlay z-order after a player reveal opens."""
+        callback = self._on_reveal_complete
+        if not callable(callback):
+            return
+        try:
+            callback()
+        except Exception:
+            # Reveals should remain resilient even if the parent table is closing.
+            pass
 
     def reveal(self) -> None:
         """Reveal the selected handout from the workspace panel action."""

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1555,6 +1555,7 @@ class GMTableView(ctk.CTkFrame):
                     wrappers=self.wrappers,
                     map_wrapper=self.map_wrapper,
                     initial_state=definition.state,
+                    on_reveal_complete=self._restore_fixed_overlay_after_reveal,
                 )
             if kind == "container_window":
                 return GMTableContainerPage(
@@ -2145,6 +2146,27 @@ class GMTableView(ctk.CTkFrame):
             popup, "Scenarios", wrapper, template, _open_selected
         )
         view.pack(fill="both", expand=True)
+
+    def _restore_fixed_overlay_after_reveal(self) -> None:
+        """Re-lift the fixed overlay after handout reveals create player windows."""
+        workspace = getattr(self, "workspace", None)
+        fixed_overlay = getattr(workspace, "fixed_overlay", None)
+        if fixed_overlay is None:
+            return
+
+        def _raise_overlay() -> None:
+            try:
+                fixed_overlay.refresh_geometry()
+                fixed_overlay.lift()
+            except Exception:
+                pass
+
+        _raise_overlay()
+        for delay_ms in (50, 200, 500):
+            try:
+                self.after(delay_ms, _raise_overlay)
+            except Exception:
+                break
 
     def _open_handouts_selection_for_fixed_overlay(self) -> None:
         """Ask which scenario should power a fixed-overlay handouts item."""


### PR DESCRIPTION
### Motivation
- Revealing a handout image could cause the GM Table's fixed overlay to disappear behind the newly opened player display, requiring a manual refresh of the GM Table to restore it.
- The change aims to keep the fixed overlay visible and usable after a handout/image reveal opens.

### Description
- Add an optional `on_reveal_complete` callback to `GMTableHandoutsPage` and store it as `_on_reveal_complete` so the page can notify its owner after a reveal attempt. (`modules/scenarios/gm_table/handouts/page.py`)
- Invoke the callback in a `finally` block after calling `reveal_handout`, ensuring the owner is notified even if reveal code raises. (`_open_handout` → `_notify_reveal_complete`)
- Wire the handouts page from `GMTableView` to provide `self._restore_fixed_overlay_after_reveal` as the `on_reveal_complete` handler. (`modules/scenarios/gm_table_view.py`) 
- Implement `_restore_fixed_overlay_after_reveal` to `refresh_geometry()` and `lift()` the fixed overlay immediately and schedule short delayed retries (50ms, 200ms, 500ms) to reliably restore z-order across platforms and window managers.
- All changes include defensive exception handling so reveals remain resilient while restoring overlay z-order.

### Testing
- `python -m py_compile modules/scenarios/gm_table/handouts/page.py modules/scenarios/gm_table_view.py` — succeeded.
- `git diff --check` — no issues detected.
- `python -m pytest tests -q` — test collection failed in this environment due to unrelated test-environment issues (duplicate test module basename and `customtkinter` being stubbed as a `types.SimpleNamespace` missing UI classes), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a469048d0e8832ba84016dab1c576d3)