### PR TITLE
Fix portrait generation dialog height

### DIFF
--- a/modules/generic/editor/window_components/portrait_generation_dialog.py
+++ b/modules/generic/editor/window_components/portrait_generation_dialog.py
@@ -96,8 +96,8 @@ class PortraitGenerationDialog(ctk.CTkToplevel):
         self._cfg_label_var = ctk.StringVar()
 
         self.title("Portrait Generation")
-        self.geometry("520x590")
-        self.minsize(500, 560)
+        self.geometry("520x680")
+        self.minsize(500, 650)
         self.transient(master)
         self.grab_set()
         self._build_ui()


### PR DESCRIPTION
### Motivation
- The Portrait Generation dialog was too short and its bottom action buttons were nearly hidden, making the controls hard to use.

### Description
- Increased the dialog default size and minimum height in `PortraitGenerationDialog` (changed `self.geometry("520x590")` → `self.geometry("520x680")` and `self.minsize(500, 560)` → `self.minsize(500, 650)`) in `modules/generic/editor/window_components/portrait_generation_dialog.py` to prevent clipping.

### Testing
- Ran `python -m py_compile modules/generic/editor/window_components/portrait_generation_dialog.py` which succeeded.
- Ran `pytest -q tests/test_portrait_generation_dialog.py` which completed with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a572c1fc600832b8ac9ccd4c371e169)