### PR TITLE
Fix AI scenario entity link normalization

### DIFF
--- a/modules/campaigns/services/ai/arc_scenario_entities.py
+++ b/modules/campaigns/services/ai/arc_scenario_entities.py
@@ -70,6 +70,13 @@ def build_existing_entity_lookup(foundation: dict[str, Any]) -> dict[str, set[st
             lookup[entity_type] = set()
             continue
 
-        lookup[entity_type] = {str(value).strip().casefold() for value in raw_values if str(value).strip()}
+        names: set[str] = set()
+        for value in raw_values:
+            name = str(value).strip()
+            if not name:
+                continue
+            names.add(name)
+            names.add(name.casefold())
+        lookup[entity_type] = names
 
     return lookup

--- a/modules/campaigns/services/ai/arc_scenario_expansion_service.py
+++ b/modules/campaigns/services/ai/arc_scenario_expansion_service.py
@@ -315,19 +315,6 @@ class ArcScenarioExpansionService:
         factions = ArcScenarioExpansionService._normalize_string_list(payload.get("Factions"))
         objects = ArcScenarioExpansionService._normalize_string_list(payload.get("Objects"))
 
-        ArcScenarioExpansionService._backfill_missing_entity_creations(
-            title=title,
-            summary=summary,
-            parent_arc_name=parent_arc_name,
-            places=places,
-            npcs=npcs,
-            villains=villains,
-            creatures=creatures,
-            factions=factions,
-            entity_creations=entity_creations,
-            existing_entities=existing_entities,
-        )
-
         links, scene_entities, entity_creations = validate_and_fix_scene_entity_links(
             title=title,
             ai_client=self.ai_client,
@@ -429,12 +416,49 @@ class ArcScenarioExpansionService:
 
     @staticmethod
     def _normalize_string_list(value: Any) -> list[str]:
-        """Normalize string list."""
-        if value in (None, ""):
+        """Normalize an AI list field into clean entity names.
+
+        Newer local models sometimes return a list of entity objects in link
+        fields (for example ``Places: [{"Name": ...}]``) or wrap that list as
+        a JSON string.  Persisting ``str(dict)`` creates garbage rows whose names
+        are JSON fragments, so accept those shapes but always extract the Name.
+        """
+        parsed = deserialize_possible_json(value)
+        if parsed in (None, ""):
             return []
-        if not isinstance(value, list):
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+        if isinstance(parsed, str):
             raise ArcScenarioExpansionValidationError("Scenario link fields must be JSON arrays")
-        return [str(item).strip() for item in value if str(item).strip()]
+        if not isinstance(parsed, list):
+            raise ArcScenarioExpansionValidationError("Scenario link fields must be JSON arrays")
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in parsed:
+            name = ArcScenarioExpansionService._extract_entity_name(item)
+            if not name:
+                continue
+            key = name.casefold()
+            if key in seen:
+                continue
+            normalized.append(name)
+            seen.add(key)
+        return normalized
+
+    @staticmethod
+    def _extract_entity_name(value: Any) -> str:
+        """Return a display-safe entity name from a scalar or object."""
+        parsed = deserialize_possible_json(value)
+        if isinstance(parsed, dict):
+            for key in ("Name", "name", "Title", "title"):
+                name = str(parsed.get(key) or "").strip()
+                if name:
+                    return name
+            return ""
+        if isinstance(parsed, (list, tuple, set)):
+            return ""
+        return str(parsed or "").strip()
 
     @staticmethod
     def _normalize_entity_creations(value: Any) -> dict[str, list[dict[str, Any]]]:
@@ -712,17 +736,20 @@ class ArcScenarioExpansionService:
     @staticmethod
     def _normalize_created_records(value: Any, entity_type: str) -> list[dict[str, Any]]:
         """Normalize created records."""
-        if value in (None, ""):
+        parsed = deserialize_possible_json(value)
+        if parsed in (None, ""):
             return []
-        if not isinstance(value, list):
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+        if not isinstance(parsed, list):
             raise ArcScenarioExpansionValidationError(
                 f"EntityCreations.{entity_type} must be a JSON array"
             )
 
         normalized: list[dict[str, Any]] = []
         seen: set[str] = set()
-        for record in value:
-            # Process each record from value.
+        for record in parsed:
+            # Process each record from parsed.
             if not isinstance(record, dict):
                 raise ArcScenarioExpansionValidationError(
                     f"EntityCreations.{entity_type} entries must be JSON objects"

--- a/tests/campaigns/services/test_arc_scenario_expansion_service.py
+++ b/tests/campaigns/services/test_arc_scenario_expansion_service.py
@@ -762,3 +762,36 @@ def test_arc_scenario_expansion_auto_fixes_scene_entity_typos_from_db_catalog():
     first = result["arcs"][0]["scenarios"][0]
     assert first["Places"] == ["Rainmarket"]
     assert first["NPCs"] == ["Rika Vale"]
+
+
+def test_arc_scenario_expansion_extracts_entity_names_from_object_links():
+    """Verify entity link normalizing extracts names instead of stringifying JSON objects."""
+    payload = [
+        {"Name": "Ghost Subway – Platform 12", "Description": "A cracked platform."},
+        {"name": "Sky Gardens of the Megatower", "NPCs": ["Liora"]},
+        "Liora",
+        {"Title": "Fallback Title"},
+        {"Description": "No usable name"},
+    ]
+
+    assert ArcScenarioExpansionService._normalize_string_list(payload) == [
+        "Ghost Subway – Platform 12",
+        "Sky Gardens of the Megatower",
+        "Liora",
+        "Fallback Title",
+    ]
+
+
+def test_arc_scenario_expansion_accepts_json_string_created_records():
+    """Verify wrapped JSON object records are parsed before EntityCreations persistence."""
+    records = ArcScenarioExpansionService._normalize_created_records(
+        '{"Name":"Silicon Vault – Novatek Data Hub","Description":"A labyrinth of humming servers."}',
+        "places",
+    )
+
+    assert records == [
+        {
+            "Name": "Silicon Vault – Novatek Data Hub",
+            "Description": "A labyrinth of humming servers.",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Extract entity names from object-shaped AI link fields instead of saving JSON fragments as NPC/place names.
- Parse JSON-wrapped EntityCreations records before persistence normalization.
- Let scene entity validation resolve typos before placeholder creation, preserving existing entity names.

## Tests
- `pytest tests/campaigns/test_campaign_forge_persistence.py tests/campaigns/services/test_arc_scenario_expansion_service.py -q`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f79dc8758832b953a9ed8d0965c61)