### PR TITLE
Add scenario portrait manager and "Generate Portraits..." menu for scenarios

### DIFF
--- a/modules/generic/generic_list_view.py
+++ b/modules/generic/generic_list_view.py
@@ -43,6 +43,7 @@ from modules.objects.object_constants import OBJECT_CATEGORY_ALLOWED
 from modules.ai.pipeline import execute_ai_chat
 from modules.generic.entities.linking import entity_label_map, resolve_entity_slug
 from modules.generic.entities.merge import EntityMergeError, merge_selected_entities
+from modules.generic.portrait_manager import ScenarioPortraitManagerDialog, resolve_scenario_linked_entities
 
 log_module_import(__name__)
 
@@ -3107,6 +3108,10 @@ class GenericListView(ctk.CTkFrame):
                 label="Generate Newsletter...",
                 command=lambda: self.open_newsletter_preview(iid),
             )
+            menu.add_command(
+                label="Generate Portraits...",
+                command=lambda: self.open_scenario_portrait_manager(iid),
+            )
         if item:
             menu.add_command(
                 label="Display on Second Screen",
@@ -4556,6 +4561,36 @@ class GenericListView(ctk.CTkFrame):
                 self.after(0, lambda: self._set_ai_categorize_running(False))
 
         threading.Thread(target=run, daemon=True).start()
+
+
+    def open_scenario_portrait_manager(self, iid):
+        """Open a portrait-management dialog for entities linked to a scenario."""
+        scenario, _base_id = self._find_item_by_iid(iid)
+        if not scenario:
+            messagebox.showerror("Generate Portraits", "Unable to resolve the selected scenario.")
+            return
+        entities = resolve_scenario_linked_entities(scenario)
+        if not entities:
+            messagebox.showinfo(
+                "Generate Portraits",
+                "No linked entities could be resolved for this scenario.",
+            )
+            return
+
+        def _on_portrait_change(_entity):
+            try:
+                self.reload_from_db()
+            except Exception:
+                pass
+
+        dialog = ScenarioPortraitManagerDialog(
+            self,
+            scenario=scenario,
+            entities=entities,
+            on_change=_on_portrait_change,
+        )
+        dialog.lift()
+        dialog.focus_force()
 
     def _find_item_by_iid(self, iid):
         """Find item by iid."""

--- a/modules/generic/portrait_manager/__init__.py
+++ b/modules/generic/portrait_manager/__init__.py
@@ -1,0 +1,4 @@
+"""Scenario portrait-management UI and helpers."""
+from modules.generic.portrait_manager.entity_portrait_actions import ScenarioPortraitEntity, extract_scenario_linked_entity_names, has_resolved_portrait, missing_portrait_indices, portrait_status, resolve_scenario_linked_entities
+from modules.generic.portrait_manager.scenario_portrait_manager_dialog import ScenarioPortraitManagerDialog
+__all__ = ["ScenarioPortraitEntity", "ScenarioPortraitManagerDialog", "extract_scenario_linked_entity_names", "has_resolved_portrait", "missing_portrait_indices", "portrait_status", "resolve_scenario_linked_entities"]

--- a/modules/generic/portrait_manager/entity_portrait_actions.py
+++ b/modules/generic/portrait_manager/entity_portrait_actions.py
@@ -1,0 +1,126 @@
+"""Reusable portrait helpers for scenario-linked entity portrait management."""
+from __future__ import annotations
+import shutil, time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.portrait_helper import parse_portrait_value, primary_portrait, resolve_portrait_candidate, serialize_portrait_value
+
+SCENARIO_PORTRAIT_LINK_FIELDS = ("NPCs", "Places", "Creatures", "Villains", "Factions", "Objects", "PCs", "Clues", "Informations", "Books")
+SCENARIO_FIELD_TO_ENTITY_TYPE = {"NPCs":"npcs", "Places":"places", "Creatures":"creatures", "Villains":"villains", "Factions":"factions", "Objects":"objects", "PCs":"pcs", "Clues":"clues", "Informations":"informations", "Books":"books"}
+
+@dataclass
+class ScenarioPortraitEntity:
+    """A scenario-linked entity and the model wrapper that persists it."""
+    entity_type: str
+    name: str
+    record: dict[str, Any]
+    wrapper: GenericModelWrapper
+    source_field: str = ""
+    @property
+    def key_field(self) -> str:
+        return self.wrapper._infer_key_field()
+
+def _coerce_link_names(value: Any) -> list[str]:
+    """Return display names from a scenario relationship field value."""
+    if value in (None, ""):
+        return []
+    if isinstance(value, dict):
+        candidates: Iterable[Any] = value.values()
+    elif isinstance(value, (list, tuple, set)):
+        candidates = value
+    else:
+        candidates = str(value).split(",")
+    names: list[str] = []
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            raw = candidate.get("Name") or candidate.get("Title") or candidate.get("name") or candidate.get("title") or candidate.get("text")
+        else:
+            raw = candidate
+        name = str(raw or "").strip()
+        if name and name not in names:
+            names.append(name)
+    return names
+
+def extract_scenario_linked_entity_names(scenario: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """Extract ``(entity_type, name, source_field)`` links from a scenario record."""
+    links: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for field in SCENARIO_PORTRAIT_LINK_FIELDS:
+        entity_type = SCENARIO_FIELD_TO_ENTITY_TYPE[field]
+        for name in _coerce_link_names(scenario.get(field)):
+            key = (entity_type, name.casefold())
+            if key in seen:
+                continue
+            seen.add(key)
+            links.append((entity_type, name, field))
+    return links
+
+def resolve_scenario_linked_entities(scenario: dict[str, Any], wrapper_factory: Callable[[str], GenericModelWrapper] = GenericModelWrapper) -> list[ScenarioPortraitEntity]:
+    """Resolve linked scenario names into entity records using GenericModelWrapper."""
+    wrappers: dict[str, GenericModelWrapper] = {}
+    cache: dict[str, dict[str, dict[str, Any]]] = {}
+    resolved: list[ScenarioPortraitEntity] = []
+    for entity_type, name, source_field in extract_scenario_linked_entity_names(scenario):
+        wrapper = wrappers.setdefault(entity_type, wrapper_factory(entity_type))
+        if entity_type not in cache:
+            key_field = wrapper._infer_key_field()
+            cache[entity_type] = {str(item.get(key_field) or item.get("Name") or item.get("Title") or "").casefold(): item for item in wrapper.load_items()}
+        record = cache[entity_type].get(name.casefold())
+        if record:
+            resolved.append(ScenarioPortraitEntity(entity_type, name, record, wrapper, source_field))
+    return resolved
+
+def portrait_paths(record: dict[str, Any]) -> list[str]:
+    """Return parsed portrait paths from an entity record."""
+    return [path for path in parse_portrait_value(record.get("Portrait", "")) if path]
+
+def has_resolved_portrait(record: dict[str, Any], campaign_dir: str | None = None) -> bool:
+    """Return True when an entity has a primary portrait that resolves to an existing asset."""
+    campaign_dir = campaign_dir or ConfigHelper.get_campaign_dir()
+    primary = primary_portrait(portrait_paths(record))
+    return bool(primary and resolve_portrait_candidate(primary, campaign_dir))
+
+def portrait_status(record: dict[str, Any], campaign_dir: str | None = None) -> str:
+    """Return a compact UI status for an entity portrait."""
+    paths = portrait_paths(record)
+    if not paths:
+        return "Missing"
+    if has_resolved_portrait(record, campaign_dir):
+        return "Ready"
+    return "Missing file"
+
+def missing_portrait_indices(entities: list[ScenarioPortraitEntity], campaign_dir: str | None = None) -> list[int]:
+    """Return indexes of entities without a resolvable portrait, preserving scenario order."""
+    return [index for index, entity in enumerate(entities) if not has_resolved_portrait(entity.record, campaign_dir)]
+
+def campaign_relative_path(path: str) -> str:
+    """Normalize a path relative to the active campaign directory when possible."""
+    if not path:
+        return ""
+    candidate = Path(path)
+    if candidate.is_absolute():
+        try:
+            return candidate.resolve().relative_to(Path(ConfigHelper.get_campaign_dir()).resolve()).as_posix()
+        except ValueError:
+            return candidate.as_posix()
+    return candidate.as_posix()
+
+def copy_portrait_to_campaign(src_path: str, entity_name: str) -> str:
+    """Copy a selected portrait into the campaign portrait folder."""
+    campaign_dir = Path(ConfigHelper.get_campaign_dir())
+    portrait_folder = campaign_dir / "assets" / "portraits"
+    portrait_folder.mkdir(parents=True, exist_ok=True)
+    safe_name = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in entity_name) or "entity"
+    source = Path(src_path)
+    safe_stem = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in source.stem) or "portrait"
+    dest = portrait_folder / f"{safe_name}_{safe_stem}_{time.time_ns()}{source.suffix.lower()}"
+    shutil.copy(str(source), dest)
+    return campaign_relative_path(str(dest))
+
+def set_entity_portraits(entity: ScenarioPortraitEntity, paths: list[str]) -> None:
+    """Persist an entity's portrait list through its wrapper."""
+    entity.record["Portrait"] = serialize_portrait_value([campaign_relative_path(path) for path in paths if path])
+    entity.wrapper.save_item(entity.record)

