### PR TITLE
Support AI-formatted scene headings and italic field labels

### DIFF
--- a/modules/scenarios/generated_scenario_parser.py
+++ b/modules/scenarios/generated_scenario_parser.py
@@ -39,10 +39,15 @@ _SECTION_ALIASES = {
     "villains": "Villains",
 }
 _SCENE_HEADING_RE = re.compile(
-    r"^\s{0,3}#{2,6}\s*(?:scene\s*)?(\d+)?\s*[:.)-]?\s*(.*)$", re.IGNORECASE
+    r"^\s{0,3}(?:#{2,6}\s*)?(?:\*{1,2})?"
+    r"(?:scene\s*)?(\d+)?\s*[:.)-]?\s*(.*?)"
+    r"(?:\*{1,2})?\s*$",
+    re.IGNORECASE,
 )
 _FIELD_RE = re.compile(
-    r"^\s*(?:[-*]\s*)?(?:\*\*)?([A-Za-z][A-Za-z0-9 (),/&-]{1,60})(?:\*\*)?\s*:\s*(.*)$"
+    r"^\s*(?:[-*]\s*)?(?:\*{1,2})?"
+    r"([A-Za-z][A-Za-z0-9 (),/&-]{1,60})"
+    r"(?:\*{1,2})?\s*:\s*(.*)$"
 )
 _MARKDOWN_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scenarios/test_generated_scenario_parser.py
+++ b/tests/scenarios/test_generated_scenario_parser.py
@@ -70,3 +70,43 @@ The masquerade is about to collapse.
     npc_values = [str(value) for npc in parsed["NPCs"] for value in npc.values()]
     leaked_tokens = ["```json", "[", "{", "}", '"Name": "Lysa Vale"']
     assert not any(token in value for token in leaked_tokens for value in npc_values)
+
+
+def test_italic_scene_headings_with_italic_bullet_fields_parse_scenes():
+    """Italic scene labels from AI output should split into structured scenes."""
+    parsed = parse_markdown_scenario(
+        """
+The crystal comet falls tonight.
+
+*Scene 1:*
+- *Purpose:* Discover the comet shrine before the cult arrives.
+- *Location:* Starfall Meadow
+- *NPCs:* Mira Dawn; Old Fen
+
+*Scene 2:*
+- *Purpose:* Negotiate with the witness who saw the impact.
+- *Location:* Watchtower Ruins
+- *NPCs:* Captain Rusk
+
+*Scene 3:*
+- *Purpose:* Stop the ritual under the fractured moonstone.
+- *Location:* Moonstone Vault
+- *NPCs:* Sable Choir; Mira Dawn
+"""
+    )
+
+    scenes = parsed["Scenes"]
+    assert len(scenes) == 3
+    assert [scene["Title"] for scene in scenes] == ["Scene 1", "Scene 2", "Scene 3"]
+    assert [scene["NPCs"] for scene in scenes] == [
+        ["Mira Dawn", "Old Fen"],
+        ["Captain Rusk"],
+        ["Sable Choir", "Mira Dawn"],
+    ]
+    assert [scene["Places"] for scene in scenes] == [
+        ["Starfall Meadow"],
+        ["Watchtower Ruins"],
+        ["Moonstone Vault"],
+    ]
+    assert parsed["NPCs"] == ["Mira Dawn", "Old Fen", "Captain Rusk", "Sable Choir"]
+    assert parsed["Places"] == ["Starfall Meadow", "Watchtower Ruins", "Moonstone Vault"]


### PR DESCRIPTION
### Motivation
- AI outputs often mark scenes with `*Scene 1:*`, `**Scene 1:**`, or `Scene 1:` in addition to existing `## Scene 1` syntax, so the parser must recognize these to reliably split scenes.
- Field labels in AI output are frequently wrapped in italics/bold (e.g. `- *NPCs:*`), so field extraction should accept those without changing title extraction behavior.

### Description
- Extend `_SCENE_HEADING_RE` in `modules/scenarios/generated_scenario_parser.py` to accept optional surrounding single/double asterisks and optional leading hashes so it recognizes `*Scene 1:*`, `**Scene 1:**`, `Scene 1:`, and the existing `## Scene 1` forms while preserving existing title extraction.
- Relax `_FIELD_RE` to allow single or double asterisks wrapping field names so bullet fields like `- *Purpose:*`, `- *Location:*`, and `- *NPCs:*` are parsed as structured fields.
- Add a regression test `test_italic_scene_headings_with_italic_bullet_fields_parse_scenes` in `tests/scenarios/test_generated_scenario_parser.py` that supplies three `*Scene N:*` blocks with italic bullet fields and asserts scene count, titles, `NPCs`, and `Places` as well as promotion to top-level lists.

### Testing
- Ran `pytest tests/scenarios/test_generated_scenario_parser.py -q` and the file-level tests passed.
- Ran the full scenario test suite with `pytest tests/scenarios -q` which produced `273 passed, 2 failed`; the two failures are unrelated Tk GUI tests that fail in a headless CI environment due to missing `$DISPLAY` (Tcl/Tk `Tk()` initialization error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc1d12e00832b8af5332d40c48ef3)