### PR TITLE
Persist AI-generated NPCs and Places when saving scenarios

### DIFF
--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -25,6 +25,9 @@ from modules.scenarios.ai_scenario_generator import (
     validate_required_answers,
 )
 from modules.scenarios.prompt_library_dialog import PromptLibraryDialog
+from modules.scenarios.services.generated_entity_persistence import (
+    GeneratedScenarioEntityPersistence,
+)
 
 log_module_import(__name__)
 
@@ -563,8 +566,24 @@ class ScenarioGeneratorView(ctk.CTkFrame):
                 return
             existing.append(scenario_entity)
             wrapper.save_items(existing)
+            entity_result = GeneratedScenarioEntityPersistence().save_missing_entities(
+                scenario_entity
+            )
         except Exception as exc:
             log_exception("Scenario database save failed")
             messagebox.showerror("Save Error", str(exc))
             return
-        messagebox.showinfo("Saved", f"Scenario '{title}' added to database.")
+        created_bits = []
+        if entity_result.npcs_created:
+            created_bits.append(f"{len(entity_result.npcs_created)} NPC(s)")
+        if entity_result.places_created:
+            created_bits.append(f"{len(entity_result.places_created)} place(s)")
+        entity_summary = (
+            "\nCreated missing entities: " + ", ".join(created_bits)
+            if created_bits
+            else ""
+        )
+        messagebox.showinfo(
+            "Saved",
+            f"Scenario '{title}' added to database.{entity_summary}",
+        )

--- a/modules/scenarios/services/__init__.py
+++ b/modules/scenarios/services/__init__.py
@@ -1,0 +1,2 @@
+"""Scenario service helpers."""
+

