### PR TITLE
Discard AI skill-only NPC traits and normalize Atouts correctly

### DIFF
--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable
 
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.importers.pdf_entity_importer import format_longtext_value, to_longtext
+from modules.pcs.character_creation.constants import SKILLS as SAVAGE_FATE_SKILLS
 from modules.scenarios.services.generated_entity_descriptions import (
     build_entity_description,
     build_npc_role,
@@ -260,21 +261,34 @@ def _split_atouts_section(text: str) -> tuple[str, str]:
 
 
 def _normalize_npc_traits(traits: Any) -> Any:
-    """Normalize AI-shaped NPC traits before rich-text formatting."""
+    """Normalize AI-shaped NPC traits before rich-text formatting.
+
+    Scenario AI sometimes uses the NPC ``Traits`` field for raw skills.  Savage
+    Fate NPC traits should instead be Atouts/advantages, so skill-only lists are
+    discarded rather than persisted as misleading bullets.
+    """
     if not isinstance(traits, list) or not traits:
         return traits
-    if not all(isinstance(item, dict) for item in traits):
-        return traits
 
-    atouts = _trait_dict_values(traits)
-    if not atouts:
-        return traits
-    return "Atouts:\n" + "\n".join(f"- {atout}" for atout in atouts)
+    if all(isinstance(item, dict) for item in traits):
+        atouts = _trait_dict_values(traits)
+        if not atouts:
+            return ""
+        return _format_atouts_block(atouts)
+
+    readable_traits = [
+        str(item).strip()
+        for item in traits
+        if item is not None and str(item).strip() and not _is_savage_fate_skill(item)
+    ]
+    if not readable_traits:
+        return ""
+    return readable_traits
 
 
 def _trait_dict_values(items: list[dict[str, Any]]) -> list[str]:
-    """Extract readable trait/advantage values from object-array AI output."""
-    supported_keys = ("atout", "asset", "advantage", "trait")
+    """Extract readable atout/advantage values from object-array AI output."""
+    supported_keys = ("atout", "asset", "advantage")
     values: list[str] = []
     for item in items:
         normalized_keys = {str(key).strip().casefold(): key for key in item}
@@ -289,13 +303,58 @@ def _trait_dict_values(items: list[dict[str, Any]]) -> list[str]:
             values.extend(
                 str(value).strip()
                 for value in source_value
-                if value is not None and str(value).strip()
+                if value is not None
+                and str(value).strip()
+                and not _is_savage_fate_skill(value)
             )
             continue
         text = str(source_value or "").strip()
-        if text:
+        if text and not _is_savage_fate_skill(text):
             values.append(text)
     return values
+
+
+_ENGLISH_SKILL_ALIASES = {
+    "academics",
+    "athletics",
+    "combat",
+    "command",
+    "craft",
+    "cunning",
+    "deceive",
+    "deception",
+    "diplomacy",
+    "drive",
+    "empathy",
+    "fight",
+    "investigation",
+    "lore",
+    "medicine",
+    "negotiation",
+    "notice",
+    "perception",
+    "persuasion",
+    "pilot",
+    "rapport",
+    "resources",
+    "shoot",
+    "stealth",
+    "survival",
+    "technology",
+    "will",
+}
+_SAVAGE_FATE_SKILL_NAMES = {skill.casefold() for skill in SAVAGE_FATE_SKILLS} | _ENGLISH_SKILL_ALIASES
+
+
+def _is_savage_fate_skill(value: Any) -> bool:
+    """Return whether a generated trait is actually a Savage Fate skill name."""
+    text = str(value or "").strip().casefold()
+    return text in _SAVAGE_FATE_SKILL_NAMES
+
+
+def _format_atouts_block(atouts: list[str]) -> str:
+    """Format extracted atouts as a dedicated Traits block."""
+    return "Atouts:\n" + "\n".join(f"- {atout}" for atout in atouts)
 
 
 def _merge_traits_with_atouts(traits: Any, atouts: str) -> str:

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -302,6 +302,7 @@ def test_save_missing_entities_normalizes_object_array_traits_as_atouts(tmp_path
                     {"Asset": "NanoChip"},
                     {"Advantage": "CombatTraining"},
                     {"Trait": "CoolUnderFire"},
+                    {"Advantage": "Diplomacy"},
                 ],
             }
         ],
