### PR TITLE
Ensure generated entity descriptions are image-ready

### DIFF
--- a/modules/campaigns/services/ai/arc_scenario_expansion_service.py
+++ b/modules/campaigns/services/ai/arc_scenario_expansion_service.py
@@ -307,6 +307,13 @@ class ArcScenarioExpansionService:
             raise ArcScenarioExpansionValidationError(
                 f"Generated scenario '{title}' for arc '{parent_arc_name}' must include at least 3 scenes"
             )
+        ArcScenarioExpansionService._ensure_entity_creation_visual_descriptions(
+            entity_creations=entity_creations,
+            scenario_title=title,
+            scenario_summary=summary,
+            parent_arc_name=parent_arc_name,
+            scenes=scenes,
+        )
 
         places = ArcScenarioExpansionService._normalize_string_list(payload.get("Places"))
         npcs = ArcScenarioExpansionService._normalize_string_list(payload.get("NPCs"))
@@ -413,6 +420,96 @@ class ArcScenarioExpansionService:
             "Objects": objects,
             "EntityCreations": entity_creations,
         }
+
+
+    @staticmethod
+    def _ensure_entity_creation_visual_descriptions(
+        *,
+        entity_creations: dict[str, list[dict[str, Any]]],
+        scenario_title: str,
+        scenario_summary: str,
+        parent_arc_name: str,
+        scenes: list[str],
+    ) -> None:
+        """Ensure generated entity descriptions are visual enough for image prompts.
+
+        Some local models put scene bookkeeping text in created entity Description
+        fields (for example "Scene 3: Purpose: ..." or an Atouts list).  Those
+        snippets are useful for traceability, but they are poor entity records
+        and cannot drive portrait or place image generation.  Keep the record
+        saveable by replacing weak descriptions with a concrete visual prompt
+        assembled from the scenario context and the scenes where the entity
+        appears.
+        """
+
+        for entity_type, records in entity_creations.items():
+            for record in records or []:
+                if not isinstance(record, dict):
+                    continue
+                name = str(record.get("Name") or "").strip()
+                if not name:
+                    continue
+                description = str(record.get("Description") or "").strip()
+                if ArcScenarioExpansionService._is_weak_entity_description(description):
+                    record["Description"] = ArcScenarioExpansionService._build_visual_entity_description(
+                        entity_type=entity_type,
+                        name=name,
+                        scenario_title=scenario_title,
+                        scenario_summary=scenario_summary,
+                        parent_arc_name=parent_arc_name,
+                        scenes=scenes,
+                    )
+
+    @staticmethod
+    def _is_weak_entity_description(description: str) -> bool:
+        """Return True when a created entity description is not image-ready."""
+        text = str(description or "").strip()
+        if len(text) < 140:
+            return True
+        lowered = text.casefold()
+        weak_markers = ("scene ", "purpose:", "atouts:", "objective:", "stakes:")
+        return any(marker in lowered for marker in weak_markers) and len(text) < 260
+
+    @staticmethod
+    def _build_visual_entity_description(
+        *,
+        entity_type: str,
+        name: str,
+        scenario_title: str,
+        scenario_summary: str,
+        parent_arc_name: str,
+        scenes: list[str],
+    ) -> str:
+        """Build a concrete visual description suitable for AI art generation."""
+        entity_label = {
+            "places": "location",
+            "npcs": "NPC portrait subject",
+            "villains": "villain portrait subject",
+            "factions": "faction visual identity",
+            "creatures": "creature design",
+        }.get(entity_type, "entity")
+        scene_context = ArcScenarioExpansionService._scene_context_for_entity(name, scenes)
+        arc_text = f" in the '{parent_arc_name}' arc" if parent_arc_name else ""
+        summary_text = scenario_summary.strip() or "a tense tabletop RPG scenario"
+        return (
+            f"Image-ready description for {name}, a {entity_label}{arc_text} from scenario "
+            f"'{scenario_title}'. Use a cinematic tabletop RPG illustration style. "
+            f"Depict the details implied by the scenario premise: {summary_text}. "
+            f"Visual focus: distinctive silhouette, clear mood, readable materials, lighting, "
+            f"environmental clues, and dramatic composition that can be used directly as an AI art prompt. "
+            f"Scene context: {scene_context}"
+        )
+
+    @staticmethod
+    def _scene_context_for_entity(name: str, scenes: list[str]) -> str:
+        """Return compact scene text mentioning the entity, or broad scenario scene context."""
+        key = name.casefold()
+        matches = [scene.replace("\n", "; ") for scene in scenes if key in scene.casefold()]
+        selected = matches[:2] or [scene.replace("\n", "; ") for scene in scenes[:2]]
+        context = " | ".join(part.strip() for part in selected if part.strip())
+        if not context:
+            return "Keep the design specific, atmospheric, and immediately drawable."
+        return context[:700]
 
     @staticmethod
     def _normalize_string_list(value: Any) -> list[str]:

