### PR TITLE
Use AI-provided content for NPCs/Places and persist Scenes for generated scenarios

### DIFF
--- a/modules/scenarios/generated_scenario_parser.py
+++ b/modules/scenarios/generated_scenario_parser.py
@@ -1,10 +1,20 @@
 """Normalize AI-generated scenario payloads into editable scenario fields."""
+
 from __future__ import annotations
 
 import re
 from typing import Any
 
-_ENTITY_FIELDS = ("NPCs", "Places", "Creatures", "Factions", "Objects", "Maps", "Bases", "Villains")
+_ENTITY_FIELDS = (
+    "NPCs",
+    "Places",
+    "Creatures",
+    "Factions",
+    "Objects",
+    "Maps",
+    "Bases",
+    "Villains",
+)
 _SECTION_ALIASES = {
     "title": "Title",
     "scenario title": "Title",
@@ -27,8 +37,12 @@ _SECTION_ALIASES = {
     "bases": "Bases",
     "villains": "Villains",
 }
-_SCENE_HEADING_RE = re.compile(r"^\s{0,3}#{2,6}\s*(?:scene\s*)?(\d+)?\s*[:.)-]?\s*(.*)$", re.IGNORECASE)
-_FIELD_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:\*\*)?([A-Za-z][A-Za-z0-9 ()/&-]{1,45})(?:\*\*)?\s*:\s*(.*)$")
+_SCENE_HEADING_RE = re.compile(
+    r"^\s{0,3}#{2,6}\s*(?:scene\s*)?(\d+)?\s*[:.)-]?\s*(.*)$", re.IGNORECASE
+)
+_FIELD_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:\*\*)?([A-Za-z][A-Za-z0-9 (),/&-]{1,60})(?:\*\*)?\s*:\s*(.*)$"
+)
 _MARKDOWN_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*$")
 
 
@@ -86,7 +100,9 @@ def _normalize_mapping(data: dict[str, Any]) -> dict[str, Any]:
         scenes = parsed.get("Scenes") or [{"Text": str(scenes)}]
     if not isinstance(scenes, list):
         scenes = [scenes]
-    normalized_scenes = [_normalize_scene(scene, idx) for idx, scene in enumerate(scenes, start=1)]
+    normalized_scenes = [
+        _normalize_scene(scene, idx) for idx, scene in enumerate(scenes, start=1)
+    ]
     result["Scenes"] = normalized_scenes
     _promote_scene_entities(result, normalized_scenes)
     return result
@@ -115,7 +131,10 @@ def _split_scene_blocks(text: str) -> tuple[str, list[tuple[str, str]]]:
         match = _SCENE_HEADING_RE.match(line)
         line_label = line.lower().lstrip("# ").strip()
         if match and (match.group(1) or line_label.startswith("scene ")):
-            title = match.group(2).strip() or f"Scene {match.group(1) or len(scene_indices)+1}"
+            title = (
+                match.group(2).strip()
+                or f"Scene {match.group(1) or len(scene_indices)+1}"
+            )
             scene_indices.append((i, title))
     if not scene_indices:
         return text, []
@@ -168,7 +187,11 @@ def _parse_scene_block(title: str, body: str) -> dict[str, Any]:
             if key == "Places":
                 scene["Places"] = _coerce_names(value)
                 continue
-            if key in {"Summary", "Secrets"} or field.group(1).strip().lower() in {"purpose", "atouts", "stakes"}:
+            if key in {"Summary", "Secrets"} or field.group(1).strip().lower() in {
+                "purpose",
+                "atouts",
+                "stakes",
+            }:
                 if value:
                     text_lines.append(f"{field.group(1).strip()}: {value}")
                 continue
@@ -177,7 +200,9 @@ def _parse_scene_block(title: str, body: str) -> dict[str, Any]:
     return scene
 
 
-def _promote_scene_entities(result: dict[str, Any], scenes: list[dict[str, Any]]) -> None:
+def _promote_scene_entities(
+    result: dict[str, Any], scenes: list[dict[str, Any]]
+) -> None:
     for key in _ENTITY_FIELDS:
         combined = _coerce_names(result.get(key))
         for scene in scenes:
@@ -202,9 +227,17 @@ def _coerce_names(value: Any) -> list[str]:
             values.extend(_coerce_names(item))
         return _dedupe(values)
     if isinstance(value, dict):
