### PR TITLE
Extract shared SwarmUI portrait service and adapt editor/dialog to use it

### DIFF
--- a/modules/generic/editor/window_components/portrait_and_image_workflows.py
+++ b/modules/generic/editor/window_components/portrait_and_image_workflows.py
@@ -7,6 +7,14 @@ from modules.generic.editor.window_components.portrait_generation_dialog import 
     clamp_portrait_cfg_scale,
     clamp_portrait_image_count,
 )
+from modules.helpers.swarmui_portrait_service import (
+    PortraitGenerationSource,
+    SwarmUIPortraitSettings,
+    cleanup_swarmui,
+    generate_portrait_candidates,
+    launch_swarmui,
+    save_generated_portrait_candidate,
+)
 
 
 class GenericEditorWindowPortraitAndImageWorkflows:
@@ -419,39 +427,19 @@ class GenericEditorWindowPortraitAndImageWorkflows:
 
         messagebox.showinfo("Paste Image", "Clipboard content is not an image.")
     def launch_swarmui(self):
-        """Launch swarmui."""
-        global SWARMUI_PROCESS
-        # Retrieve the SwarmUI path from config.ini
-        swarmui_path = ConfigHelper.get("Paths", "swarmui_path", fallback=r"E:\SwarmUI\SwarmUI")
-        # Build the command by joining the path with the batch file name
-        SWARMUI_CMD = os.path.join(swarmui_path, "launch-windows.bat")
-        env = os.environ.copy()
-        env.pop('VIRTUAL_ENV', None)
-        if SWARMUI_PROCESS is None or SWARMUI_PROCESS.poll() is not None:
-            try:
-                # Keep swarmui resilient if this step fails.
-                SWARMUI_PROCESS = subprocess.Popen(
-                    SWARMUI_CMD,
-                    shell=True,
-                    cwd=swarmui_path,
-                    env=env
-                )
-                # Wait a little for the process to initialize.
-                time.sleep(120.0)
-            except Exception as e:
-                messagebox.showerror("Error", f"Failed to launch SwarmUI: {e}")
+        """Launch SwarmUI through the shared portrait service."""
+        try:
+            launch_swarmui()
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to launch SwarmUI: {e}")
+
     def cleanup_swarmui(self):
-        """
-        Terminate the SwarmUI process if it is running.
-        """
-        global SWARMUI_PROCESS
-        if SWARMUI_PROCESS is not None and SWARMUI_PROCESS.poll() is None:
-            SWARMUI_PROCESS.terminate()
+        """Terminate the SwarmUI process if it is running."""
+        cleanup_swarmui()
+
     def create_portrait_with_swarmui(self):
         """Create a portrait by delegating image generation to SwarmUI."""
-
         self.launch_swarmui()
-        # Ask for model
         model_options = get_available_models()
         if not model_options:
             messagebox.showerror("Error", "No models available in SwarmUI models folder.")
@@ -472,99 +460,46 @@ class GenericEditorWindowPortraitAndImageWorkflows:
             image_count=dialog.result["image_count"],
             cfgscale=dialog.result["cfgscale"],
         )
+
     def generate_portrait(self, selected_model, image_count=None, cfgscale=None):
-        """
-        Generates a portrait image using the SwarmUI API and associates the resulting
-        image with the current NPC by updating its 'Portrait' field.
-        """
-        SWARM_API_URL = "http://127.0.0.1:7801"  # Change if needed
+        """Generate and attach a portrait using the shared SwarmUI service."""
+        key_field = self.model_wrapper._infer_key_field() if self.model_wrapper else "Name"
+        entity_name = str(
+            self.item.get(key_field)
+            or self.item.get("Name")
+            or self.item.get("Title")
+            or "Unknown"
+        )
+        source = PortraitGenerationSource(name=entity_name, record=self.item, key_field=key_field)
+        settings = SwarmUIPortraitSettings(
+            model=str(selected_model),
+            image_count=clamp_portrait_image_count(image_count),
+            cfgscale=clamp_portrait_cfg_scale(cfgscale),
+        )
+
         try:
