### PR TITLE
Add persistent campaign synchronization metadata

### DIFF
--- a/modules/generic/campaign_sync/__init__.py
+++ b/modules/generic/campaign_sync/__init__.py
@@ -1,0 +1,5 @@
+"""Campaign synchronization identity, revisions, and snapshot utilities."""
+
+from .models import CampaignSyncMetadata, RemoteCampaignRevision
+
+__all__ = ["CampaignSyncMetadata", "RemoteCampaignRevision"]

--- a/modules/generic/campaign_sync/hashing.py
+++ b/modules/generic/campaign_sync/hashing.py
@@ -1,0 +1,28 @@
+"""Deterministic SHA-256 hashing for campaign snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_campaign_snapshot(campaign_root: Path) -> str:
+    """Hash names and contents, excluding local sync bookkeeping."""
+    root = Path(campaign_root).resolve()
+    digest = hashlib.sha256()
+    for path in sorted((item for item in root.rglob("*") if item.is_file()), key=lambda item: item.relative_to(root).as_posix()):
+        relative = path.relative_to(root).as_posix()
+        if relative.startswith(".gmcd/"):
+            continue
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(bytes.fromhex(sha256_file(path)))
+    return digest.hexdigest()

--- a/modules/generic/campaign_sync/metadata_store.py
+++ b/modules/generic/campaign_sync/metadata_store.py
@@ -1,0 +1,74 @@
+"""Atomic persistence for shared and installation-local sync state."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
+
+from .models import CampaignSyncMetadata
+
+SYNC_RELATIVE_PATH = Path(".gmcd") / "sync.json"
+
+
+def _atomic_json_write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+@dataclass
+class CampaignSyncMetadataStore:
+    campaign_root: Path
+
+    @property
+    def path(self) -> Path:
+        return Path(self.campaign_root) / SYNC_RELATIVE_PATH
+
+    def read(self) -> Optional[CampaignSyncMetadata]:
+        if not self.path.exists():
+            return None
+        value = json.loads(self.path.read_text(encoding="utf-8"))
+        return CampaignSyncMetadata.from_dict(value)
+
+    def write(self, metadata: CampaignSyncMetadata) -> None:
+        _atomic_json_write(self.path, metadata.to_dict())
+
+
+class InstallationStateStore:
+    """Machine-local state, deliberately stored outside every campaign."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = Path(path or (Path.home() / ".gmcd" / "installation.json"))
+
+    def read(self) -> dict:
+        if not self.path.exists():
+            return {}
+        value = json.loads(self.path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
+
+    def write(self, state: dict) -> None:
+        _atomic_json_write(self.path, state)
+
+    def installation_id(self) -> str:
+        state = self.read()
+        value = state.get("installation_id")
+        if value:
+            return str(value)
+        value = str(uuid4())
+        state["installation_id"] = value
+        self.write(state)
+        return value

--- a/modules/generic/campaign_sync/models.py
+++ b/modules/generic/campaign_sync/models.py
@@ -1,0 +1,94 @@
+"""Typed data exchanged by campaign synchronization components."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+
+def _valid_uuid(value: str) -> str:
+    return str(UUID(str(value)))
+
+
+def _valid_sha256(value: str) -> str:
+    normalized = str(value).lower()
+    if len(normalized) != 64 or any(character not in "0123456789abcdef" for character in normalized):
+        raise ValueError("snapshot_sha256 must be a 64-character hexadecimal digest")
+    return normalized
+
+
+def _validate_revision(revision: int, parent_revision: Optional[int]) -> None:
+    if isinstance(revision, bool) or revision < 1:
+        raise ValueError("revision must be a positive integer")
+    if parent_revision is not None and (
+        isinstance(parent_revision, bool) or not 0 <= parent_revision < revision
+    ):
+        raise ValueError("parent_revision must precede revision")
+
+
+@dataclass(frozen=True)
+class CampaignSyncMetadata:
+    """Shared, campaign-local synchronization metadata."""
+
+    campaign_id: str
+    revision: int
+    parent_revision: Optional[int]
+    snapshot_sha256: str
+    published_at: str
+    publisher_installation_id: str
+    bundle_version: int
+    change_summary: Optional[str] = None
+    snapshot_mode: str = "full_campaign"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "campaign_id", _valid_uuid(self.campaign_id))
+        object.__setattr__(self, "snapshot_sha256", _valid_sha256(self.snapshot_sha256))
+        _validate_revision(self.revision, self.parent_revision)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+    @classmethod
+    def from_dict(cls, value: Dict[str, Any]) -> "CampaignSyncMetadata":
+        return cls(
+            campaign_id=str(value["campaign_id"]),
+            revision=int(value["revision"]),
+            parent_revision=(int(value["parent_revision"]) if value.get("parent_revision") is not None else None),
+            snapshot_sha256=str(value.get("snapshot_sha256") or ""),
+            published_at=str(value.get("published_at") or ""),
+            publisher_installation_id=str(value.get("publisher_installation_id") or ""),
+            bundle_version=int(value.get("bundle_version") or 0),
+            change_summary=(str(value["change_summary"]) if value.get("change_summary") is not None else None),
+            snapshot_mode=str(value.get("snapshot_mode") or "full_campaign"),
+        )
+
+
+@dataclass(frozen=True)
+class RemoteCampaignRevision:
+    """Revision information discoverable from release metadata alone."""
+
+    campaign_id: str
+    revision: int
+    parent_revision: Optional[int]
+    snapshot_sha256: str
+    snapshot_mode: str
+    published_at: Optional[str] = None
+    change_summary: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "campaign_id", _valid_uuid(self.campaign_id))
+        object.__setattr__(self, "snapshot_sha256", _valid_sha256(self.snapshot_sha256))
+        _validate_revision(self.revision, self.parent_revision)
+
+    @classmethod
+    def from_dict(cls, value: Dict[str, Any]) -> "RemoteCampaignRevision":
+        return cls(
+            campaign_id=str(value["campaign_id"]),
+            revision=int(value["revision"]),
+            parent_revision=(int(value["parent_revision"]) if value.get("parent_revision") is not None else None),
+            snapshot_sha256=str(value.get("snapshot_sha256") or ""),
+            snapshot_mode=str(value.get("snapshot_mode") or "full_campaign"),
+            published_at=(str(value["published_at"]) if value.get("published_at") else None),
+            change_summary=(str(value["change_summary"]) if value.get("change_summary") else None),
+        )

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import json
-import os
 import shutil
 import sqlite3
 import tempfile