--- a/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
+++ b/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
@@ -1,0 +1,237 @@
+"""Dialog for managing portraits of entities linked to a scenario."""
+from __future__ import annotations
+from pathlib import Path
+import customtkinter as ctk
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+from PIL import Image, ImageGrab
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.portrait_helper import parse_portrait_value, primary_portrait, resolve_portrait_path
+from modules.ui.image_browser_dialog import ImageBrowserDialog
+from modules.ui.webview.pywebview_client import PyWebviewClient
+from modules.generic.portrait_manager.entity_portrait_actions import ScenarioPortraitEntity, campaign_relative_path, copy_portrait_to_campaign, missing_portrait_indices, portrait_status, set_entity_portraits
+
+class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
+    """Manage portraits for all entities referenced by one scenario."""
+    def __init__(self, master, *, scenario: dict, entities: list[ScenarioPortraitEntity], on_change=None):
+        super().__init__(master)
+        self.scenario = scenario
+        self.entities = entities
+        self.on_change = on_change
+        self.current_index = 0 if entities else -1
+        self._preview_image = None
+        self._row_ids: dict[int, str] = {}
+        self.title(f"Scenario Portraits - {scenario.get('Title', 'Scenario')}")
+        self.geometry("980x640")
+        self.transient(master)
+        self._build_ui()
+        self._refresh_all()
+        if self.entities:
+            self._select_index(0)
+
+    def _build_ui(self):
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.pack(fill="x", padx=12, pady=(12, 6))
+        ctk.CTkLabel(header, text="Generate and manage portraits for linked scenario entities", font=ctk.CTkFont(size=18, weight="bold")).pack(anchor="w")
+        nav = ctk.CTkFrame(self, fg_color="transparent")
+        nav.pack(fill="x", padx=12, pady=6)
+        ctk.CTkButton(nav, text="Previous missing", command=self.previous_missing).pack(side="left", padx=4)
+        ctk.CTkButton(nav, text="Next missing", command=self.next_missing).pack(side="left", padx=4)
+        ctk.CTkButton(nav, text="Skip", command=self.next_missing).pack(side="left", padx=4)
+        self.missing_label = ctk.CTkLabel(nav, text="")
+        self.missing_label.pack(side="left", padx=12)
+        body = ctk.CTkFrame(self)
+        body.pack(fill="both", expand=True, padx=12, pady=6)
+        self.tree = ttk.Treeview(body, columns=("type", "name", "status", "preview"), show="headings", height=14)
+        for column, label, width in (("type", "Entity Type", 120), ("name", "Entity Name", 240), ("status", "Portrait Status", 130), ("preview", "Current Portrait", 300)):
+            self.tree.heading(column, text=label)
+            self.tree.column(column, width=width, anchor="w")
+        self.tree.pack(side="left", fill="both", expand=True, padx=(0, 8), pady=8)
+        self.tree.bind("<<TreeviewSelect>>", self._on_tree_select)
+        right = ctk.CTkFrame(body)
+        right.pack(side="right", fill="y", padx=(8, 0), pady=8)
+        self.preview_label = ctk.CTkLabel(right, text="[No Portrait]", width=256, height=256)
+        self.preview_label.pack(padx=8, pady=8)
+        self.detail_label = ctk.CTkLabel(right, text="", justify="left")
+        self.detail_label.pack(fill="x", padx=8, pady=(0, 8))
+        actions = ctk.CTkFrame(right, fg_color="transparent")
+        actions.pack(fill="x", padx=8, pady=4)
+        for label, command in (("Add", self.add_portrait), ("Search", self.search_portrait), ("Image Library", self.open_image_library), ("Paste", self.paste_portrait), ("Create Portrait", self.create_portrait), ("Primary", self.make_primary), ("Remove", self.remove_portrait)):
+            ctk.CTkButton(actions, text=label, command=command, width=118).pack(fill="x", pady=3)
+
+    def _entity(self):
+        if 0 <= self.current_index < len(self.entities):
+            return self.entities[self.current_index]
+        return None
+
+    def _refresh_all(self):
+        self.tree.delete(*self.tree.get_children())
+        self._row_ids.clear()
+        for index, entity in enumerate(self.entities):
+            paths = parse_portrait_value(entity.record.get("Portrait", ""))
+            primary = primary_portrait(paths)
+            row_id = self.tree.insert("", "end", values=(entity.entity_type, entity.name, portrait_status(entity.record), primary or "[No Portrait]"))
+            self._row_ids[index] = row_id
+        self._refresh_missing_label()
+
+    def _refresh_current(self):
+        entity = self._entity()
+        if not entity:
+            return
+        row_id = self._row_ids.get(self.current_index)
+        paths = parse_portrait_value(entity.record.get("Portrait", ""))
+        primary = primary_portrait(paths)
+        if row_id:
+            self.tree.item(row_id, values=(entity.entity_type, entity.name, portrait_status(entity.record), primary or "[No Portrait]"))
+        self._refresh_preview()
+        self._refresh_missing_label()
+        if callable(self.on_change):
+            self.on_change(entity)
+
+    def _refresh_missing_label(self):
+        missing = missing_portrait_indices(self.entities)
+        self.missing_label.configure(text=f"Missing portraits: {len(missing)} / {len(self.entities)}")
+
+    def _select_index(self, index: int):
+        if not self.entities:
+            return
+        self.current_index = max(0, min(index, len(self.entities) - 1))
+        row_id = self._row_ids.get(self.current_index)
+        if row_id:
+            self.tree.selection_set(row_id)
+            self.tree.see(row_id)
+        self._refresh_preview()
+
+    def _on_tree_select(self, _event=None):
+        selected = self.tree.selection()
+        if not selected:
+            return
+        for index, row_id in self._row_ids.items():
+            if row_id == selected[0]:
+                self.current_index = index
+                break
+        self._refresh_preview()
+
+    def _refresh_preview(self):
+        entity = self._entity()
+        if not entity:
+            self.preview_label.configure(image=None, text="[No Portrait]")
+            return
+        self.detail_label.configure(text=f"{entity.entity_type}: {entity.name}\nSource: {entity.source_field}")
+        primary = primary_portrait(parse_portrait_value(entity.record.get("Portrait", "")))
+        resolved = resolve_portrait_path(primary, ConfigHelper.get_campaign_dir()) if primary else None
+        try:
+            if resolved and Path(resolved).exists():
+                image = Image.open(resolved).resize((256, 256))
+                self._preview_image = ctk.CTkImage(light_image=image, size=(256, 256))
+                self.preview_label.configure(image=self._preview_image, text="")
+                return
+        except Exception:
+            pass
+        self._preview_image = None
+        self.preview_label.configure(image=None, text="[No Portrait]")
+
+    def _paths(self) -> list[str]:
+        entity = self._entity()
+        return list(parse_portrait_value(entity.record.get("Portrait", ""))) if entity else []
+
+    def _save_paths(self, paths: list[str]):
+        entity = self._entity()
+        if not entity:
+            return
+        set_entity_portraits(entity, paths)
+        self._refresh_current()
+
+    def previous_missing(self):
+        self._move_missing(-1)
+
+    def next_missing(self):
+        self._move_missing(1)
+
+    def _move_missing(self, direction: int):
+        missing = missing_portrait_indices(self.entities)
+        if not missing:
+            return
+        if self.current_index not in missing:
+            target = missing[0] if direction >= 0 else missing[-1]
+        else:
+            pos = missing.index(self.current_index)
+            target = missing[(pos + direction) % len(missing)]
+        self._select_index(target)
+
+    def add_portrait(self):
+        entity = self._entity()
+        if not entity:
+            return
+        paths = filedialog.askopenfilenames(title="Select Portrait Image(s)", filetypes=[("Image Files", "*.png;*.jpg;*.jpeg;*.gif;*.bmp;*.webp"), ("All Files", "*.*")])
+        current = self._paths()
+        for path in paths:
+            if Path(path).is_file():
+                current.append(copy_portrait_to_campaign(path, entity.name))
+        self._save_paths(current)
+
+    def search_portrait(self):
+        entity = self._entity()
+        if entity:
+            PyWebviewClient(title="Image Browser").open(ImageBrowserDialog.build_search_url(entity.name))
+
+    def open_image_library(self):
+        opener = self._resolve_image_library_opener()
+        entity = self._entity()
+        if not callable(opener) or not entity:
+            messagebox.showerror("Image Library", "Image library is unavailable from this window.")
+            return
+        opener(search_query=entity.name, on_attach_to_entity=self._attach_from_library)
+
+    def _resolve_image_library_opener(self):
+        widget = self.master
+        while widget is not None:
+            opener = getattr(widget, "open_image_library_browser", None)
+            if callable(opener):
+                return opener
+            widget = getattr(widget, "master", None) or getattr(widget, "parent", None)
+        return None
+
+    def _attach_from_library(self, image_result):
+        entity = self._entity()
+        source = str(getattr(image_result, "path", image_result))
+        if entity and Path(source).is_file():
+            self._save_paths(self._paths() + [copy_portrait_to_campaign(source, entity.name)])
+
+    def paste_portrait(self):
+        entity = self._entity()
+        if not entity:
+            return
+        data = ImageGrab.grabclipboard()
+        if isinstance(data, list):
+            for path in data:
+                if Path(path).is_file():
+                    self._save_paths(self._paths() + [copy_portrait_to_campaign(path, entity.name)])
+                    return
+        if isinstance(data, Image.Image):
+            folder = Path(ConfigHelper.get_campaign_dir()) / "assets" / "portraits"
+            folder.mkdir(parents=True, exist_ok=True)
+            dest = folder / f"{entity.name.replace(' ', '_')}_{id(self)}.png"
+            data.save(dest, format="PNG")
+            self._save_paths(self._paths() + [campaign_relative_path(str(dest))])
+            return
+        messagebox.showinfo("Paste Portrait", "No image found in clipboard.")
+
+    def create_portrait(self):
+        entity = self._entity()
+        if not entity:
+            return
+        from modules.generic.generic_editor_window import GenericEditorWindow
+        editor = GenericEditorWindow(self, entity.record, entity.wrapper, callback=lambda *_args: self._refresh_current())
+        editor.create_portrait_with_swarmui()
+        self._refresh_current()
+
+    def make_primary(self):
+        paths = self._paths()
+        if len(paths) > 1:
+            self._save_paths([paths[-1], *paths[:-1]])
+
+    def remove_portrait(self):
+        paths = self._paths()
+        if paths:
+            self._save_paths(paths[1:])