-        return _coerce_names(value.get("Name") or value.get("Title") or value.get("name") or value.get("title"))
+        return _coerce_names(
+            value.get("Name")
+            or value.get("Title")
+            or value.get("name")
+            or value.get("title")
+        )
     text = _clean_value(str(value))
-    parts = re.split(r",|;|\band\b|&", text)
+    lines = [line.strip(" -*•") for line in text.splitlines() if line.strip(" -*•")]
+    if len(lines) > 1:
+        return _dedupe(lines)
+    parts = re.split(r";|\band\b|&", text)
     return _dedupe(part.strip(" -*•") for part in parts if part.strip(" -*•"))
 
 
@@ -222,12 +255,21 @@ def _clean_value(value: Any) -> str:
 
 
 def _extract_inline_field(text: str, field_name: str) -> str:
-    match = re.search(rf"^\s*(?:\*\*)?{re.escape(field_name)}(?:\*\*)?\s*:\s*(.+)$", text, re.IGNORECASE | re.MULTILINE)
+    match = re.search(
+        rf"^\s*(?:\*\*)?{re.escape(field_name)}(?:\*\*)?\s*:\s*(.+)$",
+        text,
+        re.IGNORECASE | re.MULTILINE,
+    )
     return match.group(1).strip() if match else ""
 
 
 def _strip_known_inline_fields(text: str) -> str:
-    return re.sub(r"^\s*(?:\*\*)?(?:Title|Scenario Title)(?:\*\*)?\s*:.+$", "", text, flags=re.IGNORECASE | re.MULTILINE)
+    return re.sub(
+        r"^\s*(?:\*\*)?(?:Title|Scenario Title)(?:\*\*)?\s*:.+$",
+        "",
+        text,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
 
 
 def _scene_text(scene: dict[str, Any]) -> str:

--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -535,6 +535,11 @@ class ScenarioGeneratorView(ctk.CTkFrame):
                     if isinstance(parsed.get("Objects"), list)
                     else []
                 ),
+                "Scenes": (
+                    parsed.get("Scenes")
+                    if isinstance(parsed.get("Scenes"), list)
+                    else []
+                ),
             }
         else:
             summary = "\n".join(f"{k}: {v}" for k, v in self.current_campaign.items())