@@ -13,6 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Dict, Iterable, List, Optional, Tuple
+from uuid import uuid4
 
 from modules.audio.entity_audio import normalize_audio_reference
 from modules.generic.ambiance_wallpaper_bundle import (
@@ -31,6 +31,12 @@ from modules.generic.cross_campaign_gm_tables import (
     merge_gm_virtual_tables,
 )
 from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.generic.campaign_sync.hashing import hash_campaign_snapshot
+from modules.generic.campaign_sync.metadata_store import (
+    CampaignSyncMetadataStore,
+    InstallationStateStore,
+)
+from modules.generic.campaign_sync.models import CampaignSyncMetadata
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.portrait_helper import (
     parse_portrait_value,
@@ -704,6 +710,7 @@ def export_bundle(
     include_systems: bool = True,
     include_random_tables: bool = False,
     gm_virtual_tables: Optional[List[dict]] = None,
+    change_summary: Optional[str] = None,
     progress_callback=None,
 ) -> dict:
     """Export bundle."""
@@ -735,6 +742,22 @@ def export_bundle(
         "assets": [],
         "bundle_mode": "full_campaign" if include_database else "asset_bundle",
     }
+    if include_database:
+        sync_store = CampaignSyncMetadataStore(source_campaign.root)
+        previous_sync = sync_store.read()
+        revision = (previous_sync.revision + 1) if previous_sync else 1
+        sync_metadata = CampaignSyncMetadata(
+            campaign_id=(previous_sync.campaign_id if previous_sync else str(uuid4())),
+            revision=revision,
+            parent_revision=(previous_sync.revision if previous_sync else None),
+            snapshot_sha256=hash_campaign_snapshot(source_campaign.root),
+            published_at=manifest["created_at"],
+            publisher_installation_id=InstallationStateStore().installation_id(),
+            bundle_version=BUNDLE_VERSION,
+            change_summary=change_summary,
+            snapshot_mode="full_campaign",
+        )
+        manifest["sync"] = sync_metadata.to_dict()
 
     assets_lookup: Dict[str, Path] = {}
 
@@ -854,8 +877,9 @@ def export_bundle(
                     "file_name": source_campaign.db_path.name,
                     "relative_path": f"database/{source_campaign.db_path.name}",
                     "size": int(stat.st_size),
-                    "modified_at": datetime.utcfromtimestamp(stat.st_mtime).isoformat()
-                    + "Z",
+                    "modified_at": datetime.fromtimestamp(
+                        stat.st_mtime, timezone.utc
+                    ).isoformat().replace("+00:00", "Z"),
                 }
             except Exception as exc:
                 log_exception(
@@ -876,6 +900,11 @@ def export_bundle(
                     continue
                 arcname = file_path.relative_to(temp_root).as_posix()
                 zf.write(file_path, arcname)
+
+        # Advance local state only after the complete snapshot was written.  A
+        # failed export must not consume a revision number.
+        if include_database:
+            sync_store.write(sync_metadata)
 
         _call_progress(progress_callback, "Export completed", 1.0)
     finally:

--- a/modules/generic/github_gallery_client.py
+++ b/modules/generic/github_gallery_client.py
@@ -10,9 +10,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 from urllib.parse import quote
+from uuid import UUID
 
 import requests
 
+from modules.generic.campaign_sync.models import RemoteCampaignRevision
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.logging_helper import log_exception, log_info, log_module_import, log_warning
 from modules.helpers.secret_helper import decrypt_secret
@@ -47,6 +49,11 @@ class GalleryBundleSummary:
     is_draft: bool
     asset_count: int
     asset_download_count: int
+    campaign_id: Optional[str] = None
+    revision: Optional[int] = None
+    parent_revision: Optional[int] = None
+    snapshot_sha256: str = ""
+    snapshot_mode: str = ""
 
     @property
     def display_title(self) -> str:
@@ -181,6 +188,19 @@ class GithubGalleryClient:
         )
         return results
 
+    def highest_revision(
+        self, campaign_id: str, *, include_drafts: bool = False
+    ) -> Optional[GalleryBundleSummary]:
+        """Return the highest valid synchronized revision for an exact UUID."""
+        normalized_campaign_id = str(UUID(str(campaign_id)))
+        candidates = [
+            bundle
+            for bundle in self.list_bundles(include_drafts=include_drafts)
+            if bundle.campaign_id == normalized_campaign_id
+            and bundle.revision is not None
+        ]
+        return max(candidates, key=lambda bundle: bundle.revision or 0, default=None)
+
     # ----------------------------------------------------------- Downloading
     def download_bundle(
         self,
@@ -244,8 +264,14 @@ class GithubGalleryClient:
             raise FileNotFoundError(archive_path)
         session = self._create_session(auth=True)
         metadata = self._metadata_from_manifest(manifest, title, description)
-        tag_slug = _slugify(title or archive_path.stem)
-        tag_name = f"bundle-{tag_slug}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+        remote_revision = self._remote_revision_from_metadata(metadata)
+        if remote_revision is not None:
+            tag_name = (
+                f"campaign-{remote_revision.campaign_id}-r{remote_revision.revision}"
+            )
+        else:
+            tag_slug = _slugify(title or archive_path.stem)
+            tag_name = f"bundle-{tag_slug}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
         payload = {
             "tag_name": tag_name,
             "name": title,
@@ -357,6 +383,11 @@ class GithubGalleryClient:
         entity_counts: Dict[str, int] = {}
         source_campaign = ""
         manifest_created_at = ""
+        campaign_id = None
+        revision = None
+        parent_revision = None
+        snapshot_sha256 = ""
+        snapshot_mode = ""
         if isinstance(metadata, dict):
             # Handle the branch where isinstance(metadata, dict).
             description = str(metadata.get("description") or "")
@@ -373,6 +404,13 @@ class GithubGalleryClient:
             elif isinstance(source_data, str):
                 source_campaign = source_data
             manifest_created_at = str(metadata.get("created_at") or "")
+            remote_revision = self._remote_revision_from_metadata(metadata)
+            if remote_revision is not None:
+                campaign_id = remote_revision.campaign_id
+                revision = remote_revision.revision
+                parent_revision = remote_revision.parent_revision
+                snapshot_sha256 = remote_revision.snapshot_sha256
+                snapshot_mode = remote_revision.snapshot_mode
 
         summary = GalleryBundleSummary(
             release_id=int(release.get("id") or 0),
@@ -393,6 +431,11 @@ class GithubGalleryClient:
             is_draft=bool(release.get("draft")),
             asset_count=len(release.get("assets") or []),
             asset_download_count=int(asset.get("download_count") or 0),
+            campaign_id=campaign_id,
+            revision=revision,
+            parent_revision=parent_revision,
+            snapshot_sha256=snapshot_sha256,
+            snapshot_mode=snapshot_mode,
         )
         if not summary.download_url:
             raise RuntimeError("Bundle asset missing download URL")
@@ -474,7 +517,37 @@ class GithubGalleryClient:
                 "file_name": str(database_entry.get("file_name") or ""),
                 "size": int(database_entry.get("size") or 0),
             }
+        sync_entry = manifest.get("sync")
+        if isinstance(sync_entry, dict):
+            metadata["sync"] = {
+                key: sync_entry.get(key)
+                for key in (
+                    "campaign_id",
+                    "revision",
+                    "parent_revision",
+                    "snapshot_sha256",
+                    "published_at",
+                    "publisher_installation_id",
+                    "bundle_version",
+                    "change_summary",
+                    "snapshot_mode",
+                )
+                if sync_entry.get(key) is not None
+            }
         return metadata
+
+    @staticmethod
+    def _remote_revision_from_metadata(
+        metadata: Dict[str, object],
+    ) -> Optional[RemoteCampaignRevision]:
+        """Parse valid sync metadata; malformed data remains a manual bundle."""
+        sync = metadata.get("sync")
+        if not isinstance(sync, dict):
+            return None
+        try:
+            return RemoteCampaignRevision.from_dict(sync)
+        except (KeyError, TypeError, ValueError):
+            return None
 
 
 def _slugify(value: str) -> str:

--- a/tests/generic/campaign_sync/test_gallery_revisions.py
+++ b/tests/generic/campaign_sync/test_gallery_revisions.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+import sys
+import types
+from uuid import uuid4
+
+if "cryptography.fernet" not in sys.modules:
+    cryptography = types.ModuleType("cryptography")
+    fernet = types.ModuleType("cryptography.fernet")
+    fernet.Fernet = object
+    fernet.InvalidToken = ValueError
+    cryptography.fernet = fernet
+    sys.modules["cryptography"] = cryptography
+    sys.modules["cryptography.fernet"] = fernet
+
+from modules.generic.github_gallery_client import GalleryBundleSummary, GithubGalleryClient
+
+
+def _summary(campaign_id, revision, name="Same name"):
+    return GalleryBundleSummary(
+        1, 2, name, "tag", "bundle.zip", "https://example/bundle.zip", 10,
+        datetime.now(timezone.utc), "author", "", {}, name, "", {}, "", False,
+        1, 0, campaign_id=campaign_id, revision=revision,
+    )
+
+
+def test_highest_revision_uses_campaign_id_not_display_name(monkeypatch):
+    wanted, unrelated = str(uuid4()), str(uuid4())
+    client = GithubGalleryClient(repo="owner/repo")
+    monkeypatch.setattr(client, "list_bundles", lambda **kwargs: [
+        _summary(wanted, 2), _summary(unrelated, 99), _summary(wanted, 4)
+    ])
+    assert client.highest_revision(wanted).revision == 4
+
+
+def test_highest_revision_normalizes_campaign_uuid(monkeypatch):
+    wanted = str(uuid4())
+    client = GithubGalleryClient(repo="owner/repo")
+    monkeypatch.setattr(client, "list_bundles", lambda **kwargs: [_summary(wanted, 3)])
+
+    assert client.highest_revision(wanted.upper()).revision == 3
+
+
+def test_old_manifest_is_manual_non_synchronized_bundle():
+    client = GithubGalleryClient(repo="owner/repo")
+    metadata = client._metadata_from_manifest({"version": 1, "entities": {}}, "Old", "")
+    summary = client._build_summary(
+        {"id": 1, "name": "Old", "assets": [{}]},
+        {"id": 2, "name": "old.zip", "browser_download_url": "https://example/old.zip"},
+        metadata,
+    )
+    assert summary.campaign_id is None
+    assert summary.revision is None
+
+
+def test_malformed_sync_metadata_is_manual_non_synchronized_bundle():
+    client = GithubGalleryClient(repo="owner/repo")
+    metadata = {"sync": {"campaign_id": "not-a-uuid", "revision": -1}}
+    summary = client._build_summary(
+        {"id": 1, "name": "Manual", "assets": [{}]},
+        {"id": 2, "name": "manual.zip", "browser_download_url": "https://example/manual.zip"},
+        metadata,
+    )
+
+    assert summary.campaign_id is None
+    assert summary.revision is None
+
+
+def test_sync_metadata_without_digest_is_manual_non_synchronized_bundle():
+    client = GithubGalleryClient(repo="owner/repo")
+    metadata = {
+        "sync": {
+            "campaign_id": str(uuid4()),
+            "revision": 1,
+            "snapshot_mode": "full_campaign",
+        }
+    }
+    summary = client._build_summary(
+        {"id": 1, "name": "Manual", "assets": [{}]},
+        {"id": 2, "name": "manual.zip", "browser_download_url": "https://example/manual.zip"},
+        metadata,
+    )
+
+    assert summary.campaign_id is None
+    assert summary.revision is None

--- a/tests/generic/campaign_sync/test_metadata_store.py
+++ b/tests/generic/campaign_sync/test_metadata_store.py
@@ -1,0 +1,27 @@
+from uuid import uuid4
+
+from modules.generic.campaign_sync.metadata_store import (
+    CampaignSyncMetadataStore,
+    InstallationStateStore,
+)
+from modules.generic.campaign_sync.models import CampaignSyncMetadata
+
+
+def test_campaign_identity_persists_in_campaign_local_store(tmp_path):
+    store = CampaignSyncMetadataStore(tmp_path)
+    campaign_id = str(uuid4())
+    metadata = CampaignSyncMetadata(
+        campaign_id=campaign_id, revision=1, parent_revision=None,
+        snapshot_sha256="f" * 64, published_at="now",
+        publisher_installation_id="installation", bundle_version=1,
+    )
+    store.write(metadata)
+
+    assert store.read() == metadata
+    assert store.path == tmp_path / ".gmcd" / "sync.json"
+
+
+def test_machine_state_is_separate_from_campaign(tmp_path):
+    local = InstallationStateStore(tmp_path / "machine" / "installation.json")
+    first = local.installation_id()
+    assert local.installation_id() == first

--- a/tests/generic/campaign_sync/test_models.py
+++ b/tests/generic/campaign_sync/test_models.py
@@ -1,0 +1,45 @@
+from uuid import uuid4
+
+import pytest
+
+from modules.generic.campaign_sync.models import CampaignSyncMetadata, RemoteCampaignRevision
+
+
+def test_revision_round_trip_preserves_sync_fields():
+    metadata = CampaignSyncMetadata(
+        campaign_id=str(uuid4()),
+        revision=3,
+        parent_revision=2,
+        snapshot_sha256="a" * 64,
+        published_at="2026-07-26T12:00:00Z",
+        publisher_installation_id=str(uuid4()),
+        bundle_version=1,
+        change_summary="New encounter",
+    )
+
+    assert CampaignSyncMetadata.from_dict(metadata.to_dict()) == metadata
+
+
+def test_revision_rejects_non_monotonic_parent():
+    with pytest.raises(ValueError):
+        CampaignSyncMetadata(
+            campaign_id=str(uuid4()), revision=2, parent_revision=2,
+            snapshot_sha256="", published_at="", publisher_installation_id="x",
+            bundle_version=1,
+        )
+
+
+def test_remote_revision_rejects_non_monotonic_parent():
+    with pytest.raises(ValueError, match="parent_revision"):
+        RemoteCampaignRevision(
+            campaign_id=str(uuid4()), revision=3, parent_revision=3,
+            snapshot_sha256="a" * 64, snapshot_mode="full_campaign",
+        )
+
+
+def test_remote_revision_requires_a_valid_snapshot_digest():
+    with pytest.raises(ValueError, match="snapshot_sha256"):
+        RemoteCampaignRevision(
+            campaign_id=str(uuid4()), revision=1, parent_revision=None,
+            snapshot_sha256="", snapshot_mode="full_campaign",
+        )

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -109,6 +109,34 @@ def test_export_bundle_raises_when_database_missing(tmp_path):
     assert not destination.exists()
 
 
+def test_full_campaign_export_persists_sync_identity_and_advances_revision(
+    tmp_path, monkeypatch
+):
+    campaign_root = tmp_path / "campaign"
+    campaign_root.mkdir()
+    database = campaign_root / "campaign.db"
+    sqlite3.connect(database).close()
+    source = CampaignDatabase("Same display name", campaign_root, database)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    first = export_bundle(
+        tmp_path / "first.zip", source, {}, include_database=True,
+        include_systems=False,
+    )
+    second = export_bundle(
+        tmp_path / "second.zip", source, {}, include_database=True,
+        include_systems=False,
+    )
+
+    assert first["sync"]["campaign_id"] == second["sync"]["campaign_id"]
+    assert first["sync"]["revision"] == 1
+    assert second["sync"]["revision"] == 2
+    assert second["sync"]["parent_revision"] == 1
+    stored = json.loads((campaign_root / ".gmcd" / "sync.json").read_text())
+    assert stored["campaign_id"] == first["sync"]["campaign_id"]
+    assert "Same display name" not in first["sync"].values()
+
+
 def test_collect_assets_includes_image_library_files(tmp_path):
     """Image library entries should include file references for bundle export."""
     campaign_root = tmp_path / "campaign"


### PR DESCRIPTION
### Motivation
- Provide deterministic, shareable synchronization identity and revision tracking for full-campaign exports so multiple installations can reliably identify and update the same campaign snapshot.
- Keep machine-specific state (installation ID, last-check times) separate from shared campaign metadata to avoid leaking or persisting local details into campaign bundles.
- Expose sync metadata in gallery listings so remote clients can discover campaign UUID, revision lineage, digest, and snapshot mode without downloading archives.

### Description
- Add a dedicated package `modules/generic/campaign_sync/` with `models.py` (typed dataclasses `CampaignSyncMetadata` and `RemoteCampaignRevision` and validation), `hashing.py` (`hash_campaign_snapshot` and `sha256_file`), `metadata_store.py` (atomic campaign-local store `CampaignSyncMetadataStore` and machine-local `InstallationStateStore`), and `__init__.py`.
- Update `export_bundle` in `modules/generic/cross_campaign_asset_service.py` to generate `sync` metadata for full-campaign exports using a persistent `campaign_id` (UUID), monotonic `revision`/`parent_revision`, deterministic `snapshot_sha256`, `publisher_installation_id`, `bundle_version`, `snapshot_mode`, and optional `change_summary`, and to persist the campaign-local `sync.json` at `<campaign root>/.gmcd/sync.json` only after the ZIP is written successfully.
- Extend `modules/generic/github_gallery_client.py` to serialize `sync` data into gallery metadata parsing, add `_remote_revision_from_metadata` and `highest_revision` (which queries by normalized `campaign_id`), and use a stable tag convention `campaign-<campaign_id>-r<revision>` when publishing synchronized releases while preserving legacy/manual bundles.
- Add unit tests under `tests/generic/campaign_sync/` and extend `tests/test_cross_campaign_asset_service.py` to cover identity persistence, revision advancement and serialization, backward compatibility with old/malformed manifests, and selection of the highest revision by `campaign_id` rather than display name.

### Testing
- Ran `pytest -q tests/generic/campaign_sync tests/test_cross_campaign_asset_service.py` and the targeted synchronization tests passed (`34 passed`).
- Ran linter and basic checks with `ruff check` on the new and modified modules and `python -m compileall -q` for byte-compile verification, both of which succeeded.
- Verified `export_bundle` persists campaign-local `sync.json` at `<campaign root>/.gmcd/sync.json` only after successful archive creation and that gallery summaries expose `campaign_id`, `revision`, `parent_revision`, `snapshot_sha256`, and `snapshot_mode`.
- Known limitation: full `pytest -q` collection in this environment is blocked by ~30 pre-existing/environmental collection errors unrelated to these changes (mock/GUI test issues), so only the targeted sync tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66537a9f24832b997673f150f1687c)