### PR TITLE
Fix fixed overlay reveal z-order refresh

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/controller.py
+++ b/modules/scenarios/gm_table/fixed_overlay/controller.py
@@ -28,6 +28,10 @@ class FixedOverlayController:
         """Refresh the fixed overlay placement after its anchor geometry changes."""
         self.view._refresh_geometry()
 
+    def refresh_geometry_without_lift(self) -> None:
+        """Refresh overlay placement without raising it above other toplevels."""
+        self.view.refresh_geometry_without_lift()
+
     def lift(self) -> None:
         self.refresh_geometry()
         self.view.lift()

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -181,7 +181,11 @@ class FixedOverlayView:
         self._refresh_items()
         self._refresh_geometry()
 
-    def _refresh_geometry(self) -> None:
+    def refresh_geometry_without_lift(self) -> None:
+        """Refresh placement without changing global window stacking order."""
+        self._refresh_geometry(lift_overlay=False)
+
+    def _refresh_geometry(self, *, lift_overlay: bool = True) -> None:
         if not self._state.visible:
             self.place_forget()
             return
@@ -212,7 +216,8 @@ class FixedOverlayView:
         if not self._state.collapsed:
             self._state.width = width
         FixedOverlayView._place_with_width(self, width)
-        self.lift()
+        if lift_overlay:
+            self.lift()
 
     def _place_with_width(self, width: int) -> None:
         """Place the overlay with an explicit width for reliable geometry."""

--- a/modules/scenarios/gm_table/handouts/page.py
+++ b/modules/scenarios/gm_table/handouts/page.py
@@ -352,8 +352,8 @@ class GMTableHandoutsPage(ctk.CTkFrame):
             self._notify_reveal_complete()
 
     def _notify_reveal_complete(self) -> None:
-        """Let the owner restore overlay z-order after a player reveal opens."""
-        callback = self._on_reveal_complete
+        """Let the owner refresh table overlay geometry after a player reveal opens."""
+        callback = getattr(self, "_on_reveal_complete", None)
         if not callable(callback):
             return
         try:

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -2148,23 +2148,26 @@ class GMTableView(ctk.CTkFrame):
         view.pack(fill="both", expand=True)
 
     def _restore_fixed_overlay_after_reveal(self) -> None:
-        """Re-lift the fixed overlay after handout reveals create player windows."""
+        """Refresh fixed-overlay geometry after handout reveals create player windows."""
         workspace = getattr(self, "workspace", None)
         fixed_overlay = getattr(workspace, "fixed_overlay", None)
         if fixed_overlay is None:
             return
 
-        def _raise_overlay() -> None:
+        def _refresh_overlay_geometry() -> None:
             try:
-                fixed_overlay.refresh_geometry()
-                fixed_overlay.lift()
+                refresh_without_lift = getattr(
+                    fixed_overlay, "refresh_geometry_without_lift", None
+                )
+                if callable(refresh_without_lift):
+                    refresh_without_lift()
             except Exception:
                 pass
 
-        _raise_overlay()
+        _refresh_overlay_geometry()
         for delay_ms in (50, 200, 500):
             try:
-                self.after(delay_ms, _raise_overlay)
+                self.after(delay_ms, _refresh_overlay_geometry)
             except Exception:
                 break
 

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -1401,3 +1401,46 @@ def test_handle_add_option_creates_pdf_viewer_panel(monkeypatch) -> None:
     GMTableView._handle_add_option(view, "Open PDF")
     assert created[0][0] == "pdf_viewer"
     assert created[0][2]["current_page"] == 1
+
+
+def test_restore_fixed_overlay_after_reveal_refreshes_without_lifting() -> None:
+    """Handout reveal completion should not lift fixed overlay over the handout."""
+    calls = []
+
+    class _FixedOverlay:
+        def refresh_geometry_without_lift(self) -> None:
+            calls.append("refresh_without_lift")
+
+        def refresh_geometry(self) -> None:
+            calls.append("refresh")
+
+        def lift(self) -> None:
+            calls.append("lift")
+
+    view = GMTableView.__new__(GMTableView)
+    view.workspace = SimpleNamespace(fixed_overlay=_FixedOverlay())
+    view.after = lambda _delay, callback: callback()
+
+    GMTableView._restore_fixed_overlay_after_reveal(view)
+
+    assert calls == ["refresh_without_lift"] * 4
+
+
+def test_restore_fixed_overlay_after_reveal_does_not_fallback_to_lifting_refresh() -> None:
+    """Missing no-lift API should not call legacy refresh methods that lift toplevels."""
+    calls = []
+
+    class _LegacyFixedOverlay:
+        def refresh_geometry(self) -> None:
+            calls.append("refresh")
+
+        def lift(self) -> None:
+            calls.append("lift")
+
+    view = GMTableView.__new__(GMTableView)
+    view.workspace = SimpleNamespace(fixed_overlay=_LegacyFixedOverlay())
+    view.after = lambda _delay, callback: callback()
+
+    GMTableView._restore_fixed_overlay_after_reveal(view)
+
+    assert calls == []


### PR DESCRIPTION
### Motivation
- Handout reveals created player windows that could be layered above the GM Table fixed overlay, and the existing delayed `lift()` calls raised the overlay above the newly opened handout window, obstructing the reveal.
- The goal is to keep the fixed overlay positioned and visible on the GM Table without lifting it over the revealed handout window.

### Description
- Update `GMTableView._restore_fixed_overlay_after_reveal` to only schedule geometry refreshes and stop calling `lift()` after a reveal by invoking a no-lift refresh when available instead of globally raising the overlay.
- Add `refresh_geometry_without_lift()` to `modules/scenarios/gm_table/fixed_overlay/controller.py` that delegates to a new `FixedOverlayView.refresh_geometry_without_lift()` helper.
- Change `modules/scenarios/gm_table/fixed_overlay/view.py` to introduce a `lift_overlay` flag on `_refresh_geometry` and add `refresh_geometry_without_lift()` which refreshes placement without calling `Toplevel.lift()`; existing callers that expect the old behavior still call `lift()` via `lift()` or `refresh_geometry()`.
- Harden `modules/scenarios/gm_table/handouts/page.py::_notify_reveal_complete` to use `getattr(self, "_on_reveal_complete", None)` so missing/test fixtures do not raise on reveal completion.
- Add regression tests in `tests/scenarios/gm_table/test_gm_table_view.py` asserting `_restore_fixed_overlay_after_reveal` uses the no-lift refresh path and does not fall back to legacy lifting refresh methods.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_gm_table_view.py tests/scenarios/gm_table/test_gm_table_handouts_page.py -q`, all tests passed (`60 passed`).
- Compiled modules with `python -m compileall` for the modified files to ensure syntax correctness and ran `git diff --check` to verify no whitespace/errors in diffs; both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4695563a54832b9df418188be4a422)