### PR TITLE
Format NPC longtext list imports

### DIFF
--- a/modules/importers/pdf_entity_importer.py
+++ b/modules/importers/pdf_entity_importer.py
@@ -40,16 +40,80 @@ def parse_json_relaxed(payload: str):
     raise RuntimeError("Failed to parse JSON from AI response")
 
 
-def to_longtext(value):
-    """Convert plain strings into the rich-text JSON structure used by the DB."""
+def format_longtext_value(value):
+    """Return a human-readable plain-text value for longtext fields.
+
+    AI importers may return longtext fields as lists. Store those lists as
+    readable text instead of JSON so editor fields display naturally.
+    """
     if isinstance(value, dict) and "text" in value:
         return value
-    if isinstance(value, (list, dict)):
-        try:
-            value = json.dumps(value, ensure_ascii=False, indent=2)
-        except Exception:
-            value = str(value)
-    return ai_text_to_rtf_json(str(value) if value is not None else "")
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return _format_longtext_list(value)
+    if isinstance(value, dict):
+        return _format_longtext_dict(value)
+    return str(value)
+
+
+def _format_longtext_list(items, *, indent: int = 0) -> str:
+    """Format list items as newline bullets, including nested dictionaries."""
+    lines: list[str] = []
+    prefix = " " * indent
+    for item in items:
+        if item is None:
+            continue
+        if isinstance(item, dict):
+            body = _format_longtext_dict(item, indent=indent + 2)
+            if body.strip():
+                lines.append(f"{prefix}- {body.lstrip()}")
+            continue
+        if isinstance(item, list):
+            body = _format_longtext_list(item, indent=indent + 2)
+            if body.strip():
+                lines.append(f"{prefix}- {body.lstrip()}")
+            continue
+        text = str(item).strip()
+        if text:
+            lines.append(f"{prefix}- {text}")
+    return "\n".join(lines)
+
+
+def _format_longtext_dict(data, *, indent: int = 0) -> str:
+    """Format dictionaries as readable key/value text instead of raw JSON."""
+    lines: list[str] = []
+    prefix = " " * indent
+    for key, value in data.items():
+        if value is None:
+            continue
+        label = str(key).strip()
+        if not label:
+            continue
+        if isinstance(value, dict):
+            nested = _format_longtext_dict(value, indent=indent + 2)
+            if nested.strip():
+                lines.append(f"{prefix}{label}:")
+                lines.append(nested)
+            continue
+        if isinstance(value, list):
+            nested = _format_longtext_list(value, indent=indent + 2)
+            if nested.strip():
+                lines.append(f"{prefix}{label}:")
+                lines.append(nested)
+            continue
+        text = str(value).strip()
+        if text:
+            lines.append(f"{prefix}{label}: {text}")
+    return "\n".join(lines)
+
+
+def to_longtext(value):
+    """Convert plain strings into the rich-text JSON structure used by the DB."""
+    formatted = format_longtext_value(value)
+    if isinstance(formatted, dict) and "text" in formatted:
+        return formatted
+    return ai_text_to_rtf_json(str(formatted) if formatted is not None else "")
 
 
 def to_list(value) -> list[str]:
@@ -57,9 +121,17 @@ def to_list(value) -> list[str]:
     if value is None:
         return []
     if isinstance(value, list):
-        return [str(item).strip() for item in value if item is not None and str(item).strip()]
+        return [
+            str(item).strip()
+            for item in value
+            if item is not None and str(item).strip()
+        ]
     if isinstance(value, dict):
-        return [str(item).strip() for item in value.values() if item is not None and str(item).strip()]
+        return [
+            str(item).strip()
+            for item in value.values()
+            if item is not None and str(item).strip()
+        ]
     if isinstance(value, str):
         # Handle the branch where isinstance(value, str).
         parts = []

--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, Iterable
 
 from modules.generic.generic_model_wrapper import GenericModelWrapper
