### PR TITLE
Fix generated scenario NPC and place persistence

### DIFF
--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -117,7 +117,16 @@ def build_final_prompt(prompt: ScenarioPrompt, answers: Mapping[str, str]) -> tu
     missing = [name for name in placeholders if not str(answers.get(name, "")).strip()]
     formatted = prompt.prompt_text.format_map(SafeFormatDict({k: str(v) for k, v in answers.items()}))
     answer_lines = [f"- {question.label} ({question.key}): {answers.get(question.key, question.default)}" for question in prompt.questions]
-    final = f"{formatted}\n\n# Collected answers\n" + "\n".join(answer_lines)
+    entity_schema_hint = (
+        "\n\n# Entity output requirements\n"
+        "When the scenario includes NPCs or Places, return them as structured JSON objects, "
+        "not just prose fragments. NPC objects should include Name, Role, Description, "
+        "Secret, Quote, RoleplayingCues, Personality, Motivation, Background, Traits, "
+        "Factions, Objects, Portrait when known. Place objects should include Name, "
+        "Description, NPCs, PlayerDisplay, Secrets, Portrait when known. The scenario's "
+        "NPCs and Places may still be concise, but descriptions must contain usable GM content.\n"
+    )
+    final = f"{formatted}\n\n# Collected answers\n" + "\n".join(answer_lines) + entity_schema_hint
     return final, missing
 
 