--- a/modules/scenarios/services/generated_entity_descriptions.py
+++ b/modules/scenarios/services/generated_entity_descriptions.py
@@ -1,0 +1,154 @@
+"""Description builders for entities created from AI-generated scenarios."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ENTITY_FIELDS = ("NPCs", "Places")
+
+
+def build_entity_description(
+    data: dict[str, Any], scenario: dict[str, Any] | None, entity_type: str
+) -> str:
+    """Return entity-specific descriptive text found in the generated scenario payload.
+
+    The function intentionally never emits template filler.  If the generator only
+    supplied a bare name, it falls back to scene excerpts or scenario prose that
+    actually came from the AI output.
+    """
+    for key in ("Description", "Summary", "Details", "Text", "Gist"):
+        text = _clean_text(data.get(key))
+        if text:
+            return text
+
+    name = _entity_name(data)
+    scene_excerpt = _description_from_scenes(name, scenario, entity_type)
+    if scene_excerpt:
+        return scene_excerpt
+
+    contextual = _scenario_context(scenario)
+    return contextual
+
+
+def build_npc_role(data: dict[str, Any], description: str) -> str:
+    """Return a non-generic NPC role from generated scenario fields."""
+    for key in ("Role", "Function", "Occupation", "Archetype", "Type"):
+        role = _clean_text(data.get(key))
+        if role and role.casefold() != "scenario npc":
+            return role
+    return _derive_role_from_description(description)
+
+
+def linked_npcs_for_place(
+    data: dict[str, Any], all_npc_names: list[str], scenario: dict[str, Any] | None
+) -> list[str]:
+    """Return NPC links for a generated place using explicit or scene-level links."""
+    explicit = _names(data.get("NPCs"))
+    if explicit:
+        return explicit
+    place_name = _entity_name(data)
+    if not place_name:
+        return all_npc_names
+    found: list[str] = []
+    for scene in _scenes(scenario):
+        if (
+            place_name not in _names(scene.get("Places"))
+            and place_name.casefold() not in _scene_blob(scene).casefold()
+        ):
+            continue
+        for npc in _names(scene.get("NPCs")):
+            if npc not in found:
+                found.append(npc)
+    return found or all_npc_names
+
+
+def _description_from_scenes(
+    name: str, scenario: dict[str, Any] | None, entity_type: str
+) -> str:
+    if not name:
+        return ""
+    lines: list[str] = []
+    field = "NPCs" if entity_type.casefold() == "npc" else "Places"
+    name_key = name.casefold()
+    for scene in _scenes(scenario):
+        scene_names = [value.casefold() for value in _names(scene.get(field))]
+        blob = _scene_blob(scene)
+        if name_key not in scene_names and name_key not in blob.casefold():
+            continue
+        title = _clean_text(scene.get("Title") or scene.get("Name"))
+        text = _clean_text(
+            scene.get("Text")
+            or scene.get("Summary")
+            or scene.get("Description")
+            or scene.get("Gist")
+        )
+        if title and text:
+            lines.append(f"{title}: {text}")
+        elif text:
+            lines.append(text)
+        elif title:
+            lines.append(title)
+    return "\n\n".join(lines)
+
+
+def _scenario_context(scenario: dict[str, Any] | None) -> str:
+    if not isinstance(scenario, dict):
+        return ""
+    parts = [_clean_text(scenario.get("Summary")), _clean_text(scenario.get("Secrets"))]
+    return "\n\n".join(part for part in parts if part)
+
+
+def _derive_role_from_description(description: str) -> str:
+    text = _clean_text(description)
+    if not text:
+        return ""
+    first_line = text.splitlines()[0]
+    first_sentence = first_line.split(".", 1)[0].strip()
+    return first_sentence[:80]
+
+
+def _scene_blob(scene: dict[str, Any]) -> str:
+    chunks = []
+    for key, value in scene.items():
+        if key in _ENTITY_FIELDS:
+            continue
+        if isinstance(value, (str, int, float)):
+            chunks.append(str(value))
+    return "\n".join(chunks)
+
+
+def _scenes(scenario: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(scenario, dict):
+        return []
+    scenes = scenario.get("Scenes") or []
+    if isinstance(scenes, dict):
+        scenes = scenes.get("Scenes") or []
+    if not isinstance(scenes, list):
+        return []
+    return [scene for scene in scenes if isinstance(scene, dict)]
+
+
+def _entity_name(data: dict[str, Any]) -> str:
+    return _clean_text(
+        data.get("Name") or data.get("Title") or data.get("name") or data.get("title")
+    )
+
+
+def _names(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        return [_entity_name(value)] if _entity_name(value) else []
+    if isinstance(value, (list, tuple, set)):
+        result: list[str] = []
+        for item in value:
+            for name in _names(item):
+                if name and name not in result:
+                    result.append(name)
+        return result
+    text = _clean_text(value)
+    return [text] if text else []
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()

--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -1,4 +1,5 @@
 """Persist entities referenced by generated scenarios."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -6,6 +7,11 @@ from typing import Any, Iterable
 
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.importers.pdf_entity_importer import to_longtext
+from modules.scenarios.services.generated_entity_descriptions import (
+    build_entity_description,
+    build_npc_role,
+    linked_npcs_for_place,
+)
 
 
 @dataclass(frozen=True)
@@ -49,22 +55,33 @@ class GeneratedScenarioEntityPersistence:
         npc_records = _entity_records(source.get("NPCs") or scenario.get("NPCs"))
         place_records = _entity_records(source.get("Places") or scenario.get("Places"))
         npc_names = _entity_names(npc_records)
-        created_npcs = self._save_missing_npcs(npc_records, title)
-        created_places = self._save_missing_places(place_records, npc_names, title)
+        created_npcs = self._save_missing_npcs(npc_records, title, source)
+        created_places = self._save_missing_places(
+            place_records, npc_names, title, source
+        )
 
         # If only scene-level entities were present, keep the old name-based
         # behavior as a final fallback.
         if not npc_records:
-            created_npcs = self._save_missing_npcs(_entity_records(scenario.get("NPCs")), title)
+            created_npcs = self._save_missing_npcs(
+                _entity_records(scenario.get("NPCs")), title, source
+            )
         if not place_records:
-            created_places = self._save_missing_places(_entity_records(scenario.get("Places")), npc_names, title)
+            created_places = self._save_missing_places(
+                _entity_records(scenario.get("Places")), npc_names, title, source
+            )
 
         return GeneratedEntitySaveResult(
             npcs_created=created_npcs,
             places_created=created_places,
         )
 
