### PR TITLE
Structure AI-generated scenarios into scenes and links

### DIFF
--- a/modules/generic/editor/window_components/ai_scenario_generation.py
+++ b/modules/generic/editor/window_components/ai_scenario_generation.py
@@ -3,6 +3,7 @@
 from modules.generic.editor.window_context import *
 from modules.campaigns.services.ai.generation_policy import build_hard_constraints_block
 from modules.campaigns.services.generation_defaults_service import CampaignGenerationDefaultsService
+from modules.scenarios.generated_scenario_parser import normalize_generated_scenario_payload
 
 
 class GenericEditorWindowAIScenarioGeneration:
@@ -348,12 +349,54 @@ class GenericEditorWindowAIScenarioGeneration:
                 phase="scenario_generation",
                 phase_message="Generating scenario content",
             )
-            data = None
             try:
-                data = LocalAIClient._parse_json_safe(content)
+                data = normalize_generated_scenario_payload(LocalAIClient._parse_json_safe(content))
             except Exception:
-                # If not JSON, fallback: put entire text into Summary
-                data = {"Title": "Generated Scenario", "Summary": content, "Secrets": "", "Scenes": []}
+                # If not JSON, parse the markdown/plain text instead of losing
+                # scenes and entity references into Summary.
+                data = normalize_generated_scenario_payload(content)
+
+            def _apply_linked_list(field_name, values):
+                if not isinstance(values, (list, tuple, set)):
+                    return
+                cleaned = []
+                for value in values:
+                    text = str(value).strip()
+                    if text and text not in cleaned:
+                        cleaned.append(text)
+                if not cleaned:
+                    return
+                widgets = self.field_widgets.get(field_name, [])
+                vars_list = self.field_widgets.get(f"{field_name}_vars", [])
+                add_combobox = self.field_widgets.get(f"{field_name}_add_combobox")
+                while len(widgets) < len(cleaned) and callable(add_combobox):
+                    add_combobox()
+                    widgets = self.field_widgets.get(field_name, [])
+                    vars_list = self.field_widgets.get(f"{field_name}_vars", [])
+                if len(widgets) > len(cleaned):
+                    for widget in widgets[len(cleaned):]:
+                        try:
+                            widget.master.destroy()
+                        except Exception:
+                            pass
+                    del widgets[len(cleaned):]
+                    if len(vars_list) > len(cleaned):
+                        del vars_list[len(cleaned):]
+                for index, name in enumerate(cleaned):
+                    if index < len(vars_list):
+                        vars_list[index].set(name)
+                    elif index < len(widgets):
+                        try:
+                            widgets[index].configure(state="normal")
+                            widgets[index].delete(0, "end")
+                            widgets[index].insert(0, name)
+                            widgets[index].configure(state="readonly")
+                        except Exception:
+                            pass
+                self.item[field_name] = cleaned
+
+            for linked_field in ("NPCs", "Places", "Creatures", "Factions", "Objects", "Maps", "Bases", "Villains"):
+                _apply_linked_list(linked_field, data.get(linked_field))
 
             # Apply fields
             title = data.get("Title") or self.item.get("Title")
@@ -416,6 +459,28 @@ class GenericEditorWindowAIScenarioGeneration:
                     if isinstance(sc, dict):
                         title_value = sc.get("Title") or sc.get("Scene")
                         raw_text = sc.get("Text") or sc.get("text") or sc.get("Summary") or sc
+                        for label, names in (sc.items()):
+                            if label not in state.get("entities", {}):
+                                continue
+                            state["entities"][label] = []
+                            for name in names if isinstance(names, (list, tuple, set)) else [names]:
+                                cleaned = str(name).strip()
+                                if cleaned and cleaned not in state["entities"][label]:
+                                    state["entities"][label].append(cleaned)
+                            frame = (state.get("entity_chip_frames") or {}).get(label)
+                            if frame is not None:
+                                for widget in list(frame.winfo_children()):
+                                    try:
+                                        widget.destroy()
+                                    except Exception:
+                                        pass
+                                if state["entities"].get(label):
+                                    if not frame.winfo_manager():
+                                        frame.pack(fill="x", padx=20, pady=(1, 0))
+                                    for entity_name in state["entities"][label]:
+                                        chip = ctk.CTkFrame(frame, fg_color="#3A3A3A")
+                                        chip.pack(side="left", padx=4, pady=2)
+                                        ctk.CTkLabel(chip, text=entity_name).pack(side="left", padx=(6, 6))
                     if title_entry is not None:
                         try:
                             # Keep AI generate full scenario resilient if this step fails.
