### PR TITLE
Ensure GM Table fixed overlay restores visible

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -3361,7 +3361,15 @@ class GMTableWorkspace(ctk.CTkFrame):
             ]
         )
         if hasattr(self, "fixed_overlay"):
-            self.fixed_overlay.restore(payload.get("fixed_overlay") if isinstance(payload.get("fixed_overlay"), dict) else None)
+            saved_fixed_overlay = payload.get("fixed_overlay")
+            fixed_overlay_payload = (
+                dict(saved_fixed_overlay) if isinstance(saved_fixed_overlay, dict) else None
+            )
+            if fixed_overlay_payload is not None:
+                fixed_overlay_payload["visible"] = True
+            self.fixed_overlay.restore(fixed_overlay_payload)
+            self.after_idle(self._refresh_fixed_overlay_after_surface_map)
+            self._sync_fixed_overlay_layer("fixed overlay restored", allow_lift=True)
         panels = [item for item in list(payload.get("panels") or []) if isinstance(item, dict)]
         panels.sort(key=lambda item: int((item.get("state") or {}).get("z", 0)))
         for item in panels:

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -1597,6 +1597,69 @@ def test_show_bookmark_menu_lists_bookmarks_without_submenus() -> None:
     assert workspace._bookmark_menu.release_count == 1
 
 
+def test_restore_forces_fixed_overlay_visible_without_dropping_saved_state() -> None:
+    """GM Table launch restores the fixed overlay visible with saved details intact."""
+    restored_payloads = []
+    calls = []
+
+    class _FakeFixedOverlay:
+        def restore(self, payload) -> None:
+            restored_payloads.append(payload)
+
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace.clear = lambda: None
+    workspace.clamp_panels = lambda: None
+    workspace.add_panel = lambda definition, *, geometry=None: _FakePanel(
+        geometry["width"],
+        geometry["height"],
+        x=int(geometry["x"]),
+        y=int(geometry["y"]),
+    )
+    workspace.after_idle = lambda callback: callback()
+    workspace._refresh_fixed_overlay_after_surface_map = lambda: calls.append("refresh")
+    workspace._sync_fixed_overlay_layer = lambda reason, *, allow_lift: calls.append(
+        (reason, allow_lift)
+    )
+    workspace.fixed_overlay = _FakeFixedOverlay()
+    saved_fixed_overlay = {
+        "visible": False,
+        "collapsed": True,
+        "width": 420,
+        "selected_item_ids": ["fixed_note"],
+        "items": [
+            {
+                "item_id": "fixed_note",
+                "kind": "note",
+                "title": "Pinned Note",
+                "state": {"text": "Keep me"},
+            }
+        ],
+    }
+
+    GMTableWorkspace.restore(
+        workspace, {"fixed_overlay": saved_fixed_overlay, "panels": []}
+    )
+
+    assert saved_fixed_overlay["visible"] is False
+    assert restored_payloads == [
+        {
+            "visible": True,
+            "collapsed": True,
+            "width": 420,
+            "selected_item_ids": ["fixed_note"],
+            "items": [
+                {
+                    "item_id": "fixed_note",
+                    "kind": "note",
+                    "title": "Pinned Note",
+                    "state": {"text": "Keep me"},
+                }
+            ],
+        }
+    ]
+    assert calls == ["refresh", ("fixed overlay restored", True)]
+
+
 def test_restore_defaults_home_camera_to_saved_camera_when_missing() -> None:
     """Legacy layouts with camera but no home camera should reuse the saved camera."""
     workspace = GMTableWorkspace.__new__(GMTableWorkspace)


### PR DESCRIPTION
### Motivation
- Restoring a saved GM Table layout could leave the viewport-fixed overlay hidden if the saved payload had `visible: False`, preventing the GM from immediately seeing pinned items on launch.
- The intent is to always show the fixed overlay when a table is launched while preserving the rest of the saved overlay state (items, width, collapsed, selected_item_ids).

### Description
- Update `GMTableWorkspace.restore()` to copy the saved `fixed_overlay` dict and set `"visible" = True` on the copy before passing it to `fixed_overlay.restore()` so the original payload is not mutated and all other fields are preserved.
- After restoring the overlay payload, schedule the existing geometry refresh via `self.after_idle(self._refresh_fixed_overlay_after_surface_map)` and call `self._sync_fixed_overlay_layer("fixed overlay restored", allow_lift=True)` to ensure geometry and stacking are refreshed.
- Add a regression test `test_restore_forces_fixed_overlay_visible_without_dropping_saved_state()` in `tests/scenarios/gm_table/test_workspace.py` that verifies the saved dict is not mutated, preserved fields (`items`, `width`, `collapsed`, `selected_item_ids`) are retained, `visible` is forced on in the restore payload, and the refresh/sync hooks are invoked.

### Testing
- Ran targeted workspace tests with `pytest -q tests/scenarios/gm_table/test_workspace.py -k 'fixed_overlay_visible or restore'` and the focused suite passed (`11 passed, 39 deselected`).
- Verified Python syntax with `python -m py_compile modules/scenarios/gm_table/workspace.py tests/scenarios/gm_table/test_workspace.py` which succeeded.
- Ran the full workspace test module with `pytest -q tests/scenarios/gm_table/test_workspace.py`, which produced two failures tied to Tk requiring a display (`no display name and no $DISPLAY environment variable`) in this headless CI environment; the failures are environmental and not related to the change itself, while the other tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46bb81b5e0832ba021219da537a2d5)