-            # Step 1: Obtain a new session from SwarmUI
-            session_url = f"{SWARM_API_URL}/API/GetNewSession"
-            session_response = requests.post(session_url, json={}, headers={"Content-Type": "application/json"})
-            session_data = session_response.json()
-            session_id = session_data.get("session_id")
-            if not session_id:
-                messagebox.showerror("Error", "Failed to obtain session ID from Swarm API.")
-                return
-
-            # Build a prompt based on the current NPC's data (you can enhance this as needed)
-            npc_name = self.item.get("Name", "Unknown")
-            npc_role = self.item.get("Role", "Unknown")
-            npc_faction = self.item.get("Factions", "Unknown")
-            npc_object = self.item.get("Objects", "Unknown")
-            npc_desc = self.item.get("Description", "Unknown") 
-            npc_desc =  text_helpers.format_longtext(npc_desc)
-            npc_desc = f"{npc_desc} {npc_role} {npc_faction} {npc_object}"
-            prompt = f"{npc_desc}"
-
-            # Step 2: Define image generation parameters
-            prompt_data = {
-                "session_id": session_id,
-                "images": clamp_portrait_image_count(image_count),  # Generate selected candidates
-                "prompt": prompt,
-                "negativeprompt": "blurry, low quality, comics style, mangastyle, paint style, watermark, ugly, monstrous, too many fingers, too many legs, too many arms, bad hands, unrealistic weapons, bad grip on equipment, nude",
-                "model": selected_model,
-                "width": 1024,
-                "height": 1024,
-                "cfgscale": clamp_portrait_cfg_scale(cfgscale),
-                "steps": 20,
-                "seed": -1
-            }
-            generate_url = f"{SWARM_API_URL}/API/GenerateText2Image"
-            image_response = requests.post(generate_url, json=prompt_data, headers={"Content-Type": "application/json"})
-            image_data = image_response.json()
-
-            images = image_data.get("images")
-            if not images or len(images) == 0:
-                messagebox.showerror("Error", "Image generation failed. Check API response.")
-                return
-
-            # Step 3: Download all generated images into memory
-            thumbs = []
-            images_bytes = []
-            for rel_path in images:
-                try:
-                    # Keep generate portrait resilient if this step fails.
-                    url = f"{SWARM_API_URL}/{rel_path}"
-                    resp = requests.get(url)
-                    if resp.status_code == 200:
-                        images_bytes.append(resp.content)
-                        img = Image.open(BytesIO(resp.content)).convert("RGB")
-                        thumb = img.copy()
-                        thumb.thumbnail((256, 256))
-                        thumbs.append(thumb)
-                except Exception:
-                    continue
-
-            if not thumbs:
-                messagebox.showerror("Error", "Failed to download generated images.")
-                return
-
-            # Step 4: Let user choose one of the generated images
-            chosen_index = self._show_image_selection_window(thumbs)
-            if chosen_index is None or chosen_index < 0 or chosen_index >= len(images_bytes):
-                return  # User cancelled
-
-            chosen_bytes = images_bytes[chosen_index]
-
-            # Step 5: Save the chosen image locally and update the NPC's Portrait field
-            output_filename = f"{safe_filename_component(npc_name, fallback='Unknown')}_portrait.png"
-            with open(output_filename, "wb") as f:
-                f.write(chosen_bytes)
-
-            # Associate the selected portrait with the NPC data.
-            generated_path = self.copy_and_resize_portrait(output_filename)
-            self._add_portrait_path(generated_path, make_primary=not self.portrait_paths)
-
-            # Copy the original generated file to assets/generated and delete local temp
-            GENERATED_FOLDER = os.path.join(ConfigHelper.get_campaign_dir(), "assets", "generated")
-            os.makedirs(GENERATED_FOLDER, exist_ok=True)
-            shutil.copy(output_filename, os.path.join(GENERATED_FOLDER, output_filename))
-            os.remove(output_filename)
-
+            template = load_template(self.model_wrapper.entity_type) if self.model_wrapper else None
+            candidates = generate_portrait_candidates(source, settings, template=template)
         except Exception as e:
             messagebox.showerror("Error", f"An error occurred: {e}")
+            return
+
+        chosen_index = self._show_image_selection_window([candidate.thumbnail for candidate in candidates])
+        if chosen_index is None or chosen_index < 0 or chosen_index >= len(candidates):
+            return
+
+        try:
+            result = save_generated_portrait_candidate(
+                source,
+                candidates[chosen_index],
+                copy_portrait=lambda src_path, _name: self.copy_and_resize_portrait(src_path),
+            )
+        except Exception as e:
+            messagebox.showerror("Error", f"Unable to save selected portrait: {e}")
+            return
+
+        for portrait_path in result.portrait_paths:
+            self._add_portrait_path(portrait_path, make_primary=not self.portrait_paths)
     def _show_image_selection_window(self, pil_images):
         """
         Display a modal window with thumbnails side by side for the user to choose.

--- a/modules/generic/portrait_manager/swarmui_portrait_generator.py
+++ b/modules/generic/portrait_manager/swarmui_portrait_generator.py
@@ -1,103 +1,33 @@
-"""Reusable SwarmUI portrait generation for scenario portrait workflows."""
+"""Scenario portrait adapters for the shared SwarmUI portrait service."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from io import BytesIO
-import os
-from pathlib import Path
-import shutil
-import subprocess
-import tempfile
-import time
-from typing import Any, Callable
-
-import customtkinter as ctk
-from PIL import Image
-import requests
+from typing import Any
 
 from modules.generic.portrait_manager.entity_portrait_actions import (
     ScenarioPortraitEntity,
     copy_portrait_to_campaign,
 )