@@ -483,8 +548,15 @@ def _build_one_click_scenario_user_prompt(
         "  \"Title\": string,\n"
         "  \"Summary\": string (1-3 short paragraphs, Markdown allowed),\n"
         "  \"Secrets\": string (a single compact secret),\n"
-        "  \"Scenes\": [string, ...] (3-5 concise scene beats; reference the selected entities by NAME)\n"
+        "  \"NPCs\": [string, ...],\n"
+        "  \"Places\": [string, ...],\n"
+        "  \"Creatures\": [string, ...],\n"
+        "  \"Factions\": [string, ...],\n"
+        "  \"Objects\": [string, ...],\n"
+        "  \"Scenes\": [\n"
+        "    {\"Title\": string, \"Text\": string, \"NPCs\": [string], \"Places\": [string], \"Creatures\": [string], \"Factions\": [string], \"Objects\": [string]}\n"
+        "  ]\n"
         "}\n"
-        "Constraints: Integrate the selected entities coherently. No extra keys. No code blocks. Keep within ~600 words.\n"
+        "Constraints: Integrate and link the selected entities coherently. Entity arrays must contain exact selected names only. No extra keys. No code blocks. Keep within ~600 words.\n"
         f"{_format_editor_prompt_block(hard_constraints_block)}"
     )

--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import re
 import socket
 import urllib.error
 import urllib.request
@@ -12,6 +11,7 @@ from typing import Mapping
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.logging_helper import log_exception
 from modules.scenarios.ai_prompt_library import ScenarioPrompt, extract_placeholders
+from modules.scenarios.generated_scenario_parser import normalize_generated_scenario_payload
 
 
 class AIGenerationError(RuntimeError):
