### PR TITLE
Normalize legacy default prompt question keys for migration

### DIFF
--- a/modules/scenarios/ai_prompt_library.py
+++ b/modules/scenarios/ai_prompt_library.py
@@ -144,6 +144,11 @@ LEGACY_DEFAULT_OPTIONAL_QUESTION_KEYS = {
 }
 
 
+def _normalized_question_keys(questions: list[PromptQuestion]) -> set[str]:
+    """Return normalized question keys for identity and migration checks."""
+    return {question.key.strip().casefold() for question in questions}
+
+
 def default_prompt_questions() -> list[PromptQuestion]:
     """Return the current question flow for the built-in default prompt."""
     return [
@@ -267,7 +272,7 @@ class PromptLibrary:
         for prompt in prompts:
             if not _is_builtin_default_prompt(prompt):
                 continue
-            question_keys = {question.key.strip() for question in prompt.questions}
+            question_keys = _normalized_question_keys(prompt.questions)
             if not question_keys.intersection(LEGACY_DEFAULT_OPTIONAL_QUESTION_KEYS):
                 continue
             prompt.questions = default_prompt_questions()

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -52,7 +52,7 @@ def test_prompt_library_migrates_legacy_builtin_default_questions(tmp_path):
             PromptQuestion("scenario_type", "Type"),
             PromptQuestion("theme", "Theme"),
             PromptQuestion("location", "Location"),
-            PromptQuestion("tone", "Tone", False),
+            PromptQuestion("Tone", "Tone", False),
             PromptQuestion("party_level", "Party level", False),
             PromptQuestion("system", "System", False),
             PromptQuestion("additional_constraints", "Additional constraints", False),


### PR DESCRIPTION
### Motivation
- Ensure the built-in default prompt migration reliably detects legacy optional question keys (regardless of case) and persists the migrated three-question flow so the UI no longer shows the old extra question.

### Description
- Add `_normalized_question_keys(questions)` to produce casefolded question keys and use it in `_migrate_builtin_default_questions` so legacy keys like `"Tone"` or `"tone"` are recognized and the prompt is normalized to `default_prompt_questions()` without touching custom prompts, and leave existing save-on-migrate behavior intact.
- Update tests to cover case-insensitive legacy optional key names.

### Testing
- Ran `pytest tests/test_ai_prompt_scenario_generation.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cff193c40832b8ea512b11ee7a7a5)