### PR TITLE
Add CFG scale selection for portrait generation

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -67,6 +67,10 @@ from modules.helpers.portrait_helper import parse_portrait_value, serialize_port
 from modules.ui.system_selector_dialog import CampaignSystemSelectorDialog
 from modules.ui.database_manager_dialog import DatabaseManagerDialog
 from modules.ui.system_manager_dialog import SystemManagerDialog
+from modules.generic.editor.window_components.portrait_generation_dialog import (
+    PortraitGenerationDialog,
+    clamp_portrait_cfg_scale,
+)
 from modules.ui.menu_bar import AppMenuBar
 from modules.ui.ambiance import SecondScreenAmbiancePlayer
 from modules.ui.ambiance.control_window import AmbianceControlWindow
@@ -4140,26 +4144,13 @@ class MainWindow(ctk.CTk):
         ctk.CTkButton(top, text="Continue", command=on_confirm).pack(pady=10)
 
     def generate_missing_npc_portraits(self):
-        """Handle generate missing NPC portraits."""
-        def confirm_model_and_continue():
-            """Handle confirm model and continue."""
-            ConfigHelper.set("LastUsed", "model", self.selected_model.get())
-            top.destroy()
-            self.generate_portraits_continue_npcs()
-        top = ctk.CTkToplevel(self)
-        top.title("Select AI Model for NPCs")
-        top.geometry("400x200")
-        top.transient(self)
-        top.grab_set()
-        ctk.CTkLabel(top, text="Select AI Model to use for NPC portrait generation:").pack(pady=20)
-        last_model = ConfigHelper.get("LastUsed", "model", fallback=None)
-        # Use ctk.StringVar
-        if last_model in self.model_options:
-            self.selected_model = ctk.StringVar(value=last_model)
-        else:
-            self.selected_model = ctk.StringVar(value=self.model_options[0])
-        ctk.CTkOptionMenu(top, values=self.model_options, variable=self.selected_model).pack(pady=10)
-        ctk.CTkButton(top, text="Continue", command=confirm_model_and_continue).pack(pady=10)
+        """Ask for NPC portrait generation settings before generating."""
+        settings = self._ask_portrait_generation_settings()
+        if not settings:
+            return
+        self.selected_model = ctk.StringVar(value=settings["model"])
+        self.selected_cfgscale = clamp_portrait_cfg_scale(settings["cfgscale"])
+        self.generate_portraits_continue_npcs()
 
     def generate_portraits_continue_npcs(self):
         """Handle generate portraits continue NPCs."""
@@ -4188,25 +4179,25 @@ class MainWindow(ctk.CTk):
         conn.close()
 
     def generate_missing_creature_portraits(self):
-        """Handle generate missing creature portraits."""
-        def confirm_model_and_continue():
-            """Handle confirm model and continue."""
-            ConfigHelper.set("LastUsed", "model", self.selected_model.get())
-            top.destroy()
-            self.generate_portraits_continue_creatures()
-        top = ctk.CTkToplevel(self)
-        top.title("Select AI Model for Creatures")
-        top.geometry("400x200")
-        top.transient(self)
-        top.grab_set()
-        ctk.CTkLabel(top, text="Select AI Model to use for creature portrait generation:").pack(pady=20)
+        """Ask for creature portrait generation settings before generating."""
+        settings = self._ask_portrait_generation_settings()
+        if not settings:
+            return
+        self.selected_model = ctk.StringVar(value=settings["model"])
+        self.selected_cfgscale = clamp_portrait_cfg_scale(settings["cfgscale"])
+        self.generate_portraits_continue_creatures()
+
+    def _ask_portrait_generation_settings(self):
+        """Collect shared SwarmUI portrait generation settings."""
         last_model = ConfigHelper.get("LastUsed", "model", fallback=None)
-        if last_model in self.model_options:
-            self.selected_model = ctk.StringVar(value=last_model)
-        else:
-            self.selected_model = ctk.StringVar(value=self.model_options[0])
-        ctk.CTkOptionMenu(top, values=self.model_options, variable=self.selected_model).pack(pady=10)
-        ctk.CTkButton(top, text="Continue", command=confirm_model_and_continue).pack(pady=10)
+        selected_model = last_model if last_model in self.model_options else self.model_options[0]
+        dialog = PortraitGenerationDialog(
+            self,
+            model_options=self.model_options,
+            selected_model=selected_model,
+        )
+        self.wait_window(dialog)
+        return dialog.result
 
     def generate_portraits_continue_creatures(self):
         """Handle generate portraits continue creatures."""
