### PR TITLE
Add configurable portrait generation candidate count

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -567,3 +567,6 @@ grid_cell_pixels = 50.0
 grid_scale = 10.0
 unit = m
 
+[PortraitGeneration]
+image_count = 6
+

--- a/modules/generic/editor/window_components/portrait_and_image_workflows.py
+++ b/modules/generic/editor/window_components/portrait_and_image_workflows.py
@@ -1,7 +1,8 @@
-﻿"""Utilities for window components portrait and image workflows."""
+"""Utilities for window components portrait and image workflows."""
 
 from modules.generic.editor.window_context import *
 from modules.generic.editor.styles import EDITOR_PALETTE, primary_button_style, tk_listbox_theme
+from modules.generic.editor.window_components.portrait_generation_dialog import PortraitGenerationDialog, clamp_portrait_image_count
 
 
 class GenericEditorWindowPortraitAndImageWorkflows:
@@ -452,30 +453,21 @@ class GenericEditorWindowPortraitAndImageWorkflows:
             messagebox.showerror("Error", "No models available in SwarmUI models folder.")
             return
 
-        # Pop-up to select model
-        top = ctk.CTkToplevel(self)
-        top.title("Select AI Model")
-        top.geometry("400x200")
-        top.transient(self)
-        top.grab_set()
-
-        model_var = ctk.StringVar(value=model_options[0])
         last_model = ConfigHelper.get("LastUsed", "model", fallback=None)