@@ -103,33 +103,7 @@ def validate_required_answers(prompt: ScenarioPrompt, answers: Mapping[str, str]
 
 def parse_generated_scenario(text: str) -> dict[str, str | list[str]]:
     """Best-effort parser that extracts common scenario sections without crashing."""
-    result: dict[str, str | list[str]] = {
-        "Title": "",
-        "Summary": text.strip(),
-        "Secrets": "",
-        "Places": [],
-        "NPCs": [],
-        "Objects": [],
-    }
-    title_match = re.search(r"^\s*Title\s*:\s*(.+)$", text, flags=re.IGNORECASE | re.MULTILINE)
-    if title_match:
-        result["Title"] = title_match.group(1).strip()
-    sections: dict[str, str] = {}
-    matches = list(re.finditer(r"^\s*([A-Za-z][A-Za-z0-9 ,/&-]+)\s*:\s*$", text, flags=re.MULTILINE))
-    for index, match in enumerate(matches):
-        key = match.group(1).strip().lower()
-        start = match.end()
-        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
-        sections[key] = text[start:end].strip()
-    if sections.get("scenario summary, maximum 8 short lines"):
-        result["Summary"] = sections["scenario summary, maximum 8 short lines"]
-    if sections.get("secrets and twists"):
-        result["Secrets"] = sections["secrets and twists"]
-    for section_name, target in (("locations", "Places"), ("npcs", "NPCs")):
-        raw = sections.get(section_name, "")
-        if raw:
-            result[target] = [line.strip(" -*") for line in raw.splitlines() if line.strip()][:20]
-    return result
+    return normalize_generated_scenario_payload(text)
 
 
 class AIScenarioGenerator:

--- a/modules/scenarios/generated_scenario_parser.py
+++ b/modules/scenarios/generated_scenario_parser.py
@@ -1,0 +1,237 @@
+"""Normalize AI-generated scenario payloads into editable scenario fields."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_ENTITY_FIELDS = ("NPCs", "Places", "Creatures", "Factions", "Objects", "Maps", "Bases", "Villains")
+_SECTION_ALIASES = {
+    "title": "Title",
+    "scenario title": "Title",
+    "summary": "Summary",
+    "scenario summary": "Summary",
+    "scenario summary max 8 lines": "Summary",
+    "scenario summary maximum 8 short lines": "Summary",
+    "secrets": "Secrets",
+    "secrets and twists": "Secrets",
+    "twists": "Secrets",
+    "npcs": "NPCs",
+    "npc": "NPCs",
+    "places": "Places",
+    "locations": "Places",
+    "location": "Places",
+    "creatures": "Creatures",
+    "factions": "Factions",
+    "objects": "Objects",
+    "maps": "Maps",
+    "bases": "Bases",
+    "villains": "Villains",
+}
+_SCENE_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s*(?:scene\s*)?(\d+)?\s*[:.)-]?\s*(.*)$", re.IGNORECASE)
+_FIELD_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:\*\*)?([A-Za-z][A-Za-z0-9 ()/&-]{1,45})(?:\*\*)?\s*:\s*(.*)$")
+_MARKDOWN_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*$")
+
+
+def normalize_generated_scenario_payload(raw: Any) -> dict[str, Any]:
+    """Return a scenario dict with structured scenes and top-level entity links."""
+    if isinstance(raw, dict):
+        return _normalize_mapping(raw)
+    return parse_markdown_scenario(str(raw or ""))
+
+
+def parse_markdown_scenario(text: str) -> dict[str, Any]:
+    """Parse common markdown/plain-text scenario output into scenario fields."""
+    text = str(text or "").strip()
+    result: dict[str, Any] = {"Title": "", "Summary": text, "Secrets": "", "Scenes": []}
+    if not text:
+        return result
+
+    before_scenes, scene_blocks = _split_scene_blocks(text)
+    sections = _extract_sections(before_scenes)
+
+    title = sections.get("Title") or _extract_inline_field(before_scenes, "title")
+    if title:
+        result["Title"] = _clean_value(title)
+
+    summary = sections.get("Summary")
+    if summary:
+        result["Summary"] = summary.strip()
+    elif before_scenes.strip():
+        result["Summary"] = _strip_known_inline_fields(before_scenes).strip() or text
+
+    secrets = sections.get("Secrets")
+    if secrets:
+        result["Secrets"] = secrets.strip()
+
+    for key in _ENTITY_FIELDS:
+        values = _coerce_names(sections.get(key))
+        if values:
+            result[key] = values
+
+    scenes = [_parse_scene_block(title_part, body) for title_part, body in scene_blocks]
+    scenes = [scene for scene in scenes if scene.get("Title") or _scene_text(scene)]
+    if scenes:
+        result["Scenes"] = scenes
+        _promote_scene_entities(result, scenes)
+    return result
+
+
+def _normalize_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    result = dict(data)
+    scenes = result.get("Scenes") or []
+    if isinstance(scenes, dict) and isinstance(scenes.get("Scenes"), list):
+        scenes = scenes["Scenes"]
+    if isinstance(scenes, (str, bytes)):
+        parsed = parse_markdown_scenario(str(scenes))
+        scenes = parsed.get("Scenes") or [{"Text": str(scenes)}]
+    if not isinstance(scenes, list):
+        scenes = [scenes]
+    normalized_scenes = [_normalize_scene(scene, idx) for idx, scene in enumerate(scenes, start=1)]
+    result["Scenes"] = normalized_scenes
+    _promote_scene_entities(result, normalized_scenes)
+    return result
+
+
+def _normalize_scene(scene: Any, index: int) -> dict[str, Any]:
+    if isinstance(scene, dict):
+        normalized = dict(scene)
+        if "Text" not in normalized:
+            for key in ("Summary", "Description", "Gist", "Purpose"):
+                if normalized.get(key):
+                    normalized["Text"] = normalized[key]
+                    break
+        for key in _ENTITY_FIELDS:
+            if key in normalized:
+                normalized[key] = _coerce_names(normalized.get(key))
+        return normalized
+    parsed = _parse_scene_block(f"Scene {index}", str(scene or ""))
+    return parsed
+
+
+def _split_scene_blocks(text: str) -> tuple[str, list[tuple[str, str]]]:
+    lines = text.splitlines()
+    scene_indices: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        match = _SCENE_HEADING_RE.match(line)
+        line_label = line.lower().lstrip("# ").strip()
+        if match and (match.group(1) or line_label.startswith("scene ")):
+            title = match.group(2).strip() or f"Scene {match.group(1) or len(scene_indices)+1}"
+            scene_indices.append((i, title))
+    if not scene_indices:
+        return text, []
+    before = "\n".join(lines[: scene_indices[0][0]])
+    blocks = []
+    for pos, (start, title) in enumerate(scene_indices):
+        end = scene_indices[pos + 1][0] if pos + 1 < len(scene_indices) else len(lines)
+        blocks.append((title, "\n".join(lines[start + 1 : end]).strip()))
+    return before, blocks
+
+
+def _extract_sections(text: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        heading = _MARKDOWN_HEADING_RE.match(line)
+        field = _FIELD_RE.match(line)
+        key = None
+        rest = ""
+        if heading:
+            key = _canonical_key(heading.group(1))
+        elif field:
+            key = _canonical_key(field.group(1))
+            rest = field.group(2).strip()
+        if heading or field:
+            if key:
+                current = key
+                sections.setdefault(current, [])
+                if rest:
+                    sections[current].append(rest)
+                continue
+            current = None
+            continue
+        if current:
+            sections[current].append(line)
+    return {key: _clean_value("\n".join(lines)) for key, lines in sections.items()}
+
+
+def _parse_scene_block(title: str, body: str) -> dict[str, Any]:
+    scene: dict[str, Any] = {"Title": _clean_value(title), "Text": ""}
+    text_lines: list[str] = []
+    for line in str(body or "").splitlines():
+        field = _FIELD_RE.match(line)
+        if field:
+            key = _canonical_key(field.group(1))
+            value = _clean_value(field.group(2))
+            if key in _ENTITY_FIELDS:
+                scene[key] = _coerce_names(value)
+                continue
+            if key == "Places":
+                scene["Places"] = _coerce_names(value)
+                continue
+            if key in {"Summary", "Secrets"} or field.group(1).strip().lower() in {"purpose", "atouts", "stakes"}:
+                if value:
+                    text_lines.append(f"{field.group(1).strip()}: {value}")
+                continue
+        text_lines.append(line)
+    scene["Text"] = _clean_value("\n".join(text_lines))
+    return scene
+
+
+def _promote_scene_entities(result: dict[str, Any], scenes: list[dict[str, Any]]) -> None:
+    for key in _ENTITY_FIELDS:
+        combined = _coerce_names(result.get(key))
+        for scene in scenes:
+            for name in _coerce_names(scene.get(key)):
+                if name not in combined:
+                    combined.append(name)
+        if combined:
+            result[key] = combined
+
+
+def _canonical_key(label: str) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]+", " ", str(label).lower()).strip()
+    return _SECTION_ALIASES.get(normalized)
+
+
+def _coerce_names(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        values: list[str] = []
+        for item in value:
+            values.extend(_coerce_names(item))
+        return _dedupe(values)
+    if isinstance(value, dict):
+        return _coerce_names(value.get("Name") or value.get("Title") or value.get("name") or value.get("title"))
+    text = _clean_value(str(value))
+    parts = re.split(r",|;|\band\b|&", text)
+    return _dedupe(part.strip(" -*•") for part in parts if part.strip(" -*•"))
+
+
+def _dedupe(values) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        text = str(value).strip()
+        if text and text not in result:
+            result.append(text)
+    return result
+
+
+def _clean_value(value: Any) -> str:
+    return re.sub(r"^[-*•\s]+", "", str(value or "").replace("**", "")).strip()
+
+
+def _extract_inline_field(text: str, field_name: str) -> str:
+    match = re.search(rf"^\s*(?:\*\*)?{re.escape(field_name)}(?:\*\*)?\s*:\s*(.+)$", text, re.IGNORECASE | re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def _strip_known_inline_fields(text: str) -> str:
+    return re.sub(r"^\s*(?:\*\*)?(?:Title|Scenario Title)(?:\*\*)?\s*:.+$", "", text, flags=re.IGNORECASE | re.MULTILINE)
+
+
+def _scene_text(scene: dict[str, Any]) -> str:
+    text = scene.get("Text", "")
+    if isinstance(text, dict):
+        return str(text.get("text", ""))
+    return str(text or "")


### PR DESCRIPTION
### Motivation
- AI responses were often plain text/markdown instead of JSON, and the editor fallback saved the whole response into the scenario `Summary` while leaving `Scenes` and relation fields empty.
- The intent is to turn AI output into structured scenario entities (scenes plus linked NPCs/Places/etc.) so saved scenarios contain proper scene objects and links instead of one long summary.

### Description
- Added a reusable parser `modules/scenarios/generated_scenario_parser.py` that normalizes AI JSON or markdown output into scenario fields, structured `Scenes`, and top-level entity arrays (`NPCs`, `Places`, `Creatures`, `Factions`, `Objects`, `Maps`, `Bases`, `Villains`).
- Updated the editor generation flow in `modules/generic/editor/window_components/ai_scenario_generation.py` to use `normalize_generated_scenario_payload` for both JSON and non-JSON responses, populate top-level linked list widgets from parsed entity arrays, and inject scene-level entity chips into the scene editors.
- Rewired `modules/scenarios/ai_scenario_generator.py` so the legacy `parse_generated_scenario` helper delegates to the new parser for consistent behavior across generation paths.
- Tightened the AI prompt to request structured per-scene objects and explicit entity arrays so generated payloads are more directly mappable to editor fields.

### Testing
- Ran compilation checks with `python -m py_compile modules/generic/editor/window_components/ai_scenario_generation.py modules/scenarios/ai_scenario_generator.py modules/scenarios/generated_scenario_parser.py`, which succeeded.
- Executed a parser smoke test using `normalize_generated_scenario_payload(...)` on a sample markdown scenario and asserted title, scene count, and extracted entity/place names; the assertions passed (`parser ok`).
- Ran `git diff --check` as an automated safety check; it reported no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d040840a8832ba70a5d185c4057c5)