### PR TITLE
Fix scenario portrait preview clearing

### DIFF
--- a/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
+++ b/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
@@ -113,24 +113,35 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
                 break
         self._refresh_preview()
 
+    def _clear_preview_image(self, text: str = "[No Portrait]"):
+        try:
+            self.preview_label.configure(image="", text=text)
+        except tk.TclError:
+            try:
+                if self.preview_label.winfo_exists():
+                    self.preview_label.configure(text=text)
+            except tk.TclError:
+                pass
+        self._preview_image = None
+
     def _refresh_preview(self):
         entity = self._entity()
         if not entity:
-            self.preview_label.configure(image=None, text="[No Portrait]")
+            self._clear_preview_image()
             return
         self.detail_label.configure(text=f"{entity.entity_type}: {entity.name}\nSource: {entity.source_field}")
         primary = primary_portrait(parse_portrait_value(entity.record.get("Portrait", "")))
         resolved = resolve_portrait_path(primary, ConfigHelper.get_campaign_dir()) if primary else None
         try:
             if resolved and Path(resolved).exists():
-                image = Image.open(resolved).resize((256, 256))
+                with Image.open(resolved) as source:
+                    image = source.resize((256, 256)).copy()
                 self._preview_image = ctk.CTkImage(light_image=image, size=(256, 256))
                 self.preview_label.configure(image=self._preview_image, text="")
                 return
         except Exception:
             pass
-        self._preview_image = None
-        self.preview_label.configure(image=None, text="[No Portrait]")
+        self._clear_preview_image()
 
     def _paths(self) -> list[str]:
         entity = self._entity()


### PR DESCRIPTION
### Motivation
- Prevent Tk image reference loss and avoid stale previews when switching or clearing portraits in the scenario portrait manager.
- Make the preview label clearing CustomTkinter-safe and robust to widget-lifetime race conditions.
- Ensure the PIL image backing the CTk image is copied while still inside a context manager so the Tk image reference remains valid.

### Description
- Added helper `._clear_preview_image(self, text: str = "[No Portrait]")` which configures the preview label to an empty image/text with a narrow `tk.TclError` fallback and then sets `self._preview_image = None`.
- Replaced direct `self.preview_label.configure(image=None, text="[No Portrait]")` calls in `_refresh_preview()` with the new `._clear_preview_image()` helper.
- Updated successful image-loading branch in `_refresh_preview()` to use `with Image.open(resolved) as source: image = source.resize((256, 256)).copy()` then assign `self._preview_image = ctk.CTkImage(...)` before calling `self.preview_label.configure(image=self._preview_image, text="")`.
- Added a guarded fallback in the helper that only reconfigures text if the widget still exists to avoid `TclError` on torn-down widgets.

### Testing
- Ran `python -m py_compile modules/generic/portrait_manager/scenario_portrait_manager_dialog.py` which succeeded.
- Ran `git diff --check` which reported no whitespace or diff errors.
- Confirmed the module compiles and basic static checks pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a560fe67024832bb115ea58f26d8792)