@@ -317,5 +318,38 @@ def test_save_missing_entities_normalizes_object_array_traits_as_atouts(tmp_path
     assert "• RedHoloSight" in saved_npc["Traits"]["text"]
     assert "• NanoChip" in saved_npc["Traits"]["text"]
     assert "• CombatTraining" in saved_npc["Traits"]["text"]
-    assert "• CoolUnderFire" in saved_npc["Traits"]["text"]
+    assert "CoolUnderFire" not in saved_npc["Traits"]["text"]
+    assert "Diplomacy" not in saved_npc["Traits"]["text"]
     assert "Atout:" not in saved_npc["Traits"]["text"]
+
+
+def test_save_missing_entities_discards_skill_only_traits(tmp_path):
+    """Verify AI skill lists do not masquerade as Savage Fate Atouts."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=GenericModelWrapper("places", db_path=str(db_path)),
+    )
+    parsed_payload = {
+        "Title": "Court of Glass",
+        "NPCs": [
+            {
+                "Name": "Silas Wren",
+                "Traits": ["Cunning", "Negotiation", "Diplomacy"],
+            }
+        ],
+    }
+
+    persistence.save_missing_entities(
+        {"Title": "Court of Glass", "NPCs": ["Silas Wren"], "Places": []},
+        parsed_payload,
+    )
+
+    saved_npc = npc_wrapper.load_item_by_key("Silas Wren", key_field="Name")
+    assert saved_npc["Traits"]["text"] == ""
+    assert "Cunning" not in saved_npc["Traits"]["text"]
+    assert "Negotiation" not in saved_npc["Traits"]["text"]
+    assert "Diplomacy" not in saved_npc["Traits"]["text"]


### PR DESCRIPTION
### Motivation
- AI-generated scenario output sometimes places Savage/Fate skill names in an NPC `Traits` list, which should not be persisted as Atouts/advantages. 
- Persisting plain skill lists (e.g., `Cunning`, `Negotiation`, `Diplomacy`) as bullets in `Traits` is misleading for Savage Fate campaigns and must be avoided. 
- The code should still extract true Atouts when the AI emits object-array advantage entries (like `Atout`, `Asset`, `Advantage`).

### Description
- Change `_normalize_npc_traits` to treat object-array trait lists as Atouts when appropriate and to discard skill-only string lists instead of turning them into bullets. 
- Import Savage Fate skill names (`SKILLS`) and add English skill aliases plus `_is_savage_fate_skill` so generated trait strings that match skills are identified and filtered. 
- Restrict `_trait_dict_values` to explicit keys `Atout`/`Asset`/`Advantage` and filter out any values that look like Savage Fate skill names, and add `_format_atouts_block` to render the Atouts block. 
- Update tests in `tests/scenarios/test_generated_entity_persistence.py` to add a regression `test_save_missing_entities_discards_skill_only_traits` and adjust object-array expectations, and modify `modules/scenarios/services/generated_entity_persistence.py` accordingly.

### Testing
- Verified file syntax with `python -m py_compile modules/scenarios/services/generated_entity_persistence.py tests/scenarios/test_generated_entity_persistence.py`. 
- Ran the scenario persistence unit tests with `pytest tests/scenarios/test_generated_entity_persistence.py -q` which passed. 
- Ran the wider set `pytest tests/scenarios/test_generated_entity_persistence.py tests/ai/automation/test_prompt_builder_tone_contract.py -q` and received all tests passing (final run reported 12 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5017eb10832bbc96134b89bcf17b)