### PR TITLE
Separate fixed overlay visibility from geometry sync

### DIFF
--- a/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
+++ b/modules/scenarios/gm_table/fixed_overlay/overlay_window.py
@@ -37,6 +37,8 @@ class TransparentOverlayWindow:
         self._visible = False
         self._geometry_retry_id: str | None = None
         self._place_options: dict[str, object] = {}
+        self._last_geometry_failure_reason = ""
+        self._destroyed = False
         self.window = tk.Toplevel(master.winfo_toplevel())
         self.window.withdraw()
         self.window.overrideredirect(True)
@@ -77,7 +79,7 @@ class TransparentOverlayWindow:
 
     def _on_anchor_configure(self, _event: object = None) -> None:
         if self._visible:
-            self._apply_geometry()
+            self.ensure_visible()
 
     def _on_anchor_destroy(self, event: object = None) -> None:
         if event is not None and getattr(event, "widget", None) is self.master:
@@ -91,20 +93,74 @@ class TransparentOverlayWindow:
             shell_kwargs["fg_color"] = TRANSPARENT_COLOR
         self.shell.configure(**shell_kwargs)
 
+    @property
+    def last_geometry_failure_reason(self) -> str:
+        """Return the last reason geometry could not be applied safely."""
+        return self._last_geometry_failure_reason
+
     def place_configure(self, **kwargs: object) -> None:
+        """Store placement options without changing logical visibility."""
         self._place_options.update(kwargs)
         self._width = max(1, int(kwargs.get("width") or self._width))
-        self._visible = True
-        if self._apply_geometry():
-            self.window.deiconify()
 
     def place(self, **kwargs: object) -> None:
         self.place_configure(**kwargs)
 
     def place_forget(self) -> None:
+        self.hide()
+
+    def show(self) -> bool:
+        """Mark the overlay visible and map it once anchor geometry is ready."""
+        self._visible = True
+        return self.ensure_visible()
+
+    def hide(self) -> None:
+        """Mark the overlay hidden and withdraw the toplevel immediately."""
         self._visible = False
         self._cancel_geometry_retry()
-        self.window.withdraw()
+        try:
+            self.window.withdraw()
+        except tk.TclError:
+            pass
+
+    def is_geometry_ready(self) -> bool:
+        """Return whether the anchor can provide useful geometry right now."""
+        try:
+            self.master.update_idletasks()
+            mapped = bool(self.master.winfo_ismapped())
+            width = self.master.winfo_width()
+            height = self.master.winfo_height()
+        except tk.TclError as exc:
+            self._last_geometry_failure_reason = f"anchor unavailable: {exc}"
+            return False
+        if not mapped:
+            self._last_geometry_failure_reason = "anchor is unmapped"
+            return False
+        if width <= 1 or height <= 1:
+            self._last_geometry_failure_reason = (
+                f"anchor size is not ready: width={width}, height={height}"
+            )
+            return False
+        self._last_geometry_failure_reason = ""
+        return True
+
+    def sync_to_anchor(self) -> bool:
+        """Apply stored placement options to the toplevel geometry."""
+        return self._apply_geometry()
+
+    def ensure_visible(self) -> bool:
+        """Map the overlay when possible, retrying while its owner still exists."""
+        if not self._visible or self._destroyed:
+            return False
+        if self.sync_to_anchor():
+            try:
+                self.window.deiconify()
+            except tk.TclError as exc:
+                self._last_geometry_failure_reason = f"overlay unavailable: {exc}"
+                return False
+            return True
+        self._schedule_geometry_retry()
+        return False
 
     def _cancel_geometry_retry(self) -> None:
         if self._geometry_retry_id is None:
@@ -116,7 +172,7 @@ class TransparentOverlayWindow:
         self._geometry_retry_id = None
 
     def _schedule_geometry_retry(self) -> None:
-        if not self._visible or self._geometry_retry_id is not None:
+        if self._destroyed or not self._visible or self._geometry_retry_id is not None:
             return
         try:
             self._geometry_retry_id = self.master.after(50, self._run_geometry_retry)
@@ -125,8 +181,7 @@ class TransparentOverlayWindow:
 
     def _run_geometry_retry(self) -> None:
         self._geometry_retry_id = None
-        if self._visible and self._apply_geometry():
-            self.window.deiconify()
+        self.ensure_visible()
 
     def _apply_geometry(self) -> bool:
         try:
@@ -134,21 +189,29 @@ class TransparentOverlayWindow:
             mapped = bool(self.master.winfo_ismapped())
             width = self.master.winfo_width()
             height = self.master.winfo_height()
