### PR TITLE
Validate generated entity names

### DIFF
--- a/modules/scenarios/generated_scenario_parser.py
+++ b/modules/scenarios/generated_scenario_parser.py
@@ -6,6 +6,10 @@ import json
 import re
 from typing import Any
 
+from modules.scenarios.services.generated_entity_name_validation import (
+    normalize_generated_entity_name,
+)
+
 _ENTITY_FIELDS = (
     "NPCs",
     "Places",
@@ -198,12 +202,13 @@ def _parse_entity_json_records(raw_json: str) -> list[dict[str, Any]]:
     for item in parsed:
         if not isinstance(item, dict):
             continue
-        name = item.get("Name") or item.get("Title") or item.get("name") or item.get("title")
-        if not str(name or "").strip():
+        name = normalize_generated_entity_name(
+            item.get("Name") or item.get("Title") or item.get("name") or item.get("title")
+        )
+        if not name:
             continue
         record = {str(key): value for key, value in item.items()}
-        if not record.get("Name"):
-            record["Name"] = str(name).strip()
+        record["Name"] = name
         records.append(record)
     return records
 
@@ -326,7 +331,7 @@ def _entity_records_from_value(value: Any) -> list[dict[str, Any]]:
         if isinstance(item, dict):
             records.extend(_parse_entity_json_records(json.dumps(item)))
         else:
-            name = str(item or "").strip()
+            name = normalize_generated_entity_name(item)
             if name:
                 records.append({"Name": name})
     return _dedupe_entity_records(records)
@@ -363,7 +368,7 @@ def _coerce_names(value: Any) -> list[str]:
 def _dedupe(values) -> list[str]:
     result: list[str] = []
     for value in values:
-        text = str(value).strip()
+        text = normalize_generated_entity_name(value)
         if text and text not in result:
             result.append(text)
     return result

--- a/modules/scenarios/services/generated_entity_name_validation.py
+++ b/modules/scenarios/services/generated_entity_name_validation.py
@@ -1,0 +1,50 @@
+"""Validation helpers for AI-generated scenario entity names."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_MARKDOWN_FENCE_RE = re.compile(r"^```(?:[A-Za-z0-9_-]+)?$", re.IGNORECASE)
+_JSON_FRAGMENT_RE = re.compile(r'^"[^"\\]+"\s*:\s*.+,?$')
+_SECTION_LABELS = {
+    "npc",
+    "npcs",
+    "location",
+    "locations",
+    "place",
+    "places",
+    "secret",
+    "secrets",
+}
+
+
+def normalize_generated_entity_name(value: Any) -> str:
+    """Return a display-ready generated entity name, or ``""`` if invalid."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+
+    text = text.strip(" \t\r\n-*•")
+    if not text:
+        return ""
+
+    if _MARKDOWN_FENCE_RE.fullmatch(text):
+        return ""
+    if _JSON_FRAGMENT_RE.fullmatch(text):
+        return ""
+    if text.endswith(":") and text[:-1].strip().casefold() in _SECTION_LABELS:
+        return ""
+    if not any(char.isalnum() for char in text):
+        return ""
+
+    return _strip_balanced_display_quotes(text)
+
+
+def _strip_balanced_display_quotes(text: str) -> str:
+    """Remove one layer of surrounding display quotes from a generated name."""
+    quote_pairs = (("\"", "\""), ("'", "'"), ("“", "”"), ("‘", "’"))
+    for opening, closing in quote_pairs:
+        if text.startswith(opening) and text.endswith(closing) and len(text) >= 2:
+            return text[1:-1].strip()
+    return text

--- a/modules/scenarios/services/generated_entity_persistence.py
+++ b/modules/scenarios/services/generated_entity_persistence.py
@@ -14,6 +14,9 @@ from modules.scenarios.services.generated_entity_descriptions import (
     build_npc_role,
     linked_npcs_for_place,
 )
+from modules.scenarios.services.generated_entity_name_validation import (
+    normalize_generated_entity_name,
+)
 
 
 @dataclass(frozen=True)
@@ -155,9 +158,11 @@ def _entity_records(value: Any) -> list[dict[str, Any]]:
             or value.get("title")
         )
         record = {str(k): v for k, v in value.items()}
-        if name and not record.get("Name"):
-            record["Name"] = name
-        return [record] if record.get("Name") else []
+        normalized_name = normalize_generated_entity_name(name)
+        if not normalized_name:
+            return []
+        record["Name"] = normalized_name
+        return [record]
     if isinstance(value, str):
         values: Iterable[Any] = value.split(",")
     elif isinstance(value, (list, tuple, set)):
@@ -170,7 +175,7 @@ def _entity_records(value: Any) -> list[dict[str, Any]]:
         if isinstance(item, dict):
             records.extend(_entity_records(item))
             continue
-        name = str(item or "").strip()
+        name = normalize_generated_entity_name(item)
         if name:
             records.append({"Name": name})
     return _dedupe_records(records)
@@ -178,9 +183,9 @@ def _entity_records(value: Any) -> list[dict[str, Any]]:
 
 def _entity_names(records: list[dict[str, Any]]) -> list[str]:
     return [
-        str(record.get("Name") or "").strip()
+        name
         for record in records
-        if str(record.get("Name") or "").strip()
+        if (name := normalize_generated_entity_name(record.get("Name")))
     ]
 
 
@@ -188,12 +193,14 @@ def _dedupe_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     seen: set[str] = set()
     for record in records:
-        name = str(record.get("Name") or "").strip()
+        name = normalize_generated_entity_name(record.get("Name"))
         key = name.casefold()
         if not name or key in seen:
             continue
         seen.add(key)
