### PR TITLE
Add Ollama model selection for scenario AI generation

### DIFF
--- a/modules/ai/model_selection_dialog.py
+++ b/modules/ai/model_selection_dialog.py
@@ -1,0 +1,65 @@
+"""Reusable CustomTkinter dialog for selecting a local AI model."""
+
+from __future__ import annotations
+
+from tkinter import messagebox
+
+import customtkinter as ctk
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.window_helper import position_window_at_top
+
+
+class AIModelSelectionDialog(ctk.CTkToplevel):
+    """Modal dialog allowing the user to pick one available AI model."""
+
+    def __init__(self, master, models: list[str], *, title: str = "Select AI Model") -> None:
+        """Initialize the AIModelSelectionDialog instance."""
+        super().__init__(master)
+        self.title(title)
+        self.geometry("420x180")
+        self.resizable(False, False)
+        self.selected_model: str | None = None
+        self._models = list(models or [])
+
+        last_model = ConfigHelper.get("LastUsed", "scenario_ai_model", fallback=None)
+        default_model = last_model if last_model in self._models else (self._models[0] if self._models else "")
+        self.model_var = ctk.StringVar(value=default_model)
+
+        self._build_ui()
+        self.transient(master)
+        self.grab_set()
+        position_window_at_top(self)
+        self.wait_window(self)
+
+    def _build_ui(self) -> None:
+        """Build dialog widgets."""
+        frame = ctk.CTkFrame(self)
+        frame.pack(fill="both", expand=True, padx=16, pady=16)
+
+        label = ctk.CTkLabel(
+            frame,
+            text="Choose the Ollama model to use for this scenario generation:",
+            anchor="w",
+            wraplength=360,
+        )
+        label.pack(fill="x", pady=(0, 10))
+
+        option = ctk.CTkOptionMenu(frame, values=self._models, variable=self.model_var)
+        option.pack(fill="x", pady=(0, 16))
+
+        buttons = ctk.CTkFrame(frame, fg_color="transparent")
+        buttons.pack(fill="x")
+
+        ctk.CTkButton(buttons, text="Cancel", command=self.destroy).pack(side="right", padx=(8, 0))
+        ctk.CTkButton(buttons, text="Use Model", command=self._confirm).pack(side="right")
+
+    def _confirm(self) -> None:
+        """Confirm the current model selection."""
+        model = self.model_var.get().strip()
+        if not model:
+            messagebox.showwarning("No model selected", "Please select a model before generating.")
+            return
+        ConfigHelper.set("LastUsed", "scenario_ai_model", model)
+        self.selected_model = model
+        self.destroy()

--- a/modules/ai/ollama_model_service.py
+++ b/modules/ai/ollama_model_service.py
@@ -1,0 +1,65 @@
+"""Helpers for discovering locally available Ollama models."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import requests
+
+
+class OllamaModelService:
+    """Discover model names from Ollama without requiring generation calls."""
+
+    def __init__(self, base_url: str = "http://127.0.0.1:11434") -> None:
+        """Initialize the OllamaModelService instance."""
+        self.base_url = (base_url or "http://127.0.0.1:11434").rstrip("/")
+
+    def list_models(self) -> list[str]:
+        """Return available Ollama model names, preferring ``ollama list`` output."""
+        models = self._list_models_from_cli()
+        if models:
+            return models
+        return self._list_models_from_api()
+
+    @staticmethod
+    def _list_models_from_cli() -> list[str]:
+        """Return model names from the ``ollama list`` command."""
+        try:
+            completed = subprocess.run(
+                ["ollama", "list"],
+                capture_output=True,
+                check=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception:
+            return []
+
+        names: list[str] = []
+        for line in (completed.stdout or "").splitlines():
+            line = line.strip()
+            if not line or line.lower().startswith("name"):
+                continue
+            name = line.split()[0].strip()
+            if name and name not in names:
+                names.append(name)
+        return names
+
+    def _list_models_from_api(self) -> list[str]:
+        """Return model names from Ollama's HTTP tags endpoint."""
+        try:
+            response = requests.get(f"{self.base_url}/api/tags", timeout=5)
+            response.raise_for_status()
+            payload: Any = response.json()
+        except Exception:
+            return []
+
+        names: list[str] = []
+        for model in payload.get("models", []) if isinstance(payload, dict) else []:
+            if not isinstance(model, dict):
+                continue
+            name = str(model.get("name") or "").strip()
+            if name and name not in names:
+                names.append(name)
+        return names

--- a/modules/generic/editor/window_components/ai_scenario_generation.py
+++ b/modules/generic/editor/window_components/ai_scenario_generation.py
@@ -4,6 +4,8 @@ from modules.generic.editor.window_context import *
 from modules.campaigns.services.ai.generation_policy import build_hard_constraints_block
 from modules.campaigns.services.generation_defaults_service import CampaignGenerationDefaultsService
 from modules.scenarios.generated_scenario_parser import normalize_generated_scenario_payload
