### PR TITLE
Add AI model options builder and integrate into ScenarioGeneratorView

### DIFF
--- a/modules/scenarios/scenario_generator_view.py
+++ b/modules/scenarios/scenario_generator_view.py
@@ -29,6 +29,7 @@ from modules.scenarios.ai_scenario_generator import (
     validate_required_answers,
 )
 from modules.scenarios.prompt_library_dialog import PromptLibraryDialog
+from modules.scenarios.services.ai_model_options import build_ai_model_options
 from modules.scenarios.services.generated_entity_persistence import (
     GeneratedScenarioEntityPersistence,
     scenario_entity_names,
@@ -67,11 +68,15 @@ class ScenarioGeneratorView(ctk.CTkFrame):
     def _load_ai_models(self) -> list[str]:
         """Return the configured AI model without blocking on Ollama discovery."""
         config = AIProviderConfig.from_config()
-        fallback_model = (
-            ConfigHelper.get("LastUsed", "scenario_ai_model", fallback=config.model)
-            or config.model
-        ).strip()
-        return [fallback_model or config.model]
+        last_used_model = ConfigHelper.get(
+            "LastUsed", "scenario_ai_model", fallback=config.model
+        )
+        models, _selected_model = build_ai_model_options(
+            configured_model=config.model,
+            last_used_model=last_used_model,
+            discovered_models=[],
+        )
+        return models
 
     def _start_ai_model_discovery(self) -> None:
         """Discover Ollama models in the background and refresh the selector."""
@@ -89,14 +94,22 @@ class ScenarioGeneratorView(ctk.CTkFrame):
 
     def _update_ai_model_options(self, models: list[str]) -> None:
         """Apply discovered model names to the AI selector on the Tk thread."""
-        discovered_models = [model for model in models if model]
-        if not discovered_models:
-            return
-        current_model = self.ai_model_var.get().strip()
-        selected_model = (
-            current_model if current_model in discovered_models else discovered_models[0]
+        config = AIProviderConfig.from_config()
+        last_used_model = ConfigHelper.get(
+            "LastUsed", "scenario_ai_model", fallback=config.model
         )
-        self.ai_models = discovered_models
+        current_model = self.ai_model_var.get().strip()
+        model_options, selected_model = build_ai_model_options(
+            configured_model=config.model,
+            last_used_model=last_used_model,
+            discovered_models=models,
+            current_model=current_model,
+        )
+        if not model_options:
+            return
+        if model_options == self.ai_models and selected_model == current_model:
+            return
+        self.ai_models = model_options
         self.ai_model_menu.configure(values=self.ai_models)
         self.ai_model_var.set(selected_model)
 

--- a/modules/scenarios/services/ai_model_options.py
+++ b/modules/scenarios/services/ai_model_options.py
@@ -1,0 +1,38 @@
+"""Helpers for preparing AI model selector options."""
+
+from __future__ import annotations
+
+
+def unique_model_names(*model_groups: list[str] | tuple[str, ...]) -> list[str]:
+    """Return non-empty model names without duplicates, preserving order."""
+    names: list[str] = []
+    for models in model_groups:
+        for model in models:
+            normalized = str(model or "").strip()
+            if normalized and normalized not in names:
+                names.append(normalized)
+    return names
+
+
+def build_ai_model_options(
+    *,
+    configured_model: str,
+    last_used_model: str | None,
+    discovered_models: list[str] | tuple[str, ...],
+    current_model: str | None = None,
+) -> tuple[list[str], str]:
+    """Build selector options and selected model from config and discovery results."""
+    fallback_model = str(last_used_model or configured_model or "").strip()
+    configured_model = str(configured_model or "").strip()
+    current_model = str(current_model or "").strip()
+
+    options = unique_model_names(
+        [current_model],
+        [fallback_model],
+        list(discovered_models),
+        [configured_model],
+    )
+    selected_model = (
+        current_model if current_model in options else options[0] if options else ""
+    )
+    return options, selected_model

--- a/tests/scenarios/services/test_ai_model_options.py
+++ b/tests/scenarios/services/test_ai_model_options.py
@@ -1,0 +1,28 @@
+"""Tests for AI model selector option preparation."""
+
+from modules.scenarios.services.ai_model_options import build_ai_model_options
+
+
+def test_build_ai_model_options_preserves_discovered_models():
+    """Verify discovered Ollama models are added alongside the fallback model."""
+    options, selected = build_ai_model_options(
+        configured_model="llama3.1",
+        last_used_model="gpt-oss:20b",
+        discovered_models=["qwen2.5:7b", "phi4:latest"],
+        current_model="gpt-oss:20b",
+    )
+
+    assert options == ["gpt-oss:20b", "qwen2.5:7b", "phi4:latest", "llama3.1"]
+    assert selected == "gpt-oss:20b"
+
+
+def test_build_ai_model_options_keeps_fallback_when_discovery_empty():
+    """Verify the selector never becomes empty when discovery returns no models."""
+    options, selected = build_ai_model_options(
+        configured_model="llama3.1",
+        last_used_model=None,
+        discovered_models=[],
+    )
+
+    assert options == ["llama3.1"]
+    assert selected == "llama3.1"


### PR DESCRIPTION
### Motivation
- Consolidate logic for assembling AI model selector options from configured, last-used, discovered, and current values into a single helper. 
- Avoid surprising selector state changes and reduce duplication between initial load and discovery update paths. 

### Description
- Introduced `modules/scenarios/services/ai_model_options.py` providing `unique_model_names` and `build_ai_model_options` to produce ordered, de-duplicated model option lists and a selected model. 
- Updated `ScenarioGeneratorView._load_ai_models` to use `build_ai_model_options` when preparing initial model options. 
- Updated `ScenarioGeneratorView._update_ai_model_options` to use `build_ai_model_options` and short-circuit if options are unchanged to avoid unnecessary UI updates. 
- Removed the previous ad-hoc fallback selection logic and centralized behavior around `configured_model`, `last_used_model`, `discovered_models`, and `current_model`. 

### Testing
- Added unit tests in `tests/scenarios/services/test_ai_model_options.py` covering preserved discovery ordering and fallback behavior with empty discovery. 
- Ran the new tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f75eb0c98832ba62492551099bc34)