### PR TITLE
Add dialog-owned portrait generation picker and save flow

### DIFF
--- a/modules/generic/portrait_manager/components/__init__.py
+++ b/modules/generic/portrait_manager/components/__init__.py
@@ -1,0 +1,1 @@
+"""UI components for scenario portrait management."""

--- a/modules/generic/portrait_manager/components/generated_portrait_selection_dialog.py
+++ b/modules/generic/portrait_manager/components/generated_portrait_selection_dialog.py
@@ -1,0 +1,75 @@
+"""Dialog-owned candidate selection UI for generated scenario portraits."""
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from modules.generic.portrait_manager.swarmui_portrait_generator import GeneratedPortraitCandidate
+
+
+class GeneratedPortraitSelectionDialog(ctk.CTkToplevel):
+    """Modal picker that lets the user choose one generated portrait candidate."""
+
+    def __init__(self, master, *, entity_name: str, candidates: list[GeneratedPortraitCandidate]):
+        super().__init__(master)
+        self.result: GeneratedPortraitCandidate | None = None
+        self._candidates = candidates
+        self._images: list[ctk.CTkImage] = []
+
+        self.title(f"Choose Portrait - {entity_name}")
+        self.transient(master)
+        self.grab_set()
+        self._build_ui(entity_name)
+        self._fit_to_candidates()
+
+    def _build_ui(self, entity_name: str) -> None:
+        shell = ctk.CTkFrame(self, corner_radius=16)
+        shell.pack(fill="both", expand=True, padx=12, pady=12)
+        ctk.CTkLabel(
+            shell,
+            text=f"Select a portrait for {entity_name}",
+            font=ctk.CTkFont(size=18, weight="bold"),
+        ).pack(anchor="w", padx=12, pady=(12, 4))
+        ctk.CTkLabel(
+            shell,
+            text="Click a generated candidate to attach it to the current scenario entity.",
+            justify="left",
+            text_color=("#5f6368", "#b8beca"),
+        ).pack(anchor="w", padx=12, pady=(0, 12))
+
+        grid = ctk.CTkFrame(shell, fg_color="transparent")
+        grid.pack(fill="both", expand=True, padx=6, pady=6)
+        cols = min(5, max(1, len(self._candidates)))
+        for column in range(cols):
+            grid.grid_columnconfigure(column, weight=1)
+        for index, candidate in enumerate(self._candidates):
+            image = ctk.CTkImage(light_image=candidate.thumbnail, size=(180, 180))
+            self._images.append(image)
+            ctk.CTkButton(
+                grid,
+                image=image,
+                text=f"Use candidate #{index + 1}",
+                compound="top",
+                width=190,
+                height=220,
+                command=lambda selected=index: self._choose(selected),
+            ).grid(row=index // cols, column=index % cols, padx=6, pady=6, sticky="nsew")
+
+        actions = ctk.CTkFrame(shell, fg_color="transparent")
+        actions.pack(fill="x", padx=12, pady=(8, 12))
+        ctk.CTkButton(actions, text="Cancel", fg_color="transparent", border_width=1, command=self._cancel).pack(side="right")
+
+    def _fit_to_candidates(self) -> None:
+        self.update_idletasks()
+        cols = min(5, max(1, len(self._candidates)))
+        rows = (len(self._candidates) + cols - 1) // cols
+        width = min(1120, max(420, cols * 210 + 60))
+        height = min(820, max(360, rows * 240 + 150))
+        self.geometry(f"{width}x{height}")
+
+    def _choose(self, index: int) -> None:
+        self.result = self._candidates[index]
+        self.destroy()
+
+    def _cancel(self) -> None:
+        self.result = None
+        self.destroy()

--- a/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
+++ b/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
@@ -16,11 +16,13 @@ from modules.generic.editor.window_components.portrait_generation_dialog import 
     clamp_portrait_cfg_scale,
     clamp_portrait_image_count,
 )
+from modules.generic.portrait_manager.components.generated_portrait_selection_dialog import GeneratedPortraitSelectionDialog
 from modules.generic.portrait_manager.entity_portrait_actions import ScenarioPortraitEntity, campaign_relative_path, copy_portrait_to_campaign, missing_portrait_indices, portrait_status, set_entity_portraits
 from modules.generic.portrait_manager.swarmui_portrait_generator import (
     SwarmUIPortraitSettings,
-    generate_scenario_portrait,
+    generate_scenario_portrait_candidates,
     launch_swarmui,
+    save_generated_portrait_candidate,
 )
 
 class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
@@ -282,8 +284,7 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
             cfgscale=clamp_portrait_cfg_scale(dialog.result["cfgscale"]),
         )
         try:
