### PR TITLE
Add AI Prompt Library and Ollama-backed Scenario Generator (UI + persistence)

### DIFF
--- a/docs/ai_scenario_generator_manual_checklist.md
+++ b/docs/ai_scenario_generator_manual_checklist.md
@@ -1,0 +1,16 @@
+# AI Scenario Generator Manual Test Checklist
+
+Use this checklist after UI changes to the scenario generator.
+
+- Create a prompt in **Manage Prompts**.
+- Edit the prompt name, prompt text, category, description, and questions.
+- Duplicate a prompt and confirm duplicate-name validation can be resolved by renaming.
+- Delete a prompt and confirm the confirmation dialog appears.
+- Export prompts to JSON, then import them back.
+- Restore default prompts and verify **Professional RPG Scenario** is available.
+- Generate a scenario with Ollama unavailable and verify a clear provider-unavailable error is shown.
+- Generate a scenario with Ollama running and verify the UI stays responsive while loading.
+- Edit the AI-generated result preview.
+- Save the edited scenario to the DB and verify duplicate titles are blocked.
+- Export the AI-generated scenario to DOCX.
+- Switch back to random generator mode and verify legacy generation, saving, and DOCX export still work.

--- a/modules/scenarios/ai_prompt_library.py
+++ b/modules/scenarios/ai_prompt_library.py
@@ -1,0 +1,288 @@
+"""Persistent AI prompt library for scenario generation."""
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from string import Formatter
+from typing import Any
+
+from modules.helpers.config_helper import ConfigHelper
+
+_PLACEHOLDER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class PromptLibraryError(ValueError):
+    """Raised when prompt library data is invalid."""
+
+
+@dataclass
+class PromptQuestion:
+    """Question used to collect a placeholder value from the user."""
+
+    key: str
+    label: str
+    required: bool = True
+    default: str = ""
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PromptQuestion":
+        """Create a question from a JSON-compatible dictionary."""
+        key = str(payload.get("key") or payload.get("placeholder") or "").strip()
+        label = str(payload.get("label") or payload.get("question") or key).strip()
+        return cls(
+            key=key,
+            label=label,
+            required=bool(payload.get("required", True)),
+            default=str(payload.get("default", "")),
+        )
+
+
+@dataclass
+class ScenarioPrompt:
+    """Stored reusable scenario-generation prompt."""
+
+    id: str
+    name: str
+    description: str
+    category: str
+    prompt_text: str
+    questions: list[PromptQuestion] = field(default_factory=list)
+    created_at: str = ""
+    updated_at: str = ""
+
+    @classmethod
+    def new(
+        cls,
+        name: str,
+        description: str,
+        category: str,
+        prompt_text: str,
+        questions: list[PromptQuestion],
+    ) -> "ScenarioPrompt":
+        """Create a new prompt with generated identity and timestamps."""
+        now = _utc_now()
+        return cls(str(uuid.uuid4()), name, description, category, prompt_text, questions, now, now)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ScenarioPrompt":
+        """Create a prompt from a JSON-compatible dictionary."""
+        questions = [PromptQuestion.from_dict(q) for q in payload.get("questions", []) if isinstance(q, dict)]
+        now = _utc_now()
+        return cls(
+            id=str(payload.get("id") or uuid.uuid4()),
+            name=str(payload.get("name") or "").strip(),
+            description=str(payload.get("description") or ""),
+            category=str(payload.get("category") or payload.get("genre") or ""),
+            prompt_text=str(payload.get("prompt_text") or ""),
+            questions=questions,
+            created_at=str(payload.get("created_at") or now),
+            updated_at=str(payload.get("updated_at") or now),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return asdict(self)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def get_prompt_library_path() -> Path:
+    """Return the prompt library JSON path in the campaign/config area."""
+    campaign_dir = Path(ConfigHelper.get_campaign_dir())
+    if str(campaign_dir) in {"", "."}:
+        campaign_dir = Path("config")
+    return campaign_dir / "scenario_prompt_library.json"
+
+
+def extract_placeholders(prompt_text: str) -> list[str]:
+    """Extract valid Python-format placeholders from prompt text."""
+    names: list[str] = []
+    for _, field_name, _, _ in Formatter().parse(prompt_text or ""):
+        if not field_name:
+            continue
+        name = field_name.split(".", 1)[0].split("[", 1)[0]
+        if _PLACEHOLDER_RE.match(name) and name not in names:
+            names.append(name)
+    return names
+
+
+def validate_prompt(prompt: ScenarioPrompt, existing: list[ScenarioPrompt] | None = None) -> list[str]:
+    """Return validation errors for a prompt."""
+    errors: list[str] = []
+    if not prompt.name.strip():
+        errors.append("Prompt name is required.")
+    if not prompt.prompt_text.strip():
+        errors.append("Prompt text is required.")
+    if existing:
+        lowered = prompt.name.strip().lower()
+        if any(p.id != prompt.id and p.name.strip().lower() == lowered for p in existing):
+            errors.append(f"A prompt named '{prompt.name}' already exists.")
+    for question in prompt.questions:
+        if not question.key.strip():
+            errors.append("Every question needs a placeholder key.")
+        elif not _PLACEHOLDER_RE.match(question.key.strip()):
+            errors.append(f"Invalid placeholder key: {question.key}")
+        if not question.label.strip():
+            errors.append(f"Question '{question.key}' needs a label.")
+    return errors
+
+
+DEFAULT_PROMPT_TEXT = """# Role
+You are a professional RPG scenario writer working in the RPG industry. Your style is original, witty, sensory, mysterious, and immediately usable at the table. Use strong hooks, meaningful NPC motives, scene escalation, player agency, secrets, revelations, and playable conflicts.
+
+# User answers
+- Type or background: {scenario_type}
+- Theme: {theme}
+- Location: {location}
+- Tone: {tone}
+- Party level: {party_level}
+- System: {system}
+- Additional constraints: {additional_constraints}
+
+# Rules
+1. Reread, criticize, and improve your own scenario before giving the final answer.
+2. Use the five senses in descriptions when useful: sight, sound, smell, touch, taste.
+3. Create original NPCs with physical descriptions, short backgrounds, and clear motives.
+4. Create at least 3 personal ways to connect the player characters to the scenario.
+5. Include at least 3 scenes. Each scene clearly lists its locations, NPCs, and each NPC's role.
+6. Every important location is original and fully described. If combat can happen there, include tactical features such as height, holes, fire, moving machinery, unstable ground, crowds, darkness, water, vehicles, traps, or cover.
+7. The main scenario summary is 8 short lines maximum.
+8. NPCs and locations appear after the summary and do not count toward those 8 lines.
+9. Each NPC is 3 lines maximum. Each location is 3 lines maximum.
+10. Every important detail for an NPC, scene, or place is written as an “Atout”, like Savage/Fate-style RPG tags.
+11. Use every rule in every generated scenario.
+
+# Required output format
+Title:
+Pitch:
+Scenario Summary, maximum 8 short lines:
+Scenes:
+Scene 1:
+* Purpose:
+* Location:
+* NPCs:
+* Atouts:
+Scene 2:
+* Purpose:
+* Location:
+* NPCs:
+* Atouts:
+Scene 3:
+* Purpose:
+* Location:
+* NPCs:
+* Atouts:
+NPCs:
+Locations:
+PC Connections:
+Secrets and Twists:
+Atouts Summary:
+GM Notes:
+"""
+
+
+def default_prompts() -> list[ScenarioPrompt]:
+    """Return built-in prompts used to seed or restore the library."""
+    return [
+        ScenarioPrompt.new(
+            name="Professional RPG Scenario",
+            description="Industry-style prompt for a complete, playable RPG scenario.",
+            category="Generic RPG",
+            prompt_text=DEFAULT_PROMPT_TEXT,
+            questions=[
+                PromptQuestion("scenario_type", "Type or background (medfan, sci-fi, Star Wars, Dresden Files...)", True),
+                PromptQuestion("theme", "Theme of the scenario", True),
+                PromptQuestion("location", "Location of the scenario", True),
+                PromptQuestion("tone", "Tone", False, "mysterious and cinematic"),
+                PromptQuestion("party_level", "Party level / power scale", False, "appropriate for the current campaign"),
+                PromptQuestion("system", "Game system", False, "system-neutral"),
+                PromptQuestion("additional_constraints", "Additional constraints", False, "none"),
+            ],
+        )
+    ]
+
+
+class PromptLibrary:
+    """Load, validate, save, import, and export scenario prompts."""
+
+    def __init__(self, path: Path | None = None):
+        self.path = path or get_prompt_library_path()
+
+    def load(self) -> list[ScenarioPrompt]:
+        """Load prompts, seeding defaults when no library exists."""
+        if not self.path.exists():
+            prompts = default_prompts()
+            self.save(prompts)
+            return prompts
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise PromptLibraryError(f"Invalid prompt library JSON: {exc}") from exc
+        items = raw.get("prompts", raw) if isinstance(raw, dict) else raw
+        if not isinstance(items, list):
+            raise PromptLibraryError("Prompt library JSON must contain a list of prompts.")
+        prompts = [ScenarioPrompt.from_dict(item) for item in items if isinstance(item, dict)]
+        if not prompts:
+            prompts = default_prompts()
+            self.save(prompts)
+        return prompts
+
+    def save(self, prompts: list[ScenarioPrompt]) -> None:
+        """Persist prompts to JSON."""
+        names: list[str] = []
+        for prompt in prompts:
+            errors = validate_prompt(prompt, [p for p in prompts if p is not prompt])
+            if errors:
+                raise PromptLibraryError("\n".join(errors))
+            name_key = prompt.name.strip().lower()
+            if name_key in names:
+                raise PromptLibraryError(f"Duplicate prompt name: {prompt.name}")
+            names.append(name_key)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"version": 1, "prompts": [prompt.to_dict() for prompt in prompts]}
+        self.path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def import_from_file(self, source: str | Path, merge: bool = True) -> list[ScenarioPrompt]:
+        """Import prompts from JSON and return the saved library."""
+        try:
+            raw = json.loads(Path(source).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise PromptLibraryError(f"Invalid JSON import: {exc}") from exc
+        items = raw.get("prompts", raw) if isinstance(raw, dict) else raw
+        if not isinstance(items, list):
+            raise PromptLibraryError("Imported JSON must contain a list of prompts.")
+        imported = [ScenarioPrompt.from_dict(item) for item in items if isinstance(item, dict)]
+        existing = self.load() if merge else []
+        by_name = {p.name.strip().lower(): p for p in existing}
+        for prompt in imported:
+            prompt.id = str(uuid.uuid4()) if prompt.name.strip().lower() in by_name else prompt.id
+            prompt.updated_at = _utc_now()
+            by_name[prompt.name.strip().lower()] = prompt
+        prompts = list(by_name.values())
+        self.save(prompts)
+        return prompts
+
+    def export_to_file(self, prompts: list[ScenarioPrompt], target: str | Path) -> None:
+        """Export prompts to JSON."""
+        Path(target).write_text(
+            json.dumps({"version": 1, "prompts": [p.to_dict() for p in prompts]}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    def restore_defaults(self, keep_existing: bool = False) -> list[ScenarioPrompt]:
+        """Restore built-in prompts, optionally keeping custom prompts."""
+        prompts = self.load() if keep_existing and self.path.exists() else []
+        existing_names = {p.name.strip().lower() for p in prompts}
+        for prompt in default_prompts():
+            if prompt.name.strip().lower() not in existing_names:
+                prompts.append(prompt)
+        if not keep_existing:
+            prompts = default_prompts()
+        self.save(prompts)
+        return prompts

--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -1,0 +1,151 @@
+"""AI scenario generation service and text parsing helpers."""
+from __future__ import annotations
+
+import json
+import re
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Mapping
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.logging_helper import log_exception
+from modules.scenarios.ai_prompt_library import ScenarioPrompt, extract_placeholders
+
+
+class AIGenerationError(RuntimeError):
+    """Raised when AI scenario generation fails."""
+
+
+@dataclass
+class AIProviderConfig:
+    """Configuration for an AI chat provider."""
+
+    base_url: str = "http://localhost:11434"
+    model: str = "llama3.1"
+    temperature: float = 0.7
+    timeout: int = 120
+
+    @classmethod
+    def from_config(cls) -> "AIProviderConfig":
+        """Load provider configuration from ConfigHelper."""
+        return cls(
+            base_url=(ConfigHelper.get("AI", "base_url", fallback="http://localhost:11434") or "http://localhost:11434").rstrip("/"),
+            model=ConfigHelper.get("AI", "model", fallback="llama3.1") or "llama3.1",
+            temperature=float(ConfigHelper.get("AI", "temperature", fallback="0.7") or 0.7),
+            timeout=int(float(ConfigHelper.get("AI", "timeout", fallback="120") or 120)),
+        )
+
+
+class OllamaScenarioProvider:
+    """Minimal Ollama /api/chat provider."""
+
+    def __init__(self, config: AIProviderConfig | None = None):
+        self.config = config or AIProviderConfig.from_config()
+
+    def generate(self, prompt: str) -> str:
+        """Send prompt to Ollama and return generated text."""
+        url = f"{self.config.base_url}/api/chat"
+        payload = {
+            "model": self.config.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "options": {"temperature": self.config.temperature},
+        }
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.config.timeout) as response:
+                data = json.loads(response.read().decode("utf-8"))
+        except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
+            raise AIGenerationError(
+                f"AI provider unavailable at {self.config.base_url}. Make sure Ollama is running and the model '{self.config.model}' is installed."
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise AIGenerationError("AI provider returned invalid JSON.") from exc
+        message = data.get("message", {}) if isinstance(data, dict) else {}
+        content = str(message.get("content") or data.get("response") or "").strip()
+        if not content:
+            raise AIGenerationError("AI provider returned an empty scenario.")
+        return content
+
+
+class SafeFormatDict(dict):
+    """Formatter mapping that leaves unknown placeholders visible."""
+
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
+def build_final_prompt(prompt: ScenarioPrompt, answers: Mapping[str, str]) -> tuple[str, list[str]]:
+    """Build the final AI prompt and return unresolved placeholder warnings."""
+    placeholders = extract_placeholders(prompt.prompt_text)
+    missing = [name for name in placeholders if not str(answers.get(name, "")).strip()]
+    formatted = prompt.prompt_text.format_map(SafeFormatDict({k: str(v) for k, v in answers.items()}))
+    answer_lines = [f"- {question.label} ({question.key}): {answers.get(question.key, question.default)}" for question in prompt.questions]
+    final = f"{formatted}\n\n# Collected answers\n" + "\n".join(answer_lines)
+    return final, missing
+
+
+def validate_required_answers(prompt: ScenarioPrompt, answers: Mapping[str, str]) -> list[str]:
+    """Return labels for missing required answers."""
+    missing: list[str] = []
+    for question in prompt.questions:
+        if question.required and not str(answers.get(question.key, question.default)).strip():
+            missing.append(question.label)
+    return missing
+
+
+def parse_generated_scenario(text: str) -> dict[str, str | list[str]]:
+    """Best-effort parser that extracts common scenario sections without crashing."""
+    result: dict[str, str | list[str]] = {
+        "Title": "",
+        "Summary": text.strip(),
+        "Secrets": "",
+        "Places": [],
+        "NPCs": [],
+        "Objects": [],
+    }
+    title_match = re.search(r"^\s*Title\s*:\s*(.+)$", text, flags=re.IGNORECASE | re.MULTILINE)
+    if title_match:
+        result["Title"] = title_match.group(1).strip()
+    sections: dict[str, str] = {}
+    matches = list(re.finditer(r"^\s*([A-Za-z][A-Za-z0-9 ,/&-]+)\s*:\s*$", text, flags=re.MULTILINE))
+    for index, match in enumerate(matches):
+        key = match.group(1).strip().lower()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections[key] = text[start:end].strip()
+    if sections.get("scenario summary, maximum 8 short lines"):
+        result["Summary"] = sections["scenario summary, maximum 8 short lines"]
+    if sections.get("secrets and twists"):
+        result["Secrets"] = sections["secrets and twists"]
+    for section_name, target in (("locations", "Places"), ("npcs", "NPCs")):
+        raw = sections.get(section_name, "")
+        if raw:
+            result[target] = [line.strip(" -*") for line in raw.splitlines() if line.strip()][:20]
+    return result
+
+
+class AIScenarioGenerator:
+    """Service layer for prompt-based AI scenario generation."""
+
+    def __init__(self, provider: OllamaScenarioProvider | None = None):
+        self.provider = provider or OllamaScenarioProvider()
+
+    def generate(self, prompt: ScenarioPrompt, answers: Mapping[str, str]) -> str:
+        """Generate a scenario from a stored prompt and user answers."""
+        missing_required = validate_required_answers(prompt, answers)
+        if missing_required:
+            raise AIGenerationError("Missing required answers: " + ", ".join(missing_required))
+        final_prompt, unresolved = build_final_prompt(prompt, answers)
+        try:
+            return self.provider.generate(final_prompt)
+        except Exception:
+            log_exception("AI scenario generation failed")
+            raise

--- a/modules/scenarios/prompt_library_dialog.py
+++ b/modules/scenarios/prompt_library_dialog.py
@@ -1,0 +1,192 @@
+"""CustomTkinter dialog for managing scenario AI prompts."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+import customtkinter as ctk
+
+from modules.helpers.logging_helper import log_exception
+from modules.scenarios.ai_prompt_library import (
+    PromptLibrary,
+    PromptLibraryError,
+    PromptQuestion,
+    ScenarioPrompt,
+    _utc_now,
+    validate_prompt,
+)
+
+
+class PromptLibraryDialog(ctk.CTkToplevel):
+    """Prompt library CRUD/import/export dialog."""
+
+    def __init__(self, parent, library: PromptLibrary, on_change=None):
+        super().__init__(parent)
+        self.title("Manage Scenario Prompts")
+        self.geometry("1100x720")
+        self.library = library
+        self.on_change = on_change
+        self.prompts = self.library.load()
+        self.selected_id: str | None = None
+        self.name_var = tk.StringVar()
+        self.category_var = tk.StringVar()
+        self.description_var = tk.StringVar()
+        self._build_widgets()
+        self._refresh_list()
+        if self.prompts:
+            self._select_prompt(self.prompts[0].id)
+        self.grab_set()
+
+    def _build_widgets(self) -> None:
+        self.grid_columnconfigure(1, weight=1)
+        self.grid_rowconfigure(0, weight=1)
+        left = ctk.CTkFrame(self)
+        left.grid(row=0, column=0, sticky="nsew", padx=10, pady=10)
+        left.grid_rowconfigure(0, weight=1)
+        self.listbox = tk.Listbox(left, width=30, exportselection=False)
+        self.listbox.grid(row=0, column=0, columnspan=2, sticky="nsew", padx=6, pady=6)
+        self.listbox.bind("<<ListboxSelect>>", self._on_select)
+        buttons = [
+            ("New", self._new_prompt), ("Duplicate", self._duplicate_prompt),
+            ("Delete", self._delete_prompt), ("Import", self._import_prompts),
+            ("Export", self._export_prompts), ("Restore Defaults", self._restore_defaults),
+        ]
+        for idx, (label, command) in enumerate(buttons, start=1):
+            ctk.CTkButton(left, text=label, command=command).grid(row=idx, column=0, columnspan=2, sticky="ew", padx=6, pady=3)
+
+        right = ctk.CTkFrame(self)
+        right.grid(row=0, column=1, sticky="nsew", padx=(0, 10), pady=10)
+        right.grid_columnconfigure(1, weight=1)
+        right.grid_rowconfigure(4, weight=1)
+        ctk.CTkLabel(right, text="Name").grid(row=0, column=0, sticky="w", padx=8, pady=4)
+        ctk.CTkEntry(right, textvariable=self.name_var).grid(row=0, column=1, sticky="ew", padx=8, pady=4)
+        ctk.CTkLabel(right, text="Category / Genre").grid(row=1, column=0, sticky="w", padx=8, pady=4)
+        ctk.CTkEntry(right, textvariable=self.category_var).grid(row=1, column=1, sticky="ew", padx=8, pady=4)
+        ctk.CTkLabel(right, text="Description").grid(row=2, column=0, sticky="w", padx=8, pady=4)
+        ctk.CTkEntry(right, textvariable=self.description_var).grid(row=2, column=1, sticky="ew", padx=8, pady=4)
+        ctk.CTkLabel(right, text="Questions (one per line: key|Label|required|default)").grid(row=3, column=0, columnspan=2, sticky="w", padx=8)
+        self.prompt_text = ctk.CTkTextbox(right, wrap="word")
+        self.prompt_text.grid(row=4, column=0, columnspan=2, sticky="nsew", padx=8, pady=4)
+        self.questions_text = ctk.CTkTextbox(right, height=120, wrap="word")
+        self.questions_text.grid(row=5, column=0, columnspan=2, sticky="ew", padx=8, pady=4)
+        footer = ctk.CTkFrame(right)
+        footer.grid(row=6, column=0, columnspan=2, sticky="ew", padx=8, pady=8)
+        ctk.CTkButton(footer, text="Save Prompt", command=self._save_current).pack(side="right", padx=5)
+        ctk.CTkButton(footer, text="Close", command=self.destroy).pack(side="right", padx=5)
+
+    def _refresh_list(self) -> None:
+        self.listbox.delete(0, tk.END)
+        for prompt in self.prompts:
+            self.listbox.insert(tk.END, prompt.name)
+
+    def _on_select(self, _event=None) -> None:
+        selection = self.listbox.curselection()
+        if selection:
+            self._select_prompt(self.prompts[selection[0]].id)
+
+    def _select_prompt(self, prompt_id: str) -> None:
+        prompt = next((p for p in self.prompts if p.id == prompt_id), None)
+        if not prompt:
+            return
+        self.selected_id = prompt.id
+        self.name_var.set(prompt.name)
+        self.category_var.set(prompt.category)
+        self.description_var.set(prompt.description)
+        self.prompt_text.delete("1.0", "end")
+        self.prompt_text.insert("1.0", prompt.prompt_text)
+        self.questions_text.delete("1.0", "end")
+        lines = [f"{q.key}|{q.label}|{str(q.required).lower()}|{q.default}" for q in prompt.questions]
+        self.questions_text.insert("1.0", "\n".join(lines))
+
+    def _parse_questions(self) -> list[PromptQuestion]:
+        questions: list[PromptQuestion] = []
+        for line in self.questions_text.get("1.0", "end").splitlines():
+            if not line.strip():
+                continue
+            parts = [part.strip() for part in line.split("|", 3)]
+            while len(parts) < 4:
+                parts.append("")
+            questions.append(PromptQuestion(parts[0], parts[1] or parts[0], parts[2].lower() not in {"false", "0", "no", "optional"}, parts[3]))
+        return questions
+
+    def _save_current(self) -> None:
+        if not self.selected_id:
+            self._new_prompt()
+        prompt = next((p for p in self.prompts if p.id == self.selected_id), None)
+        if not prompt:
+            return
+        prompt.name = self.name_var.get().strip()
+        prompt.category = self.category_var.get().strip()
+        prompt.description = self.description_var.get().strip()
+        prompt.prompt_text = self.prompt_text.get("1.0", "end").strip()
+        prompt.questions = self._parse_questions()
+        prompt.updated_at = _utc_now()
+        errors = validate_prompt(prompt, self.prompts)
+        if errors:
+            messagebox.showerror("Invalid Prompt", "\n".join(errors), parent=self)
+            return
+        try:
+            self.library.save(self.prompts)
+        except PromptLibraryError as exc:
+            messagebox.showerror("Prompt Library", str(exc), parent=self)
+            return
+        self._refresh_list()
+        if self.on_change:
+            self.on_change()
+
+    def _new_prompt(self) -> None:
+        prompt = ScenarioPrompt.new("New Prompt", "", "", "Write a scenario about {theme}.", [PromptQuestion("theme", "Theme", True)])
+        self.prompts.append(prompt)
+        self.selected_id = prompt.id
+        self._refresh_list()
+        self._select_prompt(prompt.id)
+
+    def _duplicate_prompt(self) -> None:
+        prompt = next((p for p in self.prompts if p.id == self.selected_id), None)
+        if not prompt:
+            return
+        copy = ScenarioPrompt.new(f"{prompt.name} Copy", prompt.description, prompt.category, prompt.prompt_text, list(prompt.questions))
+        self.prompts.append(copy)
+        self._refresh_list()
+        self._select_prompt(copy.id)
+
+    def _delete_prompt(self) -> None:
+        prompt = next((p for p in self.prompts if p.id == self.selected_id), None)
+        if not prompt or not messagebox.askyesno("Delete Prompt", f"Delete '{prompt.name}'?", parent=self):
+            return
+        self.prompts = [p for p in self.prompts if p.id != prompt.id]
+        self.library.save(self.prompts)
+        self._refresh_list()
+        self.selected_id = None
+        if self.prompts:
+            self._select_prompt(self.prompts[0].id)
+        if self.on_change:
+            self.on_change()
+
+    def _import_prompts(self) -> None:
+        filename = filedialog.askopenfilename(filetypes=[("JSON", "*.json")], parent=self)
+        if not filename:
+            return
+        try:
+            self.prompts = self.library.import_from_file(filename, merge=True)
+        except Exception as exc:
+            log_exception("Prompt import failed")
+            messagebox.showerror("Import failed", str(exc), parent=self)
+            return
+        self._refresh_list()
+        if self.on_change:
+            self.on_change()
+
+    def _export_prompts(self) -> None:
+        filename = filedialog.asksaveasfilename(defaultextension=".json", filetypes=[("JSON", "*.json")], parent=self)
+        if filename:
+            self.library.export_to_file(self.prompts, filename)
+
+    def _restore_defaults(self) -> None:
+        keep = messagebox.askyesno("Restore Defaults", "Keep existing custom prompts and add missing defaults?", parent=self)
+        self.prompts = self.library.restore_defaults(keep_existing=keep)
+        self._refresh_list()
+        if self.prompts:
+            self._select_prompt(self.prompts[0].id)
+        if self.on_change:
+            self.on_change()

--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -1,171 +1,324 @@
+"""View for random and AI-assisted scenario generation."""
 
-"""View for scenario generator."""
+from __future__ import annotations
 
+import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
 import customtkinter as ctk
 
 from campaign_generator import GENERATOR_FUNCTIONS, export_to_docx
-from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.campaigns.shared.arc_status import DEFAULT_SCENARIO_STATUS
-from modules.helpers.logging_helper import log_module_import
+from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.helpers.logging_helper import log_exception, log_module_import
+from modules.scenarios.ai_prompt_library import PromptLibrary, ScenarioPrompt
+from modules.scenarios.ai_scenario_generator import (
+    AIGenerationError,
+    AIScenarioGenerator,
+    build_final_prompt,
+    parse_generated_scenario,
+    validate_required_answers,
+)
+from modules.scenarios.prompt_library_dialog import PromptLibraryDialog
 
 log_module_import(__name__)
 
+
 class ScenarioGeneratorView(ctk.CTkFrame):
-    """Frame embedding the scenario generator inside the main application."""
+    """Frame embedding random and AI prompt-based scenario generation."""
 
     def __init__(self, parent):
         """Initialize the ScenarioGeneratorView instance."""
         super().__init__(parent)
-
+        self.mode_var = ctk.StringVar(value="Random generator")
         self.setting_var = ctk.StringVar(value=list(GENERATOR_FUNCTIONS.keys())[0])
         self.title_var = ctk.StringVar(value="")
-        self.current_campaign = None
-
+        self.prompt_library = PromptLibrary()
+        self.prompts: list[ScenarioPrompt] = []
+        self.prompt_var = ctk.StringVar(value="")
+        self.question_mode_var = ctk.StringVar(value="Guided")
+        self.answer_vars: dict[str, tk.StringVar] = {}
+        self.guided_index = 0
+        self.guided_answers: dict[str, str] = {}
+        self.current_campaign: dict[str, str] | None = None
+        self.current_ai_text = ""
+        self._load_prompts()
         self._build_widgets()
+        self._on_mode_changed(self.mode_var.get())
 
-    # ------------------------------------------------------------------
-    def _build_widgets(self):
+    def _load_prompts(self) -> None:
+        """Load prompt names for the selector."""
+        try:
+            self.prompts = self.prompt_library.load()
+        except Exception as exc:
+            log_exception("Failed to load prompt library")
+            messagebox.showerror("Prompt Library", str(exc))
+            self.prompts = []
+        if self.prompts and not self.prompt_var.get():
+            self.prompt_var.set(self.prompts[0].name)
+
+    def _build_widgets(self) -> None:
         """Build widgets."""
         top = ctk.CTkFrame(self)
         top.pack(fill="x", padx=10, pady=10)
+        ctk.CTkLabel(top, text="Mode:").pack(side="left")
+        ctk.CTkOptionMenu(top, values=["Random generator", "AI prompt generator"], variable=self.mode_var, command=self._on_mode_changed).pack(side="left", padx=5)
 
-        ctk.CTkLabel(top, text="Setting:").pack(side="left")
-        ctk.CTkOptionMenu(top, values=list(GENERATOR_FUNCTIONS.keys()),
-                          variable=self.setting_var).pack(side="left", padx=5)
-        ctk.CTkButton(top, text="Generate", command=self.generate_campaign).pack(side="left", padx=5)
+        self.random_frame = ctk.CTkFrame(self)
+        ctk.CTkLabel(self.random_frame, text="Setting:").pack(side="left")
+        ctk.CTkOptionMenu(self.random_frame, values=list(GENERATOR_FUNCTIONS.keys()), variable=self.setting_var).pack(side="left", padx=5)
+        ctk.CTkButton(self.random_frame, text="Generate", command=self.generate_campaign).pack(side="left", padx=5)
 
+        self.ai_frame = ctk.CTkFrame(self)
+        ctk.CTkLabel(self.ai_frame, text="Prompt:").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        self.prompt_menu = ctk.CTkOptionMenu(self.ai_frame, values=self._prompt_names(), variable=self.prompt_var, command=lambda _v: self._render_questions())
+        self.prompt_menu.grid(row=0, column=1, sticky="ew", padx=6, pady=4)
+        ctk.CTkButton(self.ai_frame, text="Manage Prompts", command=self._open_prompt_manager).grid(row=0, column=2, padx=6, pady=4)
+        ctk.CTkLabel(self.ai_frame, text="Question mode:").grid(row=0, column=3, sticky="w", padx=6, pady=4)
+        ctk.CTkOptionMenu(self.ai_frame, values=["Guided", "Advanced/manual"], variable=self.question_mode_var, command=lambda _v: self._render_questions()).grid(row=0, column=4, padx=6, pady=4)
+        self.ai_frame.grid_columnconfigure(1, weight=1)
+        self.questions_frame = ctk.CTkFrame(self.ai_frame)
+        self.questions_frame.grid(row=1, column=0, columnspan=5, sticky="ew", padx=6, pady=6)
+        self.questions_frame.grid_columnconfigure(1, weight=1)
+        actions = ctk.CTkFrame(self.ai_frame)
+        actions.grid(row=2, column=0, columnspan=5, sticky="ew", padx=6, pady=6)
+        self.guided_back_btn = ctk.CTkButton(actions, text="Back", command=self._guided_back)
+        self.guided_back_btn.pack(side="left", padx=4)
+        self.guided_next_btn = ctk.CTkButton(actions, text="Next", command=self._guided_next)
+        self.guided_next_btn.pack(side="left", padx=4)
+        self.generate_ai_btn = ctk.CTkButton(actions, text="Generate with AI", command=self.generate_with_ai)
+        self.generate_ai_btn.pack(side="left", padx=4)
+        self.progress_label = ctk.CTkLabel(actions, text="")
+        self.progress_label.pack(side="left", padx=10)
 
-        # Scrollable area for displaying generated scenario cards
         self.results_frame = ctk.CTkScrollableFrame(self, fg_color="#2c3e50")
         self.results_frame.pack(fill="both", expand=True, padx=10, pady=10)
+        self.ai_result_text = ctk.CTkTextbox(self.results_frame, wrap="word")
 
         bottom = ctk.CTkFrame(self)
         bottom.pack(fill="x", padx=10, pady=(0, 10))
-
         ctk.CTkLabel(bottom, text="Title:").pack(side="left")
         ctk.CTkEntry(bottom, textvariable=self.title_var).pack(side="left", padx=5, fill="x", expand=True)
-        self.export_btn = ctk.CTkButton(bottom, text="Export to DOCX",
-                                       command=self.export_docx, state="disabled")
+        self.export_btn = ctk.CTkButton(bottom, text="Export to DOCX", command=self.export_docx, state="disabled")
         self.export_btn.pack(side="left", padx=5)
-        self.add_btn = ctk.CTkButton(bottom, text="Add to DB",
-                                    command=self.add_to_db, state="disabled")
+        self.add_btn = ctk.CTkButton(bottom, text="Save to DB", command=self.add_to_db, state="disabled")
         self.add_btn.pack(side="left", padx=5)
+        self._render_questions()
 
+    def _prompt_names(self) -> list[str]:
+        return [prompt.name for prompt in self.prompts] or [""]
 
-    # ------------------------------------------------------------------
-    def generate_campaign(self):
-        """Handle generate campaign."""
-        setting = self.setting_var.get()
-        try:
-            generator = GENERATOR_FUNCTIONS[setting]
-            campaign = generator()
-        except Exception as e:
-            messagebox.showerror("Error", f"Failed to generate scenario: {e}")
+    def _current_prompt(self) -> ScenarioPrompt | None:
+        return next((prompt for prompt in self.prompts if prompt.name == self.prompt_var.get()), None)
+
+    def _on_mode_changed(self, _value: str) -> None:
+        self.random_frame.pack_forget()
+        self.ai_frame.pack_forget()
+        if self.mode_var.get() == "AI prompt generator":
+            self.ai_frame.pack(fill="x", padx=10, pady=(0, 10))
+        else:
+            self.random_frame.pack(fill="x", padx=10, pady=(0, 10))
+
+    def _open_prompt_manager(self) -> None:
+        PromptLibraryDialog(self, self.prompt_library, on_change=self._reload_prompts_from_dialog)
+
+    def _reload_prompts_from_dialog(self) -> None:
+        self._load_prompts()
+        self.prompt_menu.configure(values=self._prompt_names())
+        if self.prompts:
+            self.prompt_var.set(self.prompts[0].name)
+        self._render_questions()
+
+    def _render_questions(self) -> None:
+        for child in self.questions_frame.winfo_children():
+            child.destroy()
+        prompt = self._current_prompt()
+        self.answer_vars = {}
+        if not prompt:
+            ctk.CTkLabel(self.questions_frame, text="No prompt available. Use Manage Prompts to create one.").grid(row=0, column=0, sticky="w")
             return
+        questions = prompt.questions
+        if self.question_mode_var.get() == "Guided":
+            self.guided_index = min(self.guided_index, max(len(questions) - 1, 0))
+            if not questions:
+                ctk.CTkLabel(self.questions_frame, text="This prompt has no questions.").grid(row=0, column=0, sticky="w")
+                return
+            question = questions[self.guided_index]
+            ctk.CTkLabel(self.questions_frame, text=f"Question {self.guided_index + 1}/{len(questions)}: {question.label}").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+            var = tk.StringVar(value=self.guided_answers.get(question.key, question.default))
+            self.answer_vars[question.key] = var
+            ctk.CTkEntry(self.questions_frame, textvariable=var).grid(row=1, column=0, sticky="ew", padx=6, pady=4)
+        else:
+            for row, question in enumerate(questions):
+                ctk.CTkLabel(self.questions_frame, text=question.label).grid(row=row, column=0, sticky="w", padx=6, pady=3)
+                var = tk.StringVar(value=self.guided_answers.get(question.key, question.default))
+                self.answer_vars[question.key] = var
+                ctk.CTkEntry(self.questions_frame, textvariable=var).grid(row=row, column=1, sticky="ew", padx=6, pady=3)
 
-        self.current_campaign = campaign
+    def _collect_answers(self) -> dict[str, str]:
+        answers = dict(self.guided_answers)
+        for key, var in self.answer_vars.items():
+            answers[key] = var.get().strip()
+        return answers
 
+    def _guided_next(self) -> None:
+        prompt = self._current_prompt()
+        if not prompt:
+            return
+        self.guided_answers.update(self._collect_answers())
+        if self.guided_index < len(prompt.questions) - 1:
+            self.guided_index += 1
+            self._render_questions()
 
-        # Clear previous results
+    def _guided_back(self) -> None:
+        self.guided_answers.update(self._collect_answers())
+        if self.guided_index > 0:
+            self.guided_index -= 1
+            self._render_questions()
+
+    def _clear_results(self) -> None:
         for child in self.results_frame.winfo_children():
             child.destroy()
 
-        # Display each entry as a styled card similar to the original UI
+    def generate_campaign(self) -> None:
+        """Generate a legacy random scenario."""
+        setting = self.setting_var.get()
+        try:
+            campaign = GENERATOR_FUNCTIONS[setting]()
+        except Exception as exc:
+            log_exception("Random scenario generation failed")
+            messagebox.showerror("Error", f"Failed to generate scenario: {exc}")
+            return
+        self.current_campaign = campaign
+        self.current_ai_text = ""
+        self._clear_results()
         for key, value in campaign.items():
-            # Process each (key, value) from campaign.items().
-            card = ctk.CTkFrame(
-                self.results_frame,
-                fg_color="#34495e",
-                corner_radius=4,
-            )
-            title_lbl = ctk.CTkLabel(
-                card,
-                text=key,
-                text_color="#ecf0f1",
-                font=("Helvetica", 16, "bold"),
-                anchor="w",
-            )
-            desc_lbl = ctk.CTkLabel(
-                card,
-                text=value,
-                text_color="#bdc3c7",
-                justify="left",
-                wraplength=1580,
-                font=("Helvetica", 14),
-            )
+            card = ctk.CTkFrame(self.results_frame, fg_color="#34495e", corner_radius=4)
+            title_lbl = ctk.CTkLabel(card, text=key, text_color="#ecf0f1", font=("Helvetica", 16, "bold"), anchor="w")
+            desc_lbl = ctk.CTkLabel(card, text=value, text_color="#bdc3c7", justify="left", wraplength=1580, font=("Helvetica", 14))
             title_lbl.pack(anchor="w", padx=8, pady=(4, 0))
             desc_lbl.pack(anchor="w", fill="x", padx=8, pady=(0, 6))
             card.pack(fill="x", expand=True, padx=5, pady=5)
-
-            def _update_desc_wrap(_event=None, label=desc_lbl, parent=card):
-                """Update desc wrap."""
-                try:
-                    label.configure(wraplength=max(320, parent.winfo_width() - 24))
-                except Exception:
-                    pass
-
-            card.bind("<Configure>", _update_desc_wrap, add="+")
-            self.after_idle(_update_desc_wrap)
-
         self.export_btn.configure(state="normal")
         self.add_btn.configure(state="normal")
 
-    # ------------------------------------------------------------------
-    def export_docx(self):
-        """Export docx."""
-        if not self.current_campaign:
+    def generate_with_ai(self) -> None:
+        """Generate a scenario from the selected AI prompt without freezing the UI."""
+        prompt = self._current_prompt()
+        if not prompt:
+            messagebox.showwarning("No Prompt", "Select or create a prompt first.")
+            return
+        answers = self._collect_answers()
+        missing = validate_required_answers(prompt, answers)
+        if missing:
+            messagebox.showwarning("Missing Answers", "Please answer: " + ", ".join(missing))
+            return
+        _final, unresolved = build_final_prompt(prompt, answers)
+        if unresolved:
+            messagebox.showwarning("Placeholder Warning", "Unanswered placeholders: " + ", ".join(unresolved))
+        self.generate_ai_btn.configure(state="disabled")
+        self.progress_label.configure(text="Generating with AI...")
+
+        def worker() -> None:
+            try:
+                result = AIScenarioGenerator().generate(prompt, answers)
+            except Exception as exc:
+                self.after(0, lambda: self._on_ai_error(exc))
+                return
+            self.after(0, lambda: self._on_ai_success(result))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_ai_success(self, text: str) -> None:
+        self.generate_ai_btn.configure(state="normal")
+        self.progress_label.configure(text="")
+        if not text.strip():
+            messagebox.showerror("AI Error", "AI provider returned an empty scenario.")
+            return
+        self.current_ai_text = text.strip()
+        parsed = parse_generated_scenario(self.current_ai_text)
+        self.current_campaign = self._ai_export_payload(self.current_ai_text)
+        if parsed.get("Title") and not self.title_var.get().strip():
+            self.title_var.set(str(parsed["Title"]))
+        self._clear_results()
+        self.ai_result_text = ctk.CTkTextbox(self.results_frame, wrap="word")
+        self.ai_result_text.insert("1.0", self.current_ai_text)
+        self.ai_result_text.pack(fill="both", expand=True, padx=5, pady=5)
+        self.export_btn.configure(state="normal")
+        self.add_btn.configure(state="normal")
+
+    def _on_ai_error(self, exc: Exception) -> None:
+        self.generate_ai_btn.configure(state="normal")
+        self.progress_label.configure(text="")
+        log_exception("AI scenario generation failed")
+        if isinstance(exc, AIGenerationError):
+            messagebox.showerror("AI Provider Unavailable", str(exc))
+        else:
+            messagebox.showerror("AI Error", f"Failed to generate scenario: {exc}")
+
+    def _current_result_text(self) -> str:
+        if self.current_ai_text and self.ai_result_text.winfo_exists():
+            return self.ai_result_text.get("1.0", "end").strip()
+        if self.current_campaign:
+            return "\n".join(f"{k}: {v}" for k, v in self.current_campaign.items())
+        return ""
+
+    def _ai_export_payload(self, text: str) -> dict[str, str]:
+        parsed = parse_generated_scenario(text)
+        return {"Generated Scenario": text, "Secrets": str(parsed.get("Secrets", ""))}
+
+    def export_docx(self) -> None:
+        """Export the current scenario to DOCX."""
+        if not self.current_campaign and not self.current_ai_text:
             messagebox.showwarning("No Scenario", "Generate a scenario first.")
             return
-
-        filename = filedialog.asksaveasfilename(
-            defaultextension=".docx",
-            filetypes=[("Word Document", "*.docx")],
-            title="Save Scenario" )
+        filename = filedialog.asksaveasfilename(defaultextension=".docx", filetypes=[("Word Document", "*.docx")], title="Save Scenario")
         if not filename:
             return
-
         try:
-            export_to_docx(self.current_campaign, filename)
-        except Exception as e:
-            messagebox.showerror("Export Error", str(e))
+            payload = self._ai_export_payload(self._current_result_text()) if self.current_ai_text else self.current_campaign
+            export_to_docx(payload, filename)
+        except Exception as exc:
+            log_exception("Scenario DOCX export failed")
+            messagebox.showerror("Export Error", str(exc))
             return
-
         messagebox.showinfo("Exported", "Scenario exported to DOCX.")
 
-    # ------------------------------------------------------------------
-    def add_to_db(self):
-        """Handle add to DB."""
-        if not self.current_campaign:
+    def add_to_db(self) -> None:
+        """Save the current scenario to the database."""
+        if not self.current_campaign and not self.current_ai_text:
             messagebox.showwarning("No Scenario", "Generate a scenario first.")
             return
-
         title = self.title_var.get().strip()
         if not title:
             messagebox.showwarning("Missing Title", "Please provide a title for the scenario.")
             return
-
-        summary = "\n".join(f"{k}: {v}" for k, v in self.current_campaign.items())
-        scenario_entity = {
-            "Title": title,
-            "Status": DEFAULT_SCENARIO_STATUS,
-            "Summary": summary,
-            "Secrets": "",
-            "Places": [],
-            "NPCs": [],
-            "Objects": [],
-        }
-
-        wrapper = GenericModelWrapper("scenarios")
-        existing = wrapper.load_items()
-        if any(s.get("Title") == title for s in existing):
-            messagebox.showwarning("Duplicate Title", f"A scenario titled '{title}' already exists.")
+        if self.current_ai_text:
+            text = self._current_result_text()
+            parsed = parse_generated_scenario(text)
+            scenario_entity = {
+                "Title": title,
+                "Status": DEFAULT_SCENARIO_STATUS,
+                "Summary": str(parsed.get("Summary") or text),
+                "Secrets": str(parsed.get("Secrets") or ""),
+                "Places": parsed.get("Places") if isinstance(parsed.get("Places"), list) else [],
+                "NPCs": parsed.get("NPCs") if isinstance(parsed.get("NPCs"), list) else [],
+                "Objects": parsed.get("Objects") if isinstance(parsed.get("Objects"), list) else [],
+            }
+        else:
+            summary = "\n".join(f"{k}: {v}" for k, v in self.current_campaign.items())
+            scenario_entity = {"Title": title, "Status": DEFAULT_SCENARIO_STATUS, "Summary": summary, "Secrets": "", "Places": [], "NPCs": [], "Objects": []}
+        try:
+            wrapper = GenericModelWrapper("scenarios")
+            existing = wrapper.load_items()
+            if any(str(s.get("Title", "")).strip().lower() == title.lower() for s in existing):
+                messagebox.showwarning("Duplicate Title", f"A scenario titled '{title}' already exists. Please rename it before saving.")
+                return
+            existing.append(scenario_entity)
+            wrapper.save_items(existing)
+        except Exception as exc:
+            log_exception("Scenario database save failed")
+            messagebox.showerror("Save Error", str(exc))
             return
-
-        existing.append(scenario_entity)
-        wrapper.save_items(existing)
         messagebox.showinfo("Saved", f"Scenario '{title}' added to database.")
-
-    # ------------------------------------------------------------------

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -1,0 +1,81 @@
+"""Tests for AI prompt library and scenario generation helpers."""
+
+
+import pytest
+
+from modules.scenarios.ai_prompt_library import (
+    PromptLibrary,
+    PromptLibraryError,
+    PromptQuestion,
+    ScenarioPrompt,
+    extract_placeholders,
+    validate_prompt,
+)
+from modules.scenarios.ai_scenario_generator import build_final_prompt, parse_generated_scenario, validate_required_answers
+
+
+def test_extract_placeholders_ignores_duplicates_and_invalid_format_parts():
+    assert extract_placeholders("Use {theme} in {location}. Again {theme} and {npc.name}.") == ["theme", "location", "npc"]
+
+
+def test_validate_prompt_requires_name_text_and_unique_names():
+    prompt = ScenarioPrompt.new("", "", "", "", [])
+    existing = [ScenarioPrompt.new("Existing", "", "", "Text", [])]
+    duplicate = ScenarioPrompt.new("Existing", "", "", "Text", [])
+    errors = validate_prompt(prompt, existing)
+    assert "Prompt name is required." in errors
+    assert "Prompt text is required." in errors
+    assert validate_prompt(duplicate, existing) == ["A prompt named 'Existing' already exists."]
+
+
+def test_prompt_library_load_save_import_export_roundtrip(tmp_path):
+    library = PromptLibrary(tmp_path / "prompts.json")
+    prompt = ScenarioPrompt.new("Mystery", "Desc", "Modern", "Write {theme}", [PromptQuestion("theme", "Theme")])
+    library.save([prompt])
+    loaded = library.load()
+    assert loaded[0].name == "Mystery"
+    exported = tmp_path / "export.json"
+    library.export_to_file(loaded, exported)
+    imported_library = PromptLibrary(tmp_path / "imported.json")
+    imported = imported_library.import_from_file(exported, merge=False)
+    assert imported[0].questions[0].key == "theme"
+
+
+def test_prompt_library_rejects_invalid_json_import(tmp_path):
+    library = PromptLibrary(tmp_path / "prompts.json")
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(PromptLibraryError):
+        library.import_from_file(bad)
+
+
+def test_build_final_prompt_and_required_answers():
+    prompt = ScenarioPrompt.new(
+        "Prompt",
+        "",
+        "",
+        "Type {scenario_type}; theme {theme}; unknown {unknown}",
+        [PromptQuestion("scenario_type", "Type"), PromptQuestion("theme", "Theme")],
+    )
+    assert validate_required_answers(prompt, {"scenario_type": "fantasy"}) == ["Theme"]
+    final, unresolved = build_final_prompt(prompt, {"scenario_type": "fantasy", "theme": "betrayal"})
+    assert "Type fantasy" in final
+    assert unresolved == ["unknown"]
+
+
+def test_parse_generated_scenario_sections_best_effort():
+    text = """Title: The Ash Bell
+Scenario Summary, maximum 8 short lines:
+A bell wakes the dead.
+Secrets and Twists:
+The priest is the bell.
+NPCs:
+- Mara, ash-smudged smith
+Locations:
+- The cracked belfry
+"""
+    parsed = parse_generated_scenario(text)
+    assert parsed["Title"] == "The Ash Bell"
+    assert parsed["Secrets"] == "The priest is the bell."
+    assert parsed["NPCs"] == ["Mara, ash-smudged smith"]
+    assert parsed["Places"] == ["The cracked belfry"]


### PR DESCRIPTION
### Motivation
- Provide a reusable Prompt Library so users can store, edit and reuse AI prompts for scenario generation.  
- Add an AI-driven scenario generator that can build prompts from user answers and call a local Ollama-compatible provider while keeping the existing random generator intact.  
- Keep the UI responsive and preserve existing DB export/Docx workflows while allowing users to review and save AI-generated content.

### Description
- Added a JSON-backed prompt library with typed dataclasses, validation, placeholder extraction, import/export, duplicate/duplicate-name handling, restore-defaults, and a seeded `Professional RPG Scenario` default prompt in `modules/scenarios/ai_prompt_library.py`.  
- Implemented an AI service layer with an Ollama `/api/chat` provider, prompt-building helpers, required-answer validation, best-effort parsing of generated sections, and clear provider error handling in `modules/scenarios/ai_scenario_generator.py`.  
- Added a CustomTkinter prompt manager dialog `modules/scenarios/prompt_library_dialog.py` for CRUD, import/export, duplicate, delete-with-confirmation and restore-defaults.  
- Extended `ScenarioGeneratorView` to support mode switching between the legacy random generator and the new AI prompt generator, guided/manual question flows, threaded AI generation with progress UI, editable AI preview, DOCX export compatibility, and saving generated scenarios to the existing `scenarios` DB table (file: `modules/scenarios/scenario_generator_view.py`).  
- Added unit tests for pure helpers and library roundtrips in `tests/test_ai_prompt_scenario_generation.py` and a manual QA checklist at `docs/ai_scenario_generator_manual_checklist.md`.

### Testing
- Ran unit tests `pytest tests/test_ai_prompt_scenario_generation.py` and the existing generator refactor tests together via `pytest tests/test_campaign_generator_refactor.py tests/test_ai_prompt_scenario_generation.py` and all tests passed (combined run: 10 passed).  
- Compiled the new/modified modules with `python -m compileall` to ensure syntax correctness and there were no compile errors.  
- Basic manual checklist added for UI/QA verification of prompt CRUD, import/export, Ollama unavailable/running flows, generating, editing, saving to DB, and DOCX export.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cede67d2c832bb10722056d36a819)