### PR TITLE
Add Ollama max_tokens config and send `num_predict` when positive

### DIFF
--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -26,6 +26,15 @@ class AIProviderConfig:
     model: str = "llama3.1"
     temperature: float = 0.7
     timeout: int = 120
+    max_tokens: int = 0
+
+    @staticmethod
+    def _parse_max_tokens(value: object) -> int:
+        """Safely parse the optional maximum token count."""
+        try:
+            return int(str(value).strip())
+        except (TypeError, ValueError):
+            return 0
 
     @classmethod
     def from_config(cls) -> "AIProviderConfig":
@@ -35,6 +44,7 @@ class AIProviderConfig:
             model=ConfigHelper.get("AI", "model", fallback="llama3.1") or "llama3.1",
             temperature=float(ConfigHelper.get("AI", "temperature", fallback="0.7") or 0.7),
             timeout=int(float(ConfigHelper.get("AI", "timeout", fallback="120") or 120)),
+            max_tokens=cls._parse_max_tokens(ConfigHelper.get("AI", "max_tokens", fallback="0")),
         )
 
 
@@ -47,11 +57,15 @@ class OllamaScenarioProvider:
     def generate(self, prompt: str) -> str:
         """Send prompt to Ollama and return generated text."""
         url = f"{self.config.base_url}/api/chat"
+        options = {"temperature": self.config.temperature}
+        if self.config.max_tokens > 0:
+            options["num_predict"] = self.config.max_tokens
+
         payload = {
             "model": self.config.model,
             "messages": [{"role": "user", "content": prompt}],
             "stream": False,
-            "options": {"temperature": self.config.temperature},
+            "options": options,
         }
         request = urllib.request.Request(
             url,

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -11,7 +11,13 @@ from modules.scenarios.ai_prompt_library import (
     extract_placeholders,
     validate_prompt,
 )
-from modules.scenarios.ai_scenario_generator import build_final_prompt, parse_generated_scenario, validate_required_answers
+from modules.scenarios.ai_scenario_generator import (
+    AIProviderConfig,
+    OllamaScenarioProvider,
+    build_final_prompt,
+    parse_generated_scenario,
+    validate_required_answers,
+)
 
 
 def test_extract_placeholders_ignores_duplicates_and_invalid_format_parts():
@@ -226,3 +232,96 @@ def test_ollama_provider_reports_model_http_error(monkeypatch):
     assert "Ollama is reachable" in message
     assert "ollama pull gpt-oss:20b" in message
     assert "model" in message
+
+
+class _FakeOllamaResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return b'{"message": {"content": "Generated scenario"}}'
+
+
+def test_ollama_provider_sends_positive_max_tokens_as_num_predict(monkeypatch):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    captured_payloads = []
+    provider = OllamaScenarioProvider(AIProviderConfig(max_tokens=512))
+
+    def fake_urlopen(request, **_kwargs):
+        captured_payloads.append(generator.json.loads(request.data.decode("utf-8")))
+        return _FakeOllamaResponse()
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", fake_urlopen)
+
+    assert provider.generate("hello") == "Generated scenario"
+    assert captured_payloads[0]["options"]["num_predict"] == 512
+
+
+@pytest.mark.parametrize("max_tokens", [0, -25])
+def test_ollama_provider_omits_non_positive_max_tokens(monkeypatch, max_tokens):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    captured_payloads = []
+    provider = OllamaScenarioProvider(AIProviderConfig(max_tokens=max_tokens))
+
+    def fake_urlopen(request, **_kwargs):
+        captured_payloads.append(generator.json.loads(request.data.decode("utf-8")))
+        return _FakeOllamaResponse()
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", fake_urlopen)
+
+    assert provider.generate("hello") == "Generated scenario"
+    assert "num_predict" not in captured_payloads[0]["options"]
+
+
+def test_ai_provider_config_defaults_invalid_max_tokens_to_zero(monkeypatch):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    def fake_get(_section, key, fallback=None):
+        values = {
+            "base_url": "http://example.test/",
+            "model": "test-model",
+            "temperature": "0.3",
+            "timeout": "10",
+            "max_tokens": "not-an-int",
+        }
+        return values.get(key, fallback)
+
+    monkeypatch.setattr(generator.ConfigHelper, "get", fake_get)
+
+    config = AIProviderConfig.from_config()
+
+    assert config.max_tokens == 0
+
+
+def test_ollama_provider_generates_with_invalid_configured_max_tokens(monkeypatch):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    captured_payloads = []
+
+    def fake_get(_section, key, fallback=None):
+        values = {
+            "base_url": "http://example.test/",
+            "model": "test-model",
+            "temperature": "0.3",
+            "timeout": "10",
+            "max_tokens": "invalid",
+        }
+        return values.get(key, fallback)
+
+    def fake_urlopen(request, **_kwargs):
+        captured_payloads.append(generator.json.loads(request.data.decode("utf-8")))
+        return _FakeOllamaResponse()
+
+    monkeypatch.setattr(generator.ConfigHelper, "get", fake_get)
+    monkeypatch.setattr(generator.urllib.request, "urlopen", fake_urlopen)
+
+    provider = OllamaScenarioProvider()
+
+    assert provider.generate("hello") == "Generated scenario"
+    assert provider.config.max_tokens == 0
+    assert "num_predict" not in captured_payloads[0]["options"]


### PR DESCRIPTION
### Motivation
- Allow configuring an upper bound for Ollama-generated tokens from the `[AI] max_tokens` setting so callers can control output length.
- Parse the configured value safely to avoid crashes on invalid user input and keep a sensible default (`0`).

### Description
- Added `max_tokens: int = 0` to `AIProviderConfig` and a helper `_parse_max_tokens` to safely parse integer-like config values.
- In `AIProviderConfig.from_config` read `[AI] max_tokens` via `ConfigHelper.get("AI", "max_tokens", fallback="0")` and parse it with `_parse_max_tokens` (invalid values become `0`).
- Updated `OllamaScenarioProvider.generate` to build an `options` dict (`{"temperature": self.config.temperature}`) and to include `"num_predict"` only when `self.config.max_tokens > 0`, then use `options` in the request payload.
- Added tests in `tests/test_ai_prompt_scenario_generation.py` that assert a positive `max_tokens` becomes `num_predict`, that non-positive values omit `num_predict`, and that invalid configured values default to `0` without breaking generation.

### Testing
- Ran the new/targeted tests with `pytest -q tests/test_ai_prompt_scenario_generation.py -k 'max_tokens or invalid_configured'`, and they passed.
- Ran the full file `pytest -q tests/test_ai_prompt_scenario_generation.py`; this run failed on a pre-existing, unrelated test `test_parse_generated_scenario_sections_best_effort` (the failure is not caused by the max token changes), while the newly added max-token tests still passed.
- No other automated test suites were changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2e665f5c832b88f1c5639a1d48dd)