### PR TITLE
feat: add find field to GM table book panels

### DIFF
--- a/modules/books/pdf_viewer_panel.py
+++ b/modules/books/pdf_viewer_panel.py
@@ -25,6 +25,8 @@ class PDFViewerFrame(ctk.CTkFrame):
         self.current_page = int(state.get("current_page") or 1)
         self.zoom = float(state.get("zoom") or 1.25)
         self.search_query = str(state.get("search_query") or "")
+        self._search_matches: list[int] = []
+        self._search_match_index = -1
         self._on_state_changed = on_state_changed
         self._render_token = 0
         self._page_image = None
@@ -46,6 +48,14 @@ class PDFViewerFrame(ctk.CTkFrame):
         ctk.CTkButton(controls, text="+", width=36, command=lambda: self.adjust_zoom(0.25)).pack(side="left", padx=(4,0))
         ctk.CTkButton(controls, text="Reset Zoom", width=96, command=self.reset_zoom).pack(side="left", padx=8)
         self.zoom_label = ctk.CTkLabel(controls, text="Zoom: 125%"); self.zoom_label.pack(side="left")
+        ctk.CTkLabel(controls, text="Find:").pack(side="left", padx=(12, 4))
+        self.search_var = tk.StringVar(value=self.search_query)
+        search_entry = ctk.CTkEntry(controls, width=180, textvariable=self.search_var)
+        search_entry.pack(side="left")
+        search_entry.bind("<Return>", lambda _e: self.find_next())
+        ctk.CTkButton(controls, text="Next", width=58, command=self.find_next).pack(side="left", padx=(4, 0))
+        self.search_status_label = ctk.CTkLabel(controls, text="")
+        self.search_status_label.pack(side="left", padx=(6, 0))
         body = ctk.CTkFrame(self); body.grid(row=1, column=0, sticky="nsew", padx=6, pady=(0,6)); body.grid_rowconfigure(0, weight=1); body.grid_columnconfigure(0, weight=1)
         self.canvas = tk.Canvas(body, bg="#0B1020", highlightthickness=0)
         self.canvas.grid(row=0, column=0, sticky="nsew")
@@ -61,6 +71,7 @@ class PDFViewerFrame(ctk.CTkFrame):
 
     def open_pdf(self, pdf_path: str, *, initial_page: int = 1, zoom: float | None = None) -> None:
         self.pdf_path = str(pdf_path or ""); self.attachment_path = self.pdf_path
+        self._reset_search_results()
         if zoom is not None: self.zoom = self._clamp_zoom(zoom)
         try:
             self._document = open_document(self.pdf_path, campaign_dir=self.campaign_dir) if self.pdf_path else None
@@ -69,6 +80,63 @@ class PDFViewerFrame(ctk.CTkFrame):
             log_warning(f"Unable to open PDF '{self.pdf_path}': {exc}", func_name="PDFViewerFrame.open_pdf")
             self._document = None; self.page_count = 0
         self.go_to_page(initial_page, render=True)
+
+
+    def _reset_search_results(self) -> None:
+        self._search_matches = []
+        self._search_match_index = -1
+
+    def _normalize_search_query(self, query: str) -> str:
+        return str(query or "").strip()
+
+    def _page_contains_query(self, page_index: int, query: str) -> bool:
+        if not self._document or not query:
+            return False
+        try:
+            page = self._document.load_page(page_index)
+            text = page.get_text("text") if hasattr(page, "get_text") else page.get_text()
+        except Exception:
+            return False
+        return query.casefold() in str(text or "").casefold()
+
+    def _build_search_matches(self, query: str) -> list[int]:
+        if not query or not self._document or not self.page_count:
+            return []
+        return [
+            page_number
+            for page_number in range(1, self.page_count + 1)
+            if self._page_contains_query(page_number - 1, query)
+        ]
+
+    def _update_search_status(self, text: str) -> None:
+        label = getattr(self, "search_status_label", None)
+        if label is not None:
+            label.configure(text=text)
+
+    def find_next(self) -> None:
+        query_var = getattr(self, "search_var", None)
+        query = self._normalize_search_query(query_var.get() if query_var is not None else self.search_query)
+        if not query:
+            self.search_query = ""
+            self._reset_search_results()
+            self._update_search_status("")
+            self._changed()
+            return
+
+        if query != self.search_query or not self._search_matches:
+            self.search_query = query
+            self._search_matches = self._build_search_matches(query)
+            self._search_match_index = -1
+
+        if not self._search_matches:
+            self._update_search_status("No matches")
+            self._changed()
+            return
+
+        self._search_match_index = (self._search_match_index + 1) % len(self._search_matches)
+        target_page = self._search_matches[self._search_match_index]
+        self._update_search_status(f"Match {self._search_match_index + 1}/{len(self._search_matches)}")
+        self.go_to_page(target_page)
 
     def _clamp_page(self, page: int) -> int:
         page = max(1, int(page or 1))

