### PR TITLE
Add streaming Ollama scenario generation

### DIFF
--- a/modules/scenarios/ai_scenario_generator.py
+++ b/modules/scenarios/ai_scenario_generator.py
@@ -27,6 +27,7 @@ class AIProviderConfig:
     temperature: float = 0.7
     timeout: int = 120
     max_tokens: int = 0
+    stream: bool = True
 
     @staticmethod
     def _parse_max_tokens(value: object) -> int:
@@ -45,6 +46,7 @@ class AIProviderConfig:
             temperature=float(ConfigHelper.get("AI", "temperature", fallback="0.7") or 0.7),
             timeout=int(float(ConfigHelper.get("AI", "timeout", fallback="120") or 120)),
             max_tokens=cls._parse_max_tokens(ConfigHelper.get("AI", "max_tokens", fallback="0")),
+            stream=ConfigHelper.getboolean("AI", "stream", fallback=True),
         )
 
 
@@ -64,7 +66,7 @@ class OllamaScenarioProvider:
         payload = {
             "model": self.config.model,
             "messages": [{"role": "user", "content": prompt}],
-            "stream": False,
+            "stream": self.config.stream,
             "options": options,
         }
         request = urllib.request.Request(
@@ -75,7 +77,7 @@ class OllamaScenarioProvider:
         )
         try:
             with urllib.request.urlopen(request, timeout=self.config.timeout) as response:
-                data = json.loads(response.read().decode("utf-8"))
+                content = self._read_streaming_response(response) if self.config.stream else self._read_response(response)
         except urllib.error.HTTPError as exc:
             raise AIGenerationError(self._format_http_error(exc)) from exc
         except (TimeoutError, socket.timeout) as exc:
@@ -90,12 +92,32 @@ class OllamaScenarioProvider:
             ) from exc
         except json.JSONDecodeError as exc:
             raise AIGenerationError("AI provider returned invalid JSON.") from exc
-        message = data.get("message", {}) if isinstance(data, dict) else {}
-        content = str(message.get("content") or data.get("response") or "").strip()
         if not content:
             raise AIGenerationError("AI provider returned an empty scenario.")
         return content
 
+    @staticmethod
+    def _read_response(response) -> str:
+        """Read one non-streaming Ollama JSON response."""
+        data = json.loads(response.read().decode("utf-8"))
+        message = data.get("message", {}) if isinstance(data, dict) else {}
+        return str(message.get("content") or data.get("response") or "").strip()
+
+    @staticmethod
+    def _read_streaming_response(response) -> str:
+        """Read newline-delimited Ollama JSON chunks and stitch content fragments."""
+        fragments: list[str] = []
+        for raw_line in response:
+            line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else str(raw_line)
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            message = data.get("message", {}) if isinstance(data, dict) else {}
+            fragment = message.get("content")
+            if fragment:
+                fragments.append(str(fragment))
+        return "".join(fragments).strip()
 
     def _format_http_error(self, exc: urllib.error.HTTPError) -> str:
         """Return an actionable message for Ollama HTTP errors."""

--- a/tests/test_ai_prompt_scenario_generation.py
+++ b/tests/test_ai_prompt_scenario_generation.py
@@ -244,6 +244,57 @@ class _FakeOllamaResponse:
     def read(self):
         return b'{"message": {"content": "Generated scenario"}}'
 
+    def __iter__(self):
+        return iter([b'{"message": {"content": "Generated scenario"}}\n'])
+
+
+class _FakeStreamingOllamaResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def __iter__(self):
+        return iter([
+            b'{"message": {"content": "The Ash "}}\n',
+            b'\n',
+            b'{"message": {"content": "Bell"}}\n',
+            b'{"done": true}\n',
+        ])
+
+
+def test_ollama_provider_stitches_newline_delimited_streaming_chunks(monkeypatch):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    captured_payloads = []
+    provider = OllamaScenarioProvider(AIProviderConfig(stream=True))
+
+    def fake_urlopen(request, **_kwargs):
+        captured_payloads.append(generator.json.loads(request.data.decode("utf-8")))
+        return _FakeStreamingOllamaResponse()
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", fake_urlopen)
+
+    assert provider.generate("hello") == "The Ash Bell"
+    assert captured_payloads[0]["stream"] is True
+
+
+def test_ollama_provider_keeps_non_streaming_mode_when_disabled(monkeypatch):
+    from modules.scenarios import ai_scenario_generator as generator
+
+    captured_payloads = []
+    provider = OllamaScenarioProvider(AIProviderConfig(stream=False))
+
+    def fake_urlopen(request, **_kwargs):
+        captured_payloads.append(generator.json.loads(request.data.decode("utf-8")))
+        return _FakeOllamaResponse()
+
+    monkeypatch.setattr(generator.urllib.request, "urlopen", fake_urlopen)
+
+    assert provider.generate("hello") == "Generated scenario"
+    assert captured_payloads[0]["stream"] is False
+
 
 def test_ollama_provider_sends_positive_max_tokens_as_num_predict(monkeypatch):
     from modules.scenarios import ai_scenario_generator as generator
@@ -288,6 +339,7 @@ def test_ai_provider_config_defaults_invalid_max_tokens_to_zero(monkeypatch):
             "temperature": "0.3",
             "timeout": "10",
             "max_tokens": "not-an-int",
+            "stream": "false",
         }
         return values.get(key, fallback)
 
@@ -310,6 +362,7 @@ def test_ollama_provider_generates_with_invalid_configured_max_tokens(monkeypatc
             "temperature": "0.3",
             "timeout": "10",
             "max_tokens": "invalid",
+            "stream": "false",
         }
         return values.get(key, fallback)
 


### PR DESCRIPTION
### Motivation
- Allow using Ollama `/api/chat` streaming mode so large or progressive responses can be read as newline-delimited JSON fragments and stitched together. 
- Preserve existing non-streaming behavior and make streaming controllable via the `[AI] stream` config flag.

### Description
- Add `stream: bool` to `AIProviderConfig` and load it with `ConfigHelper.getboolean("AI", "stream", fallback=True)`, exposing the `[AI] stream = true` option. 
- Send `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2f18c050832bad3ce8e6c0df8022)