--- a/tests/generic/portrait_manager/test_entity_portrait_actions.py
+++ b/tests/generic/portrait_manager/test_entity_portrait_actions.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from modules.generic.portrait_manager.entity_portrait_actions import (
+    ScenarioPortraitEntity,
+    extract_scenario_linked_entity_names,
+    missing_portrait_indices,
+    portrait_status,
+    resolve_scenario_linked_entities,
+)
+
+class DummyWrapper:
+    def __init__(self, entity_type, items=None):
+        self.entity_type = entity_type
+        self._items = items or []
+    def _infer_key_field(self, key_field=None):
+        return "Title" if self.entity_type == "books" else "Name"
+    def load_items(self):
+        return list(self._items)
+    def save_item(self, item):
+        self.saved = item
+
+def test_extract_scenario_linked_entity_names_from_supported_fields():
+    scenario = {
+        "NPCs": ["Alice", {"Name": "Bob"}],
+        "Places": "Town, Forest",
+        "Books": [{"Title": "Codex"}],
+        "NPCs": ["Alice", "Alice"],
+    }
+    assert extract_scenario_linked_entity_names(scenario) == [
+        ("npcs", "Alice", "NPCs"),
+        ("places", "Town", "Places"),
+        ("places", "Forest", "Places"),
+        ("books", "Codex", "Books"),
+    ]
+
+def test_resolve_scenario_linked_entities_uses_entity_wrapper_key_fields():
+    data = {
+        "npcs": [{"Name": "Alice"}],
+        "books": [{"Title": "Codex"}],
+    }
+    def factory(entity_type):
+        return DummyWrapper(entity_type, data.get(entity_type, []))
+    entities = resolve_scenario_linked_entities({"NPCs": ["Alice"], "Books": ["Codex"]}, factory)
+    assert [(entity.entity_type, entity.name, entity.record) for entity in entities] == [
+        ("npcs", "Alice", {"Name": "Alice"}),
+        ("books", "Codex", {"Title": "Codex"}),
+    ]
+
+def test_portrait_status_detection(tmp_path, monkeypatch):
+    monkeypatch.setattr("modules.helpers.config_helper.ConfigHelper.get_campaign_dir", lambda: str(tmp_path))
+    portrait = tmp_path / "assets" / "portraits" / "alice.png"
+    portrait.parent.mkdir(parents=True)
+    portrait.write_bytes(b"x")
+    assert portrait_status({"Portrait": "assets/portraits/alice.png"}) == "Ready"
+    assert portrait_status({"Portrait": "assets/portraits/missing.png"}) == "Missing file"
+    assert portrait_status({"Portrait": ""}) == "Missing"
+
+def test_missing_portrait_ordering(tmp_path, monkeypatch):
+    monkeypatch.setattr("modules.helpers.config_helper.ConfigHelper.get_campaign_dir", lambda: str(tmp_path))
+    portrait = tmp_path / "ok.png"
+    portrait.write_bytes(b"x")
+    wrapper = DummyWrapper("npcs")
+    entities = [
+        ScenarioPortraitEntity("npcs", "A", {"Name": "A", "Portrait": ""}, wrapper),
+        ScenarioPortraitEntity("npcs", "B", {"Name": "B", "Portrait": str(portrait)}, wrapper),
+        ScenarioPortraitEntity("npcs", "C", {"Name": "C", "Portrait": "missing.png"}, wrapper),
+    ]
+    assert missing_portrait_indices(entities) == [0, 2]