-        
-        if last_model in model_options:
-            selected_model = ctk.StringVar(value=last_model)
-        else:
-            selected_model = ctk.StringVar(value=model_options[0])
-        ctk.CTkLabel(top, text="Select AI Model for this NPC:").pack(pady=20)
-        ctk.CTkOptionMenu(top, values=model_options, variable=selected_model).pack(pady=10)
-
-        def on_confirm():
-            """Handle confirm."""
-            top.destroy()
-            ConfigHelper.set("LastUsed", "model", selected_model.get())
-            self.generate_portrait(selected_model.get())
-        ctk.CTkButton(top, text="Generate", command=on_confirm).pack(pady=10)
-    def generate_portrait(self, selected_model):
+        selected_model = last_model if last_model in model_options else model_options[0]
+        dialog = PortraitGenerationDialog(
+            self,
+            model_options=model_options,
+            selected_model=selected_model,
+        )
+        self.wait_window(dialog)
+        if not dialog.result:
+            return
+        self.generate_portrait(
+            dialog.result["model"],
+            image_count=dialog.result["image_count"],
+        )
+    def generate_portrait(self, selected_model, image_count=None):
         """
         Generates a portrait image using the SwarmUI API and associates the resulting
         image with the current NPC by updating its 'Portrait' field.
@@ -504,7 +496,7 @@ class GenericEditorWindowPortraitAndImageWorkflows:
             # Step 2: Define image generation parameters
             prompt_data = {
                 "session_id": session_id,
-                "images": 6,  # Generate multiple candidates
+                "images": clamp_portrait_image_count(image_count),  # Generate selected candidates
                 "prompt": prompt,
                 "negativeprompt": "blurry, low quality, comics style, mangastyle, paint style, watermark, ugly, monstrous, too many fingers, too many legs, too many arms, bad hands, unrealistic weapons, bad grip on equipment, nude",
                 "model": selected_model,
@@ -544,7 +536,7 @@ class GenericEditorWindowPortraitAndImageWorkflows:
                 messagebox.showerror("Error", "Failed to download generated images.")
                 return
 
-            # Step 4: Let user choose one of the 6 images
+            # Step 4: Let user choose one of the generated images
             chosen_index = self._show_image_selection_window(thumbs)
             if chosen_index is None or chosen_index < 0 or chosen_index >= len(images_bytes):
                 return  # User cancelled
@@ -594,15 +586,13 @@ class GenericEditorWindowPortraitAndImageWorkflows:
             selected["idx"] = i
             top.destroy()
 
-        # Layout: 3 columns x 2 rows (up to 6 images)
-        cols = 6 if len(pil_images) <= 6 else 6
-        # Place horizontally side by side if <= 6
-        for i, img in enumerate(pil_images[:6]):
-            cimg = ctk.CTkImage(light_image=img, size=(256, 256))
+        cols = min(5, max(1, len(pil_images)))
+        for i, img in enumerate(pil_images):
+            cimg = ctk.CTkImage(light_image=img, size=(180, 180))
             ctk_images.append(cimg)
-            btn = ctk.CTkButton(container, image=cimg, text="", width=260, height=260,
+            btn = ctk.CTkButton(container, image=cimg, text=f"#{i + 1}", compound="top", width=188, height=214,
                                 command=lambda idx=i: on_choose(idx))
-            btn.grid(row=0, column=i, padx=5, pady=5)
+            btn.grid(row=i // cols, column=i % cols, padx=6, pady=6, sticky="nsew")
 
         # Cancel button
         cancel_btn = ctk.CTkButton(top, text="Cancel", command=lambda: (setattr(selected, "idx", None), top.destroy()))
@@ -616,8 +606,9 @@ class GenericEditorWindowPortraitAndImageWorkflows:
 
         # Size window to fit thumbnails in a row
         top.update_idletasks()
-        total_w = min(6, len(pil_images)) * (260 + 10) + 20
-        total_h = 320
+        rows = (len(pil_images) + cols - 1) // cols
+        total_w = cols * (188 + 14) + 40
+        total_h = rows * (214 + 14) + 90
         try:
             top.geometry(f"{total_w}x{total_h}")
         except Exception:

--- a/modules/generic/editor/window_components/portrait_generation_dialog.py
+++ b/modules/generic/editor/window_components/portrait_generation_dialog.py
@@ -1,0 +1,150 @@
+"""Dialog helpers for configuring portrait generation."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.helpers.config_helper import ConfigHelper
+
+
+PORTRAIT_GENERATION_SECTION = "PortraitGeneration"
+PORTRAIT_IMAGE_COUNT_KEY = "image_count"
+DEFAULT_PORTRAIT_IMAGE_COUNT = 6
+MIN_PORTRAIT_IMAGE_COUNT = 1
+MAX_PORTRAIT_IMAGE_COUNT = 10
+
+
+def clamp_portrait_image_count(value) -> int:
+    """Return a safe portrait generation image count in the supported range."""
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        count = DEFAULT_PORTRAIT_IMAGE_COUNT
+    return max(MIN_PORTRAIT_IMAGE_COUNT, min(MAX_PORTRAIT_IMAGE_COUNT, count))
+
+
+def get_default_portrait_image_count() -> int:
+    """Read the configured portrait generation image count."""
+    raw_value = ConfigHelper.get(
+        PORTRAIT_GENERATION_SECTION,
+        PORTRAIT_IMAGE_COUNT_KEY,
+        fallback=str(DEFAULT_PORTRAIT_IMAGE_COUNT),
+    )
+    return clamp_portrait_image_count(raw_value)
+
+
+def save_default_portrait_image_count(count: int) -> None:
+    """Persist the portrait generation image count for future generations."""
+    ConfigHelper.set(
+        PORTRAIT_GENERATION_SECTION,
+        PORTRAIT_IMAGE_COUNT_KEY,
+        clamp_portrait_image_count(count),
+    )
+
+
+class PortraitGenerationDialog(ctk.CTkToplevel):
+    """Modal dialog that collects SwarmUI model and candidate count."""
+
+    def __init__(self, master, *, model_options: list[str], selected_model: str):
+        super().__init__(master)
+        self.result: dict[str, object] | None = None
+        self._model_options = model_options
+        self._count_var = ctk.IntVar(value=get_default_portrait_image_count())
+        self._selected_model = ctk.StringVar(value=selected_model)
+        self._count_label_var = ctk.StringVar()
+
+        self.title("Portrait Generation")
+        self.geometry("480x430")
+        self.minsize(460, 400)
+        self.transient(master)
+        self.grab_set()
+        self._build_ui()
+        self._update_count_label(self._count_var.get())
+
+    def _build_ui(self) -> None:
+        shell = ctk.CTkFrame(self, corner_radius=18)
+        shell.pack(fill="both", expand=True, padx=18, pady=18)
+        shell.grid_columnconfigure(0, weight=1)
+
+        ctk.CTkLabel(
+            shell,
+            text="Create AI Portraits",
+            font=ctk.CTkFont(size=22, weight="bold"),
+        ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 4))
+        ctk.CTkLabel(
+            shell,
+            text="Choose the model and how many portrait candidates SwarmUI should generate.",
+            wraplength=400,
+            justify="left",
+            text_color=("#5f6368", "#b8beca"),
+        ).grid(row=1, column=0, sticky="w", padx=20, pady=(0, 18))
+
+        model_card = ctk.CTkFrame(shell, corner_radius=14, fg_color=("#edf2ff", "#1e293b"))
+        model_card.grid(row=2, column=0, sticky="ew", padx=20, pady=(0, 14))
+        model_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(model_card, text="AI model", font=ctk.CTkFont(size=14, weight="bold")).grid(
+            row=0, column=0, sticky="w", padx=16, pady=(14, 6)
+        )
+        ctk.CTkOptionMenu(
+            model_card,
+            values=self._model_options,
+            variable=self._selected_model,
+            height=36,
+        ).grid(row=1, column=0, sticky="ew", padx=16, pady=(0, 16))
+
+        count_card = ctk.CTkFrame(shell, corner_radius=14, fg_color=("#f8fafc", "#111827"))
+        count_card.grid(row=3, column=0, sticky="ew", padx=20, pady=(0, 14))
+        count_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(count_card, textvariable=self._count_label_var, font=ctk.CTkFont(size=16, weight="bold")).grid(
+            row=0, column=0, sticky="w", padx=16, pady=(14, 2)
+        )
+        ctk.CTkLabel(
+            count_card,
+            text="More candidates gives better choice, but takes longer to generate.",
+            wraplength=380,
+            justify="left",
+            text_color=("#667085", "#9ca3af"),
+        ).grid(row=1, column=0, sticky="w", padx=16, pady=(0, 8))
+        ctk.CTkSlider(
+            count_card,
+            from_=MIN_PORTRAIT_IMAGE_COUNT,
+            to=MAX_PORTRAIT_IMAGE_COUNT,
+            number_of_steps=MAX_PORTRAIT_IMAGE_COUNT - MIN_PORTRAIT_IMAGE_COUNT,
+            variable=self._count_var,
+            command=self._update_count_label,
+        ).grid(row=2, column=0, sticky="ew", padx=16, pady=(6, 8))
+        quick_row = ctk.CTkFrame(count_card, fg_color="transparent")
+        quick_row.grid(row=3, column=0, sticky="ew", padx=16, pady=(0, 14))
+        for count in (1, 3, 6, 10):
+            ctk.CTkButton(
+                quick_row,
+                text=str(count),
+                width=48,
+                command=lambda value=count: self._set_count(value),
+            ).pack(side="left", padx=(0, 8))
+
+        actions = ctk.CTkFrame(shell, fg_color="transparent")
+        actions.grid(row=4, column=0, sticky="ew", padx=20, pady=(4, 18))
+        ctk.CTkButton(actions, text="Cancel", fg_color="transparent", border_width=1, command=self._cancel).pack(side="right", padx=(8, 0))
+        ctk.CTkButton(actions, text="Generate Portraits", command=self._confirm).pack(side="right")
+
+    def _set_count(self, value: int) -> None:
+        self._count_var.set(clamp_portrait_image_count(value))
+        self._update_count_label(self._count_var.get())
+
+    def _update_count_label(self, raw_value) -> None:
+        count = clamp_portrait_image_count(round(float(raw_value)))
+        self._count_var.set(count)
+        suffix = "candidate" if count == 1 else "candidates"
+        self._count_label_var.set(f"Generate {count} portrait {suffix}")
+
+    def _confirm(self) -> None:
+        count = clamp_portrait_image_count(self._count_var.get())
+        save_default_portrait_image_count(count)
+        ConfigHelper.set("LastUsed", "model", self._selected_model.get())
+        self.result = {"model": self._selected_model.get(), "image_count": count}
+        self.destroy()
+
+    def _cancel(self) -> None:
+        self.result = None
+        self.destroy()

