### PR TITLE
Sanitize generated portrait filenames

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -39,6 +39,7 @@ from modules.helpers.template_loader import (
     list_manageable_entities,
 )
 from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.filename_helper import safe_filename_component
 from modules.helpers.backup_helper import (
     BackupError,
     ManifestError,
@@ -4272,7 +4273,7 @@ class MainWindow(ctk.CTk):
             if downloaded_image.status_code != 200:
                 print(f"Failed to download generated image for NPC '{npc_name}'")
                 return
-            output_filename = f"{npc_name.replace(' ', '_')}_portrait.png"
+            output_filename = f"{safe_filename_component(npc_name, fallback='Unknown')}_portrait.png"
             with open(output_filename, "wb") as f:
                 f.write(downloaded_image.content)
             GENERATED_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "generated")
@@ -4330,7 +4331,7 @@ class MainWindow(ctk.CTk):
             if downloaded_image.status_code != 200:
                 print(f"Failed to download generated image for Creature '{creature_name}'")
                 return
-            output_filename = f"{creature_name.replace(' ', '_')}_portrait.png"
+            output_filename = f"{safe_filename_component(creature_name, fallback='Unknown')}_portrait.png"
             with open(output_filename, "wb") as f:
                 f.write(downloaded_image.content)
             GENERATED_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "generated")

--- a/modules/generic/editor/window_components/asset_path_and_preview.py
+++ b/modules/generic/editor/window_components/asset_path_and_preview.py
@@ -212,7 +212,7 @@ class GenericEditorWindowAssetPathAndPreview:
 
         image_folder.mkdir(parents=True, exist_ok=True)
 
-        image_name = self.item.get('Name', 'Unnamed').replace(' ', '_')
+        image_name = safe_filename_component(self.item.get('Name', 'Unnamed'), fallback='Unnamed')
         ext = os.path.splitext(src_path)[-1].lower()
         dest_filename = f"{image_name}_{id(self)}{ext}"
         dest_path = image_folder / dest_filename
@@ -231,7 +231,7 @@ class GenericEditorWindowAssetPathAndPreview:
 
         portrait_folder.mkdir(parents=True, exist_ok=True)
 
-        npc_name = self.item.get('Name', 'Unnamed').replace(' ', '_')
+        npc_name = safe_filename_component(self.item.get('Name', 'Unnamed'), fallback='Unnamed')
         source_stem = os.path.splitext(os.path.basename(src_path))[0]
         sanitized_stem = ''.join(
             char if char.isalnum() or char in {'_', '-'} else '_'

--- a/modules/generic/editor/window_components/portrait_and_image_workflows.py
+++ b/modules/generic/editor/window_components/portrait_and_image_workflows.py
@@ -230,7 +230,7 @@ class GenericEditorWindowPortraitAndImageWorkflows:
                 portrait_folder = campaign_dir / 'assets' / 'portraits'
                 portrait_folder.mkdir(parents=True, exist_ok=True)
 
-                base_name = (self.item.get('Name') or 'Unnamed').replace(' ', '_')
+                base_name = safe_filename_component(self.item.get('Name'), fallback='Unnamed')
                 dest_filename = f"{base_name}_{id(self)}.png"
                 dest_path = portrait_folder / dest_filename
 
@@ -380,7 +380,7 @@ class GenericEditorWindowPortraitAndImageWorkflows:
                 image_folder = campaign_dir / 'assets' / 'images' / 'map_images'
                 image_folder.mkdir(parents=True, exist_ok=True)
 
-                base_name = (self.item.get('Name') or 'Unnamed').replace(' ', '_')
+                base_name = safe_filename_component(self.item.get('Name'), fallback='Unnamed')
                 dest_filename = f"{base_name}_{id(self)}.png"
                 dest_path = image_folder / dest_filename
 
@@ -549,7 +549,7 @@ class GenericEditorWindowPortraitAndImageWorkflows:
             chosen_bytes = images_bytes[chosen_index]
 
             # Step 5: Save the chosen image locally and update the NPC's Portrait field
-            output_filename = f"{npc_name.replace(' ', '_')}_portrait.png"
+            output_filename = f"{safe_filename_component(npc_name, fallback='Unknown')}_portrait.png"
             with open(output_filename, "wb") as f:
                 f.write(chosen_bytes)
 

--- a/modules/generic/editor/window_context.py
+++ b/modules/generic/editor/window_context.py
@@ -14,6 +14,7 @@ from PIL import ImageGrab
 from tkinter import filedialog,  messagebox
 from modules.helpers.swarmui_helper import get_available_models
 from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.filename_helper import safe_filename_component
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.generic.generic_list_selection_view import GenericListSelectionView
 from modules.helpers.template_loader import load_template

--- a/modules/helpers/filename_helper.py
+++ b/modules/helpers/filename_helper.py
@@ -1,0 +1,30 @@
+"""Helpers for building filesystem-safe filenames."""
+
+from __future__ import annotations
+
+import re
+
+_WINDOWS_RESERVED_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_COLLAPSED_UNDERSCORES = re.compile(r"_+")
+
+
+def safe_filename_component(value: object, fallback: str = "file") -> str:
+    """Return a string safe to use as one segment of a filename on Windows/Linux."""
+    text = str(value or "").strip()
+    text = _INVALID_FILENAME_CHARS.sub("_", text)
+    text = "".join(ch if ch.isalnum() or ch in {"_", "-", ".", " "} else "_" for ch in text)
+    text = text.replace(" ", "_")
+    text = _COLLAPSED_UNDERSCORES.sub("_", text).strip("._")
+    if not text:
+        text = fallback
+    if text.upper() in _WINDOWS_RESERVED_NAMES:
+        text = f"{text}_"
+    return text


### PR DESCRIPTION
### Motivation
- Selecting generated images failed when entity names contained characters invalid for filesystem paths (e.g. `Lysa "Silk" Kaczmarek`) causing `[Errno 22] Invalid argument` during file write/copy. 
- The change aims to make filenames produced for temporary/generated portraits and copied assets safe on Windows/Linux so image selection and copying no longer error.

### Description
- Add a new helper `safe_filename_component` in `modules/helpers/filename_helper.py` to produce filesystem-safe filename segments and handle Windows reserved names. 
- Wire the helper into the editor context (`modules/generic/editor/window_context.py`) and replace naive `replace(' ', '_')` usages with `safe_filename_component` when creating temp/generated filenames and asset destinations. 
- Updated portrait/image workflows in `modules/generic/editor/window_components/portrait_and_image_workflows.py`, asset copy logic in `modules/generic/editor/window_components/asset_path_and_preview.py`, and SwarmUI generation paths in `main_window.py` to use sanitized names. 
- Preserves previous behavior for normal names while preventing invalid characters and reserved-name collisions.

### Testing
- Compiled affected modules with `python -m compileall ...` which completed without errors. 
- Ran a simple assertion script verifying `safe_filename_component('Lysa "Silk" Kaczmarek') == 'Lysa_Silk_Kaczmarek'` and `safe_filename_component('CON') == 'CON_'`, and both assertions passed. 
- Confirmed that the image-download / save flow now writes sanitized temporary filenames (observed during local testing of the generation workflow) and no longer errors when selecting generated images.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a560abf5f7c832bad8a4d35dddb16dd)