-            result = generate_scenario_portrait(
-                self,
+            candidates = generate_scenario_portrait_candidates(
                 entity,
                 settings,
                 template=template,
@@ -291,8 +292,25 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
         except Exception as exc:
             messagebox.showerror("Create Portrait", f"An error occurred: {exc}")
             return
-        if not result:
+        if not candidates:
+            messagebox.showinfo("Create Portrait", "No portrait candidates were generated.")
             return
+
+        selection_dialog = GeneratedPortraitSelectionDialog(
+            self,
+            entity_name=entity.name,
+            candidates=candidates,
+        )
+        self.wait_window(selection_dialog)
+        if not selection_dialog.result:
+            return
+
+        try:
+            result = save_generated_portrait_candidate(entity, selection_dialog.result)
+        except Exception as exc:
+            messagebox.showerror("Create Portrait", f"Unable to save selected portrait: {exc}")
+            return
+
         self._save_paths(self._paths() + result.portrait_paths)
 
     def make_primary(self):

--- a/modules/generic/portrait_manager/swarmui_portrait_generator.py
+++ b/modules/generic/portrait_manager/swarmui_portrait_generator.py
@@ -44,6 +44,14 @@ class SwarmUIPortraitSettings:
 
 
 @dataclass(frozen=True)
+class GeneratedPortraitCandidate:
+    """A downloaded SwarmUI portrait candidate before user selection."""
+
+    image_bytes: bytes
+    thumbnail: Image.Image
+
+
+@dataclass(frozen=True)
 class GeneratedPortraitResult:
     """Paths produced by a successful portrait generation."""
 
@@ -92,6 +100,38 @@ def build_portrait_prompt(
     return " ".join(parts) or entity.name or "fantasy portrait"
 
 
+def generate_scenario_portrait_candidates(
+    entity: ScenarioPortraitEntity,
+    settings: SwarmUIPortraitSettings,
+    *,
+    template: dict[str, Any] | None = None,
+    prompt_fields: list[str] | None = None,
+) -> list[GeneratedPortraitCandidate]:
+    """Generate and download SwarmUI portrait candidates without selecting or saving them."""
+    session_id = _get_swarm_session_id()
+    prompt = build_portrait_prompt(entity, template, prompt_fields=prompt_fields)
+    image_paths = _request_swarm_images(session_id, prompt, settings)
+    image_bytes = _download_generated_images(image_paths)
+    if not image_bytes:
+        raise RuntimeError("Failed to download generated images.")
+    return [
+        GeneratedPortraitCandidate(image_bytes=content, thumbnail=_make_thumbnail(content))
+        for content in image_bytes
+    ]
+
+
+def save_generated_portrait_candidate(
+    entity: ScenarioPortraitEntity,
+    candidate: GeneratedPortraitCandidate,
+) -> GeneratedPortraitResult:
+    """Persist a selected generated candidate and return campaign-relative portrait paths."""
+    portrait_path, generated_path = _store_selected_portrait(entity, candidate.image_bytes)
+    return GeneratedPortraitResult(
+        portrait_paths=[portrait_path],
+        generated_asset_paths=[generated_path] if generated_path else [],
+    )
+
+
 def generate_scenario_portrait(
     parent,
     entity: ScenarioPortraitEntity,
@@ -105,25 +145,17 @@ def generate_scenario_portrait(
 
     Returns campaign-relative portrait paths suitable for ``set_entity_portraits``.
     """
-    session_id = _get_swarm_session_id()
-    prompt = build_portrait_prompt(entity, template, prompt_fields=prompt_fields)
-    image_paths = _request_swarm_images(session_id, prompt, settings)
-    image_bytes = _download_generated_images(image_paths)
-    if not image_bytes:
-        raise RuntimeError("Failed to download generated images.")
-
-    thumbs = [_make_thumbnail(content) for content in image_bytes]
-    chosen_index = show_image_selection_window(parent, thumbs)
-    if chosen_index is None:
-        return None
-    if chosen_index < 0 or chosen_index >= len(image_bytes):
-        return None
-
-    portrait_path, generated_path = _store_selected_portrait(entity, image_bytes[chosen_index])
-    result = GeneratedPortraitResult(
-        portrait_paths=[portrait_path],
-        generated_asset_paths=[generated_path] if generated_path else [],
+    candidates = generate_scenario_portrait_candidates(
+        entity,
+        settings,
+        template=template,
+        prompt_fields=prompt_fields,
     )
+    chosen_index = show_image_selection_window(parent, [candidate.thumbnail for candidate in candidates])
+    if chosen_index is None or chosen_index < 0 or chosen_index >= len(candidates):
+        return None
+
+    result = save_generated_portrait_candidate(entity, candidates[chosen_index])
     if callable(on_generated):
         on_generated(result)
     return result


### PR DESCRIPTION
### Motivation
- Provide a dialog-owned workflow for generating, previewing, selecting, and saving AI-generated portraits without opening a detached entity editor. 
- Keep UI and persistence inside `ScenarioPortraitManagerDialog` so generated portraits attach directly to the current `ScenarioPortraitEntity` and the dialog refreshes the preview and row.

### Description
- Added a reusable selection dialog `GeneratedPortraitSelectionDialog` under `modules/generic/portrait_manager/components/` that previews generated thumbnails and returns the chosen candidate. 
- Split SwarmUI generation into candidate generation and persistence helpers by introducing `GeneratedPortraitCandidate`, `generate_scenario_portrait_candidates(...)`, and `save_generated_portrait_candidate(...)` in `modules/generic/portrait_manager/swarmui_portrait_generator.py`, while preserving the legacy `generate_scenario_portrait(...)` compatibility flow. 
- Updated `ScenarioPortraitManagerDialog` (`modules/generic/portrait_manager/scenario_portrait_manager_dialog.py`) to open `PortraitGenerationDialog` for model/settings, call `generate_scenario_portrait_candidates(...)`, show the new selection dialog, then save the chosen image via `save_generated_portrait_candidate(...)` and attach it using the existing `_save_paths(...)`/`set_entity_portraits(...)` path so the UI refreshes the current row and preview. 
- Created component package `modules/generic/portrait_manager/components/__init__.py` and kept all new UI owned by the manager dialog (no detached entity editors opened).

### Testing
- Compiled updated modules with `python -m compileall modules/generic/portrait_manager/scenario_portrait_manager_dialog.py modules/generic/portrait_manager/swarmui_portrait_generator.py modules/generic/portrait_manager/components/generated_portrait_selection_dialog.py` which succeeded. 
- Ran unit tests `python -m pytest tests/generic/portrait_manager/test_entity_portrait_actions.py tests/generic/portrait_manager/test_generic_list_view_menu_static.py` and they passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5612f1c3a8832b995ac3ab4d1ed7aa)