@@ -4265,7 +4256,7 @@ class MainWindow(ctk.CTk):
                 "model": self.selected_model.get(),
                 "width": 1024,
                 "height": 1024,
-                "cfgscale": 9,
+                "cfgscale": clamp_portrait_cfg_scale(getattr(self, "selected_cfgscale", None)),
                 "steps": 20,
                 "seed": -1
             }
@@ -4323,7 +4314,7 @@ class MainWindow(ctk.CTk):
                 "model": self.selected_model.get(),
                 "width": 1024,
                 "height": 1024,
-                "cfgscale": 9,
+                "cfgscale": clamp_portrait_cfg_scale(getattr(self, "selected_cfgscale", None)),
                 "steps": 20,
                 "seed": -1
             }

--- a/modules/generic/editor/window_components/portrait_and_image_workflows.py
+++ b/modules/generic/editor/window_components/portrait_and_image_workflows.py
@@ -2,7 +2,11 @@
 
 from modules.generic.editor.window_context import *
 from modules.generic.editor.styles import EDITOR_PALETTE, primary_button_style, tk_listbox_theme
-from modules.generic.editor.window_components.portrait_generation_dialog import PortraitGenerationDialog, clamp_portrait_image_count
+from modules.generic.editor.window_components.portrait_generation_dialog import (
+    PortraitGenerationDialog,
+    clamp_portrait_cfg_scale,
+    clamp_portrait_image_count,
+)
 
 
 class GenericEditorWindowPortraitAndImageWorkflows:
@@ -466,8 +470,9 @@ class GenericEditorWindowPortraitAndImageWorkflows:
         self.generate_portrait(
             dialog.result["model"],
             image_count=dialog.result["image_count"],
+            cfgscale=dialog.result["cfgscale"],
         )