+from modules.ai.model_selection_dialog import AIModelSelectionDialog
+from modules.ai.ollama_model_service import OllamaModelService
 
 
 class GenericEditorWindowAIScenarioGeneration:
@@ -335,6 +337,10 @@ class GenericEditorWindowAIScenarioGeneration:
                 examples_text=examples_text,
                 hard_constraints_block=hard_constraints_block,
             )
+            selected_ai_model = self._choose_scenario_generation_model()
+            if not selected_ai_model:
+                return
+
             # Build prompt and call AI
             content = run_ai_editor_chat(
                 self._get_ai(),
@@ -347,7 +353,8 @@ class GenericEditorWindowAIScenarioGeneration:
                 entity_type="scenarios",
                 action_label="Generate Scenario",
                 phase="scenario_generation",
-                phase_message="Generating scenario content",
+                phase_message=f"Generating scenario content with {selected_ai_model}",
+                model=selected_ai_model,
             )
             try:
                 data = normalize_generated_scenario_payload(LocalAIClient._parse_json_safe(content))
@@ -503,6 +510,21 @@ class GenericEditorWindowAIScenarioGeneration:
 
         except Exception as e:
             messagebox.showerror("AI Error", f"Failed to generate scenario: {e}")
+
+    def _choose_scenario_generation_model(self) -> str | None:
+        """Prompt the user to choose an Ollama model for scenario generation."""
+        ai_client = self._get_ai()
+        service = OllamaModelService(getattr(ai_client, "base_url", "http://127.0.0.1:11434"))
+        models = service.list_models()
+        if not models:
+            messagebox.showerror(
+                "No Ollama models found",
+                "No local Ollama models were found. Install a model with `ollama pull <model>` and try again.",
+            )
+            return None
+
+        dialog = AIModelSelectionDialog(self, models, title="Scenario AI Model")
+        return dialog.selected_model
 
 
 def _load_editor_hard_constraints_block(

--- a/tests/ai/test_ollama_model_service.py
+++ b/tests/ai/test_ollama_model_service.py
@@ -1,0 +1,37 @@
+"""Tests for Ollama model discovery."""
+
+from modules.ai.ollama_model_service import OllamaModelService
+
+
+def test_list_models_from_cli_parses_ollama_table(monkeypatch):
+    """Verify that ``ollama list`` output is parsed into model names."""
+
+    class Completed:
+        stdout = (
+            "NAME                    ID              SIZE      MODIFIED\n"
+            "llama3.1:8b              abc123          4.9 GB    2 days ago\n"
+            "mistral:latest           def456          4.1 GB    1 week ago\n"
+        )
+
+    def fake_run(*args, **kwargs):
+        return Completed()
+
+    monkeypatch.setattr("modules.ai.ollama_model_service.subprocess.run", fake_run)
+
+    assert OllamaModelService._list_models_from_cli() == ["llama3.1:8b", "mistral:latest"]
+
+
+def test_list_models_falls_back_to_tags_api(monkeypatch):
+    """Verify that model discovery falls back to Ollama's tags endpoint."""
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"models": [{"name": "qwen2.5:7b"}, {"name": "phi4:latest"}]}
+
+    monkeypatch.setattr(OllamaModelService, "_list_models_from_cli", staticmethod(lambda: []))
+    monkeypatch.setattr("modules.ai.ollama_model_service.requests.get", lambda *args, **kwargs: Response())
+
+    assert OllamaModelService("http://localhost:11434").list_models() == ["qwen2.5:7b", "phi4:latest"]


### PR DESCRIPTION
### Motivation
- Let the user choose which local Ollama model to use when generating scenarios so they can pick preferred model performance/size.
- Discover available local models using the most reliable sources (`ollama list` CLI output) and fall back to the Ollama HTTP tags endpoint if needed.
- Remember the last-used scenario model to make repeated generation workflows smoother.

### Description
- Added `modules/ai/ollama_model_service.py` which exposes `OllamaModelService.list_models()` that prefers parsing `ollama list` and falls back to `GET /api/tags`.
- Added `modules/ai/model_selection_dialog.py`, a reusable CustomTkinter `AIModelSelectionDialog` that shows available models and stores the chosen model in the config under `LastUsed:scenario_ai_model`.
- Updated `modules/generic/editor/window_components/ai_scenario_generation.py` to prompt the user via `_choose_scenario_generation_model()`, abort if none chosen, and pass the selected model to the AI pipeline via `run_ai_editor_chat(..., model=selected_model)`.
- Added unit tests `tests/ai/test_ollama_model_service.py` that validate CLI parsing and HTTP fallback behavior.

### Testing
- Compiled modified modules with `python -m compileall modules/ai/ollama_model_service.py modules/ai/model_selection_dialog.py modules/generic/editor/window_components/ai_scenario_generation.py` which succeeded.
- Ran `pytest -q tests/ai/test_ollama_model_service.py tests/test_local_ai_client.py` and the tests passed.
- Ran `pytest -q tests/test_ai_prompt_scenario_generation.py tests/ai/test_ollama_model_service.py` and the test suite passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f520c5a34832ba2d819ac55a60227)