### PR TITLE
Fix legacy scenario prompt placeholder warning

### DIFF
--- a/modules/scenarios/ai_prompt_library.py
+++ b/modules/scenarios/ai_prompt_library.py
@@ -273,9 +273,12 @@ class PromptLibrary:
             if not _is_builtin_default_prompt(prompt):
                 continue
             question_keys = _normalized_question_keys(prompt.questions)
-            if not question_keys.intersection(LEGACY_DEFAULT_OPTIONAL_QUESTION_KEYS):
+            prompt_placeholders = {name.casefold() for name in extract_placeholders(prompt.prompt_text)}
+            legacy_keys = question_keys.union(prompt_placeholders)
+            if not legacy_keys.intersection(LEGACY_DEFAULT_OPTIONAL_QUESTION_KEYS):
                 continue
             prompt.questions = default_prompt_questions()
+            prompt.prompt_text = DEFAULT_PROMPT_TEXT
             prompt.updated_at = _utc_now()
             migrated = True
         return migrated

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -95,6 +95,30 @@ def test_prompt_library_migrates_builtin_default_by_known_metadata(tmp_path):
     assert [question.key for question in loaded[0].questions] == ["scenario_type", "theme", "location"]
 
 
+def test_prompt_library_migrates_builtin_default_prompt_text_placeholders(tmp_path):
+    library = PromptLibrary(tmp_path / "prompts.json")
+    legacy_prompt = ScenarioPrompt.new(
+        "Professional RPG Scenario",
+        "Industry-style prompt for a complete, playable RPG scenario.",
+        "Generic RPG",
+        "Write {scenario_type} {tone} {party_level} {system} {additional_constraints}",
+        [
+            PromptQuestion("scenario_type", "Type"),
+            PromptQuestion("theme", "Theme"),
+            PromptQuestion("location", "Location"),
+        ],
+    )
+    library.save([legacy_prompt])
+
+    loaded = library.load()
+    _final, unresolved = build_final_prompt(
+        loaded[0],
+        {"scenario_type": "medfan", "theme": "betrayal", "location": "old abbey"},
+    )
+
+    assert unresolved == []
+    assert [question.key for question in loaded[0].questions] == ["scenario_type", "theme", "location"]
+
 def test_prompt_library_rejects_invalid_json_import(tmp_path):
     library = PromptLibrary(tmp_path / "prompts.json")
     bad = tmp_path / "bad.json"


### PR DESCRIPTION
### Motivation
- Prevent legacy built-in prompts from emitting unresolved placeholder warnings when optional legacy placeholders appear in either the stored `questions` or the `prompt_text`.

### Description
- Update `PromptLibrary._migrate_builtin_default_questions` to consider placeholders extracted from `prompt.prompt_text` in addition to existing question keys, and reset `prompt.prompt_text` to `DEFAULT_PROMPT_TEXT` when migrating a legacy built-in prompt while updating `prompt.updated_at`.
- Add a regression test `test_prompt_library_migrates_builtin_default_prompt_text_placeholders` in `tests/test_ai_prompt_scenario_generation.py` that verifies the migrated prompt uses the three canonical questions and does not produce unresolved placeholders during `build_final_prompt`.

### Testing
- Ran `pytest tests/test_ai_prompt_scenario_generation.py -q`, which passed (9 passed). 
- Ran `python -m compileall modules/scenarios/ai_prompt_library.py modules/scenarios/ai_scenario_generator.py modules/scenarios/scenario_generator_view.py` with no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d00bde684832b96b145e42c34a4a1)