--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -27,6 +27,7 @@ from modules.scenarios.ai_scenario_generator import (
 from modules.scenarios.prompt_library_dialog import PromptLibraryDialog
 from modules.scenarios.services.generated_entity_persistence import (
     GeneratedScenarioEntityPersistence,
+    scenario_entity_names,
 )
 
 log_module_import(__name__)
@@ -527,14 +528,8 @@ class ScenarioGeneratorView(ctk.CTkFrame):
                 "Status": DEFAULT_SCENARIO_STATUS,
                 "Summary": str(parsed.get("Summary") or text),
                 "Secrets": str(parsed.get("Secrets") or ""),
-                "Places": (
-                    parsed.get("Places")
-                    if isinstance(parsed.get("Places"), list)
-                    else []
-                ),
-                "NPCs": (
-                    parsed.get("NPCs") if isinstance(parsed.get("NPCs"), list) else []
-                ),
+                "Places": scenario_entity_names(parsed.get("Places")),
+                "NPCs": scenario_entity_names(parsed.get("NPCs")),
                 "Objects": (
                     parsed.get("Objects")
                     if isinstance(parsed.get("Objects"), list)
@@ -567,7 +562,8 @@ class ScenarioGeneratorView(ctk.CTkFrame):
             existing.append(scenario_entity)
             wrapper.save_items(existing)
             entity_result = GeneratedScenarioEntityPersistence().save_missing_entities(
-                scenario_entity
+                scenario_entity,
+                parsed if self.current_ai_text else None,
             )
         except Exception as exc:
             log_exception("Scenario database save failed")

--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Iterable
 
 from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.importers.pdf_entity_importer import to_longtext
 
 
 @dataclass(frozen=True)
@@ -16,7 +17,12 @@ class GeneratedEntitySaveResult:
 
 
 class GeneratedScenarioEntityPersistence:
-    """Create missing NPC and place records for a generated scenario."""
+    """Create missing NPC and place records for a generated scenario.
+
+    The AI prompt generator can return either simple name lists or richer entity
+    dictionaries.  Persisting follows the PDF importer shape so generated NPCs
+    and places open with useful rich-text fields instead of placeholder text.
+    """
 
     def __init__(
         self,
@@ -28,33 +34,47 @@ class GeneratedScenarioEntityPersistence:
         self.npc_wrapper = npc_wrapper or GenericModelWrapper("npcs")
         self.place_wrapper = place_wrapper or GenericModelWrapper("places")
 
-    def save_missing_entities(self, scenario: dict[str, Any]) -> GeneratedEntitySaveResult:
-        """Create missing NPCs and places referenced by ``scenario``."""
-        title = str(scenario.get("Title") or "").strip()
-        npc_names = _coerce_names(scenario.get("NPCs"))
-        place_names = _coerce_names(scenario.get("Places"))
+    def save_missing_entities(
+        self,
+        scenario: dict[str, Any],
+        entity_source: dict[str, Any] | None = None,
+    ) -> GeneratedEntitySaveResult:
+        """Create missing NPCs and places referenced by ``scenario``.
 
-        created_npcs = self._save_missing_npcs(npc_names, title)
-        created_places = self._save_missing_places(place_names, npc_names, title)
+        ``scenario`` is the DB-ready scenario record. ``entity_source`` may be
+        the raw normalized AI payload containing richer NPC/place dictionaries.
+        """
+        source = entity_source if isinstance(entity_source, dict) else scenario
+        title = str(scenario.get("Title") or source.get("Title") or "").strip()
+        npc_records = _entity_records(source.get("NPCs") or scenario.get("NPCs"))
+        place_records = _entity_records(source.get("Places") or scenario.get("Places"))
+        npc_names = _entity_names(npc_records)
+        created_npcs = self._save_missing_npcs(npc_records, title)
+        created_places = self._save_missing_places(place_records, npc_names, title)
+
+        # If only scene-level entities were present, keep the old name-based
+        # behavior as a final fallback.
+        if not npc_records:
+            created_npcs = self._save_missing_npcs(_entity_records(scenario.get("NPCs")), title)
+        if not place_records:
+            created_places = self._save_missing_places(_entity_records(scenario.get("Places")), npc_names, title)
 
         return GeneratedEntitySaveResult(
             npcs_created=created_npcs,
             places_created=created_places,
         )
 
-    def _save_missing_npcs(self, names: list[str], scenario_title: str) -> list[str]:
+    def _save_missing_npcs(self, records: list[dict[str, Any]], scenario_title: str) -> list[str]:
         existing = self._load_index(self.npc_wrapper)
         created: list[str] = []
-        for name in names:
+        for data in records:
+            name = str(data.get("Name") or data.get("Title") or "").strip()
+            if not name:
+                continue
             key = name.casefold()
             if key in existing:
                 continue
-            record = {
-                "Name": name,
-                "Role": "Scenario NPC",
-                "Description": _generated_description("NPC", scenario_title),
-                "Notes": _generated_notes(scenario_title),
-            }
+            record = _build_npc_record(data, scenario_title)
             self.npc_wrapper.save_item(record, key_field="Name")
             existing[key] = record
             created.append(name)
@@ -62,22 +82,20 @@ class GeneratedScenarioEntityPersistence:
 
     def _save_missing_places(
         self,
-        names: list[str],
+        records: list[dict[str, Any]],
         npc_names: list[str],
         scenario_title: str,
     ) -> list[str]:
         existing = self._load_index(self.place_wrapper)
         created: list[str] = []
-        for name in names:
+        for data in records:
+            name = str(data.get("Name") or data.get("Title") or "").strip()
+            if not name:
+                continue
             key = name.casefold()
             if key in existing:
                 continue
-            record = {
-                "Name": name,
-                "Description": _generated_description("place", scenario_title),
-                "NPCs": npc_names,
-                "Notes": _generated_notes(scenario_title),
-            }
+            record = _build_place_record(data, npc_names, scenario_title)
             self.place_wrapper.save_item(record, key_field="Name")
             existing[key] = record
             created.append(name)
@@ -99,9 +117,20 @@ class GeneratedScenarioEntityPersistence:
         return index
 
 
-def _coerce_names(value: Any) -> list[str]:
+def scenario_entity_names(value: Any) -> list[str]:
+    """Return unique entity names suitable for scenario link fields."""
+    return _entity_names(_entity_records(value))
+
+
+def _entity_records(value: Any) -> list[dict[str, Any]]:
     if value is None:
         return []
+    if isinstance(value, dict):
+        name = value.get("Name") or value.get("Title") or value.get("name") or value.get("title")
+        record = {str(k): v for k, v in value.items()}
+        if name and not record.get("Name"):
+            record["Name"] = name
+        return [record] if record.get("Name") else []
     if isinstance(value, str):
         values: Iterable[Any] = value.split(",")
     elif isinstance(value, (list, tuple, set)):
@@ -109,18 +138,67 @@ def _coerce_names(value: Any) -> list[str]:
     else:
         values = [value]
 
-    names: list[str] = []
-    seen: set[str] = set()
+    records: list[dict[str, Any]] = []
     for item in values:
-        name = str(item or "").strip()
-        if not name:
+        if isinstance(item, dict):
+            records.extend(_entity_records(item))
             continue
+        name = str(item or "").strip()
+        if name:
+            records.append({"Name": name})
+    return _dedupe_records(records)
+
+
+def _entity_names(records: list[dict[str, Any]]) -> list[str]:
+    return [str(record.get("Name") or "").strip() for record in records if str(record.get("Name") or "").strip()]
+
+
+def _dedupe_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for record in records:
+        name = str(record.get("Name") or "").strip()
         key = name.casefold()
-        if key in seen:
+        if not name or key in seen:
             continue
         seen.add(key)
-        names.append(name)
-    return names
+        result.append(record)
+    return result
+
+
+def _build_npc_record(data: dict[str, Any], scenario_title: str) -> dict[str, Any]:
+    description = data.get("Description") or data.get("Summary") or _generated_description("NPC", scenario_title)
+    return {
+        "Name": str(data.get("Name") or data.get("Title") or "Unnamed").strip(),
+        "Role": data.get("Role", "Scenario NPC"),
+        "Description": to_longtext(description),
+        "Secret": to_longtext(data.get("Secret") or data.get("Secrets") or ""),
+        "Quote": data.get("Quote", ""),
+        "RoleplayingCues": to_longtext(data.get("RoleplayingCues", "")),
+        "Personality": to_longtext(data.get("Personality", "")),
+        "Motivation": to_longtext(data.get("Motivation", "")),
+        "Background": to_longtext(data.get("Background", "")),
+        "Traits": to_longtext(data.get("Traits", "")),
+        "Genre": data.get("Genre", ""),
+        "Factions": data.get("Factions", []),
+        "Objects": data.get("Objects", []),
+        "Portrait": data.get("Portrait", ""),
+        "Notes": _generated_notes(scenario_title),
+    }
+
+
+def _build_place_record(data: dict[str, Any], npc_names: list[str], scenario_title: str) -> dict[str, Any]:
+    description = data.get("Description") or data.get("Summary") or _generated_description("place", scenario_title)
+    npcs = scenario_entity_names(data.get("NPCs")) or npc_names
+    return {
+        "Name": str(data.get("Name") or data.get("Title") or "Unnamed").strip(),
+        "Description": to_longtext(description),
+        "NPCs": npcs,
+        "PlayerDisplay": data.get("PlayerDisplay", False),
+        "Secrets": to_longtext(data.get("Secrets", "")),
+        "Portrait": data.get("Portrait", ""),
+        "Notes": _generated_notes(scenario_title),
+    }
 
 
 def _generated_description(entity_label: str, scenario_title: str) -> str:
@@ -133,4 +211,3 @@ def _generated_notes(scenario_title: str) -> str:
     if scenario_title:
         return f"Auto-created when saving generated scenario: {scenario_title}"
     return "Auto-created when saving a generated scenario."
-

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -4,6 +4,7 @@ import sqlite3
 
 from modules.scenarios.services.generated_entity_persistence import (
     GeneratedScenarioEntityPersistence,
+    scenario_entity_names,
 )
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 
@@ -76,3 +77,56 @@ def test_save_missing_entities_keeps_existing_records(tmp_path):
     saved_mira = npc_wrapper.load_item_by_key("Captain Mira", key_field="Name")
     assert saved_mira["Description"] == "Existing details"
 
+
+def test_save_missing_entities_uses_structured_ai_payload(tmp_path):
+    """Verify generated entities reuse PDF-import-style rich records when available."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+    place_wrapper = GenericModelWrapper("places", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=place_wrapper,
+    )
+    parsed_payload = {
+        "Title": "Juliet's Fall",
+        "NPCs": [
+            {
+                "Name": "Juliet Vale",
+                "Role": "Fallen heir",
+                "Description": "A poised aristocrat hiding panic behind perfect etiquette.",
+                "Motivation": "Recover the ledger before her enemies do.",
+            }
+        ],
+        "Places": [
+            {
+                "Name": "Grand Ballroom",
+                "Description": "A rain-streaked event hall with cracked marble and champagne towers.",
+                "Secrets": "The balcony is rigged to collapse.",
+                "NPCs": ["Juliet Vale"],
+            }
+        ],
+    }
+
+    result = persistence.save_missing_entities(
+        {
+            "Title": "Juliet's Fall",
+            "NPCs": scenario_entity_names(parsed_payload["NPCs"]),
+            "Places": scenario_entity_names(parsed_payload["Places"]),
+        },
+        parsed_payload,
+    )
+
+    assert result.npcs_created == ["Juliet Vale"]
+    assert result.places_created == ["Grand Ballroom"]
+
+    saved_npc = npc_wrapper.load_item_by_key("Juliet Vale", key_field="Name")
+    saved_place = place_wrapper.load_item_by_key("Grand Ballroom", key_field="Name")
+
+    assert saved_npc["Role"] == "Fallen heir"
+    assert "poised aristocrat" in saved_npc["Description"]["text"]
+    assert "Recover the ledger" in saved_npc["Motivation"]["text"]
+    assert "rain-streaked event hall" in saved_place["Description"]["text"]
+    assert saved_place["NPCs"] == ["Juliet Vale"]
+    assert "balcony is rigged" in saved_place["Secrets"]["text"]


### PR DESCRIPTION
### Motivation
- The AI scenario generator produced NPC and Place references that either lacked rich fields or failed to create NPC records at save time, causing empty/malformed Place content and missing NPCs in the DB.
- The import-from-PDF path already produced correctly-shaped NPC/Place records, so generated scenarios should reuse that shape when the AI returns structured entities.

### Description
- Prompt construction now requests structured NPC and Place JSON objects from the AI by adding an entity schema hint to `build_final_prompt` in `modules/scenarios/ai_scenario_generator.py`.
- Scenario saving in `modules/scenarios/scenario_generator_view.py` stores link fields as name lists while passing the full parsed AI payload into the persistence layer when available.
- `modules/scenarios/services/generated_entity_persistence.py` was reworked to accept an optional `entity_source` payload and to normalize structured/list/string entity references, producing records using the same rich-text shape and `to_longtext` conversion used by the PDF importer.
- New helpers were added: `scenario_entity_names`, `_entity_records`, `_entity_names`, `_dedupe_records`, `_build_npc_record`, and `_build_place_record` to support structured persistence and deduplication.
- Regression test added to `tests/scenarios/test_generated_entity_persistence.py` to verify that structured AI payloads create NPCs and Places with role, description, motivation, secrets, and linked NPCs.

### Testing
- Compiled updated modules with `python -m compileall modules/scenarios/ai_scenario_generator.py modules/scenarios/services/generated_entity_persistence.py modules/scenarios/scenario_generator_view.py` which completed successfully.
- Ran the scenario persistence tests with `pytest tests/scenarios/test_generated_entity_persistence.py -q` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e1b6270e0832bac26b9e0880f9ee8)