### PR TITLE
Capture AI exception in Tkinter callback lambda to avoid NameError

### DIFF
--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -430,7 +430,7 @@ class ScenarioGeneratorView(ctk.CTkFrame):
             try:
                 result = AIScenarioGenerator().generate(prompt, answers)
             except Exception as exc:
-                self.after(0, lambda: self._on_ai_error(exc))
+                self.after(0, lambda exc=exc: self._on_ai_error(exc))
                 return
             self.after(0, lambda: self._on_ai_success(result))
 


### PR DESCRIPTION
### Motivation
- Fix a crash where the `after()` callback could raise `NameError` because the local exception variable was cleared before the lambda executed.

### Description
- Bind `exc` into the lambda default argument in `modules/scenarios/scenario_generator_view.py` by changing `self.after(0, lambda: self._on_ai_error(exc))` to `self.after(0, lambda exc=exc: self._on_ai_error(exc))`.

### Testing
- Ran `python -m py_compile modules/scenarios/scenario_generator_view.py` which succeeded.
- Ran `python -m pytest tests/scenarios/test_scene_text_payloads.py tests/scenarios/test_scene_sections_parser.py` which passed all tests (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0a3d4b3c832ba38fa41002568528)