--- a/modules/helpers/config_helper.py
+++ b/modules/helpers/config_helper.py
@@ -15,14 +15,14 @@ class ConfigHelper:
     _config_path: Path = Path("config/config.ini")
 
     @classmethod
-    def load_config(cls, file_path: Union[str, os.PathLike] = "config/config.ini"):
+    def load_config(cls, file_path: Union[str, os.PathLike, None] = None):
         """Load the configuration from ``file_path``.
 
         The file is read only when it's not cached or when the file has
         changed on disk since the last load. This allows updating the
         configuration without restarting the application.
         """
-        path = Path(file_path)
+        path = cls.get_config_path() if file_path is None else Path(file_path)
         cls._config_path = path
         mtime = os.path.getmtime(path) if path.exists() else None
 
@@ -103,7 +103,7 @@ class ConfigHelper:
     def get_config_path(cls) -> Path:
         """Return config path."""
         if not isinstance(cls._config_path, Path):
-            cls._config_path = Path("config/config.ini")
+            cls._config_path = Path(cls._config_path)
         return cls._config_path
 
     @classmethod

--- a/tests/test_portrait_generation_dialog.py
+++ b/tests/test_portrait_generation_dialog.py
@@ -1,0 +1,32 @@
+"""Tests for portrait generation configuration helpers."""
+
+from modules.generic.editor.window_components.portrait_generation_dialog import (
+    DEFAULT_PORTRAIT_IMAGE_COUNT,
+    MAX_PORTRAIT_IMAGE_COUNT,
+    MIN_PORTRAIT_IMAGE_COUNT,
+    clamp_portrait_image_count,
+    get_default_portrait_image_count,
+    save_default_portrait_image_count,
+)
+from modules.helpers.config_helper import ConfigHelper
+
+
+def test_clamp_portrait_image_count_limits_to_supported_range():
+    """Verify portrait candidate counts stay between 1 and 10."""
+    assert clamp_portrait_image_count(0) == MIN_PORTRAIT_IMAGE_COUNT
+    assert clamp_portrait_image_count(11) == MAX_PORTRAIT_IMAGE_COUNT
+    assert clamp_portrait_image_count("bad") == DEFAULT_PORTRAIT_IMAGE_COUNT
+    assert clamp_portrait_image_count("8") == 8
+
+
+def test_portrait_image_count_default_round_trips_to_config(tmp_path):
+    """Verify saving a generation count updates the active config default."""
+    config_path = tmp_path / "config.ini"
+    ConfigHelper._config = None
+    ConfigHelper._config_mtime = None
+    ConfigHelper._config_path = config_path
+
+    save_default_portrait_image_count(9)
+
+    assert get_default_portrait_image_count() == 9
+    assert "image_count = 9" in config_path.read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Give users control over how many portrait candidates SwarmUI generates (1–10) instead of the fixed 6-image flow to improve flexibility and reduce wasted work.
- Make the choice persistent so subsequent portrait generations reuse the preferred count.

