### PR TITLE
Handle object-array NPC traits from AI output

### DIFF
--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -203,7 +203,9 @@ def _build_npc_record(
 ) -> dict[str, Any]:
     description = build_entity_description(data, scenario_source, "npc")
     description, description_atouts = _split_atouts_section(description)
-    traits = _merge_traits_with_atouts(data.get("Traits", ""), description_atouts)
+    traits = _merge_traits_with_atouts(
+        _normalize_npc_traits(data.get("Traits", "")), description_atouts
+    )
     return {
         "Name": str(data.get("Name") or data.get("Title") or "Unnamed").strip(),
         "Role": build_npc_role(data, description),
@@ -255,6 +257,45 @@ def _split_atouts_section(text: str) -> tuple[str, str]:
     description = source[: match.start()].rstrip()
     atouts = source[match.start() :].strip()
     return description, atouts
+
+
+def _normalize_npc_traits(traits: Any) -> Any:
+    """Normalize AI-shaped NPC traits before rich-text formatting."""
+    if not isinstance(traits, list) or not traits:
+        return traits
+    if not all(isinstance(item, dict) for item in traits):
+        return traits
+
+    atouts = _trait_dict_values(traits)
+    if not atouts:
+        return traits
+    return "Atouts:\n" + "\n".join(f"- {atout}" for atout in atouts)
+
+
+def _trait_dict_values(items: list[dict[str, Any]]) -> list[str]:
+    """Extract readable trait/advantage values from object-array AI output."""
+    supported_keys = ("atout", "asset", "advantage", "trait")
+    values: list[str] = []
+    for item in items:
+        normalized_keys = {str(key).strip().casefold(): key for key in item}
+        source_key = next(
+            (normalized_keys[key] for key in supported_keys if key in normalized_keys),
+            None,
+        )
+        if source_key is None:
+            continue
+        source_value = item.get(source_key)
+        if isinstance(source_value, list):
+            values.extend(
+                str(value).strip()
+                for value in source_value
+                if value is not None and str(value).strip()
+            )
+            continue
+        text = str(source_value or "").strip()
+        if text:
+            values.append(text)
+    return values
 
 
 def _merge_traits_with_atouts(traits: Any, atouts: str) -> str:

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -249,3 +249,73 @@ def test_save_missing_entities_formats_npc_longtext_lists(tmp_path):
     assert "• Former courier" in saved_npc["Background"]["text"]
     assert "• Quick thinker" in saved_npc["Traits"]["text"]
     assert '"Goal"' not in saved_npc["Motivation"]["text"]
+
+
+def test_save_missing_entities_keeps_string_list_traits_readable(tmp_path):
+    """Verify string-list Traits remain readable after NPC persistence."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=GenericModelWrapper("places", db_path=str(db_path)),
+    )
+    parsed_payload = {
+        "Title": "Chrome Ghosts",
+        "NPCs": [
+            {
+                "Name": "Vera Coil",
+                "Traits": ["RedHoloSight", "NanoChip", "CombatTraining"],
+            }
+        ],
+    }
+
+    persistence.save_missing_entities(
+        {"Title": "Chrome Ghosts", "NPCs": ["Vera Coil"], "Places": []},
+        parsed_payload,
+    )
+
+    saved_npc = npc_wrapper.load_item_by_key("Vera Coil", key_field="Name")
+    assert "• RedHoloSight" in saved_npc["Traits"]["text"]
+    assert "• NanoChip" in saved_npc["Traits"]["text"]
+    assert "• CombatTraining" in saved_npc["Traits"]["text"]
+
+
+def test_save_missing_entities_normalizes_object_array_traits_as_atouts(tmp_path):
+    """Verify object-array AI advantages are normalized into an Atouts block."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=GenericModelWrapper("places", db_path=str(db_path)),
+    )
+    parsed_payload = {
+        "Title": "Chrome Ghosts",
+        "NPCs": [
+            {
+                "Name": "Sable Nyx",
+                "Traits": [
+                    {"Atout": "RedHoloSight"},
+                    {"Asset": "NanoChip"},
+                    {"Advantage": "CombatTraining"},
+                    {"Trait": "CoolUnderFire"},
+                ],
+            }
+        ],
+    }
+
+    persistence.save_missing_entities(
+        {"Title": "Chrome Ghosts", "NPCs": ["Sable Nyx"], "Places": []},
+        parsed_payload,
+    )
+
+    saved_npc = npc_wrapper.load_item_by_key("Sable Nyx", key_field="Name")
+    assert "Atouts:" in saved_npc["Traits"]["text"]
+    assert "• RedHoloSight" in saved_npc["Traits"]["text"]
+    assert "• NanoChip" in saved_npc["Traits"]["text"]
+    assert "• CombatTraining" in saved_npc["Traits"]["text"]
+    assert "• CoolUnderFire" in saved_npc["Traits"]["text"]
+    assert "Atout:" not in saved_npc["Traits"]["text"]


### PR DESCRIPTION
### Motivation
- AI payloads can return NPC `Traits` as arrays of objects like `[{"Atout": "RedHoloSight"}]`, which should be converted into readable text and merged with description `Atouts` sections.
- Ensure existing behavior for `Traits` as `list[str]` and description-extracted `Atouts:` is preserved while making object-array advantages usable in the editor.

### Description
- Normalize `Traits` in `_build_npc_record()` by calling a new `_normalize_npc_traits()` before `_merge_traits_with_atouts()` so object-array trait forms are converted first. 
- Add `_normalize_npc_traits()` and `_trait_dict_values()` to extract values from dict entries with keys `Atout`, `Asset`, `Advantage`, or `Trait` (case-insensitive) and render them as an `Atouts:` bullet block. 
- Preserve existing formatting for `list[str]` and other shapes by only transforming when `Traits` is a non-empty list of dicts containing supported keys. 
- Update tests in `tests/scenarios/test_generated_entity_persistence.py` to cover `Traits` as `list[str]`, `Traits` as `list[dict]` with `Atout`/`Asset`/`Advantage`/`Trait`, and existing behavior of moving `Atouts:` from `Description` into `Traits`.

### Testing
- Ran `pytest -q tests/scenarios/test_generated_entity_persistence.py` and all tests passed (`8 passed`), covering the new and existing cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4d3a7e20832bb81dafcc2470a6c3)