-        result.append(record)
+        normalized_record = dict(record)
+        normalized_record["Name"] = name
+        result.append(normalized_record)
     return result
 
 

--- a/tests/scenarios/test_generated_entity_persistence.py
+++ b/tests/scenarios/test_generated_entity_persistence.py
@@ -353,3 +353,70 @@ def test_save_missing_entities_discards_skill_only_traits(tmp_path):
     assert "Cunning" not in saved_npc["Traits"]["text"]
     assert "Negotiation" not in saved_npc["Traits"]["text"]
     assert "Diplomacy" not in saved_npc["Traits"]["text"]
+
+
+def test_scenario_entity_names_filters_malformed_tokens_and_normalizes_quotes():
+    """Verify persistence-side normalization prevents bogus entity records."""
+    assert scenario_entity_names(
+        [
+            "",
+            "```json",
+            "{",
+            "}",
+            "[",
+            "]",
+            "#",
+            '"""',
+            '"',
+            '"Name": "Lysa Vale",',
+            "NPCs:",
+            "Locations:",
+            "Secrets:",
+            "Lysa Vale",
+            "Agent Kira",
+            '"The Beast"',
+            "Lower East Side Warehouse District",
+        ]
+    ) == [
+        "Lysa Vale",
+        "Agent Kira",
+        "The Beast",
+        "Lower East Side Warehouse District",
+    ]
+
+
+def test_save_missing_entities_ignores_malformed_entity_names(tmp_path):
+    """Verify malformed parser output cannot create bogus NPC or place records."""
+    db_path = tmp_path / "campaign.db"
+    _create_campaign_db(db_path)
+    npc_wrapper = GenericModelWrapper("npcs", db_path=str(db_path))
+    place_wrapper = GenericModelWrapper("places", db_path=str(db_path))
+
+    persistence = GeneratedScenarioEntityPersistence(
+        npc_wrapper=npc_wrapper,
+        place_wrapper=place_wrapper,
+    )
+
+    result = persistence.save_missing_entities(
+        {
+            "Title": "Bad Tokens",
+            "NPCs": [
+                "```json",
+                "{",
+                '"Name": "Lysa Vale",',
+                "Lysa Vale",
+                '"The Beast"',
+            ],
+            "Places": ["Locations:", "#", "Lower East Side Warehouse District"],
+        }
+    )
+
+    assert result.npcs_created == ["Lysa Vale", "The Beast"]
+    assert result.places_created == ["Lower East Side Warehouse District"]
+    assert {npc["Name"] for npc in npc_wrapper.load_items()} == {
+        "Lysa Vale",
+        "The Beast",
+    }
+    assert {place["Name"] for place in place_wrapper.load_items()} == {
+        "Lower East Side Warehouse District"
+    }

--- a/tests/scenarios/test_generated_scenario_parser.py
+++ b/tests/scenarios/test_generated_scenario_parser.py
@@ -110,3 +110,31 @@ The crystal comet falls tonight.
     ]
     assert parsed["NPCs"] == ["Mira Dawn", "Old Fen", "Captain Rusk", "Sable Choir"]
     assert parsed["Places"] == ["Starfall Meadow", "Watchtower Ruins", "Moonstone Vault"]
+
+
+def test_entity_name_normalization_filters_malformed_tokens_and_keeps_valid_names():
+    """Malformed generated entity tokens should not leak into scenario links."""
+    parsed = parse_markdown_scenario(
+        '''
+NPCs:
+- ```json
+- {
+- "Name": "Lysa Vale",
+- NPCs:
+- Lysa Vale
+- Agent Kira
+- "The Beast"
+
+Locations:
+- }
+- [
+- Locations:
+- Lower East Side Warehouse District
+- #
+- "
+- """
+'''
+    )
+
+    assert parsed["NPCs"] == ["Lysa Vale", "Agent Kira", "The Beast"]
+    assert parsed["Places"] == ["Lower East Side Warehouse District"]


### PR DESCRIPTION
### Motivation
- The AI-generated scenario parser and persistence layers can receive noisy tokens (markdown fences, JSON fragments, punctuation-only lines, or section labels) that should not become entity records. 
- Normalizing and validating generated names centrally prevents malformed parser output from creating bogus NPC or Place records. 
- User-facing display names should preserve valid values and strip surrounding display quotes when appropriate.

### Description
- Add a shared validation helper `modules/scenarios/services/generated_entity_name_validation.py` implementing `normalize_generated_entity_name()` to reject empty strings, markdown fences like ```json, pure-punctuation tokens, JSON key/value fragments, and section labels, and to strip balanced display quotes. 
- Apply the validator in the parser `modules/scenarios/generated_scenario_parser.py` (JSON record parsing, entity-record promotion, `_coerce_names()`/dedupe paths) so malformed tokens are filtered before names are returned. 
- Apply the validator in persistence `modules/scenarios/services/generated_entity_persistence.py` when building `_entity_records`, deduping records, and computing `_entity_names()` so malformed names cannot be persisted. 
- Add regression tests to `tests/scenarios/test_generated_scenario_parser.py` and `tests/scenarios/test_generated_entity_persistence.py` proving malformed tokens are ignored and valid names like `Lysa Vale`, `Agent Kira`, `"The Beast"`, and `Lower East Side Warehouse District` are preserved (with quotes normalized for display names).

### Testing
- Ran the scenario parser and persistence test suites with `pytest -q tests/scenarios/test_generated_scenario_parser.py tests/scenarios/test_generated_entity_persistence.py`, and all tests passed (`14 passed`).
- New tests assert that malformed tokens are filtered at both parse and persistence layers and that valid names survive normalization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc276b470832b846710962bf8b4c6)