--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -1,0 +1,136 @@
+"""Persist entities referenced by generated scenarios."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from modules.generic.generic_model_wrapper import GenericModelWrapper
+
+
+@dataclass(frozen=True)
+class GeneratedEntitySaveResult:
+    """Summary of entity records created for a generated scenario."""
+
+    npcs_created: list[str]
+    places_created: list[str]
+
+
+class GeneratedScenarioEntityPersistence:
+    """Create missing NPC and place records for a generated scenario."""
+
+    def __init__(
+        self,
+        *,
+        npc_wrapper: Any | None = None,
+        place_wrapper: Any | None = None,
+    ):
+        """Initialize the generated entity persistence service."""
+        self.npc_wrapper = npc_wrapper or GenericModelWrapper("npcs")
+        self.place_wrapper = place_wrapper or GenericModelWrapper("places")
+
+    def save_missing_entities(self, scenario: dict[str, Any]) -> GeneratedEntitySaveResult:
+        """Create missing NPCs and places referenced by ``scenario``."""
+        title = str(scenario.get("Title") or "").strip()
+        npc_names = _coerce_names(scenario.get("NPCs"))
+        place_names = _coerce_names(scenario.get("Places"))
+
+        created_npcs = self._save_missing_npcs(npc_names, title)
+        created_places = self._save_missing_places(place_names, npc_names, title)
+
+        return GeneratedEntitySaveResult(
+            npcs_created=created_npcs,
+            places_created=created_places,
+        )
+
+    def _save_missing_npcs(self, names: list[str], scenario_title: str) -> list[str]:
+        existing = self._load_index(self.npc_wrapper)
+        created: list[str] = []
+        for name in names:
+            key = name.casefold()
+            if key in existing:
+                continue
+            record = {
+                "Name": name,
+                "Role": "Scenario NPC",
+                "Description": _generated_description("NPC", scenario_title),
+                "Notes": _generated_notes(scenario_title),
+            }
+            self.npc_wrapper.save_item(record, key_field="Name")
+            existing[key] = record
+            created.append(name)
+        return created
+
+    def _save_missing_places(
+        self,
+        names: list[str],
+        npc_names: list[str],
+        scenario_title: str,
+    ) -> list[str]:
+        existing = self._load_index(self.place_wrapper)
+        created: list[str] = []
+        for name in names:
+            key = name.casefold()
+            if key in existing:
+                continue
+            record = {
+                "Name": name,
+                "Description": _generated_description("place", scenario_title),
+                "NPCs": npc_names,
+                "Notes": _generated_notes(scenario_title),
+            }
+            self.place_wrapper.save_item(record, key_field="Name")
+            existing[key] = record
+            created.append(name)
+        return created
+
+    @staticmethod
+    def _load_index(wrapper: Any) -> dict[str, dict[str, Any]]:
+        try:
+            items = wrapper.load_items()
+        except Exception:
+            items = []
+        index: dict[str, dict[str, Any]] = {}
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("Name") or "").strip()
+            if name:
+                index[name.casefold()] = dict(item)
+        return index
+
+
+def _coerce_names(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values: Iterable[Any] = value.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        values = value
+    else:
+        values = [value]
+
+    names: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        name = str(item or "").strip()
+        if not name:
+            continue
+        key = name.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(name)
+    return names
+
+
+def _generated_description(entity_label: str, scenario_title: str) -> str:
+    if scenario_title:
+        return f"Generated from AI scenario '{scenario_title}'. Add details during prep."
+    return f"Generated from an AI scenario. Add {entity_label} details during prep."
+
+
+def _generated_notes(scenario_title: str) -> str:
+    if scenario_title:
+        return f"Auto-created when saving generated scenario: {scenario_title}"
+    return "Auto-created when saving a generated scenario."
+

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -1,0 +1,78 @@
+"""Tests for AI-generated scenario entity persistence."""
+
+import sqlite3
+
+from modules.scenarios.services.generated_entity_persistence import (
+    GeneratedScenarioEntityPersistence,
+)
+from modules.generic.generic_model_wrapper import GenericModelWrapper
+
+
+def _create_campaign_db(path):
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE npcs (Name TEXT PRIMARY KEY)")
+        conn.execute("CREATE TABLE places (Name TEXT PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_save_missing_entities_creates_npcs_and_places(tmp_path):
+    """Verify that generated scenario references become real entity records."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=GenericModelWrapper("npcs", db_path=str(db_path)),
+        place_wrapper=GenericModelWrapper("places", db_path=str(db_path)),
+    )
+
+    result = persistence.save_missing_entities(
+        {
+            "Title": "The Harbor Job",
+            "NPCs": ["Captain Mira", "Old Fenwick"],
+            "Places": ["Blackstone Harbor"],
+        }
+    )
+
+    assert result.npcs_created == ["Captain Mira", "Old Fenwick"]
+    assert result.places_created == ["Blackstone Harbor"]
+
+    npcs = GenericModelWrapper("npcs", db_path=str(db_path)).load_items()
+    places = GenericModelWrapper("places", db_path=str(db_path)).load_items()
+
+    assert {npc["Name"] for npc in npcs} == {"Captain Mira", "Old Fenwick"}
+    assert {place["Name"] for place in places} == {"Blackstone Harbor"}
+    assert places[0]["NPCs"] == ["Captain Mira", "Old Fenwick"]
+
+
+def test_save_missing_entities_keeps_existing_records(tmp_path):
+    """Verify that existing entity records are not overwritten."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+    place_wrapper = GenericModelWrapper("places", db_path=str(db_path))
+    npc_wrapper.save_item(
+        {"Name": "Captain Mira", "Description": "Existing details"},
+        key_field="Name",
+    )
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=place_wrapper,
+    )
+
+    result = persistence.save_missing_entities(
+        {
+            "Title": "The Harbor Job",
+            "NPCs": ["Captain Mira", "Old Fenwick"],
+            "Places": [],
+        }
+    )
+
+    assert result.npcs_created == ["Old Fenwick"]
+
+    saved_mira = npc_wrapper.load_item_by_key("Captain Mira", key_field="Name")
+    assert saved_mira["Description"] == "Existing details"
+


### PR DESCRIPTION
### Motivation
- Automatically create NPC and place records referenced by AI-generated scenarios to avoid missing references and reduce manual post-processing.
- Provide users with immediate feedback about any entities that were auto-created when saving a generated scenario.

### Description
- Add a new service `modules/scenarios/services/generated_entity_persistence.py` implementing `GeneratedScenarioEntityPersistence` and `GeneratedEntitySaveResult` to detect and create missing NPC and place records using `GenericModelWrapper`.
- Integrate the service into `ScenarioGeneratorView` so that after saving a generated scenario the code calls `GeneratedScenarioEntityPersistence().save_missing_entities(scenario_entity)` and augments the save confirmation shown via `messagebox.showinfo` with a summary of created entities.
- Add `modules/scenarios/services/__init__.py` to expose the service package.
- Add unit tests in `tests/scenarios/test_generated_entity_persistence.py` that exercise creation of missing entities and preservation of existing records using an on-disk SQLite DB via `GenericModelWrapper`.

### Testing
- Ran the new tests with `pytest tests/scenarios/test_generated_entity_persistence.py` which create a temporary SQLite DB and assert created records, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0ef3c9a8832ba0edfe478d731c1b)