### PR TITLE
Handle Ollama timeout errors separately

### DIFF
--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -64,7 +64,13 @@ class OllamaScenarioProvider:
                 data = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
             raise AIGenerationError(self._format_http_error(exc)) from exc
-        except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
+        except (TimeoutError, socket.timeout) as exc:
+            raise AIGenerationError(
+                f"AI provider at {self.config.base_url} did not answer within {self.config.timeout} seconds. "
+                "Ollama may still be running, but the response is too long or the model is too slow. "
+                "Increase [AI] timeout or reduce the requested output."
+            ) from exc
+        except urllib.error.URLError as exc:
             raise AIGenerationError(
                 f"Cannot reach AI provider at {self.config.base_url}. Make sure Ollama is running and reachable from this application."
             ) from exc

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -178,6 +178,28 @@ def test_ollama_provider_reports_unreachable_provider(monkeypatch):
     assert "model" not in str(excinfo.value).lower()
 
 
+def test_ollama_provider_reports_socket_timeout_as_timeout(monkeypatch):
+    import socket
+
+    from modules.scenarios import ai_scenario_generator as generator
+
+    provider = generator.OllamaScenarioProvider(
+        generator.AIProviderConfig(base_url="http://127.0.0.1:11434", model="gpt-oss:20b", timeout=5)
+    )
+
+    def raise_socket_timeout(*_args, **_kwargs):
+        raise socket.timeout("timed out")
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", raise_socket_timeout)
+
+    with pytest.raises(generator.AIGenerationError) as excinfo:
+        provider.generate("hello")
+
+    message = str(excinfo.value)
+    assert "did not answer within 5 seconds" in message
+    assert "timeout" in message
+    assert "Cannot reach AI provider" not in message
+
 def test_ollama_provider_reports_model_http_error(monkeypatch):
     from io import BytesIO
     from modules.scenarios import ai_scenario_generator as generator


### PR DESCRIPTION
### Motivation
- Make error messages more actionable by distinguishing provider timeouts from network/provider reachability issues. 
- Provide specific guidance when a model is slow or the response is too large so users can increase AI timeout or reduce output size.

### Description
- In `modules/scenarios/ai_scenario_generator.py` split the combined exception handler so `TimeoutError` and `socket.timeout` are caught separately and raise `AIGenerationError` with a timeout-specific message referencing the configured `timeout` value. 
- Preserve `urllib.error.URLError` handling for true connection/provider errors and keep the existing “Cannot reach AI provider” message. 
- Add a unit test `test_ollama_provider_reports_socket_timeout_as_timeout` to `tests/test_ai_prompt_scenario_generation.py` that simulates `socket.timeout` and asserts the timeout message mentions the configured seconds and does not claim the provider is unreachable.

### Testing
- Ran `pytest tests/test_ai_prompt_scenario_generation.py::test_ollama_provider_reports_socket_timeout_as_timeout tests/test_ai_prompt_scenario_generation.py::test_ollama_provider_reports_unreachable_provider -q`, and both tests passed. 
- Ran the whole `tests/test_ai_prompt_scenario_generation.py -q`, which revealed an existing, unrelated failure in `test_parse_generated_scenario_sections_best_effort` (parser title assertion mismatch) that is not introduced by this change. 
- The new timeout-specific behavior is covered by the added test and verified green in focused test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2d9c1654832b9a847a7cd0b69276)