### PR TITLE
Use PowerShell for Ollama model listing

### DIFF
--- a/modules/ai/ollama_model_service.py
+++ b/modules/ai/ollama_model_service.py
@@ -25,26 +25,35 @@ class OllamaModelService:
     @staticmethod
     def _list_models_from_cli() -> list[str]:
         """Return model names from the ``ollama list`` command."""
-        try:
-            completed = subprocess.run(
-                ["ollama", "list"],
-                capture_output=True,
-                check=True,
-                text=True,
-                timeout=10,
-            )
-        except Exception:
-            return []
+        commands = (
+            ["pwsh", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "ollama list"],
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "ollama list"],
+            ["ollama", "list"],
+        )
 
-        names: list[str] = []
-        for line in (completed.stdout or "").splitlines():
-            line = line.strip()
-            if not line or line.lower().startswith("name"):
+        for command in commands:
+            try:
+                completed = subprocess.run(
+                    command,
+                    capture_output=True,
+                    check=True,
+                    text=True,
+                    timeout=10,
+                )
+            except Exception:
                 continue
-            name = line.split()[0].strip()
-            if name and name not in names:
-                names.append(name)
-        return names
+
+            names: list[str] = []
+            for line in (completed.stdout or "").splitlines():
+                line = line.strip()
+                if not line or line.lower().startswith("name"):
+                    continue
+                name = line.split()[0].strip()
+                if name and name not in names:
+                    names.append(name)
+            return names
+
+        return []
 
     def _list_models_from_api(self) -> list[str]:
         """Return model names from Ollama's HTTP tags endpoint."""

--- a/tests/ai/test_ollama_model_service.py
+++ b/tests/ai/test_ollama_model_service.py
@@ -13,12 +13,23 @@ def test_list_models_from_cli_parses_ollama_table(monkeypatch):
             "mistral:latest           def456          4.1 GB    1 week ago\n"
         )
 
-    def fake_run(*args, **kwargs):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
         return Completed()
 
     monkeypatch.setattr("modules.ai.ollama_model_service.subprocess.run", fake_run)
 
     assert OllamaModelService._list_models_from_cli() == ["llama3.1:8b", "mistral:latest"]
+    command, kwargs = calls[0]
+    assert command == ["pwsh", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "ollama list"]
+    assert kwargs == {
+        "capture_output": True,
+        "check": True,
+        "text": True,
+        "timeout": 10,
+    }
 
 
 def test_list_models_falls_back_to_tags_api(monkeypatch):


### PR DESCRIPTION
### Motivation

- Improve Windows compatibility when discovering local Ollama models by invoking a PowerShell-friendly command before falling back to the direct `ollama list` invocation.

### Description

- Replace the single `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f731b3540832b9eb8ca2678afa7b7)