### Description
- Add `modules/generic/editor/window_components/portrait_generation_dialog.py` which implements `PortraitGenerationDialog`, helper functions (`clamp_portrait_image_count`, `get_default_portrait_image_count`, `save_default_portrait_image_count`) and UI (slider + quick-pick buttons) to choose model and candidate count.
- Update `modules/generic/editor/window_components/portrait_and_image_workflows.py` to open the new dialog, pass the chosen `image_count` to the SwarmUI request, and render the returned thumbnails in a responsive grid (up to 10) for selection.
- Persist the default candidate count in `config/config.ini` under the new `[PortraitGeneration]` section with `image_count` key.
- Adjust `modules/helpers/config_helper.py` so non-default config paths are respected when loading/saving (stabilizes `ConfigHelper._config_path` handling used by the new tests).
- Add `tests/test_portrait_generation_dialog.py` to verify clamping behavior and config round-trip persistence.

### Testing
- Ran `pytest -q tests/test_portrait_generation_dialog.py` and the new test passed.
- Ran a broader smoke run `pytest -q tests/test_portrait_generation_dialog.py tests/test_campaign_date_service.py tests/test_system_config.py` which completed successfully (`11 passed`).
- Compiled affected modules with `python -m compileall modules/helpers/config_helper.py modules/generic/editor/window_components/portrait_generation_dialog.py modules/generic/editor/window_components/portrait_and_image_workflows.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54b89b3690832b878a543a4cb6e406)