### PR TITLE
Use scenario DB for campaign forge entity fallbacks

### DIFF
--- a/modules/campaigns/services/campaign_forge_persistence.py
+++ b/modules/campaigns/services/campaign_forge_persistence.py
@@ -377,7 +377,8 @@ class CampaignForgePersistence:
         if not spec:
             return None
 
-        wrapper = GenericModelWrapper(spec["wrapper"])
+        db_path = getattr(self.scenario_wrapper, "_db_path", None)
+        wrapper = GenericModelWrapper(spec["wrapper"], db_path=db_path)
         self.entity_wrappers[entity_type] = wrapper
         return wrapper
 

--- a/tests/campaigns/test_campaign_forge_persistence.py
+++ b/tests/campaigns/test_campaign_forge_persistence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 from modules.campaigns.services.campaign_forge_persistence import (
     CampaignForgePersistence,
     SAVE_MODE_MERGE_KEEP_EXISTING,
@@ -87,3 +89,68 @@ def test_merge_vs_replace_behavior_for_arc_link_updates():
 
     assert merge_after == ["Legacy Lead", "Rainmarket Ultimatum", "Ash Dock Reckoning"]
     assert replace_after == ["Rainmarket Ultimatum", "Ash Dock Reckoning"]
+
+
+def _create_campaign_forge_tables(db_path):
+    """Create the minimal tables needed by campaign forge persistence tests."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("CREATE TABLE scenarios (Title TEXT PRIMARY KEY, Summary TEXT)")
+        cursor.execute("CREATE TABLE npcs (Name TEXT PRIMARY KEY, Role TEXT)")
+        cursor.execute("CREATE TABLE places (Name TEXT PRIMARY KEY, Description TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _load_names(db_path, table):
+    """Load entity names from a table in deterministic order."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT Name FROM {table} ORDER BY Name")
+        return [row[0] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+
+def test_save_from_dry_run_persists_fallback_entities_to_scenario_db(tmp_path):
+    """Verify fallback entity wrappers use the scenario wrapper database path."""
+    from modules.generic.generic_model_wrapper import GenericModelWrapper
+
+    db_path = tmp_path / "campaign.sqlite"
+    _create_campaign_forge_tables(db_path)
+    scenario_wrapper = GenericModelWrapper("scenarios", db_path=str(db_path))
+    persistence = CampaignForgePersistence(scenario_wrapper=scenario_wrapper)
+
+    payload = {
+        "arcs": [
+            {
+                "arc_name": "Arc Alpha",
+                "scenarios": [
+                    {
+                        "Title": "Market Shadows",
+                        "Summary": "New contacts and locations emerge.",
+                        "EntityCreations": {
+                            "npcs": [{"Name": "Rika Vale", "Role": "Informant"}],
+                            "places": [{"Name": "Rainmarket", "Description": "A neon bazaar."}],
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    arcs = [{"name": "Arc Alpha", "scenarios": []}]
+    dry_run = persistence.build_dry_run_report(
+        payload,
+        arcs,
+        save_mode=SAVE_MODE_REPLACE_GENERATED_ONLY,
+    )
+
+    persistence.save_from_dry_run(payload, arcs, dry_run)
+
+    assert _load_names(db_path, "npcs") == ["Rika Vale"]
+    assert _load_names(db_path, "places") == ["Rainmarket"]
+    assert persistence.entity_wrappers["npcs"]._db_path == str(db_path)
+    assert persistence.entity_wrappers["places"]._db_path == str(db_path)


### PR DESCRIPTION
### Motivation
- Ensure generated entity records created during campaign forging are persisted into the same SQLite database as the scenario being saved when a scenario wrapper uses a custom DB path. 
- Preserve support for explicitly injected entity wrappers while providing a sensible fallback that shares the scenario wrapper's storage.

### Description
- When resolving fallback wrappers in `CampaignForgePersistence._resolve_entity_wrapper`, read `db_path = getattr(self.scenario_wrapper, "_db_path", None)` and pass it into `GenericModelWrapper(spec["wrapper"], db_path=db_path)` so fallback wrappers use the scenario DB. 
- Keep the early-return behavior when an explicit wrapper is present so injected `entity_wrappers` are not overridden. 
- Add a unit test `test_save_from_dry_run_persists_fallback_entities_to_scenario_db` which creates a temporary SQLite DB, uses a `GenericModelWrapper` scenario wrapper with that `_db_path`, runs a dry-run and save, and verifies `npcs` and `places` were written into the same DB and that the created fallback wrappers have `_db_path` set.
- Files changed: `modules/campaigns/services/campaign_forge_persistence.py` and `tests/campaigns/test_campaign_forge_persistence.py`.

### Testing
- Ran `pytest tests/campaigns/test_campaign_forge_persistence.py -q` and the suite including the new test passed. 
- Ran `pytest tests/campaigns/test_campaign_forge_persistence.py tests/campaigns/services/test_arc_scenario_expansion_service.py -q` which reproduced a pre-existing failure in `test_arc_scenario_expansion_auto_fixes_scene_entity_typos_from_db_catalog` (assertion expecting `"Rainmarket"` but observed `"Rainmarrket"`). 
- Ran the single failing expansion test `pytest tests/campaigns/services/test_arc_scenario_expansion_service.py::test_arc_scenario_expansion_auto_fixes_scene_entity_typos_from_db_catalog -q` to reproduce the mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0797381c832bb8e9188ebbfa9554)