--- a/modules/campaigns/services/ai/prompt_builders.py
+++ b/modules/campaigns/services/ai/prompt_builders.py
@@ -393,6 +393,7 @@ def build_arc_scenario_expansion_prompt(
         "- Places, NPCs, Villains, Creatures, Factions, and Objects must always be JSON arrays, even when empty.\n"
         "- Reuse names from campaign foundation.existing_entities whenever they fit.\n"
         "- If you use any villain, faction, place, NPC, or creature name that is not in campaign foundation.existing_entities, include it in EntityCreations with a matching Name.\n"
+        "- EntityCreations Description fields must be full image-ready visual descriptions (appearance, mood, materials, lighting, environment, and composition), never scene labels, Purpose summaries, Atouts lists, or other bookkeeping text.\n"
         "- Keep each scenario self-contained enough to save directly as a scenario record.\n"
         f"{_format_prompt_block(hard_constraints_block)}"
     )

--- a/tests/campaigns/services/test_arc_scenario_expansion_service.py
+++ b/tests/campaigns/services/test_arc_scenario_expansion_service.py
@@ -795,3 +795,72 @@ def test_arc_scenario_expansion_accepts_json_string_created_records():
             "Description": "A labyrinth of humming servers.",
         }
     ]
+
+
+def test_arc_scenario_expansion_replaces_scene_notes_in_created_entity_descriptions():
+    """Verify created entity descriptions are image-ready, not scene bookkeeping."""
+    ai_client = _FakeAIClient(
+        """
+        {
+          "arcs": [
+            {
+              "arc_name": "Love and Cure",
+              "scenarios": [
+                {
+                  "Title": "Core of the Starvers",
+                  "Summary": "The heroes cross a starving biotech city to rescue two lovers and decide whether the AI cure should survive.",
+                  "Secrets": "The cure is also a bio-weapon.",
+                  "Scenes": [
+                    {"Title": "Ambush Rescue", "Objective": "Rescue the lovers", "Setup": "Starvers attack a broken tram station", "Challenge": "Fight through panic", "Stakes": "The cure sample is lost", "Twists": "The attackers are infected", "GMNotes": "Keep motion frantic", "Outcome": "The lovers reveal the AI core location", "Entities": {"Places": ["Broken Tram Station"], "NPCs": ["Elian Voss"], "Villains": ["AI Core"], "Factions": ["Starvers"]}},
+                    {"Title": "Hidden Cure", "Objective": "Reach the lab", "Setup": "A glass clinic glows under emergency lights", "Challenge": "Bypass quarantines", "Stakes": "The bio-weapon spreads", "Twists": "The cure needs a host", "GMNotes": "Make choices costly", "Outcome": "The core opens", "Entities": {"Places": ["Broken Tram Station"], "NPCs": ["Elian Voss"], "Villains": ["AI Core"], "Factions": ["Starvers"]}},
+                    {"Title": "AI Heart", "Objective": "Decide fate of love and cure", "Setup": "The AI core hangs in a cathedral of cables", "Challenge": "Negotiate with the machine", "Stakes": "Love or the cure may die", "Twists": "The lovers can merge with it", "GMNotes": "Offer three endings", "Outcome": "The city changes forever", "Entities": {"Places": ["Broken Tram Station"], "NPCs": ["Elian Voss"], "Villains": ["AI Core"], "Factions": ["Starvers"]}}
+                  ],
+                  "Places": ["Broken Tram Station"],
+                  "NPCs": ["Elian Voss"],
+                  "Villains": ["AI Core"],
+                  "Creatures": [],
+                  "Factions": ["Starvers"],
+                  "Objects": [],
+                  "EntityCreations": {
+                    "villains": [{"Name": "AI Core", "Description": "Scene 3: Purpose: Confront the AI core; decide fate of love and cure."}],
+                    "factions": [{"Name": "Starvers", "Description": "A desperate infected mob with ritual scars, torn respirators, and hungry luminous eyes."}],
+                    "places": [{"Name": "Broken Tram Station", "Description": "Scene 2: Purpose: Intervene in a Starver ambush; rescue the lovers.\\nAtouts: Chaos, Survival Instinct, Hidden Cure, Bio-weapon, AI Control."}],
+                    "npcs": [{"Name": "Elian Voss", "Description": "Scene 3: Purpose: Confront the AI core; decide fate of love and cure."}],
+                    "creatures": []
+                  }
+                },
+                {
+                  "Title": "Cure Aftermath",
+                  "Summary": "The survivors defend the new cure from raiders.",
+                  "Secrets": "A faction wants to corrupt it.",
+                  "Scenes": ["Guard the clinic", "Expose the saboteur", "Choose who receives the first dose"],
+                  "Places": ["Broken Tram Station"],
+                  "NPCs": ["Elian Voss"],
+                  "Villains": ["AI Core"],
+                  "Creatures": [],
+                  "Factions": ["Starvers"],
+                  "Objects": []
+                }
+              ]
+            }
+          ]
+        }
+        """
+    )
+    service = ArcScenarioExpansionService(ai_client)
+
+    result = service.generate_scenarios(
+        {
+            "name": "Biotech Hearts",
+            "existing_entities": {"villains": [], "factions": [], "places": [], "npcs": [], "creatures": []},
+        },
+        [{"name": "Love and Cure", "scenarios": ["The First Hunger"]}],
+    )
+
+    creations = result["arcs"][0]["scenarios"][0]["EntityCreations"]
+    for entity_type in ("villains", "places", "npcs"):
+        description = creations[entity_type][0]["Description"]
+        assert "Image-ready description" in description
+        assert "Purpose:" not in description
+        assert "Atouts:" not in description
+        assert len(description) > 250


