### PR TITLE
Fix scenario portrait editor launch

### DIFF
--- a/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
+++ b/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
@@ -7,6 +7,7 @@ from tkinter import filedialog, messagebox, ttk
 from PIL import Image, ImageGrab
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.portrait_helper import parse_portrait_value, primary_portrait, resolve_portrait_path
+from modules.helpers.template_loader import load_template
 from modules.ui.image_browser_dialog import ImageBrowserDialog
 from modules.ui.webview.pywebview_client import PyWebviewClient
 from modules.generic.portrait_manager.entity_portrait_actions import ScenarioPortraitEntity, campaign_relative_path, copy_portrait_to_campaign, missing_portrait_indices, portrait_status, set_entity_portraits
@@ -222,8 +223,21 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
         if not entity:
             return
         from modules.generic.generic_editor_window import GenericEditorWindow
-        editor = GenericEditorWindow(self, entity.record, entity.wrapper, callback=lambda *_args: self._refresh_current())
+
+        try:
+            template = load_template(entity.entity_type)
+        except Exception as exc:
+            messagebox.showerror(
+                "Create Portrait",
+                f"Unable to load editor template for '{entity.entity_type}': {exc}",
+            )
+            return
+
+        editor = GenericEditorWindow(self, entity.record, template, entity.wrapper)
         editor.create_portrait_with_swarmui()
+        self.wait_window(editor)
+        if getattr(editor, "saved", False):
+            entity.wrapper.save_item(entity.record)
         self._refresh_current()
 
     def make_primary(self):


### PR DESCRIPTION
### Motivation
- Avoid a `TypeError` when creating the editor from the Scenario Portrait Manager by calling `GenericEditorWindow` with the correct constructor arguments and ensure the proper template is supplied.
- Ensure generated portraits result in persisted changes to the linked entity and the portrait manager UI updates after the editor closes.

### Description
- Import `load_template` and load the entity-specific template before launching the editor, with user-visible error handling when loading fails.
- Replace the unsupported `callback=` argument with a call to `GenericEditorWindow(self, entity.record, template, entity.wrapper)` to match the expected signature.
- Wait for the editor window to close and, if `editor.saved` is true, persist the modified entity via `entity.wrapper.save_item(entity.record)` before refreshing the portrait manager.
- Refresh the portrait manager UI after the editor closes to reflect any changes.

### Testing
- Compiled the modified file with `python -m compileall modules/generic/portrait_manager/scenario_portrait_manager_dialog.py`, which succeeded.
- Ran `pytest tests/generic/portrait_manager/test_entity_portrait_actions.py`, which produced `4 passed` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb2f7f55c832ba5bb2c59373ad9bf)