--- a/tests/books/test_pdf_viewer_panel.py
+++ b/tests/books/test_pdf_viewer_panel.py
@@ -37,3 +37,84 @@ def test_pdf_viewer_discards_stale_render_requests() -> None:
     viewer = _viewer(); viewer._render_token = 4
     assert PDFViewerFrame.discard_stale_render_for_test(viewer, 3)
     assert not PDFViewerFrame.discard_stale_render_for_test(viewer, 4)
+
+class _FakePage:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def get_text(self, *_args):
+        return self._text
+
+
+class _FakeDocument:
+    def __init__(self, pages: list[str]) -> None:
+        self._pages = pages
+
+    def load_page(self, index: int) -> _FakePage:
+        return _FakePage(self._pages[index])
+
+
+class _FakeVar:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get(self) -> str:
+        return self._value
+
+
+class _FakeLabel:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def configure(self, *, text: str) -> None:
+        self.text = text
+
+
+def _search_viewer() -> PDFViewerFrame:
+    viewer = _viewer()
+    viewer._document = _FakeDocument(["Alpha start", "nothing", "alpha finish"])
+    viewer.page_count = 3
+    viewer._search_matches = []
+    viewer._search_match_index = -1
+    viewer.search_status_label = _FakeLabel()
+    viewer.search_var = _FakeVar("alpha")
+    viewer.go_to_page = lambda page, render=True: setattr(viewer, "current_page", page)
+    viewer._changed = lambda: None
+    return viewer
+
+
+def test_pdf_viewer_find_next_advances_to_next_matching_page() -> None:
+    viewer = _search_viewer()
+    viewer.search_query = ""
+
+    PDFViewerFrame.find_next(viewer)
+    assert viewer.current_page == 1
+    assert viewer.search_status_label.text == "Match 1/2"
+
+    PDFViewerFrame.find_next(viewer)
+    assert viewer.current_page == 3
+    assert viewer.search_status_label.text == "Match 2/2"
+
+    PDFViewerFrame.find_next(viewer)
+    assert viewer.current_page == 1
+    assert viewer.search_status_label.text == "Match 1/2"
+
+
+def test_pdf_viewer_find_next_rebuilds_initial_state_search() -> None:
+    viewer = _search_viewer()
+    viewer.search_query = "alpha"
+
+    PDFViewerFrame.find_next(viewer)
+
+    assert viewer.current_page == 1
+    assert viewer._search_matches == [1, 3]
+
+
+def test_pdf_viewer_find_next_reports_no_matches() -> None:
+    viewer = _search_viewer()
+    viewer.search_var = _FakeVar("missing")
+
+    PDFViewerFrame.find_next(viewer)
+
+    assert viewer.current_page == 1
+    assert viewer.search_status_label.text == "No matches"


### PR DESCRIPTION
### Motivation
- Enable quick text search inside books embedded in the GM Table so GMs can jump to the next page containing a searched string with a single Enter/Next action.
- Keep embedded PDF viewer behavior consistent with the standalone `BookViewer` search UX by tracking search state per panel.

### Description
- Added a `Find:` text field, Enter binding, `Next` button, and a match status label to the embedded PDF panel UI in `modules/books/pdf_viewer_panel.py`.
- Implemented search state and navigation with `self._search_matches`, `self._search_match_index`, `find_next()`, and helpers `_page_contains_query()` and `_build_search_matches()` that scan PDF pages case-insensitively.
- Reset search state when opening a new PDF via `open_pdf()` and update the status label with match counts or `No matches` feedback.
- Added headless unit tests in `tests/books/test_pdf_viewer_panel.py` covering repeated find-next navigation, rebuilding saved-search state, and no-match reporting.

### Testing
- Ran `pytest tests/books` and all tests in the file passed (7 tests; `tests/books/test_pdf_viewer_panel.py` included new tests) with status ✅.
- Performed syntax check with `python -m py_compile modules/books/pdf_viewer_panel.py tests/books/test_pdf_viewer_panel.py` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474de5babc832b97ee979db6d2c2a4)