### PR TITLE
Clarify Ollama provider errors

### DIFF
--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -62,9 +62,11 @@ class OllamaScenarioProvider:
         try:
             with urllib.request.urlopen(request, timeout=self.config.timeout) as response:
                 data = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise AIGenerationError(self._format_http_error(exc)) from exc
         except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
             raise AIGenerationError(
-                f"AI provider unavailable at {self.config.base_url}. Make sure Ollama is running and the model '{self.config.model}' is installed."
+                f"Cannot reach AI provider at {self.config.base_url}. Make sure Ollama is running and reachable from this application."
             ) from exc
         except json.JSONDecodeError as exc:
             raise AIGenerationError("AI provider returned invalid JSON.") from exc
@@ -73,6 +75,33 @@ class OllamaScenarioProvider:
         if not content:
             raise AIGenerationError("AI provider returned an empty scenario.")
         return content
+
+
+    def _format_http_error(self, exc: urllib.error.HTTPError) -> str:
+        """Return an actionable message for Ollama HTTP errors."""
+        detail = exc.reason or ""
+        try:
+            body = exc.read().decode("utf-8", errors="replace").strip()
+        except Exception:
+            body = ""
+        if body:
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                detail = body
+            else:
+                if isinstance(payload, dict):
+                    detail = str(payload.get("error") or payload.get("message") or detail)
+                else:
+                    detail = str(payload)
+        if exc.code == 404:
+            suffix = f" Ollama said: {detail}" if detail else ""
+            return (
+                f"Ollama is reachable at {self.config.base_url}, but model '{self.config.model}' was not accepted."
+                f" Verify the model name in AI settings or install it with: ollama pull {self.config.model}.{suffix}"
+            )
+        suffix = f" Response: {detail}" if detail else ""
+        return f"AI provider at {self.config.base_url} returned HTTP {exc.code}.{suffix}"
 
 
 class SafeFormatDict(dict):

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -157,3 +157,50 @@ Locations:
     assert parsed["Secrets"] == "The priest is the bell."
     assert parsed["NPCs"] == ["Mara, ash-smudged smith"]
     assert parsed["Places"] == ["The cracked belfry"]
+
+
+def test_ollama_provider_reports_unreachable_provider(monkeypatch):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    provider = generator.OllamaScenarioProvider(
+        generator.AIProviderConfig(base_url="http://127.0.0.1:11434", model="gpt-oss:20b")
+    )
+
+    def raise_url_error(*_args, **_kwargs):
+        raise generator.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", raise_url_error)
+
+    with pytest.raises(generator.AIGenerationError) as excinfo:
+        provider.generate("hello")
+
+    assert "Cannot reach AI provider" in str(excinfo.value)
+    assert "model" not in str(excinfo.value).lower()
+
+
+def test_ollama_provider_reports_model_http_error(monkeypatch):
+    from io import BytesIO
+    from modules.scenarios import ai_scenario_generator as generator
+
+    provider = generator.OllamaScenarioProvider(
+        generator.AIProviderConfig(base_url="http://127.0.0.1:11434", model="gpt-oss:20b")
+    )
+
+    def raise_http_error(*_args, **_kwargs):
+        raise generator.urllib.error.HTTPError(
+            "http://127.0.0.1:11434/api/chat",
+            404,
+            "Not Found",
+            hdrs=None,
+            fp=BytesIO(b'{"error":"model \\"gpt-oss:20b\\" not found"}'),
+        )
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", raise_http_error)
+
+    with pytest.raises(generator.AIGenerationError) as excinfo:
+        provider.generate("hello")
+
+    message = str(excinfo.value)
+    assert "Ollama is reachable" in message
+    assert "ollama pull gpt-oss:20b" in message
+    assert "model" in message


### PR DESCRIPTION
### Motivation
- The UI was showing a misleading "model missing" message for all network/HTTP failures when calling the local Ollama-compatible AI, which surfaced after a recent callback fix made background-thread exceptions visible.  
- Split the unreachable/connection case from HTTP error responses so the message shown is actionable and accurate.  

### Description
- Separate handling for `urllib.error.HTTPError` versus connection/timeouts in `modules/scenarios/ai_scenario_generator.py` and return distinct, clearer `AIGenerationError` messages.  
- Added a `_format_http_error` helper that extracts response body details and returns a friendly message for HTTP 404 model-not-found cases (including a suggested `ollama pull <model>` hint).  
- Adjusted the unreachable-provider message to state the provider is not reachable rather than implying the model is missing.  
- Added targeted tests in `tests/test_ai_prompt_scenario_generation.py` covering unreachable-provider and model-HTTP-error scenarios.  

### Testing
- Ran `python -m py_compile modules/scenarios/ai_scenario_generator.py` which succeeded.  
- Ran `pytest -q tests/test_ai_prompt_scenario_generation.py -k ollama` which passed (`2 passed, 9 deselected`).  
- A full run of `pytest -q tests/test_ai_prompt_scenario_generation.py` earlier surfaced an unrelated existing parser assertion failure in `test_parse_generated_scenario_sections_best_effort`, which is not caused by these error-handling changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0c81e810832b9515a7bf769c7d99)