-    def _save_missing_npcs(self, records: list[dict[str, Any]], scenario_title: str) -> list[str]:
+    def _save_missing_npcs(
+        self,
+        records: list[dict[str, Any]],
+        scenario_title: str,
+        scenario_source: dict[str, Any] | None = None,
+    ) -> list[str]:
         existing = self._load_index(self.npc_wrapper)
         created: list[str] = []
         for data in records:
@@ -74,7 +91,7 @@ class GeneratedScenarioEntityPersistence:
             key = name.casefold()
             if key in existing:
                 continue
-            record = _build_npc_record(data, scenario_title)
+            record = _build_npc_record(data, scenario_title, scenario_source)
             self.npc_wrapper.save_item(record, key_field="Name")
             existing[key] = record
             created.append(name)
@@ -85,6 +102,7 @@ class GeneratedScenarioEntityPersistence:
         records: list[dict[str, Any]],
         npc_names: list[str],
         scenario_title: str,
+        scenario_source: dict[str, Any] | None = None,
     ) -> list[str]:
         existing = self._load_index(self.place_wrapper)
         created: list[str] = []
@@ -95,7 +113,9 @@ class GeneratedScenarioEntityPersistence:
             key = name.casefold()
             if key in existing:
                 continue
-            record = _build_place_record(data, npc_names, scenario_title)
+            record = _build_place_record(
+                data, npc_names, scenario_title, scenario_source
+            )
             self.place_wrapper.save_item(record, key_field="Name")
             existing[key] = record
             created.append(name)
@@ -126,7 +146,12 @@ def _entity_records(value: Any) -> list[dict[str, Any]]:
     if value is None:
         return []
     if isinstance(value, dict):
-        name = value.get("Name") or value.get("Title") or value.get("name") or value.get("title")
+        name = (
+            value.get("Name")
+            or value.get("Title")
+            or value.get("name")
+            or value.get("title")
+        )
         record = {str(k): v for k, v in value.items()}
         if name and not record.get("Name"):
             record["Name"] = name
@@ -150,7 +175,11 @@ def _entity_records(value: Any) -> list[dict[str, Any]]:
 
 
 def _entity_names(records: list[dict[str, Any]]) -> list[str]:
-    return [str(record.get("Name") or "").strip() for record in records if str(record.get("Name") or "").strip()]
+    return [
+        str(record.get("Name") or "").strip()
+        for record in records
+        if str(record.get("Name") or "").strip()
+    ]
 
 
 def _dedupe_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -166,11 +195,15 @@ def _dedupe_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return result
 
 