-from modules.importers.pdf_entity_importer import to_longtext
+from modules.importers.pdf_entity_importer import format_longtext_value, to_longtext
 from modules.scenarios.services.generated_entity_descriptions import (
     build_entity_description,
     build_npc_role,
@@ -210,11 +210,13 @@ def _build_npc_record(
         "Description": to_longtext(description),
         "Secret": to_longtext(data.get("Secret") or data.get("Secrets") or ""),
         "Quote": data.get("Quote", ""),
-        "RoleplayingCues": to_longtext(data.get("RoleplayingCues", "")),
-        "Personality": to_longtext(data.get("Personality", "")),
-        "Motivation": to_longtext(data.get("Motivation", "")),
-        "Background": to_longtext(data.get("Background", "")),
-        "Traits": to_longtext(traits),
+        "RoleplayingCues": to_longtext(
+            format_longtext_value(data.get("RoleplayingCues", ""))
+        ),
+        "Personality": to_longtext(format_longtext_value(data.get("Personality", ""))),
+        "Motivation": to_longtext(format_longtext_value(data.get("Motivation", ""))),
+        "Background": to_longtext(format_longtext_value(data.get("Background", ""))),
+        "Traits": to_longtext(format_longtext_value(traits)),
         "Genre": data.get("Genre", ""),
         "Factions": data.get("Factions", []),
         "Objects": data.get("Objects", []),
@@ -257,7 +259,7 @@ def _split_atouts_section(text: str) -> tuple[str, str]:
 
 def _merge_traits_with_atouts(traits: Any, atouts: str) -> str:
     """Append extracted Atouts to the Traits field without losing existing traits."""
-    base = str(traits or "").strip()
+    base = str(format_longtext_value(traits) or "").strip()
     extra = str(atouts or "").strip()
     if not extra:
         return base

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -210,3 +210,42 @@ def test_save_missing_entities_moves_npc_atouts_from_description_to_traits(tmp_p
     assert "Restless and charming" in saved_npc["Traits"]["text"]
     assert "Atouts" in saved_npc["Traits"]["text"]
     assert "Quick draw" in saved_npc["Traits"]["text"]
+
+
+def test_save_missing_entities_formats_npc_longtext_lists(tmp_path):
+    """Verify list-shaped NPC longtext fields save as readable bullets."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=GenericModelWrapper("places", db_path=str(db_path)),
+    )
+    parsed_payload = {
+        "Title": "Neon Masks",
+        "NPCs": [
+            {
+                "Name": "Iris Null",
+                "RoleplayingCues": ["Avoids eye contact", "Taps coded rhythms"],
+                "Personality": ["Dry wit", "Careful listener"],
+                "Motivation": [{"Goal": "Steal the key", "Fear": "Being identified"}],
+                "Background": ["Former courier", "Knows the old tunnels"],
+                "Traits": ["Quick thinker", "Network of informants"],
+            }
+        ],
+    }
+
+    persistence.save_missing_entities(
+        {"Title": "Neon Masks", "NPCs": ["Iris Null"], "Places": []},
+        parsed_payload,
+    )
+
+    saved_npc = npc_wrapper.load_item_by_key("Iris Null", key_field="Name")
+    assert "• Avoids eye contact" in saved_npc["RoleplayingCues"]["text"]
+    assert "• Dry wit" in saved_npc["Personality"]["text"]
+    assert "Goal: Steal the key" in saved_npc["Motivation"]["text"]
+    assert "Fear: Being identified" in saved_npc["Motivation"]["text"]
+    assert "• Former courier" in saved_npc["Background"]["text"]
+    assert "• Quick thinker" in saved_npc["Traits"]["text"]
+    assert '"Goal"' not in saved_npc["Motivation"]["text"]


### PR DESCRIPTION
### Motivation
- AI/PDF importers and the scenario generator can return longtext fields as `list` or `dict`, which previously became raw JSON when persisted and displayed poorly in editors.
- Longtext fields like `RoleplayingCues`, `Traits`, `Personality`, `Motivation`, and `Background` should be human-readable (bulleted lists or key/value text) before conversion to the DB rich-text format.

### Description
- Added `format_longtext_value()`, `_format_longtext_list()`, and `_format_longtext_dict()` to `modules/importers/pdf_entity_importer.py` to convert `list[str]` to newline bullets and format `dict` values as readable key/value text, and updated `to_longtext()` to use the formatted value.
- Updated `_build_npc_record()` in `modules/scenarios/services/generated_entity_persistence.py` to run `RoleplayingCues`, `Personality`, `Motivation`, `Background`, and merged `Traits` through `format_longtext_value()` before calling `to_longtext()`; also updated `_merge_traits_with_atouts()` to normalize `traits` via the formatter.
- Added a regression test `test_save_missing_entities_formats_npc_longtext_lists` in `tests/scenarios/test_generated_entity_persistence.py` that verifies list and list-of-dict longtext values persist as readable bullets and key/value text.
- Applied code formatting updates to the modified files.

### Testing
- Ran `pytest tests/scenarios/test_generated_entity_persistence.py`, which completed successfully with all tests passing.
- Ran `python -m py_compile modules/importers/pdf_entity_importer.py modules/scenarios/services/generated_entity_persistence.py`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4c601ba8832b8997f920b5f45ff9)