### PR TITLE
Migrate legacy default scenario prompt questions

### DIFF
--- a/modules/scenarios/ai_prompt_library.py
+++ b/modules/scenarios/ai_prompt_library.py
@@ -133,6 +133,30 @@ def validate_prompt(prompt: ScenarioPrompt, existing: list[ScenarioPrompt] | Non
     return errors
 
 
+DEFAULT_PROMPT_NAME = "Professional RPG Scenario"
+DEFAULT_PROMPT_DESCRIPTION = "Industry-style prompt for a complete, playable RPG scenario."
+DEFAULT_PROMPT_CATEGORY = "Generic RPG"
+LEGACY_DEFAULT_OPTIONAL_QUESTION_KEYS = {
+    "tone",
+    "party_level",
+    "system",
+    "additional_constraints",
+}
+
+
+def default_prompt_questions() -> list[PromptQuestion]:
+    """Return the current question flow for the built-in default prompt."""
+    return [
+        PromptQuestion(
+            "scenario_type",
+            "Type or background (medfan, sci-fi, modern, Star Wars, Dresden Files, Dragonlance...)",
+            True,
+        ),
+        PromptQuestion("theme", "Theme of the scenario", True),
+        PromptQuestion("location", "Location of the scenario", True),
+    ]
+
+
 DEFAULT_PROMPT_TEXT = """# Role
 You are a professional RPG scenario writer working in the RPG industry. Your style is original, witty, sensory, mysterious, and immediately usable at the table. Use strong hooks, meaningful NPC motives, scene escalation, player agency, secrets, revelations, and playable conflicts.
 
@@ -191,17 +215,23 @@ def default_prompts() -> list[ScenarioPrompt]:
     """Return built-in prompts used to seed or restore the library."""
     return [
         ScenarioPrompt.new(
-            name="Professional RPG Scenario",
-            description="Industry-style prompt for a complete, playable RPG scenario.",
-            category="Generic RPG",
+            name=DEFAULT_PROMPT_NAME,
+            description=DEFAULT_PROMPT_DESCRIPTION,
+            category=DEFAULT_PROMPT_CATEGORY,
             prompt_text=DEFAULT_PROMPT_TEXT,
-            questions=[
-                PromptQuestion("scenario_type", "Type or background (medfan, sci-fi, modern, Star Wars, Dresden Files, Dragonlance...)", True),
-                PromptQuestion("theme", "Theme of the scenario", True),
-                PromptQuestion("location", "Location of the scenario", True),
-            ],
+            questions=default_prompt_questions(),
         )
     ]
+
+
+def _is_builtin_default_prompt(prompt: ScenarioPrompt) -> bool:
+    """Return whether a prompt clearly identifies the built-in default prompt."""
+    name_matches = prompt.name.strip().casefold() == DEFAULT_PROMPT_NAME.casefold()
+    metadata_matches = (
+        prompt.category.strip().casefold() == DEFAULT_PROMPT_CATEGORY.casefold()
+        and prompt.description.strip().casefold() == DEFAULT_PROMPT_DESCRIPTION.casefold()
+    )
+    return name_matches or metadata_matches
 
 
 class PromptLibrary:
@@ -227,7 +257,23 @@ class PromptLibrary:
         if not prompts:
             prompts = default_prompts()
             self.save(prompts)
+        elif self._migrate_builtin_default_questions(prompts):
+            self.save(prompts)
         return prompts
+
+    def _migrate_builtin_default_questions(self, prompts: list[ScenarioPrompt]) -> bool:
+        """Normalize legacy built-in default prompts to the current three-question flow."""
+        migrated = False
+        for prompt in prompts:
+            if not _is_builtin_default_prompt(prompt):
+                continue
+            question_keys = {question.key.strip() for question in prompt.questions}
+            if not question_keys.intersection(LEGACY_DEFAULT_OPTIONAL_QUESTION_KEYS):
+                continue
+            prompt.questions = default_prompt_questions()
+            prompt.updated_at = _utc_now()
+            migrated = True
+        return migrated
 
     def save(self, prompts: list[ScenarioPrompt]) -> None:
         """Persist prompts to JSON."""

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -41,6 +41,60 @@ def test_prompt_library_load_save_import_export_roundtrip(tmp_path):
     assert imported[0].questions[0].key == "theme"
 
 
+def test_prompt_library_migrates_legacy_builtin_default_questions(tmp_path):
+    library = PromptLibrary(tmp_path / "prompts.json")
+    legacy_prompt = ScenarioPrompt.new(
+        "Professional RPG Scenario",
+        "Industry-style prompt for a complete, playable RPG scenario.",
+        "Generic RPG",
+        "Write {scenario_type} {theme} {location}",
+        [
+            PromptQuestion("scenario_type", "Type"),
+            PromptQuestion("theme", "Theme"),
+            PromptQuestion("location", "Location"),
+            PromptQuestion("tone", "Tone", False),
+            PromptQuestion("party_level", "Party level", False),
+            PromptQuestion("system", "System", False),
+            PromptQuestion("additional_constraints", "Additional constraints", False),
+        ],
+    )
+    custom_prompt = ScenarioPrompt.new(
+        "Custom Scenario",
+        "Custom prompt that happens to use legacy-style optional questions.",
+        "Generic RPG",
+        "Write {scenario_type} {tone}",
+        [PromptQuestion("scenario_type", "Type"), PromptQuestion("tone", "Tone", False)],
+    )
+    library.save([legacy_prompt, custom_prompt])
+
+    loaded = library.load()
+
+    assert [question.key for question in loaded[0].questions] == ["scenario_type", "theme", "location"]
+    assert [question.key for question in loaded[1].questions] == ["scenario_type", "tone"]
+
+    reloaded = PromptLibrary(tmp_path / "prompts.json").load()
+    assert [question.key for question in reloaded[0].questions] == ["scenario_type", "theme", "location"]
+
+
+def test_prompt_library_migrates_builtin_default_by_known_metadata(tmp_path):
+    library = PromptLibrary(tmp_path / "prompts.json")
+    legacy_prompt = ScenarioPrompt.new(
+        "Renamed Default",
+        "Industry-style prompt for a complete, playable RPG scenario.",
+        "Generic RPG",
+        "Write {scenario_type} {theme} {location}",
+        [
+            PromptQuestion("scenario_type", "Type"),
+            PromptQuestion("additional_constraints", "Additional constraints", False),
+        ],
+    )
+    library.save([legacy_prompt])
+
+    loaded = library.load()
+
+    assert [question.key for question in loaded[0].questions] == ["scenario_type", "theme", "location"]
+
+
 def test_prompt_library_rejects_invalid_json_import(tmp_path):
     library = PromptLibrary(tmp_path / "prompts.json")
     bad = tmp_path / "bad.json"


### PR DESCRIPTION
### Motivation
- Existing installs sometimes contain an older built-in default prompt that included legacy optional question keys (`tone`, `party_level`, `system`, `additional_constraints`) which caused the UI to show an extra "Question 7/7: Additional constraints" step for longtime users.
- The goal is to normalize only the built-in default prompt to the new three-question flow so users keep a clean UI while preserving any user-created custom prompts.

### Description
- Added explicit built-in default identity constants `DEFAULT_PROMPT_NAME`, `DEFAULT_PROMPT_DESCRIPTION`, and `DEFAULT_PROMPT_CATEGORY` and a helper `default_prompt_questions()` that returns the new three-question flow (`scenario_type`, `theme`, `location`).
- Implemented `_is_builtin_default_prompt(prompt: ScenarioPrompt)` to detect prompts that clearly match the built-in default by name or known metadata.
- Added `_migrate_builtin_default_questions(self, prompts: list[ScenarioPrompt])` and invoked it inside `PromptLibrary.load()` so that when a builtin default prompt still contains legacy optional keys it is normalized to the new three-question flow and its `updated_at` is refreshed.
- Ensure the migration only targets prompts that match the built-in identity and only when legacy optional keys are present, leaving custom user prompts intact, and persist the migrated library via `self.save(prompts)` so the UI updates for existing users.
- Files changed: `modules/scenarios/ai_prompt_library.py` and added regression cases in `tests/test_ai_prompt_scenario_generation.py`.

### Testing
- Ran `pytest tests/test_ai_prompt_scenario_generation.py` which executed the new migration regression tests and existing cases; all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cfcfabb98832baf5d12bd52af9316)