-    def generate_portrait(self, selected_model, image_count=None):
+    def generate_portrait(self, selected_model, image_count=None, cfgscale=None):
         """
         Generates a portrait image using the SwarmUI API and associates the resulting
         image with the current NPC by updating its 'Portrait' field.
@@ -502,7 +507,7 @@ class GenericEditorWindowPortraitAndImageWorkflows:
                 "model": selected_model,
                 "width": 1024,
                 "height": 1024,
-                "cfgscale": 9,
+                "cfgscale": clamp_portrait_cfg_scale(cfgscale),
                 "steps": 20,
                 "seed": -1
             }

--- a/modules/generic/editor/window_components/portrait_generation_dialog.py
+++ b/modules/generic/editor/window_components/portrait_generation_dialog.py
@@ -9,9 +9,14 @@ from modules.helpers.config_helper import ConfigHelper
 
 PORTRAIT_GENERATION_SECTION = "PortraitGeneration"
 PORTRAIT_IMAGE_COUNT_KEY = "image_count"
+PORTRAIT_CFG_SCALE_KEY = "cfgscale"
 DEFAULT_PORTRAIT_IMAGE_COUNT = 6
 MIN_PORTRAIT_IMAGE_COUNT = 1
 MAX_PORTRAIT_IMAGE_COUNT = 10
+DEFAULT_PORTRAIT_CFG_SCALE = 9.0
+MIN_PORTRAIT_CFG_SCALE = 1.0
+MAX_PORTRAIT_CFG_SCALE = 20.0
+CFG_SCALE_STEP = 0.5
 
 
 def clamp_portrait_image_count(value) -> int:
@@ -21,6 +26,22 @@ def clamp_portrait_image_count(value) -> int:
     except (TypeError, ValueError):
         count = DEFAULT_PORTRAIT_IMAGE_COUNT
     return max(MIN_PORTRAIT_IMAGE_COUNT, min(MAX_PORTRAIT_IMAGE_COUNT, count))
+
+
+def clamp_portrait_cfg_scale(value) -> float:
+    """Return a safe CFG scale in the supported SwarmUI range."""
+    try:
+        scale = float(value)
+    except (TypeError, ValueError):
+        scale = DEFAULT_PORTRAIT_CFG_SCALE
+    scale = max(MIN_PORTRAIT_CFG_SCALE, min(MAX_PORTRAIT_CFG_SCALE, scale))
+    return round(scale * 2) / 2
+
+
+def format_cfg_scale(value) -> str:
+    """Format CFG scale without unnecessary trailing decimals."""
+    scale = clamp_portrait_cfg_scale(value)
+    return str(int(scale)) if scale.is_integer() else f"{scale:.1f}"
 
 
 def get_default_portrait_image_count() -> int:
@@ -42,6 +63,25 @@ def save_default_portrait_image_count(count: int) -> None:
     )
 
 
+def get_default_portrait_cfg_scale() -> float:
+    """Read the configured portrait generation CFG scale."""
+    raw_value = ConfigHelper.get(
+        PORTRAIT_GENERATION_SECTION,
+        PORTRAIT_CFG_SCALE_KEY,
+        fallback=str(DEFAULT_PORTRAIT_CFG_SCALE),
+    )
+    return clamp_portrait_cfg_scale(raw_value)
+
+
+def save_default_portrait_cfg_scale(scale: float) -> None:
+    """Persist the portrait generation CFG scale for future generations."""
+    ConfigHelper.set(
+        PORTRAIT_GENERATION_SECTION,
+        PORTRAIT_CFG_SCALE_KEY,
+        format_cfg_scale(scale),
+    )
+
+
 class PortraitGenerationDialog(ctk.CTkToplevel):
     """Modal dialog that collects SwarmUI model and candidate count."""
 
@@ -51,15 +91,18 @@ class PortraitGenerationDialog(ctk.CTkToplevel):
         self._model_options = model_options
         self._count_var = ctk.IntVar(value=get_default_portrait_image_count())
         self._selected_model = ctk.StringVar(value=selected_model)
+        self._cfg_scale_var = ctk.DoubleVar(value=get_default_portrait_cfg_scale())
         self._count_label_var = ctk.StringVar()
+        self._cfg_label_var = ctk.StringVar()
 
         self.title("Portrait Generation")
-        self.geometry("480x430")
-        self.minsize(460, 400)
+        self.geometry("520x590")
+        self.minsize(500, 560)
         self.transient(master)
         self.grab_set()
         self._build_ui()
         self._update_count_label(self._count_var.get())
+        self._update_cfg_label(self._cfg_scale_var.get())
 
     def _build_ui(self) -> None:
         shell = ctk.CTkFrame(self, corner_radius=18)
@@ -73,7 +116,7 @@ class PortraitGenerationDialog(ctk.CTkToplevel):
         ).grid(row=0, column=0, sticky="w", padx=20, pady=(20, 4))
         ctk.CTkLabel(
             shell,
-            text="Choose the model and how many portrait candidates SwarmUI should generate.",
+            text="Choose the model, candidate count, and CFG guidance strength SwarmUI should use.",
             wraplength=400,
             justify="left",
             text_color=("#5f6368", "#b8beca"),
@@ -123,8 +166,39 @@ class PortraitGenerationDialog(ctk.CTkToplevel):
                 command=lambda value=count: self._set_count(value),
             ).pack(side="left", padx=(0, 8))
 
+        cfg_card = ctk.CTkFrame(shell, corner_radius=14, fg_color=("#fff7ed", "#24140a"))
+        cfg_card.grid(row=4, column=0, sticky="ew", padx=20, pady=(0, 14))
+        cfg_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(cfg_card, textvariable=self._cfg_label_var, font=ctk.CTkFont(size=16, weight="bold")).grid(
+            row=0, column=0, sticky="w", padx=16, pady=(14, 2)
+        )
+        ctk.CTkLabel(
+            cfg_card,
+            text="Lower CFG is looser and more creative; higher CFG follows the prompt harder.",
+            wraplength=420,
+            justify="left",
+            text_color=("#9a3412", "#fdba74"),
+        ).grid(row=1, column=0, sticky="w", padx=16, pady=(0, 8))
+        ctk.CTkSlider(
+            cfg_card,
+            from_=MIN_PORTRAIT_CFG_SCALE,
+            to=MAX_PORTRAIT_CFG_SCALE,
+            number_of_steps=int((MAX_PORTRAIT_CFG_SCALE - MIN_PORTRAIT_CFG_SCALE) / CFG_SCALE_STEP),
+            variable=self._cfg_scale_var,
+            command=self._update_cfg_label,
+        ).grid(row=2, column=0, sticky="ew", padx=16, pady=(6, 8))
+        preset_row = ctk.CTkFrame(cfg_card, fg_color="transparent")
+        preset_row.grid(row=3, column=0, sticky="ew", padx=16, pady=(0, 14))
+        for label, scale in (("Dreamy", 5.0), ("Balanced", 9.0), ("Sharp", 12.0), ("Strict", 15.0)):
+            ctk.CTkButton(
+                preset_row,
+                text=f"{label} {format_cfg_scale(scale)}",
+                width=92,
+                command=lambda value=scale: self._set_cfg_scale(value),
+            ).pack(side="left", padx=(0, 8))
+
         actions = ctk.CTkFrame(shell, fg_color="transparent")
-        actions.grid(row=4, column=0, sticky="ew", padx=20, pady=(4, 18))
+        actions.grid(row=5, column=0, sticky="ew", padx=20, pady=(4, 18))
         ctk.CTkButton(actions, text="Cancel", fg_color="transparent", border_width=1, command=self._cancel).pack(side="right", padx=(8, 0))
         ctk.CTkButton(actions, text="Generate Portraits", command=self._confirm).pack(side="right")
 
@@ -138,11 +212,22 @@ class PortraitGenerationDialog(ctk.CTkToplevel):
         suffix = "candidate" if count == 1 else "candidates"
         self._count_label_var.set(f"Generate {count} portrait {suffix}")
 
+    def _set_cfg_scale(self, value: float) -> None:
+        self._cfg_scale_var.set(clamp_portrait_cfg_scale(value))
+        self._update_cfg_label(self._cfg_scale_var.get())
+
+    def _update_cfg_label(self, raw_value) -> None:
+        scale = clamp_portrait_cfg_scale(raw_value)
+        self._cfg_scale_var.set(scale)
+        self._cfg_label_var.set(f"CFG guidance scale: {format_cfg_scale(scale)}")
+
     def _confirm(self) -> None:
         count = clamp_portrait_image_count(self._count_var.get())
+        cfg_scale = clamp_portrait_cfg_scale(self._cfg_scale_var.get())
         save_default_portrait_image_count(count)
+        save_default_portrait_cfg_scale(cfg_scale)
         ConfigHelper.set("LastUsed", "model", self._selected_model.get())
-        self.result = {"model": self._selected_model.get(), "image_count": count}
+        self.result = {"model": self._selected_model.get(), "image_count": count, "cfgscale": cfg_scale}
         self.destroy()
 
     def _cancel(self) -> None:


### PR DESCRIPTION
### Motivation
- Allow the user to choose a CFG guidance scale before portrait/image generation and persist that choice as the campaign default in the config file. 
- Improve the portrait-generation UI to make selecting CFG scale feel polished and accessible. 

### Description
- Added CFG scale helpers, default read/save, clamping and formatting (`clamp_portrait_cfg_scale`, `format_cfg_scale`, `get_default_portrait_cfg_scale`, `save_default_portrait_cfg_scale`) to `modules/generic/editor/window_components/portrait_generation_dialog.py` and wired them into the dialog UI. 
- Enhanced the `PortraitGenerationDialog` UI with a CFG guidance card: a slider, live label, and quick-presets (`Dreamy`, `Balanced`, `Sharp`, `Strict`), and persisted the selected scale under the `PortraitGeneration` section in `config.ini`. 
- Plumbed the selected `cfgscale` through the editor and batch portrait flows so SwarmUI requests use the user-selected value instead of the previous hardcoded `9` (`modules/generic/editor/window_components/portrait_and_image_workflows.py` and `main_window.py`). 

### Testing
- Ran `python -m compileall main_window.py modules/generic/editor/window_components/portrait_generation_dialog.py modules/generic/editor/window_components/portrait_and_image_workflows.py`, which completed successfully. 
- Performed a code health check with `git diff --check`, which reported no whitespace/merge errors. 
- Attempted to run a small import/assert smoke test for the new CFG helpers, but it failed to import UI modules due to the environment missing the `customtkinter` dependency, so runtime UI tests were blocked by that missing package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56070c30a4832b9a0f29ccb4bf6f49)