### PR DESCRIPTION
### Motivation
- Local AI outputs sometimes put scene bookkeeping (e.g. `Scene 3: Purpose: ...` or `Atouts:` lists) into `EntityCreations.Description`, which is unsuitable for portrait/place image generation and downstream tooling.
- Replace those weak snippets with concrete, drawable visual prompts so generated entities can directly drive AI art and be saved as useful records.

### Description
- Add a normalization step in `ArcScenarioExpansionService` that runs ` _ensure_entity_creation_visual_descriptions` during scenario payload normalization to rewrite weak `EntityCreations` descriptions. (`modules/campaigns/services/ai/arc_scenario_expansion_service.py`)
- Implement helpers ` _is_weak_entity_description`, ` _build_visual_entity_description`, and ` _scene_context_for_entity` to detect poor descriptions and assemble image-ready prompts from scenario summary, arc, and scene context. (`modules/campaigns/services/ai/arc_scenario_expansion_service.py`)
- Strengthen the scenario expansion prompt so AI generators are instructed to produce `EntityCreations.Description` values that are full image-ready visual descriptions rather than bookkeeping text. (`modules/campaigns/services/ai/prompt_builders.py`)
- Add a regression test `test_arc_scenario_expansion_replaces_scene_notes_in_created_entity_descriptions` that validates NPC/place/villain descriptions are replaced with image-ready text. (`tests/campaigns/services/test_arc_scenario_expansion_service.py`)

### Testing
- Ran `pytest -q tests/campaigns/services/test_arc_scenario_expansion_service.py` which passed (`14 passed`).
- Compiled relevant modules with `python -m compileall modules/campaigns/services/ai/arc_scenario_expansion_service.py modules/campaigns/services/ai/prompt_builders.py` which succeeded without syntax errors.
- Ran a whitespace/check diff (`git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f84b299d4832b902844208ee415d0)