### PR TITLE
Refactor scenario portrait SwarmUI generation

### DIFF
--- a/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
+++ b/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
@@ -10,7 +10,18 @@ from modules.helpers.portrait_helper import parse_portrait_value, primary_portra
 from modules.helpers.template_loader import load_template
 from modules.ui.image_browser_dialog import ImageBrowserDialog
 from modules.ui.webview.pywebview_client import PyWebviewClient
+from modules.helpers.swarmui_helper import get_available_models
+from modules.generic.editor.window_components.portrait_generation_dialog import (
+    PortraitGenerationDialog,
+    clamp_portrait_cfg_scale,
+    clamp_portrait_image_count,
+)
 from modules.generic.portrait_manager.entity_portrait_actions import ScenarioPortraitEntity, campaign_relative_path, copy_portrait_to_campaign, missing_portrait_indices, portrait_status, set_entity_portraits
+from modules.generic.portrait_manager.swarmui_portrait_generator import (
+    SwarmUIPortraitSettings,
+    generate_scenario_portrait,
+    launch_swarmui,
+)
 
 class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
     """Manage portraits for all entities referenced by one scenario."""
@@ -233,7 +244,6 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
         entity = self._entity()
         if not entity:
             return
-        from modules.generic.generic_editor_window import GenericEditorWindow
 
         try:
             template = load_template(entity.entity_type)
@@ -244,12 +254,46 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
             )
             return
 
-        editor = GenericEditorWindow(self, entity.record, template, entity.wrapper)
-        editor.create_portrait_with_swarmui()
-        self.wait_window(editor)
-        if getattr(editor, "saved", False):
-            entity.wrapper.save_item(entity.record)
-        self._refresh_current()
+        try:
+            launch_swarmui()
+        except Exception as exc:
+            messagebox.showerror("Create Portrait", f"Failed to launch SwarmUI: {exc}")
+            return
+
+        model_options = get_available_models()
+        if not model_options:
+            messagebox.showerror("Create Portrait", "No models available in SwarmUI models folder.")
+            return
+
+        last_model = ConfigHelper.get("LastUsed", "model", fallback=None)
+        selected_model = last_model if last_model in model_options else model_options[0]
+        dialog = PortraitGenerationDialog(
+            self,
+            model_options=model_options,
+            selected_model=selected_model,
+        )
+        self.wait_window(dialog)
+        if not dialog.result:
+            return
+
+        settings = SwarmUIPortraitSettings(
+            model=str(dialog.result["model"]),
+            image_count=clamp_portrait_image_count(dialog.result["image_count"]),
+            cfgscale=clamp_portrait_cfg_scale(dialog.result["cfgscale"]),
+        )
+        try:
+            result = generate_scenario_portrait(
+                self,
+                entity,
+                settings,
+                template=template,
+            )
+        except Exception as exc:
+            messagebox.showerror("Create Portrait", f"An error occurred: {exc}")
+            return
+        if not result:
+            return
+        self._save_paths(self._paths() + result.portrait_paths)
 
     def make_primary(self):
         paths = self._paths()