-from modules.helpers import text_helpers
-from modules.helpers.config_helper import ConfigHelper
-from modules.helpers.filename_helper import safe_filename_component
-
-
-SWARM_API_URL = "http://127.0.0.1:7801"
-NEGATIVE_PROMPT = (
-    "blurry, low quality, comics style, mangastyle, paint style, watermark, "
-    "ugly, monstrous, too many fingers, too many legs, too many arms, bad hands, "
-    "unrealistic weapons, bad grip on equipment, nude"
+from modules.helpers.swarmui_portrait_service import (
+    GeneratedPortraitCandidate,
+    GeneratedPortraitResult,
+    PortraitGenerationSource,
+    SwarmUIPortraitError,
+    SwarmUIPortraitSettings,
+    build_portrait_prompt,
+    cleanup_swarmui,
+    generate_portrait_candidates,
+    launch_swarmui,
+    save_generated_portrait_candidate as save_portrait_candidate,
 )
 
-SWARMUI_PROCESS = None
 
-
-@dataclass(frozen=True)
-class SwarmUIPortraitSettings:
-    """SwarmUI generation settings selected by the user."""
-
-    model: str
-    image_count: int
-    cfgscale: float
-
-
-@dataclass(frozen=True)
-class GeneratedPortraitCandidate:
-    """A downloaded SwarmUI portrait candidate before user selection."""
-
-    image_bytes: bytes
-    thumbnail: Image.Image
-
-
-@dataclass(frozen=True)
-class GeneratedPortraitResult:
-    """Paths produced by a successful portrait generation."""
-
-    portrait_paths: list[str]
-    generated_asset_paths: list[str]
-
-
-def launch_swarmui() -> None:
-    """Launch SwarmUI when it is not already running."""
-    global SWARMUI_PROCESS
-    swarmui_path = ConfigHelper.get("Paths", "swarmui_path", fallback=r"E:\SwarmUI\SwarmUI")
-    swarmui_cmd = os.path.join(swarmui_path, "launch-windows.bat")
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    if SWARMUI_PROCESS is None or SWARMUI_PROCESS.poll() is not None:
-        SWARMUI_PROCESS = subprocess.Popen(
-            swarmui_cmd,
-            shell=True,
-            cwd=swarmui_path,
-            env=env,
-        )
-        time.sleep(120.0)
-
-
-def build_portrait_prompt(
-    entity: ScenarioPortraitEntity,
-    template: dict[str, Any] | None = None,
-    *,
-    prompt_fields: list[str] | None = None,
-) -> str:
-    """Build a SwarmUI prompt from an entity record and its template fields."""
-    fields = prompt_fields or _default_prompt_fields(entity, template)
-    parts: list[str] = []
-    for field_name in fields:
-        if field_name == "Portrait":
-            continue
-        value = entity.record.get(field_name)
-        if value in (None, ""):
-            continue
-        if isinstance(value, str):
-            text = text_helpers.format_longtext(value).strip()
-        else:
-            text = text_helpers.format_longtext(value).strip()
-        if text:
-            parts.append(text)
-    return " ".join(parts) or entity.name or "fantasy portrait"
+def portrait_source_from_entity(entity: ScenarioPortraitEntity) -> PortraitGenerationSource:
+    """Create a generic portrait generation source from a scenario entity."""
+    return PortraitGenerationSource(
+        name=entity.name,
+        record=entity.record,
+        key_field=entity.key_field,
+    )
 
 
 def generate_scenario_portrait_candidates(
@@ -107,225 +37,37 @@ def generate_scenario_portrait_candidates(
     template: dict[str, Any] | None = None,
     prompt_fields: list[str] | None = None,
 ) -> list[GeneratedPortraitCandidate]:
-    """Generate and download SwarmUI portrait candidates without selecting or saving them."""
-    session_id = _get_swarm_session_id()
-    prompt = build_portrait_prompt(entity, template, prompt_fields=prompt_fields)
-    image_paths = _request_swarm_images(session_id, prompt, settings)
-    image_bytes = _download_generated_images(image_paths)
-    if not image_bytes:
-        raise RuntimeError("Failed to download generated images.")
-    return [
-        GeneratedPortraitCandidate(image_bytes=content, thumbnail=_make_thumbnail(content))
-        for content in image_bytes
-    ]
+    """Generate portrait candidates for a scenario entity using shared service code."""
+    return generate_portrait_candidates(
+        portrait_source_from_entity(entity),
+        settings,
+        template=template,
+        prompt_fields=prompt_fields,
+    )
 
 
 def save_generated_portrait_candidate(
     entity: ScenarioPortraitEntity,
     candidate: GeneratedPortraitCandidate,
 ) -> GeneratedPortraitResult:
-    """Persist a selected generated candidate and return campaign-relative portrait paths."""
-    portrait_path, generated_path = _store_selected_portrait(entity, candidate.image_bytes)
-    return GeneratedPortraitResult(
-        portrait_paths=[portrait_path],
-        generated_asset_paths=[generated_path] if generated_path else [],
+    """Persist a selected scenario portrait candidate."""
+    return save_portrait_candidate(
+        portrait_source_from_entity(entity),
+        candidate,
+        copy_portrait=copy_portrait_to_campaign,
     )
 
 
-def generate_scenario_portrait(
-    parent,
-    entity: ScenarioPortraitEntity,
-    settings: SwarmUIPortraitSettings,
-    *,
-    template: dict[str, Any] | None = None,
-    prompt_fields: list[str] | None = None,
-    on_generated: Callable[[GeneratedPortraitResult], None] | None = None,
-) -> GeneratedPortraitResult | None:
-    """Generate, select, and persist generated portrait assets for a scenario entity.
-
-    Returns campaign-relative portrait paths suitable for ``set_entity_portraits``.
-    """
-    candidates = generate_scenario_portrait_candidates(
-        entity,
-        settings,
-        template=template,
-        prompt_fields=prompt_fields,
-    )
-    chosen_index = show_image_selection_window(parent, [candidate.thumbnail for candidate in candidates])
-    if chosen_index is None or chosen_index < 0 or chosen_index >= len(candidates):
-        return None
-
-    result = save_generated_portrait_candidate(entity, candidates[chosen_index])
-    if callable(on_generated):
-        on_generated(result)
-    return result
-
-
-def _default_prompt_fields(
-    entity: ScenarioPortraitEntity,
-    template: dict[str, Any] | None,
-) -> list[str]:
-    preferred = [
-        "Description",
-        "Role",
-        "Title",
-        "Archetype",
-        "Factions",
-        "Objects",
-        "Personality",
-        "Traits",
-        "Background",
-        "Motivation",
-        "CurrentObjective",
-        "Scheme",
-        "Notes",
-    ]
-    template_names = [
-        str(field.get("name"))
-        for field in (template or {}).get("fields", [])
-        if isinstance(field, dict) and field.get("name")
-    ]
-    selected = [name for name in preferred if name in entity.record]
-    selected.extend(name for name in template_names if name not in selected and name in entity.record)
-    key_field = entity.key_field
-    if key_field in entity.record and key_field not in selected:
-        selected.insert(0, key_field)
-    elif "Name" in entity.record and "Name" not in selected:
-        selected.insert(0, "Name")
-    return selected
-
-
-def _get_swarm_session_id() -> str:
-    session_url = f"{SWARM_API_URL}/API/GetNewSession"
-    response = requests.post(session_url, json={}, headers={"Content-Type": "application/json"})
-    response.raise_for_status()
-    session_id = response.json().get("session_id")
-    if not session_id:
-        raise RuntimeError("Failed to obtain session ID from Swarm API.")
-    return session_id
-
-
-def _request_swarm_images(
-    session_id: str,
-    prompt: str,
-    settings: SwarmUIPortraitSettings,
-) -> list[str]:
-    prompt_data = {
-        "session_id": session_id,
-        "images": settings.image_count,
-        "prompt": prompt,
-        "negativeprompt": NEGATIVE_PROMPT,
-        "model": settings.model,
-        "width": 1024,
-        "height": 1024,
-        "cfgscale": settings.cfgscale,
-        "steps": 20,
-        "seed": -1,
-    }
-    generate_url = f"{SWARM_API_URL}/API/GenerateText2Image"
-    response = requests.post(generate_url, json=prompt_data, headers={"Content-Type": "application/json"})
-    response.raise_for_status()
-    images = response.json().get("images")
-    if not images:
-        raise RuntimeError("Image generation failed. Check API response.")
-    return list(images)
-
-
-def _download_generated_images(image_paths: list[str]) -> list[bytes]:
-    images_bytes: list[bytes] = []
-    for rel_path in image_paths:
-        try:
-            response = requests.get(f"{SWARM_API_URL}/{rel_path}")
-            response.raise_for_status()
-            images_bytes.append(response.content)
-        except Exception:
-            continue
-    return images_bytes
-
-
-def _make_thumbnail(content: bytes) -> Image.Image:
-    image = Image.open(BytesIO(content)).convert("RGB")
-    thumb = image.copy()
-    thumb.thumbnail((256, 256))
-    return thumb
-
-
-def _store_selected_portrait(entity: ScenarioPortraitEntity, content: bytes) -> tuple[str, str]:
-    campaign_dir = Path(ConfigHelper.get_campaign_dir())
-    generated_folder = campaign_dir / "assets" / "generated"
-    generated_folder.mkdir(parents=True, exist_ok=True)
-    output_filename = f"{safe_filename_component(entity.name, fallback='Unknown')}_portrait_{time.time_ns()}.png"
-    generated_path = generated_folder / output_filename
-
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as temp_file:
-        temp_file.write(content)
-        temp_path = temp_file.name
-
-    try:
-        portrait_path = copy_portrait_to_campaign(temp_path, entity.name)
-        shutil.copy(temp_path, generated_path)
-    finally:
-        try:
-            os.remove(temp_path)
-        except OSError:
-            pass
-
-    try:
-        generated_relative = generated_path.relative_to(campaign_dir).as_posix()
-    except ValueError:
-        generated_relative = generated_path.as_posix()
-    return portrait_path, generated_relative
-
-
-def show_image_selection_window(parent, pil_images: list[Image.Image]) -> int | None:
-    """Display generated portrait thumbnails and return the selected index."""
-    if not pil_images:
-        return None
-
-    top = ctk.CTkToplevel(parent)
-    top.title("Choose a Portrait")
-    top.transient(parent)
-    top.grab_set()
-
-    container = ctk.CTkFrame(top)
-    container.pack(padx=10, pady=10, fill="both", expand=True)
-
-    ctk_images = []
-    selected = {"idx": None}
-
-    def on_choose(index: int) -> None:
-        selected["idx"] = index
-        top.destroy()
-
-    cols = min(5, max(1, len(pil_images)))
-    for index, image in enumerate(pil_images):
-        ctk_image = ctk.CTkImage(light_image=image, size=(180, 180))
-        ctk_images.append(ctk_image)
-        button = ctk.CTkButton(
-            container,
-            image=ctk_image,
-            text=f"#{index + 1}",
-            compound="top",
-            width=188,
-            height=214,
-            command=lambda idx=index: on_choose(idx),
-        )
-        button.grid(row=index // cols, column=index % cols, padx=6, pady=6, sticky="nsew")
-
-    def cancel() -> None:
-        selected["idx"] = None
-        top.destroy()
-
-    ctk.CTkButton(top, text="Cancel", command=cancel).pack(pady=5)
-
-    top.update_idletasks()
-    rows = (len(pil_images) + cols - 1) // cols
-    total_w = cols * (188 + 14) + 40
-    total_h = rows * (214 + 14) + 90
-    try:
-        top.geometry(f"{total_w}x{total_h}")
-    except Exception:
-        pass
-
-    top.wait_window()
-    return selected["idx"]
+__all__ = [
+    "GeneratedPortraitCandidate",
+    "GeneratedPortraitResult",
+    "PortraitGenerationSource",
+    "SwarmUIPortraitError",
+    "SwarmUIPortraitSettings",
+    "build_portrait_prompt",
+    "cleanup_swarmui",
+    "generate_scenario_portrait_candidates",
+    "launch_swarmui",
+    "portrait_source_from_entity",
+    "save_generated_portrait_candidate",
+]

--- a/modules/helpers/swarmui_portrait_service.py
+++ b/modules/helpers/swarmui_portrait_service.py
@@ -1,0 +1,263 @@
+"""UI-independent SwarmUI portrait generation service."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Any, Protocol
+
+from PIL import Image
+import requests
+
+from modules.helpers import text_helpers
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.filename_helper import safe_filename_component
+
+SWARM_API_URL = "http://127.0.0.1:7801"
+NEGATIVE_PROMPT = (
+    "blurry, low quality, comics style, mangastyle, paint style, watermark, "
+    "ugly, monstrous, too many fingers, too many legs, too many arms, bad hands, "
+    "unrealistic weapons, bad grip on equipment, nude"
+)
+
+_SWARMUI_PROCESS: subprocess.Popen | None = None
+
+
+class HttpClient(Protocol):
+    """Small protocol for mocking SwarmUI HTTP calls in tests."""
+
+    def post(self, url: str, **kwargs): ...
+    def get(self, url: str, **kwargs): ...
+
+
+@dataclass(frozen=True)
+class SwarmUIPortraitSettings:
+    """SwarmUI generation settings selected by the user."""
+
+    model: str
+    image_count: int
+    cfgscale: float
+    width: int = 1024
+    height: int = 1024
+    steps: int = 20
+    seed: int = -1
+
+
+@dataclass(frozen=True)
+class PortraitGenerationSource:
+    """Generic source data used to assemble a portrait prompt and filename."""
+
+    name: str
+    record: dict[str, Any]
+    key_field: str = "Name"
+
+
+@dataclass(frozen=True)
+class GeneratedPortraitCandidate:
+    """A downloaded SwarmUI portrait candidate before user selection."""
+
+    image_bytes: bytes
+    thumbnail: Image.Image
+
+
+@dataclass(frozen=True)
+class GeneratedPortraitResult:
+    """Paths produced by a successful portrait generation."""
+
+    portrait_paths: list[str]
+    generated_asset_paths: list[str]
+
+
+class SwarmUIPortraitError(RuntimeError):
+    """Raised when SwarmUI portrait generation or persistence fails."""
+
+
+def launch_swarmui(*, startup_delay: float = 120.0) -> None:
+    """Launch SwarmUI when it is not already running."""
+    global _SWARMUI_PROCESS
+    swarmui_path = ConfigHelper.get("Paths", "swarmui_path", fallback=r"E:\SwarmUI\SwarmUI")
+    swarmui_cmd = os.path.join(swarmui_path, "launch-windows.bat")
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    if _SWARMUI_PROCESS is None or _SWARMUI_PROCESS.poll() is not None:
+        _SWARMUI_PROCESS = subprocess.Popen(swarmui_cmd, shell=True, cwd=swarmui_path, env=env)
+        if startup_delay > 0:
+            time.sleep(startup_delay)
+
+
+def cleanup_swarmui() -> None:
+    """Terminate the SwarmUI process if this service started it."""
+    global _SWARMUI_PROCESS
+    if _SWARMUI_PROCESS is not None and _SWARMUI_PROCESS.poll() is None:
+        _SWARMUI_PROCESS.terminate()
+
+
+def build_portrait_prompt(
+    source: PortraitGenerationSource,
+    template: dict[str, Any] | None = None,
+    *,
+    prompt_fields: list[str] | None = None,
+) -> str:
+    """Build a reusable SwarmUI portrait prompt from source data."""
+    fields = prompt_fields or _default_prompt_fields(source, template)
+    parts: list[str] = []
+    for field_name in fields:
+        if field_name == "Portrait":
+            continue
+        value = source.record.get(field_name)
+        if value in (None, ""):
+            continue
+        text = text_helpers.format_longtext(value).strip()
+        if text:
+            parts.append(text)
+    return " ".join(parts) or source.name or "fantasy portrait"
+
+
+def generate_portrait_candidates(
+    source: PortraitGenerationSource,
+    settings: SwarmUIPortraitSettings,
+    *,
+    template: dict[str, Any] | None = None,
+    prompt_fields: list[str] | None = None,
+    http_client: HttpClient = requests,
+) -> list[GeneratedPortraitCandidate]:
+    """Generate and download SwarmUI portrait candidates without UI side effects."""
+    session_id = create_swarm_session(http_client=http_client)
+    prompt = build_portrait_prompt(source, template, prompt_fields=prompt_fields)
+    image_paths = request_text_to_image(session_id, prompt, settings, http_client=http_client)
+    image_bytes = download_generated_images(image_paths, http_client=http_client)
+    if not image_bytes:
+        raise SwarmUIPortraitError("Failed to download generated images.")
+    return [GeneratedPortraitCandidate(content, make_thumbnail(content)) for content in image_bytes]
+
+
+def create_swarm_session(*, http_client: HttpClient = requests) -> str:
+    """Create a SwarmUI API session and return its session id."""
+    response = http_client.post(f"{SWARM_API_URL}/API/GetNewSession", json={}, headers={"Content-Type": "application/json"})
+    response.raise_for_status()
+    session_id = response.json().get("session_id")
+    if not session_id:
+        raise SwarmUIPortraitError("Failed to obtain session ID from Swarm API.")
+    return str(session_id)
+
+
+def request_text_to_image(
+    session_id: str,
+    prompt: str,
+    settings: SwarmUIPortraitSettings,
+    *,
+    http_client: HttpClient = requests,
+) -> list[str]:
+    """Submit a GenerateText2Image request and return generated image paths."""
+    payload = {
+        "session_id": session_id,
+        "images": settings.image_count,
+        "prompt": prompt,
+        "negativeprompt": NEGATIVE_PROMPT,
+        "model": settings.model,
+        "width": settings.width,
+        "height": settings.height,
+        "cfgscale": settings.cfgscale,
+        "steps": settings.steps,
+        "seed": settings.seed,
+    }
+    response = http_client.post(f"{SWARM_API_URL}/API/GenerateText2Image", json=payload, headers={"Content-Type": "application/json"})
+    response.raise_for_status()
+    images = response.json().get("images")
+    if not images:
+        raise SwarmUIPortraitError("Image generation failed. Check API response.")
+    return [str(image) for image in images]
+
+
+def download_generated_images(image_paths: list[str], *, http_client: HttpClient = requests) -> list[bytes]:
+    """Download generated images, skipping individual failed downloads."""
+    images_bytes: list[bytes] = []
+    for rel_path in image_paths:
+        try:
+            response = http_client.get(f"{SWARM_API_URL}/{rel_path}")
+            response.raise_for_status()
+            images_bytes.append(response.content)
+        except Exception:
+            continue
+    return images_bytes
+
+
+def make_thumbnail(content: bytes, size: tuple[int, int] = (256, 256)) -> Image.Image:
+    """Create a PIL thumbnail for a generated image."""
+    image = Image.open(BytesIO(content)).convert("RGB")
+    thumbnail = image.copy()
+    thumbnail.thumbnail(size)
+    return thumbnail
+
+
+def save_generated_portrait_candidate(
+    source: PortraitGenerationSource,
+    candidate: GeneratedPortraitCandidate,
+    *,
+    copy_portrait,
+) -> GeneratedPortraitResult:
+    """Persist a selected candidate to portraits and assets/generated."""
+    portrait_path, generated_path = store_generated_portrait_bytes(
+        source.name,
+        candidate.image_bytes,
+        copy_portrait=copy_portrait,
+    )
+    return GeneratedPortraitResult([portrait_path], [generated_path] if generated_path else [])
+
+
+def store_generated_portrait_bytes(entity_name: str, content: bytes, *, copy_portrait) -> tuple[str, str]:
+    """Copy selected generated bytes to campaign portrait and generated folders."""
+    campaign_dir = Path(ConfigHelper.get_campaign_dir())
+    generated_folder = campaign_dir / "assets" / "generated"
+    generated_folder.mkdir(parents=True, exist_ok=True)
+    filename = create_generated_portrait_filename(entity_name)
+    generated_path = generated_folder / filename
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as temp_file:
+        temp_file.write(content)
+        temp_path = temp_file.name
+
+    try:
+        portrait_path = copy_portrait(temp_path, entity_name)
+        shutil.copy(temp_path, generated_path)
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+
+    try:
+        generated_relative = generated_path.relative_to(campaign_dir).as_posix()
+    except ValueError:
+        generated_relative = generated_path.as_posix()
+    return portrait_path, generated_relative
+
+
+def create_generated_portrait_filename(entity_name: str, *, suffix: str = ".png") -> str:
+    """Create a safe unique filename for a generated portrait."""
+    safe_name = safe_filename_component(entity_name, fallback="Unknown")
+    return f"{safe_name}_portrait_{time.time_ns()}{suffix}"
+
+
+def _default_prompt_fields(source: PortraitGenerationSource, template: dict[str, Any] | None) -> list[str]:
+    preferred = [
+        "Description", "Role", "Title", "Archetype", "Factions", "Objects", "Personality",
+        "Traits", "Background", "Motivation", "CurrentObjective", "Scheme", "Notes",
+    ]
+    template_names = [
+        str(field.get("name"))
+        for field in (template or {}).get("fields", [])
+        if isinstance(field, dict) and field.get("name")
+    ]
+    selected = [name for name in preferred if name in source.record]
+    selected.extend(name for name in template_names if name not in selected and name in source.record)
+    if source.key_field in source.record and source.key_field not in selected:
+        selected.insert(0, source.key_field)
+    elif "Name" in source.record and "Name" not in selected:
+        selected.insert(0, "Name")
+    return selected

--- a/tests/generic/portrait_manager/test_swarmui_portrait_service.py
+++ b/tests/generic/portrait_manager/test_swarmui_portrait_service.py
@@ -1,0 +1,85 @@
+"""Tests for the UI-independent SwarmUI portrait service."""
+from __future__ import annotations
+
+import base64
+
+from modules.helpers import swarmui_portrait_service
+from modules.helpers.swarmui_portrait_service import (
+    SWARM_API_URL,
+    PortraitGenerationSource,
+    SwarmUIPortraitSettings,
+    build_portrait_prompt,
+    create_generated_portrait_filename,
+    generate_portrait_candidates,
+)
+
+
+class FakeResponse:
+    def __init__(self, *, payload=None, content: bytes = b""):
+        self._payload = payload or {}
+        self.content = content
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class FakeHttpClient:
+    def __init__(self, image_bytes: bytes):
+        self.image_bytes = image_bytes
+        self.posts = []
+        self.gets = []
+
+    def post(self, url: str, **kwargs):
+        self.posts.append((url, kwargs))
+        if url.endswith("/API/GetNewSession"):
+            return FakeResponse(payload={"session_id": "session-1"})
+        if url.endswith("/API/GenerateText2Image"):
+            return FakeResponse(payload={"images": ["View/local/image.png"]})
+        raise AssertionError(f"Unexpected POST URL: {url}")
+
+    def get(self, url: str, **kwargs):
+        self.gets.append((url, kwargs))
+        return FakeResponse(content=self.image_bytes)
+
+
+def _png_bytes() -> bytes:
+    return base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nO3OQQ0AIBDAsAP/nuGNAvZoFSzZOjNnyNi/AwAAAAAAAAAAXgOShgHBiIFQyQAAAABJRU5ErkJggg=="
+    )
+
+
+def test_generate_portrait_candidates_uses_mocked_swarmui_http_client(monkeypatch) -> None:
+    http_client = FakeHttpClient(_png_bytes())
+    source = PortraitGenerationSource(
+        name="Captain Test",
+        record={"Name": "Captain Test", "Description": "A brave pilot", "Role": "Ace"},
+    )
+    settings = SwarmUIPortraitSettings(model="test-model", image_count=2, cfgscale=7.5)
+    monkeypatch.setattr(swarmui_portrait_service, "make_thumbnail", lambda content: "thumbnail")
+
+    candidates = generate_portrait_candidates(source, settings, http_client=http_client)
+
+    assert len(candidates) == 1
+    assert candidates[0].image_bytes == http_client.image_bytes
+    assert candidates[0].thumbnail == "thumbnail"
+    assert http_client.posts[0][0] == f"{SWARM_API_URL}/API/GetNewSession"
+    generate_url, generate_kwargs = http_client.posts[1]
+    assert generate_url == f"{SWARM_API_URL}/API/GenerateText2Image"
+    assert generate_kwargs["json"]["session_id"] == "session-1"
+    assert generate_kwargs["json"]["prompt"] == "Captain Test A brave pilot Ace"
+    assert generate_kwargs["json"]["images"] == 2
+    assert generate_kwargs["json"]["model"] == "test-model"
+    assert http_client.gets[0][0] == f"{SWARM_API_URL}/View/local/image.png"
+
+
+def test_prompt_and_filename_helpers_are_safe_and_reusable() -> None:
+    source = PortraitGenerationSource(
+        name="Unsafe / Name",
+        record={"Name": "Unsafe / Name", "Portrait": "ignored", "Description": "Useful text"},
+    )
+
+    assert build_portrait_prompt(source, prompt_fields=["Portrait", "Description"]) == "Useful text"
+    assert create_generated_portrait_filename("Unsafe / Name").startswith("Unsafe_Name_portrait_")


### PR DESCRIPTION
### Motivation
- Separate reusable SwarmUI generation logic from editor UI so prompt assembly, session creation, HTTP requests, downloads and storage are testable and usable from multiple callers.
- Keep editor/dialog code focused on UI (model selection, user interaction and selection) and make generation logic independent of `GenericEditorWindow` or other UI classes.
- Provide clear error/reporting via structured exceptions/results and make HTTP interactions mockable for unit tests.

### Description
- Added a UI-independent service `modules/helpers/swarmui_portrait_service.py` that implements dataclasses (`SwarmUIPortraitSettings`, `PortraitGenerationSource`, `GeneratedPortraitCandidate`, `GeneratedPortraitResult`), a small `HttpClient` protocol for mocking, session creation (`create_swarm_session`), text-to-image request (`request_text_to_image`), image downloading, thumbnail creation (`make_thumbnail`), generated asset persistence (`store_generated_portrait_bytes`), safe filename helper (`create_generated_portrait_filename`), and SwarmUI process `launch_swarmui`/`cleanup_swarmui` helpers.
- Converted `modules/generic/portrait_manager/swarmui_portrait_generator.py` into a thin adapter that maps `ScenarioPortraitEntity` into the shared service `PortraitGenerationSource` and re-exports the scenario-targeted helpers (`generate_scenario_portrait_candidates`, `save_generated_portrait_candidate`, etc.).
- Updated editor flow in `modules/generic/editor/window_components/portrait_and_image_workflows.py` to delegate generation, session and persistence operations to the shared service while preserving UI responsibilities (model selection, `PortraitGenerationDialog`, thumbnail selection and attaching the saved portrait via `copy_and_resize_portrait` and `_add_portrait_path`).
- Added unit tests `tests/generic/portrait_manager/test_swarmui_portrait_service.py` which mock HTTP interactions to validate session creation, `GenerateText2Image` payload assembly, download URL usage, prompt building and safe filename creation.

### Testing
- Ran Python syntax check with `python3 -m py_compile` on modified modules and it succeeded.
- Executed `pytest -q tests/generic/portrait_manager/test_swarmui_portrait_service.py` and the test passed (mocked HTTP flow verified).
- Ran a selection of related unit tests including `tests/generic/portrait_manager/test_entity_portrait_actions.py`, `tests/test_portrait_generation_dialog.py`, and `tests/generic/editor/test_asset_attach_paths.py` and they all passed (full run reported all selected tests passing).
- Overall automated checks (`py_compile` + the above `pytest` runs) completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5616d8c788832b92690681bd96ef3f)