--- a/tests/generic/portrait_manager/test_generic_list_view_menu_static.py
+++ b/tests/generic/portrait_manager/test_generic_list_view_menu_static.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+SOURCE = Path("modules/generic/generic_list_view.py").read_text()
+
+def test_scenario_context_menu_contains_generate_portraits_only_in_scenario_branch():
+    scenario_branch = SOURCE.split('if self.model_wrapper.entity_type == "scenarios":', 1)[1].split('if item:', 1)[0]
+    non_scenario_prefix = SOURCE.split('if self.model_wrapper.entity_type == "scenarios":', 1)[0]
+    assert 'label="Generate Portraits..."' in scenario_branch
+    assert 'open_scenario_portrait_manager(iid)' in scenario_branch
+    assert 'Generate Portraits...' not in non_scenario_prefix


### PR DESCRIPTION
### Motivation
- Provide a workflow to generate and manage portraits for all entities linked from a scenario without opening each entity editor individually.
- Keep portrait-related non-UI logic reusable and separate from the list view to keep the editor architecture readable.

### Description
- Add a scenario-only right-click menu command `Generate Portraits...` in `modules/generic/generic_list_view.py` that calls `open_scenario_portrait_manager(iid)` when the list view is showing `scenarios`.
- Implement `GenericListView.open_scenario_portrait_manager(self, iid)` to resolve the clicked scenario via `self._find_item_by_iid(iid)`, collect linked entities using the new helpers, open the portrait manager dialog, and refresh the list view after changes using `self.reload_from_db()`.
- Create a new package `modules/generic/portrait_manager` containing reusable helpers in `entity_portrait_actions.py` (e.g. `extract_scenario_linked_entity_names`, `resolve_scenario_linked_entities`, `portrait_status`, `missing_portrait_indices`, `copy_portrait_to_campaign`, `set_entity_portraits`) and a CTk dialog `ScenarioPortraitManagerDialog` in `scenario_portrait_manager_dialog.py` that lists each linked entity with type, name, portrait status and preview and exposes navigation (`Previous missing`, `Next missing`, `Skip`) and portrait actions (`Add`, `Search`, `Image Library`, `Paste`, `Create Portrait`, `Primary`, `Remove`).
- Reuse existing portrait helpers `parse_portrait_value`, `primary_portrait`, `resolve_portrait_candidate`, and `resolve_portrait_path` where appropriate, and delegate portrait-generation UI to the existing editor workflow (`GenericEditorWindow.create_portrait_with_swarmui`) for the `Create Portrait` action.
- Persist portrait changes through the entity `GenericModelWrapper` and refresh the dialog row, preview and missing-portrait navigation accordingly.

### Testing
- Unit tests added in `tests/generic/portrait_manager/test_entity_portrait_actions.py` and `tests/generic/portrait_manager/test_generic_list_view_menu_static.py` were run with `pytest` and passed (`5 passed`).
- Module sanity checked via `python3 -m py_compile` on the modified modules and the new portrait-manager modules and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4faa7ea4f0832bafa2a86915d7156d)