--- a/modules/generic/portrait_manager/swarmui_portrait_generator.py
+++ b/modules/generic/portrait_manager/swarmui_portrait_generator.py
@@ -1,0 +1,299 @@
+"""Reusable SwarmUI portrait generation for scenario portrait workflows."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Any, Callable
+
+import customtkinter as ctk
+from PIL import Image
+import requests
+
+from modules.generic.portrait_manager.entity_portrait_actions import (
+    ScenarioPortraitEntity,
+    copy_portrait_to_campaign,
+)
+from modules.helpers import text_helpers
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.filename_helper import safe_filename_component
+
+
+SWARM_API_URL = "http://127.0.0.1:7801"
+NEGATIVE_PROMPT = (
+    "blurry, low quality, comics style, mangastyle, paint style, watermark, "
+    "ugly, monstrous, too many fingers, too many legs, too many arms, bad hands, "
+    "unrealistic weapons, bad grip on equipment, nude"
+)
+
+SWARMUI_PROCESS = None
+
+
+@dataclass(frozen=True)
+class SwarmUIPortraitSettings:
+    """SwarmUI generation settings selected by the user."""
+
+    model: str
+    image_count: int
+    cfgscale: float
+
+
+@dataclass(frozen=True)
+class GeneratedPortraitResult:
+    """Paths produced by a successful portrait generation."""
+
+    portrait_paths: list[str]
+    generated_asset_paths: list[str]
+
+
+def launch_swarmui() -> None:
+    """Launch SwarmUI when it is not already running."""
+    global SWARMUI_PROCESS
+    swarmui_path = ConfigHelper.get("Paths", "swarmui_path", fallback=r"E:\SwarmUI\SwarmUI")
+    swarmui_cmd = os.path.join(swarmui_path, "launch-windows.bat")
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    if SWARMUI_PROCESS is None or SWARMUI_PROCESS.poll() is not None:
+        SWARMUI_PROCESS = subprocess.Popen(
+            swarmui_cmd,
+            shell=True,
+            cwd=swarmui_path,
+            env=env,
+        )
+        time.sleep(120.0)
+
+
+def build_portrait_prompt(
+    entity: ScenarioPortraitEntity,
+    template: dict[str, Any] | None = None,
+    *,
+    prompt_fields: list[str] | None = None,
+) -> str:
+    """Build a SwarmUI prompt from an entity record and its template fields."""
+    fields = prompt_fields or _default_prompt_fields(entity, template)
+    parts: list[str] = []
+    for field_name in fields:
+        if field_name == "Portrait":
+            continue
+        value = entity.record.get(field_name)
+        if value in (None, ""):
+            continue
+        if isinstance(value, str):
+            text = text_helpers.format_longtext(value).strip()
+        else:
+            text = text_helpers.format_longtext(value).strip()
+        if text:
+            parts.append(text)
+    return " ".join(parts) or entity.name or "fantasy portrait"
+
+
+def generate_scenario_portrait(
+    parent,
+    entity: ScenarioPortraitEntity,
+    settings: SwarmUIPortraitSettings,
+    *,
+    template: dict[str, Any] | None = None,
+    prompt_fields: list[str] | None = None,
+    on_generated: Callable[[GeneratedPortraitResult], None] | None = None,
+) -> GeneratedPortraitResult | None:
+    """Generate, select, and persist generated portrait assets for a scenario entity.
+
+    Returns campaign-relative portrait paths suitable for ``set_entity_portraits``.
+    """
+    session_id = _get_swarm_session_id()
+    prompt = build_portrait_prompt(entity, template, prompt_fields=prompt_fields)
+    image_paths = _request_swarm_images(session_id, prompt, settings)
+    image_bytes = _download_generated_images(image_paths)
+    if not image_bytes:
+        raise RuntimeError("Failed to download generated images.")
+
+    thumbs = [_make_thumbnail(content) for content in image_bytes]
+    chosen_index = show_image_selection_window(parent, thumbs)
+    if chosen_index is None:
+        return None
+    if chosen_index < 0 or chosen_index >= len(image_bytes):
+        return None
+
+    portrait_path, generated_path = _store_selected_portrait(entity, image_bytes[chosen_index])
+    result = GeneratedPortraitResult(
+        portrait_paths=[portrait_path],
+        generated_asset_paths=[generated_path] if generated_path else [],
+    )
+    if callable(on_generated):
+        on_generated(result)
+    return result
+
+
+def _default_prompt_fields(
+    entity: ScenarioPortraitEntity,
+    template: dict[str, Any] | None,
+) -> list[str]:
+    preferred = [
+        "Description",
+        "Role",
+        "Title",
+        "Archetype",
+        "Factions",
+        "Objects",
+        "Personality",
+        "Traits",
+        "Background",
+        "Motivation",
+        "CurrentObjective",
+        "Scheme",
+        "Notes",
+    ]
+    template_names = [
+        str(field.get("name"))
+        for field in (template or {}).get("fields", [])
+        if isinstance(field, dict) and field.get("name")
+    ]
+    selected = [name for name in preferred if name in entity.record]
+    selected.extend(name for name in template_names if name not in selected and name in entity.record)
+    key_field = entity.key_field
+    if key_field in entity.record and key_field not in selected:
+        selected.insert(0, key_field)
+    elif "Name" in entity.record and "Name" not in selected:
+        selected.insert(0, "Name")
+    return selected
+
+
+def _get_swarm_session_id() -> str:
+    session_url = f"{SWARM_API_URL}/API/GetNewSession"
+    response = requests.post(session_url, json={}, headers={"Content-Type": "application/json"})
+    response.raise_for_status()
+    session_id = response.json().get("session_id")
+    if not session_id:
+        raise RuntimeError("Failed to obtain session ID from Swarm API.")
+    return session_id
+
+
+def _request_swarm_images(
+    session_id: str,
+    prompt: str,
+    settings: SwarmUIPortraitSettings,
+) -> list[str]:
+    prompt_data = {
+        "session_id": session_id,
+        "images": settings.image_count,
+        "prompt": prompt,
+        "negativeprompt": NEGATIVE_PROMPT,
+        "model": settings.model,
+        "width": 1024,
+        "height": 1024,
+        "cfgscale": settings.cfgscale,
+        "steps": 20,
+        "seed": -1,
+    }
+    generate_url = f"{SWARM_API_URL}/API/GenerateText2Image"
+    response = requests.post(generate_url, json=prompt_data, headers={"Content-Type": "application/json"})
+    response.raise_for_status()
+    images = response.json().get("images")
+    if not images:
+        raise RuntimeError("Image generation failed. Check API response.")
+    return list(images)
+
+
+def _download_generated_images(image_paths: list[str]) -> list[bytes]:
+    images_bytes: list[bytes] = []
+    for rel_path in image_paths:
+        try:
+            response = requests.get(f"{SWARM_API_URL}/{rel_path}")
+            response.raise_for_status()
+            images_bytes.append(response.content)
+        except Exception:
+            continue
+    return images_bytes
+
+
+def _make_thumbnail(content: bytes) -> Image.Image:
+    image = Image.open(BytesIO(content)).convert("RGB")
+    thumb = image.copy()
+    thumb.thumbnail((256, 256))
+    return thumb
+
+
+def _store_selected_portrait(entity: ScenarioPortraitEntity, content: bytes) -> tuple[str, str]:
+    campaign_dir = Path(ConfigHelper.get_campaign_dir())
+    generated_folder = campaign_dir / "assets" / "generated"
+    generated_folder.mkdir(parents=True, exist_ok=True)
+    output_filename = f"{safe_filename_component(entity.name, fallback='Unknown')}_portrait_{time.time_ns()}.png"
+    generated_path = generated_folder / output_filename
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as temp_file:
+        temp_file.write(content)
+        temp_path = temp_file.name
+
+    try:
+        portrait_path = copy_portrait_to_campaign(temp_path, entity.name)
+        shutil.copy(temp_path, generated_path)
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+
+    try:
+        generated_relative = generated_path.relative_to(campaign_dir).as_posix()
+    except ValueError:
+        generated_relative = generated_path.as_posix()
+    return portrait_path, generated_relative
+
+
+def show_image_selection_window(parent, pil_images: list[Image.Image]) -> int | None:
+    """Display generated portrait thumbnails and return the selected index."""
+    if not pil_images:
+        return None
+
+    top = ctk.CTkToplevel(parent)
+    top.title("Choose a Portrait")
+    top.transient(parent)
+    top.grab_set()
+
+    container = ctk.CTkFrame(top)
+    container.pack(padx=10, pady=10, fill="both", expand=True)
+
+    ctk_images = []
+    selected = {"idx": None}
+
+    def on_choose(index: int) -> None:
+        selected["idx"] = index
+        top.destroy()
+
+    cols = min(5, max(1, len(pil_images)))
+    for index, image in enumerate(pil_images):
+        ctk_image = ctk.CTkImage(light_image=image, size=(180, 180))
+        ctk_images.append(ctk_image)
+        button = ctk.CTkButton(
+            container,
+            image=ctk_image,
+            text=f"#{index + 1}",
+            compound="top",
+            width=188,
+            height=214,
+            command=lambda idx=index: on_choose(idx),
+        )
+        button.grid(row=index // cols, column=index % cols, padx=6, pady=6, sticky="nsew")
+
+    def cancel() -> None:
+        selected["idx"] = None
+        top.destroy()
+
+    ctk.CTkButton(top, text="Cancel", command=cancel).pack(pady=5)
+
+    top.update_idletasks()
+    rows = (len(pil_images) + cols - 1) // cols
+    total_w = cols * (188 + 14) + 40
+    total_h = rows * (214 + 14) + 90
+    try:
+        top.geometry(f"{total_w}x{total_h}")
+    except Exception:
+        pass
+
+    top.wait_window()
+    return selected["idx"]


### PR DESCRIPTION
### Motivation
- Decouple SwarmUI portrait-generation from `GenericEditorWindow` so scenario-level portrait workflows can generate portraits without instantiating or waiting on the editor UI. 
- Make the SwarmUI logic reusable across portrait managers by extracting prompt-building, generation, selection, and persistence into a helper module.

### Description
- Added `modules/generic/portrait_manager/swarmui_portrait_generator.py` which exposes `SwarmUIPortraitSettings`, `generate_scenario_portrait()`, `launch_swarmui()`, and helper functions for prompt construction, SwarmUI requests, thumbnail selection, and storing generated assets. 
- Updated `modules/generic/portrait_manager/scenario_portrait_manager_dialog.py` to replace the previous `GenericEditorWindow` flow in `create_portrait()` with a direct flow that launches SwarmUI, shows `PortraitGenerationDialog`, calls the new helper to generate/select images, and then persists the returned portrait paths via the dialog's `_save_paths(...)` logic. 
- The prompt builder collects relevant template/record fields (e.g. `Description`, `Role`, `Factions`, etc.) and the generator saves both the campaign-relative portrait path used by the entity and a copy in `assets/generated`.

### Testing
- Ran `python -m py_compile modules/generic/portrait_manager/scenario_portrait_manager_dialog.py modules/generic/portrait_manager/swarmui_portrait_generator.py` which succeeded.
- Ran the test suite with `python -m pytest tests`; collection failed due to unrelated test-environment issues (duplicate test module basenames and `customtkinter` test stubs missing attributes such as `CTkToplevel`/`CTkTextbox`), so full automated test coverage for this change could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5610ad6b48832bbd7ef6eaeaad768e)