### PR TITLE
Use active campaign DB for arc entity catalog

### DIFF
--- a/modules/campaigns/services/ai/arc_scenario_entities.py
+++ b/modules/campaigns/services/ai/arc_scenario_entities.py
@@ -16,7 +16,11 @@ ENTITY_WRAPPER_SPECS: dict[str, dict[str, str]] = {
 }
 
 
-def load_existing_entity_catalog(entity_types: list[str] | tuple[str, ...] | None = None) -> dict[str, list[str]]:
+def load_existing_entity_catalog(
+    entity_types: list[str] | tuple[str, ...] | None = None,
+    *,
+    db_path: str | None = None,
+) -> dict[str, list[str]]:
     """Load existing linkable entity names for scenario-expansion prompts."""
 
     catalog: dict[str, list[str]] = {}
@@ -27,7 +31,7 @@ def load_existing_entity_catalog(entity_types: list[str] | tuple[str, ...] | Non
             continue
 
         try:
-            wrapper = GenericModelWrapper(spec["wrapper"])
+            wrapper = GenericModelWrapper(spec["wrapper"], db_path=db_path)
             items = wrapper.load_items()
         except Exception:
             catalog[entity_type] = []

--- a/modules/campaigns/ui/campaign_builder_wizard.py
+++ b/modules/campaigns/ui/campaign_builder_wizard.py
@@ -745,6 +745,7 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
 
     def _build_arc_generation_foundation(self) -> dict:
         """Build arc generation foundation."""
+        db_path = getattr(self.scenario_wrapper, "_db_path", None)
         return {
             "name": self.form_vars["name"].get().strip(),
             "genre": self.form_vars["genre"].get().strip(),
@@ -757,7 +758,8 @@ class CampaignBuilderWizard(ctk.CTkToplevel):
             "themes": [line.strip() for line in self.themes_box.get("1.0", "end").splitlines() if line.strip()],
             "notes": self.notes_box.get("1.0", "end").strip(),
             "existing_entities": load_existing_entity_catalog(
-                ("villains", "factions", "places", "npcs", "creatures")
+                ("villains", "factions", "places", "npcs", "creatures"),
+                db_path=db_path,
             ),
             "generation_defaults": dict(getattr(self, "generation_defaults", {})),
         }

--- a/tests/campaigns/ui/test_generation_defaults_foundation.py
+++ b/tests/campaigns/ui/test_generation_defaults_foundation.py
@@ -66,7 +66,13 @@ class _FakeTextBox:
 
 def test_build_arc_generation_foundation_includes_generation_defaults(monkeypatch):
     """Verify that build arc generation foundation includes generation defaults."""
-    monkeypatch.setattr(campaign_builder_wizard, "load_existing_entity_catalog", lambda _types: {"factions": ["Dawn Guard"]})
+    captured_catalog_args = {}
+
+    def _fake_load_existing_entity_catalog(_types, *, db_path=None):
+        captured_catalog_args["db_path"] = db_path
+        return {"factions": ["Dawn Guard"]}
+
+    monkeypatch.setattr(campaign_builder_wizard, "load_existing_entity_catalog", _fake_load_existing_entity_catalog)
 
     wizard = campaign_builder_wizard.CampaignBuilderWizard.__new__(campaign_builder_wizard.CampaignBuilderWizard)
     wizard.form_vars = {
@@ -81,6 +87,7 @@ def test_build_arc_generation_foundation_includes_generation_defaults(monkeypatc
     wizard.stakes_box = _FakeTextBox("Civil war")
     wizard.themes_box = _FakeTextBox("Trust\nLoyalty")
     wizard.notes_box = _FakeTextBox("Notes")
+    wizard.scenario_wrapper = SimpleNamespace(_db_path="/tmp/current-campaign.sqlite")
     wizard.generation_defaults = {
         "main_pc_factions": ["Dawn Guard"],
         "protected_factions": ["Cobalt Circle"],
@@ -92,3 +99,5 @@ def test_build_arc_generation_foundation_includes_generation_defaults(monkeypatc
 
     assert foundation["generation_defaults"]["main_pc_factions"] == ["Dawn Guard"]
     assert foundation["generation_defaults"]["allow_optional_conflicts"] is False
+    assert foundation["existing_entities"] == {"factions": ["Dawn Guard"]}
+    assert captured_catalog_args["db_path"] == "/tmp/current-campaign.sqlite"


### PR DESCRIPTION
### Motivation
- Ensure arc-generation prompts use entities from the currently-active campaign database rather than the default DB so generated arcs reference the correct campaign data.
- Make entity catalog loading pluggable with an explicit DB path to support per-campaign persistence and testing.

### Description
- Add an optional `db_path: str | None = None` keyword parameter to `load_existing_entity_catalog` and forward it into each `GenericModelWrapper` construction. (modules/campaigns/services/ai/arc_scenario_entities.py)
- Derive the active scenario database path in `CampaignBuilderWizard._build_arc_generation_foundation` via `getattr(self.scenario_wrapper, "_db_path", None)` and pass `db_path` into `load_existing_entity_catalog` for `("villains","factions","places","npcs","creatures")`. (modules/campaigns/ui/campaign_builder_wizard.py)
- Update the generation-defaults foundation test to assert that the `db_path` is propagated and that `existing_entities` are returned from the provided catalog. (tests/campaigns/ui/test_generation_defaults_foundation.py)

### Testing
- Compiled affected modules with `python -m py_compile ...` which succeeded. 
- Ran the updated unit test `pytest -q tests/campaigns/ui/test_generation_defaults_foundation.py`, which passed (`1 passed`).
- Executed an automated sqlite-based smoke test that calls `load_existing_entity_catalog(..., db_path=...)` and verified it returned entities from the supplied DB, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d08360df4832bba5f30a4fcb6a420)