-            if not mapped or width <= 1 or height <= 1:
-                self._schedule_geometry_retry()
+            if not mapped:
+                self._last_geometry_failure_reason = "anchor is unmapped"
+                return False
+            if width <= 1 or height <= 1:
+                self._last_geometry_failure_reason = (
+                    f"anchor size is not ready: width={width}, height={height}"
+                )
                 return False
             x = self.master.winfo_rootx() + int(self._place_options.get("x") or 0)
             y = self.master.winfo_rooty() + int(self._place_options.get("y") or 0)
-        except tk.TclError:
+        except tk.TclError as exc:
+            self._last_geometry_failure_reason = f"anchor unavailable: {exc}"
             return False
         self._cancel_geometry_retry()
         self.window.geometry(f"{self._width}x{height}+{x}+{y}")
+        self._last_geometry_failure_reason = ""
         return True
 
     def lift(self) -> None:
         self.window.lift()
 
     def destroy(self) -> None:
+        self._destroyed = True
         self._visible = False
         self._cancel_geometry_retry()
         try:

--- a/modules/scenarios/gm_table/fixed_overlay/view.py
+++ b/modules/scenarios/gm_table/fixed_overlay/view.py
@@ -166,6 +166,21 @@ class FixedOverlayView:
     def place_forget(self) -> None:
         self._overlay_layer.place_forget()
 
+    def show(self) -> bool:
+        return self._overlay_layer.show()
+
+    def hide(self) -> None:
+        self._overlay_layer.hide()
+
+    def sync_to_anchor(self) -> bool:
+        return self._overlay_layer.sync_to_anchor()
+
+    def ensure_visible(self) -> bool:
+        return self._overlay_layer.ensure_visible()
+
+    def is_geometry_ready(self) -> bool:
+        return self._overlay_layer.is_geometry_ready()
+
     def lift(self) -> None:
         self._overlay_layer.lift()
 
@@ -187,7 +202,11 @@ class FixedOverlayView:
 
     def _refresh_geometry(self, *, lift_overlay: bool = True) -> None:
         if not self._state.visible:
-            self.place_forget()
+            hide = getattr(self, "hide", None)
+            if callable(hide):
+                hide()
+            else:
+                self.place_forget()
             return
 
         width = (
@@ -216,6 +235,9 @@ class FixedOverlayView:
         if not self._state.collapsed:
             self._state.width = width
         FixedOverlayView._place_with_width(self, width)
+        ensure_visible = getattr(self, "ensure_visible", None)
+        if callable(ensure_visible) and not ensure_visible():
+            return
         if lift_overlay:
             self.lift()
 
@@ -233,8 +255,11 @@ class FixedOverlayView:
         place_configure = getattr(self, "place_configure", None)
         if callable(place_configure):
             place_configure(**options)
-            return
-        self.place(**options)
+        else:
+            self.place(**options)
+        sync_to_anchor = getattr(self, "sync_to_anchor", None)
+        if callable(sync_to_anchor):
+            sync_to_anchor()
 
     def _refresh_items(self) -> None:
         for child in list(self.items_host.winfo_children()):

--- a/tests/scenarios/gm_table/test_fixed_overlay_view.py
+++ b/tests/scenarios/gm_table/test_fixed_overlay_view.py
@@ -488,3 +488,112 @@ def test_build_shell_keeps_full_area_hosts_transparent(monkeypatch) -> None:
     assert overlay.items_host.kwargs["fg_color"] == fixed_overlay_view.TRANSPARENT_COLOR
     assert overlay.resize_handle.kwargs["fg_color"] == overlay._palette["panel_focus"]
     assert overlay.tab_button.kwargs["fg_color"] == overlay._palette["accent"]
+
+
+class _GeometryMaster:
+    def __init__(self, *, mapped: bool, width: int, height: int) -> None:
+        self.mapped = mapped
+        self.width = width
+        self.height = height
+        self.retry_callbacks: list[object] = []
+        self.cancelled: list[object] = []
+
+    def update_idletasks(self) -> None:
+        pass
+
+    def winfo_ismapped(self) -> bool:
+        return self.mapped
+
+    def winfo_width(self) -> int:
+        return self.width
+
+    def winfo_height(self) -> int:
+        return self.height
+
+    def winfo_rootx(self) -> int:
+        return 10
+
+    def winfo_rooty(self) -> int:
+        return 20
+
+    def after(self, _delay: int, callback: object) -> str:
+        self.retry_callbacks.append(callback)
+        return "retry-id"
+
+    def after_cancel(self, retry_id: object) -> None:
+        self.cancelled.append(retry_id)
+
+
+class _GeometryWindow:
+    def __init__(self) -> None:
+        self.geometry_calls: list[str] = []
+        self.deiconify_calls = 0
+        self.withdraw_calls = 0
+
+    def geometry(self, value: str) -> None:
+        self.geometry_calls.append(value)
+
+    def deiconify(self) -> None:
+        self.deiconify_calls += 1
+
+    def withdraw(self) -> None:
+        self.withdraw_calls += 1
+
+
+def _make_geometry_overlay(master: _GeometryMaster):
+    from modules.scenarios.gm_table.fixed_overlay.overlay_window import (
+        TransparentOverlayWindow,
+    )
+
+    overlay = TransparentOverlayWindow.__new__(TransparentOverlayWindow)
+    overlay.master = master
+    overlay.window = _GeometryWindow()
+    overlay._width = 50
+    overlay._visible = False
+    overlay._destroyed = False
+    overlay._geometry_retry_id = None
+    overlay._place_options = {"x": 3, "y": 4}
+    overlay._last_geometry_failure_reason = ""
+    return overlay
+
+
+def test_place_configure_stores_geometry_without_mapping() -> None:
+    master = _GeometryMaster(mapped=True, width=300, height=200)
+    overlay = _make_geometry_overlay(master)
+
+    overlay.place_configure(width=70, x=5)
+
+    assert overlay._visible is False
+    assert overlay.window.deiconify_calls == 0
+    assert overlay._place_options["x"] == 5
+    assert overlay._width == 70
+
+
+def test_ensure_visible_retries_until_anchor_geometry_is_ready() -> None:
+    master = _GeometryMaster(mapped=False, width=1, height=1)
+    overlay = _make_geometry_overlay(master)
+
+    assert overlay.show() is False
+    assert overlay._visible is True
+    assert overlay.window.deiconify_calls == 0
+    assert overlay._geometry_retry_id == "retry-id"
+    assert overlay.last_geometry_failure_reason == "anchor is unmapped"
+
+    master.mapped = True
+    master.width = 300
+    master.height = 200
+    overlay._run_geometry_retry()
+
+    assert overlay.window.geometry_calls == ["50x200+13+24"]
+    assert overlay.window.deiconify_calls == 1
+    assert overlay.last_geometry_failure_reason == ""
+
+
+def test_ensure_visible_stops_retrying_after_destroy() -> None:
+    master = _GeometryMaster(mapped=False, width=1, height=1)
+    overlay = _make_geometry_overlay(master)
+    overlay._visible = True
+    overlay._destroyed = True
+
+    assert overlay.ensure_visible() is False
+    assert master.retry_callbacks == []


### PR DESCRIPTION
### Motivation

- Avoid conflating placement configuration with toplevel mapping so placement can be stored without forcing a deiconify. 
- Provide an explicit API to manage logical visibility, mapping and anchor-syncing for the transparent overlay so callers can react to anchor readiness and window-manager quirks. 
- Surface the reason geometry could not be applied and retry safely until the anchor is ready or the owner is destroyed.

### Description

- Modified `TransparentOverlayWindow` so `place_configure()` only stores geometry and no longer deiconifies, and added explicit methods `show()`, `hide()`, `is_geometry_ready()`, `sync_to_anchor()` and `ensure_visible()` to manage mapping and syncing. 
- Added `_last_geometry_failure_reason` and `_destroyed` fields and updated `_apply_geometry()`, retry scheduling and `_run_geometry_retry()` to record failure reasons and stop retries when destroyed. 
- Updated `FixedOverlayView` to expose and use the new overlay API (`show`, `hide`, `sync_to_anchor`, `ensure_visible`, `is_geometry_ready`) and changed `_refresh_geometry()` to avoid silently leaving `FixedOverlayState.visible == True` when the toplevel is withdrawn. 
- Added regression tests to `tests/scenarios/gm_table/test_fixed_overlay_view.py` that ensure `place_configure()` does not map the window, that `ensure_visible()` retries until anchor geometry is ready, and that retries stop after destroy.

### Testing

- Compiled the modified modules with `python -m py_compile modules/scenarios/gm_table/fixed_overlay/overlay_window.py modules/scenarios/gm_table/fixed_overlay/view.py tests/scenarios/gm_table/test_fixed_overlay_view.py` which succeeded. 
- Ran the overlay view unit tests with `pytest tests/scenarios/gm_table/test_fixed_overlay_view.py -q` and all tests passed (`18 passed`). 
- Ran `git diff --check` to validate whitespace/checks (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46a23b7d70832ba7b7930f38724ed5)