### PR TITLE
Support bold markdown entity JSON headings

### DIFF
--- a/modules/scenarios/generated_scenario_parser.py
+++ b/modules/scenarios/generated_scenario_parser.py
@@ -131,7 +131,11 @@ def _normalize_scene(scene: Any, index: int) -> dict[str, Any]:
 
 
 _JSON_ENTITY_HEADING_RE = re.compile(
-    r"^\s{0,3}#{1,6}\s+(NPCs?|Locations?|Places?)\s*(?:\([^)]*json[^)]*\))?\s*$",
+    r"^\s{0,3}(?:"
+    r"#{1,6}\s+(?P<markdown>NPCs?|Locations?|Places?)\s*(?:\([^)]*json[^)]*\))?"
+    r"|\*\*(?P<bold_colon>NPCs?|Locations?|Places?)\s*:\*\*"
+    r"|\*\*(?P<bold>NPCs?|Locations?|Places?)\*\*\s*:"
+    r")\s*$",
     re.IGNORECASE,
 )
 _JSON_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*$", re.IGNORECASE)
@@ -149,7 +153,8 @@ def _extract_json_entity_sections(text: str) -> tuple[dict[str, list[dict[str, A
         if not heading:
             index += 1
             continue
-        canonical = "NPCs" if heading.group(1).lower().startswith("npc") else "Places"
+        entity_label = next(group for group in heading.groups() if group)
+        canonical = "NPCs" if entity_label.lower().startswith("npc") else "Places"
         cursor = index + 1
         while cursor < len(lines) and not lines[cursor].strip():
             cursor += 1

--- a/tests/scenarios/test_generated_scenario_parser.py
+++ b/tests/scenarios/test_generated_scenario_parser.py
@@ -1,0 +1,72 @@
+"""Regression tests for generated scenario markdown parsing."""
+
+from modules.scenarios.generated_scenario_parser import parse_markdown_scenario
+
+
+def test_bold_markdown_entity_json_sections_parse_structured_records_only():
+    """Bold entity labels should extract fenced JSON without prose token leakage."""
+    parsed = parse_markdown_scenario(
+        """
+The masquerade is about to collapse.
+
+**NPCs:**   
+```json
+[
+  {
+    "Name": "Lysa Vale",
+    "Role": "Disgraced heir",
+    "Motivation": "Expose the masked blackmailer."
+  },
+  {
+    "Name": "Darius Kessler",
+    "Role": "House guard",
+    "Motivation": "Keep the gala from turning violent."
+  }
+]
+```
+
+**Locations:**   
+```json
+[
+  {
+    "Name": "Moonlit Ballroom",
+    "Description": "A mirrored hall full of nervous nobles."
+  },
+  {
+    "Name": "Servants' Stair",
+    "Description": "A narrow route used for secret meetings."
+  }
+]
+```
+"""
+    )
+
+    assert parsed["NPCs"] == [
+        {
+            "Name": "Lysa Vale",
+            "Role": "Disgraced heir",
+            "Motivation": "Expose the masked blackmailer.",
+        },
+        {
+            "Name": "Darius Kessler",
+            "Role": "House guard",
+            "Motivation": "Keep the gala from turning violent.",
+        },
+    ]
+    assert parsed["Places"] == [
+        {
+            "Name": "Moonlit Ballroom",
+            "Description": "A mirrored hall full of nervous nobles.",
+        },
+        {
+            "Name": "Servants' Stair",
+            "Description": "A narrow route used for secret meetings.",
+        },
+    ]
+
+    assert [npc["Name"] for npc in parsed["NPCs"]] == ["Lysa Vale", "Darius Kessler"]
+    assert all(isinstance(npc, dict) for npc in parsed["NPCs"])
+
+    npc_values = [str(value) for npc in parsed["NPCs"] for value in npc.values()]
+    leaked_tokens = ["```json", "[", "{", "}", '"Name": "Lysa Vale"']
+    assert not any(token in value for token in leaked_tokens for value in npc_values)


### PR DESCRIPTION
### Motivation
- AI-generated scenarios sometimes emit bold-markdown field headings like `**NPCs:**` or `**Locations:**` instead of `#` headings, and the parser should extract fenced JSON blocks from those labels reliably.
- Maintain existing support for markdown headings such as `## NPCs` while preventing JSON/prose token leakage into parsed entity records.

### Description
- Extend the entity-heading detection regex `_JSON_ENTITY_HEADING_RE` to recognize three forms: standard markdown headings (`#... NPCs`), bold-with-trailing-colon (`**NPCs:**`), and bold-with-following-colon (`**NPCs**:`). (file: `modules/scenarios/generated_scenario_parser.py`)
- Update heading extraction to pick the matched named regex group and canonicalize to `NPCs` or `Places` before parsing the following fenced JSON block. (file: `modules/scenarios/generated_scenario_parser.py`)
- Add a regression test `tests/scenarios/test_generated_scenario_parser.py` that includes a generated scenario with `**NPCs:**` and `**Locations:**` followed by fenced `json` arrays, asserting parsed `NPCs` and `Places` are structured records and contain no markdown/JSON syntax tokens.

### Testing
- Ran `pytest -q tests/scenarios/test_generated_scenario_parser.py`, and the new parser test passed.
- Ran `pytest -q tests/scenarios/test_generated_scenario_parser.py tests/scenarios/test_generated_entity_persistence.py`, and both tests passed.
- Verified the local test run summary showed all executed scenario-related tests succeeding (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbfddf804832b96e331e5b34ac092)