-def _build_npc_record(data: dict[str, Any], scenario_title: str) -> dict[str, Any]:
-    description = data.get("Description") or data.get("Summary") or _generated_description("NPC", scenario_title)
+def _build_npc_record(
+    data: dict[str, Any],
+    scenario_title: str,
+    scenario_source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    description = build_entity_description(data, scenario_source, "npc")
     return {
         "Name": str(data.get("Name") or data.get("Title") or "Unnamed").strip(),
-        "Role": data.get("Role", "Scenario NPC"),
+        "Role": build_npc_role(data, description),
         "Description": to_longtext(description),
         "Secret": to_longtext(data.get("Secret") or data.get("Secrets") or ""),
         "Quote": data.get("Quote", ""),
@@ -187,9 +220,14 @@ def _build_npc_record(data: dict[str, Any], scenario_title: str) -> dict[str, An
     }
 
 
-def _build_place_record(data: dict[str, Any], npc_names: list[str], scenario_title: str) -> dict[str, Any]:
-    description = data.get("Description") or data.get("Summary") or _generated_description("place", scenario_title)
-    npcs = scenario_entity_names(data.get("NPCs")) or npc_names
+def _build_place_record(
+    data: dict[str, Any],
+    npc_names: list[str],
+    scenario_title: str,
+    scenario_source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    description = build_entity_description(data, scenario_source, "place")
+    npcs = linked_npcs_for_place(data, npc_names, scenario_source)
     return {
         "Name": str(data.get("Name") or data.get("Title") or "Unnamed").strip(),
         "Description": to_longtext(description),
@@ -199,12 +237,6 @@ def _build_place_record(data: dict[str, Any], npc_names: list[str], scenario_tit
         "Portrait": data.get("Portrait", ""),
         "Notes": _generated_notes(scenario_title),
     }
-
-
-def _generated_description(entity_label: str, scenario_title: str) -> str:
-    if scenario_title:
-        return f"Generated from AI scenario '{scenario_title}'. Add details during prep."
-    return f"Generated from an AI scenario. Add {entity_label} details during prep."
 
 
 def _generated_notes(scenario_title: str) -> str:

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -130,3 +130,49 @@ def test_save_missing_entities_uses_structured_ai_payload(tmp_path):
     assert "rain-streaked event hall" in saved_place["Description"]["text"]
     assert saved_place["NPCs"] == ["Juliet Vale"]
     assert "balcony is rigged" in saved_place["Secrets"]["text"]
+
+
+def test_save_missing_entities_uses_scene_text_instead_of_generic_fallback(tmp_path):
+    """Verify bare generated entities are enriched from generated scene text."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+    place_wrapper = GenericModelWrapper("places", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=place_wrapper,
+    )
+    parsed_payload = {
+        "Title": "Death in Love",
+        "Summary": "A doomed wedding hides a murder pact.",
+        "NPCs": ["Juliet Vale"],
+        "Places": ["Grand Ballroom"],
+        "Scenes": [
+            {
+                "Title": "The Poisoned Toast",
+                "Text": "Juliet Vale trembles while accusing the masked violinist. The Grand Ballroom erupts as guests notice the poisoned glass.",
+                "NPCs": ["Juliet Vale"],
+                "Places": ["Grand Ballroom"],
+            }
+        ],
+    }
+
+    persistence.save_missing_entities(
+        {
+            "Title": "Death in Love",
+            "NPCs": scenario_entity_names(parsed_payload["NPCs"]),
+            "Places": scenario_entity_names(parsed_payload["Places"]),
+            "Scenes": parsed_payload["Scenes"],
+        },
+        parsed_payload,
+    )
+
+    saved_npc = npc_wrapper.load_item_by_key("Juliet Vale", key_field="Name")
+    saved_place = place_wrapper.load_item_by_key("Grand Ballroom", key_field="Name")
+
+    assert "Generated from AI scenario" not in saved_npc["Description"]["text"]
+    assert "Generated from AI scenario" not in saved_place["Description"]["text"]
+    assert saved_npc["Role"] != "Scenario NPC"
+    assert "Poisoned Toast" in saved_npc["Description"]["text"]
+    assert "poisoned glass" in saved_place["Description"]["text"]


### PR DESCRIPTION
### Motivation
- Ensure NPC and Place records created from AI-generated scenarios contain usable, non-generic descriptive text and roles derived from the generated output rather than placeholder strings. 
- Ensure the generated scenario entity stored in the DB includes the parsed `Scenes` payload so scene content is preserved for later editing and entity enrichment.

### Description
- Add `modules/scenarios/services/generated_entity_descriptions.py` to derive entity descriptions, infer NPC roles, and link NPCs to places using AI-provided fields and scene excerpts instead of template filler. 
- Update `modules/scenarios/services/generated_entity_persistence.py` to use the new description/role/link helpers when building NPC and Place records and to prefer structured AI payloads or scene-derived context. 
- Persist parsed `Scenes` on the saved scenario entity in `modules/scenarios/scenario_generator_view.py` so DB scenarios include the scenes returned by the AI. 
- Improve generated-scenario markdown parsing in `modules/scenarios/generated_scenario_parser.py` to better handle section labels containing commas and to preserve comma-containing bullet text for entity lists. 
- Add a regression test in `tests/scenarios/test_generated_entity_persistence.py` validating that bare generated entities are enriched from scene text and do not contain the old generic fallback text or the generic "Scenario NPC" role.

### Testing
- Compiled impacted modules with `python -m compileall modules/scenarios/generated_scenario_parser.py modules/scenarios/scenario_generator_view.py modules/scenarios/services/generated_entity_persistence.py modules/scenarios/services/generated_entity_descriptions.py` and verified there were no syntax errors. 
- Ran unit tests with `pytest tests/scenarios/test_generated_entity_persistence.py tests/test_ai_prompt_scenario_generation.py -q` and observed all tests passed (test suite run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f35db7a08832bb5de8cf77c5c7f27)