### PR TITLE
Remove visible tone/party/system placeholders and simplify default prompts

### DIFF
--- a/modules/scenarios/ai_prompt_library.py
+++ b/modules/scenarios/ai_prompt_library.py
@@ -140,10 +140,10 @@ You are a professional RPG scenario writer working in the RPG industry. Your sty
 - Type or background: {scenario_type}
 - Theme: {theme}
 - Location: {location}
-- Tone: {tone}
-- Party level: {party_level}
-- System: {system}
-- Additional constraints: {additional_constraints}
+- Tone: cinematic, mysterious, and playable
+- Power scale: appropriate for the campaign
+- System: system-neutral unless implied by the background
+- Constraints: none unless implied by the user answers
 
 # Rules
 1. Reread, criticize, and improve your own scenario before giving the final answer.
@@ -196,13 +196,9 @@ def default_prompts() -> list[ScenarioPrompt]:
             category="Generic RPG",
             prompt_text=DEFAULT_PROMPT_TEXT,
             questions=[
-                PromptQuestion("scenario_type", "Type or background (medfan, sci-fi, Star Wars, Dresden Files...)", True),
+                PromptQuestion("scenario_type", "Type or background (medfan, sci-fi, modern, Star Wars, Dresden Files, Dragonlance...)", True),
                 PromptQuestion("theme", "Theme of the scenario", True),
                 PromptQuestion("location", "Location of the scenario", True),
-                PromptQuestion("tone", "Tone", False, "mysterious and cinematic"),
-                PromptQuestion("party_level", "Party level / power scale", False, "appropriate for the current campaign"),
-                PromptQuestion("system", "Game system", False, "system-neutral"),
-                PromptQuestion("additional_constraints", "Additional constraints", False, "none"),
             ],
         )
     ]


### PR DESCRIPTION
### Motivation
- Reduce visible user-answer placeholders in the default scenario prompt to keep tone/power/system guidance internal and clearer for the model. 
- Simplify the built-in "Professional RPG Scenario" questions to only collect the essential user inputs for scenario generation.

### Description
- Replaced the visible placeholders ` {tone}`, `{party_level}`, `{system}`, and `{additional_constraints}` in `DEFAULT_PROMPT_TEXT` with fixed internal guidance lines: `Tone: cinematic, mysterious, and playable`, `Power scale: appropriate for the campaign`, `System: system-neutral unless implied by the background`, and `Constraints: none unless implied by the user answers`.
- Updated `default_prompts()` so the "Professional RPG Scenario" `questions` list contains only `PromptQuestion("scenario_type", "Type or background (medfan, sci-fi, modern, Star Wars, Dresden Files, Dragonlance...)", True)`, `PromptQuestion("theme", "Theme of the scenario", True)`, and `PromptQuestion("location", "Location of the scenario", True)`.
- Ensured no remaining required placeholder in `DEFAULT_PROMPT_TEXT` references the removed question keys and adjusted the `scenario_type` label text.

### Testing
- Ran a small assertion script that imported `DEFAULT_PROMPT_TEXT`, `default_prompts()`, and `extract_placeholders` and asserted `extract_placeholders(DEFAULT_PROMPT_TEXT) == ['scenario_type', 'theme', 'location']` and that the prompt question keys match, which succeeded.
- Ran the unit test file `pytest tests/test_ai_prompt_scenario_generation.py` and all tests passed (6 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cf8e45cb8832baaa6e1c229defbba)