### PR TITLE
Add automatic campaign revision update checks

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -11,6 +11,7 @@ import shutil
 import re
 import unicodedata
 import threading
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 import tkinter as tk
@@ -113,6 +114,18 @@ from modules.pcs.display_pcs import display_pcs_in_banner
 from modules.pcs.character_creation import CharacterCreationView
 from modules.generic.generic_list_selection_view import GenericListSelectionView
 from modules.generic.custom_fields_editor import CustomFieldsEditor
+from modules.generic.github_gallery_client import GithubGalleryClient
+from modules.generic.campaign_sync.settings import CampaignUpdatePreferences
+from modules.generic.campaign_sync.update_checker import (
+    CampaignUpdateChecker,
+    UpdateCheckSettings,
+    UpdateStatus,
+)
+from modules.generic.campaign_sync.update_ui import (
+    CampaignUpdatePrompt,
+    CampaignUpdateSettingsDialog,
+)
+from modules.generic.cross_campaign_asset_service import install_full_campaign_bundle
 from modules.generic.new_entity_type_dialog import NewEntityTypeDialog
 from modules.auto_improve.ui.auto_improve_panel import AutoImprovePanel
 from modules.campaigns.services import (
@@ -219,6 +232,9 @@ class MainWindow(ctk.CTk):
         self._database_manager_dialog = None
         self._campaign_builder_wizard = None
         self._update_thread = None
+        self._campaign_update_checker = CampaignUpdateChecker(GithubGalleryClient())
+        self._campaign_update_prompt = None
+        self._downloaded_campaign_updates = {}
         self.whiteboard_controller = None
         root = self.winfo_toplevel()
         root.bind_all("<Control-f>", self._on_ctrl_f)
@@ -239,6 +255,7 @@ class MainWindow(ctk.CTk):
         self.after(400, self.open_audio_bar)
         self.after(600, lambda: self._queue_update_check(force=True))
         self.after(800, self._auto_open_campaign_overview)
+        self.after(1000, self._queue_campaign_update_check)
 
     def _bind_global_shortcuts(self):
         """Bind global shortcuts."""
@@ -332,6 +349,10 @@ class MainWindow(ctk.CTk):
         ctk.CTkButton(btns, text="Save", command=save).pack(side="right", padx=6)
         ctk.CTkButton(btns, text="Defaults", command=reset_defaults).pack(side="right", padx=6)
         ctk.CTkButton(btns, text="Close", command=top.destroy).pack(side="right", padx=6)
+
+    def open_campaign_update_settings(self):
+        """Open installation-local automatic campaign update preferences."""
+        CampaignUpdateSettingsDialog(self)
 
     def register_tour_widget(self, screen: str, key: str, widget):
         """Register a guided-tour target widget by stable key."""
@@ -1103,6 +1124,7 @@ class MainWindow(ctk.CTk):
             SidebarItemSpec("customize_fields", "Customize Fields", self.open_custom_fields_editor),
             SidebarItemSpec("new_entity_type", "New Entity Type", self.open_new_entity_type_dialog),
             SidebarItemSpec("system_manager", "AI Settings", self.open_ai_settings),
+            SidebarItemSpec("campaign_updates", "Campaign Update Settings", self.open_campaign_update_settings),
             SidebarItemSpec("auto_improve", "Auto-improvement (Codex CLI)", self.open_auto_improve_panel),
             SidebarItemSpec("system_manager", "Manage Campaign Systems", self.open_system_manager_dialog),
             SidebarItemSpec("db_export", "Create Campaign Backup", self.prompt_campaign_backup),
@@ -3543,7 +3565,7 @@ class MainWindow(ctk.CTk):
             detail_builder=detail_builder,
         )
 
-    def _run_progress_task(self, title, worker, success_message, detail_builder=None):
+    def _run_progress_task(self, title, worker, success_message, detail_builder=None, on_success=None):
         """Run progress task."""
         progress_win = ctk.CTkToplevel(self)
         progress_win.title(title)
@@ -3588,9 +3610,14 @@ class MainWindow(ctk.CTk):
             close_window()
             messagebox.showerror(title, detail)
 
-        def on_success(result):
+        success_callback = on_success
+
+        def handle_success(result):
             """Handle success."""
             close_window()
+            if success_callback:
+                success_callback(result)
+                return
             detail = detail_builder(result) if detail_builder else None
             message = success_message or "Operation completed."
             if detail:
@@ -3623,9 +3650,118 @@ class MainWindow(ctk.CTk):
                 self.after(0, lambda detail=detail: handle_error("Unexpected Error", detail))
                 return
 
-            self.after(0, lambda: on_success(result))
+            self.after(0, lambda: handle_success(result))
 
         threading.Thread(target=run_worker, daemon=True).start()
+
+    def _active_campaign_root(self) -> Path:
+        db_path = ConfigHelper.get("Database", "path", fallback="default_campaign.db")
+        return Path(str(db_path)).expanduser().resolve().parent
+
+    def _queue_campaign_update_check(self, *, force: bool = False) -> None:
+        """Check the currently selected campaign using the shared worker mechanism."""
+        preferences = CampaignUpdatePreferences.load()
+        root = self._active_campaign_root()
+        # A prompt belongs to the campaign that produced it.  In particular,
+        # do not leave campaign A's actions usable while campaign B is active.
+        existing = self._campaign_update_prompt
+        if existing is not None:
+            try:
+                if existing.winfo_exists():
+                    existing.destroy()
+            except Exception:
+                pass
+            self._campaign_update_prompt = None
+        settings = UpdateCheckSettings(
+            enabled=preferences.automatic_checks,
+            offline=preferences.offline,
+            interval_seconds=preferences.frequency_hours * 3600,
+            force=force,
+        )
+
+        def worker(progress):
+            progress("Checking campaign revisions…", 0.15)
+            result = self._campaign_update_checker.check(root, settings)
+            progress("Campaign check complete.", 1.0)
+            return result
+
+        self._run_progress_task(
+            "Checking Campaign Updates", worker, None,
+            on_success=lambda result: self._handle_campaign_update_result(root, result, preferences),
+        )
+
+    def _handle_campaign_update_result(self, root, result, preferences) -> None:
+        # Results can arrive after another code path selected a new database.
+        # Never offer or download an update for a campaign that is no longer
+        # active.
+        if Path(root).resolve() != self._active_campaign_root():
+            return
+        if result.status is not UpdateStatus.UPDATE_AVAILABLE:
+            return
+        if preferences.automatic_download:
+            self._download_campaign_update(root, result, show_prompt=True)
+            return
+        self._show_campaign_update_prompt(root, result)
+
+    def _show_campaign_update_prompt(self, root: Path, result) -> None:
+        existing = self._campaign_update_prompt
+        if existing is not None:
+            try:
+                if existing.winfo_exists():
+                    existing.destroy()
+            except Exception:
+                pass
+        prompt = CampaignUpdatePrompt(
+            self,
+            result,
+            on_update=lambda: self._confirm_campaign_update(root, result),
+            on_later=lambda: None,
+            on_ignore=lambda: self._campaign_update_checker.ignore_revision(
+                root, result.available_revision
+            ),
+        )
+        self._campaign_update_prompt = prompt
+
+    def _download_campaign_update(self, root: Path, result, *, show_prompt: bool) -> None:
+        temp_dir = Path(tempfile.mkdtemp(prefix="gmcd_campaign_update_"))
+        asset_name = Path(getattr(result.bundle, "asset_name", "campaign.zip") or "campaign.zip").name
+        archive = temp_dir / (asset_name if asset_name.lower().endswith(".zip") else f"{asset_name}.zip")
+
+        def worker(progress):
+            return self._campaign_update_checker.gallery_client.download_bundle(
+                result.bundle, archive, progress_callback=progress
+            )
+
+        def downloaded(path):
+            self._downloaded_campaign_updates[(str(root), result.available_revision)] = Path(path)
+            if show_prompt and Path(root).resolve() == self._active_campaign_root():
+                self._show_campaign_update_prompt(root, result)
+
+        self._run_progress_task("Downloading Campaign Update", worker, None, on_success=downloaded)
+
+    def _confirm_campaign_update(self, root: Path, result) -> None:
+        if not messagebox.askyesno(
+            "Apply Campaign Update",
+            f"Apply revision {result.available_revision} to '{result.campaign_name}' now?",
+            parent=self,
+        ):
+            return
+        archive = self._downloaded_campaign_updates.get((str(root), result.available_revision))
+        if archive is None or not archive.exists():
+            self._download_campaign_update(root, result, show_prompt=True)
+            # Download completion deliberately asks again before applying.
+            return
+
+        def worker(progress):
+            return install_full_campaign_bundle(archive, root, progress_callback=progress)
+
+        def applied(_campaign):
+            initialize_db()
+            self._reload_active_campaign_system()
+            self.refresh_entities()
+            messagebox.showinfo("Campaign Updated", f"Revision {result.available_revision} was applied.")
+
+        self._run_progress_task("Applying Campaign Update", worker, None, on_success=applied)
 
     def _format_backup_summary(self, manifest: dict | None, *, include_target: bool) -> str:
         """Format backup summary."""
@@ -4086,6 +4222,9 @@ class MainWindow(ctk.CTk):
                 self.db_tooltip.text = full_path
         except Exception:
             self.db_tooltip = None
+
+        # The configured path and campaign-bound UI are now both ready.
+        self.after_idle(lambda: self._queue_campaign_update_check(force=True))
 
     def select_swarmui_path(self):
         """Select swarmui path."""

--- a/modules/generic/campaign_sync/__init__.py
+++ b/modules/generic/campaign_sync/__init__.py
@@ -1,5 +1,9 @@
 """Campaign synchronization identity, revisions, and snapshot utilities."""
 
 from .models import CampaignSyncMetadata, RemoteCampaignRevision
+from .update_checker import CampaignUpdateChecker, CampaignUpdateResult, UpdateCheckSettings, UpdateStatus
 
-__all__ = ["CampaignSyncMetadata", "RemoteCampaignRevision"]
+__all__ = [
+    "CampaignSyncMetadata", "RemoteCampaignRevision", "CampaignUpdateChecker",
+    "CampaignUpdateResult", "UpdateCheckSettings", "UpdateStatus",
+]

--- a/modules/generic/campaign_sync/metadata_store.py
+++ b/modules/generic/campaign_sync/metadata_store.py
@@ -72,3 +72,26 @@ class InstallationStateStore:
         state["installation_id"] = value
         self.write(state)
         return value
+
+    def campaign_state(self, installation_key: str) -> dict:
+        """Return state belonging only to one local campaign installation."""
+        state = self.read()
+        campaigns = state.get("campaign_sync")
+        if not isinstance(campaigns, dict):
+            return {}
+        value = campaigns.get(str(installation_key))
+        return dict(value) if isinstance(value, dict) else {}
+
+    def update_campaign_state(self, installation_key: str, **changes: object) -> dict:
+        """Atomically merge machine-local check state for one installation."""
+        state = self.read()
+        campaigns = state.setdefault("campaign_sync", {})
+        if not isinstance(campaigns, dict):
+            campaigns = {}
+            state["campaign_sync"] = campaigns
+        current = campaigns.get(str(installation_key))
+        current = dict(current) if isinstance(current, dict) else {}
+        current.update(changes)
+        campaigns[str(installation_key)] = current
+        self.write(state)
+        return current

--- a/modules/generic/campaign_sync/models.py
+++ b/modules/generic/campaign_sync/models.py
@@ -19,10 +19,12 @@ def _valid_sha256(value: str) -> str:
 
 
 def _validate_revision(revision: int, parent_revision: Optional[int]) -> None:
-    if isinstance(revision, bool) or revision < 1:
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
         raise ValueError("revision must be a positive integer")
     if parent_revision is not None and (
-        isinstance(parent_revision, bool) or not 0 <= parent_revision < revision
+        isinstance(parent_revision, bool)
+        or not isinstance(parent_revision, int)
+        or not 0 <= parent_revision < revision
     ):
         raise ValueError("parent_revision must precede revision")
 
@@ -53,8 +55,10 @@ class CampaignSyncMetadata:
     def from_dict(cls, value: Dict[str, Any]) -> "CampaignSyncMetadata":
         return cls(
             campaign_id=str(value["campaign_id"]),
-            revision=int(value["revision"]),
-            parent_revision=(int(value["parent_revision"]) if value.get("parent_revision") is not None else None),
+            # Revisions are protocol integers.  Do not silently turn names,
+            # numeric strings, floats, or booleans into valid revisions.
+            revision=value["revision"],
+            parent_revision=value.get("parent_revision"),
             snapshot_sha256=str(value.get("snapshot_sha256") or ""),
             published_at=str(value.get("published_at") or ""),
             publisher_installation_id=str(value.get("publisher_installation_id") or ""),
@@ -85,8 +89,8 @@ class RemoteCampaignRevision:
     def from_dict(cls, value: Dict[str, Any]) -> "RemoteCampaignRevision":
         return cls(
             campaign_id=str(value["campaign_id"]),
-            revision=int(value["revision"]),
-            parent_revision=(int(value["parent_revision"]) if value.get("parent_revision") is not None else None),
+            revision=value["revision"],
+            parent_revision=value.get("parent_revision"),
             snapshot_sha256=str(value.get("snapshot_sha256") or ""),
             snapshot_mode=str(value.get("snapshot_mode") or "full_campaign"),
             published_at=(str(value["published_at"]) if value.get("published_at") else None),

--- a/modules/generic/campaign_sync/settings.py
+++ b/modules/generic/campaign_sync/settings.py
@@ -1,0 +1,38 @@
+"""Application configuration adapter for campaign update checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modules.helpers.config_helper import ConfigHelper
+
+
+SECTION = "CampaignUpdates"
+
+
+@dataclass(frozen=True)
+class CampaignUpdatePreferences:
+    automatic_checks: bool = True
+    frequency_hours: int = 24
+    automatic_download: bool = False
+    offline: bool = False
+
+    @classmethod
+    def load(cls) -> "CampaignUpdatePreferences":
+        try:
+            hours = int(ConfigHelper.get(SECTION, "frequency_hours", fallback="24") or 24)
+        except (TypeError, ValueError):
+            hours = 24
+        return cls(
+            automatic_checks=ConfigHelper.getboolean(SECTION, "automatic_checks", fallback=True),
+            frequency_hours=max(1, hours),
+            automatic_download=ConfigHelper.getboolean(SECTION, "automatic_download", fallback=False),
+            offline=ConfigHelper.getboolean(SECTION, "offline", fallback=False),
+        )
+
+    def save(self) -> None:
+        ConfigHelper.set(SECTION, "automatic_checks", str(self.automatic_checks).lower())
+        ConfigHelper.set(SECTION, "frequency_hours", self.frequency_hours)
+        ConfigHelper.set(SECTION, "automatic_download", str(self.automatic_download).lower())
+        ConfigHelper.set(SECTION, "offline", str(self.offline).lower())
+

--- a/modules/generic/campaign_sync/update_checker.py
+++ b/modules/generic/campaign_sync/update_checker.py
@@ -1,0 +1,181 @@
+"""UI-independent update discovery for synchronized campaigns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+
+from .metadata_store import CampaignSyncMetadataStore, InstallationStateStore
+
+
+class UpdateStatus(str, Enum):
+    UP_TO_DATE = "up_to_date"
+    UPDATE_AVAILABLE = "update_available"
+    OFFLINE = "offline"
+    UNLINKED = "unlinked"
+    REMOTE_INVALID = "remote_invalid"
+
+
+@dataclass(frozen=True)
+class UpdateCheckSettings:
+    enabled: bool = True
+    offline: bool = False
+    interval_seconds: int = 24 * 60 * 60
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class CampaignUpdateResult:
+    status: UpdateStatus
+    campaign_name: str
+    installed_revision: Optional[int] = None
+    available_revision: Optional[int] = None
+    published_at: Optional[datetime] = None
+    publisher: Optional[str] = None
+    change_summary: Optional[str] = None
+    bundle: object | None = None
+    checked_remote: bool = False
+    ignored: bool = False
+    error: Optional[str] = None
+
+
+class CampaignUpdateChecker:
+    """Compare local and remote integer revisions without importing any UI code."""
+
+    def __init__(
+        self,
+        gallery_client,
+        *,
+        installation_store: Optional[InstallationStateStore] = None,
+        clock: Optional[Callable[[], datetime]] = None,
+    ) -> None:
+        self.gallery_client = gallery_client
+        self.installation_store = installation_store or InstallationStateStore()
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
+
+    @staticmethod
+    def installation_key(campaign_root: Path) -> str:
+        return str(Path(campaign_root).expanduser().resolve())
+
+    def check(
+        self, campaign_root: Path, settings: UpdateCheckSettings = UpdateCheckSettings()
+    ) -> CampaignUpdateResult:
+        root = Path(campaign_root)
+        name = root.name
+        try:
+            metadata = CampaignSyncMetadataStore(root).read()
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            return CampaignUpdateResult(UpdateStatus.REMOTE_INVALID, name, error=str(exc))
+        if metadata is None or not metadata.campaign_id:
+            return CampaignUpdateResult(UpdateStatus.UNLINKED, name)
+        # Resolve campaign identity before applying connectivity preferences:
+        # an unlinked campaign remains UNLINKED even while the application is
+        # offline/disabled, and neither case ever reaches the gallery client.
+        if not settings.enabled or settings.offline:
+            return CampaignUpdateResult(
+                UpdateStatus.OFFLINE, name, installed_revision=metadata.revision
+            )
+
+        key = self.installation_key(root)
+        local_state = self.installation_store.campaign_state(key)
+        now = self.clock()
+        if not settings.force and not self._is_due(
+            local_state.get("last_checked_at"), now, settings.interval_seconds
+        ):
+            return CampaignUpdateResult(
+                UpdateStatus.UP_TO_DATE,
+                name,
+                installed_revision=metadata.revision,
+                checked_remote=False,
+            )
+
+        try:
+            remote = self.gallery_client.highest_revision(metadata.campaign_id)
+        except Exception as exc:
+            return CampaignUpdateResult(
+                UpdateStatus.OFFLINE,
+                name,
+                installed_revision=metadata.revision,
+                error=str(exc),
+            )
+
+        self.installation_store.update_campaign_state(
+            key, last_checked_at=now.astimezone(timezone.utc).isoformat()
+        )
+        if remote is None:
+            return CampaignUpdateResult(
+                UpdateStatus.UP_TO_DATE, name, metadata.revision, checked_remote=True
+            )
+        revision = getattr(remote, "revision", None)
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+            return CampaignUpdateResult(
+                UpdateStatus.REMOTE_INVALID,
+                name,
+                installed_revision=metadata.revision,
+                bundle=remote,
+                checked_remote=True,
+            )
+        if str(getattr(remote, "campaign_id", "")) != metadata.campaign_id:
+            return CampaignUpdateResult(
+                UpdateStatus.REMOTE_INVALID,
+                name,
+                installed_revision=metadata.revision,
+                bundle=remote,
+                checked_remote=True,
+            )
+
+        ignored_revision = self._integer_or_none(local_state.get("ignored_revision"))
+        available = revision > metadata.revision
+        ignored = available and ignored_revision == revision
+        status = UpdateStatus.UPDATE_AVAILABLE if available and not ignored else UpdateStatus.UP_TO_DATE
+        summary = getattr(remote, "change_summary", None)
+        if not summary:
+            remote_metadata = getattr(remote, "metadata", {})
+            sync = remote_metadata.get("sync", {}) if isinstance(remote_metadata, dict) else {}
+            summary = sync.get("change_summary") if isinstance(sync, dict) else None
+        return CampaignUpdateResult(
+            status,
+            name,
+            installed_revision=metadata.revision,
+            available_revision=revision,
+            published_at=getattr(remote, "published_at", None),
+            publisher=getattr(remote, "author", None) or None,
+            change_summary=str(summary) if summary else None,
+            bundle=remote,
+            checked_remote=True,
+            ignored=ignored,
+        )
+
+    def ignore_revision(self, campaign_root: Path, revision: int) -> None:
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+            raise ValueError("revision must be a positive integer")
+        self.installation_store.update_campaign_state(
+            self.installation_key(campaign_root), ignored_revision=revision
+        )
+
+    @staticmethod
+    def _integer_or_none(value: object) -> Optional[int]:
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    @staticmethod
+    def _is_due(value: object, now: datetime, interval_seconds: int) -> bool:
+        if not value or interval_seconds <= 0:
+            return True
+        try:
+            checked = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            if checked.tzinfo is None:
+                checked = checked.replace(tzinfo=timezone.utc)
+            return (now - checked.astimezone(timezone.utc)).total_seconds() >= interval_seconds
+        except (TypeError, ValueError):
+            return True
+
+
+__all__ = [
+    "CampaignUpdateChecker",
+    "CampaignUpdateResult",
+    "UpdateCheckSettings",
+    "UpdateStatus",
+]

--- a/modules/generic/campaign_sync/update_ui.py
+++ b/modules/generic/campaign_sync/update_ui.py
@@ -1,0 +1,98 @@
+"""Small Tk views for campaign update preferences and available updates."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from datetime import datetime
+from typing import Callable
+
+import customtkinter as ctk
+
+from .settings import CampaignUpdatePreferences
+from .update_checker import CampaignUpdateResult
+
+
+class CampaignUpdatePrompt(ctk.CTkToplevel):
+    """Non-modal prompt: the rest of the application remains usable."""
+
+    def __init__(self, master, result: CampaignUpdateResult, *, on_update: Callable[[], None],
+                 on_later: Callable[[], None], on_ignore: Callable[[], None]) -> None:
+        super().__init__(master)
+        self.title("Campaign update available")
+        self.geometry("560x390")
+        self.resizable(False, False)
+        self.transient(master)
+        self.protocol("WM_DELETE_WINDOW", self._later)
+        self._on_later = on_later
+
+        ctk.CTkLabel(self, text=f"Update available for {result.campaign_name}",
+                     font=ctk.CTkFont(size=20, weight="bold")).pack(padx=24, pady=(24, 12))
+        published = (
+            result.published_at.astimezone().strftime("%Y-%m-%d %H:%M %Z")
+            if isinstance(result.published_at, datetime)
+            else str(result.published_at or "Unknown")
+        )
+        details = [
+            f"Installed revision: {result.installed_revision}",
+            f"Available revision: {result.available_revision}",
+            f"Published: {published}",
+        ]
+        if result.publisher:
+            details.append(f"Publisher: {result.publisher}")
+        if result.change_summary:
+            details.extend(("", "Changes:", result.change_summary))
+        ctk.CTkLabel(self, text="\n".join(details), justify="left", anchor="nw",
+                     wraplength=500).pack(fill="both", expand=True, padx=28, pady=12)
+        buttons = ctk.CTkFrame(self, fg_color="transparent")
+        buttons.pack(fill="x", padx=20, pady=(8, 20))
+        ctk.CTkButton(buttons, text="Update now", command=lambda: self._choose(on_update)).pack(side="left")
+        ctk.CTkButton(buttons, text="Later", command=self._later).pack(side="left", padx=10)
+        ctk.CTkButton(buttons, text="Ignore this revision", command=lambda: self._choose(on_ignore)).pack(side="right")
+        self.lift()
+
+    def _choose(self, callback: Callable[[], None]) -> None:
+        self.destroy()
+        callback()
+
+    def _later(self) -> None:
+        self.destroy()
+        self._on_later()
+
+
+class CampaignUpdateSettingsDialog(ctk.CTkToplevel):
+    def __init__(self, master) -> None:
+        super().__init__(master)
+        self.title("Campaign Update Settings")
+        self.geometry("520x330")
+        self.resizable(False, False)
+        preferences = CampaignUpdatePreferences.load()
+        self.checks = tk.BooleanVar(value=preferences.automatic_checks)
+        self.download = tk.BooleanVar(value=preferences.automatic_download)
+        self.offline = tk.BooleanVar(value=preferences.offline)
+        self.frequency = tk.StringVar(value=str(preferences.frequency_hours))
+        frame = ctk.CTkFrame(self)
+        frame.pack(fill="both", expand=True, padx=20, pady=20)
+        ctk.CTkCheckBox(frame, text="Automatically check linked campaigns", variable=self.checks).pack(anchor="w", pady=8)
+        row = ctk.CTkFrame(frame, fg_color="transparent")
+        row.pack(fill="x", pady=8)
+        ctk.CTkLabel(row, text="Check frequency (hours):").pack(side="left")
+        ctk.CTkEntry(row, textvariable=self.frequency, width=90).pack(side="left", padx=12)
+        ctk.CTkCheckBox(frame, text="Download updates automatically (confirmation is still required to apply)",
+                        variable=self.download).pack(anchor="w", pady=8)
+        ctk.CTkCheckBox(frame, text="Offline / disable network checks", variable=self.offline).pack(anchor="w", pady=8)
+        self.error = ctk.CTkLabel(frame, text="", text_color="#ff7777")
+        self.error.pack(anchor="w", pady=4)
+        ctk.CTkButton(frame, text="Save", command=self._save).pack(side="right", pady=12)
+        self.transient(master)
+        self.lift()
+
+    def _save(self) -> None:
+        try:
+            hours = int(self.frequency.get())
+            if hours < 1:
+                raise ValueError
+        except ValueError:
+            self.error.configure(text="Frequency must be a positive whole number.")
+            return
+        CampaignUpdatePreferences(self.checks.get(), hours, self.download.get(), self.offline.get()).save()
+        self.destroy()

--- a/tests/generic/campaign_sync/test_update_checker.py
+++ b/tests/generic/campaign_sync/test_update_checker.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+from modules.generic.campaign_sync.metadata_store import (
+    CampaignSyncMetadataStore,
+    InstallationStateStore,
+)
+from modules.generic.campaign_sync.models import CampaignSyncMetadata
+from modules.generic.campaign_sync.update_checker import (
+    CampaignUpdateChecker,
+    UpdateCheckSettings,
+    UpdateStatus,
+)
+
+
+def _link(root, campaign_id, revision=2):
+    CampaignSyncMetadataStore(root).write(CampaignSyncMetadata(
+        campaign_id=campaign_id, revision=revision, parent_revision=revision - 1,
+        snapshot_sha256="a" * 64, published_at="2026-01-01T00:00:00Z",
+        publisher_installation_id="publisher", bundle_version=1,
+    ))
+
+
+def _release(campaign_id, revision, *, name="Remote", summary="New scenes"):
+    return SimpleNamespace(
+        release_id=1, asset_id=2, release_name=name, tag="tag",
+        asset_name="campaign.zip", download_url="https://example/campaign.zip",
+        published_at=datetime(2026, 7, 1, tzinfo=timezone.utc), author="alice",
+        metadata={"sync": {"change_summary": summary}},
+        campaign_id=campaign_id, revision=revision,
+    )
+
+
+class Gallery:
+    def __init__(self, releases=None, error=None):
+        self.releases = list(releases or [])
+        self.error = error
+        self.calls = []
+
+    def highest_revision(self, campaign_id):
+        self.calls.append(campaign_id)
+        if self.error:
+            raise self.error
+        matches = [item for item in self.releases if item.campaign_id == campaign_id]
+        return max(matches, key=lambda item: item.revision, default=None)
+
+
+def _checker(tmp_path, gallery, now=None):
+    return CampaignUpdateChecker(
+        gallery,
+        installation_store=InstallationStateStore(tmp_path / "installation.json"),
+        clock=lambda: now or datetime(2026, 7, 26, tzinfo=timezone.utc),
+    )
+
+
+def test_unlinked_campaign_never_calls_gallery(tmp_path):
+    gallery = Gallery()
+    result = _checker(tmp_path, gallery).check(tmp_path / "campaign")
+    assert result.status is UpdateStatus.UNLINKED
+    assert gallery.calls == []
+
+
+def test_unlinked_campaign_remains_unlinked_when_checks_are_disabled(tmp_path):
+    gallery = Gallery()
+    result = _checker(tmp_path, gallery).check(
+        tmp_path / "campaign", UpdateCheckSettings(enabled=False, offline=True)
+    )
+    assert result.status is UpdateStatus.UNLINKED
+    assert gallery.calls == []
+
+
+def test_offline_operation_never_calls_gallery(tmp_path):
+    campaign_id = str(uuid4())
+    _link(tmp_path / "campaign", campaign_id)
+    gallery = Gallery(error=OSError("offline"))
+    result = _checker(tmp_path, gallery).check(
+        tmp_path / "campaign", UpdateCheckSettings(offline=True)
+    )
+    assert result.status is UpdateStatus.OFFLINE
+    assert gallery.calls == []
+
+
+def test_network_failure_is_offline(tmp_path):
+    campaign_id = str(uuid4())
+    _link(tmp_path / "campaign", campaign_id)
+    result = _checker(tmp_path, Gallery(error=OSError("no network"))).check(tmp_path / "campaign")
+    assert result.status is UpdateStatus.OFFLINE
+
+
+def test_malformed_local_metadata_is_invalid(tmp_path):
+    sync = tmp_path / "campaign" / ".gmcd" / "sync.json"
+    sync.parent.mkdir(parents=True)
+    sync.write_text('{"campaign_id":"bad","revision":"name"}', encoding="utf-8")
+    assert _checker(tmp_path, Gallery()).check(tmp_path / "campaign").status is UpdateStatus.REMOTE_INVALID
+
+
+def test_numeric_string_local_revision_is_not_coerced(tmp_path):
+    campaign_id = str(uuid4())
+    sync = tmp_path / "campaign" / ".gmcd" / "sync.json"
+    sync.parent.mkdir(parents=True)
+    sync.write_text(
+        '{"campaign_id":"%s","revision":"2","parent_revision":1,'
+        '"snapshot_sha256":"%s"}' % (campaign_id, "a" * 64),
+        encoding="utf-8",
+    )
+    assert _checker(tmp_path, Gallery()).check(tmp_path / "campaign").status is UpdateStatus.REMOTE_INVALID
+
+
+def test_malformed_remote_revision_is_invalid(tmp_path):
+    campaign_id = str(uuid4())
+    root = tmp_path / "campaign"
+    _link(root, campaign_id)
+    remote = _release(campaign_id, 3)
+    remote.revision = "3"
+    assert _checker(tmp_path, Gallery([remote])).check(root).status is UpdateStatus.REMOTE_INVALID
+
+
+def test_ignored_revision_is_local_and_suppressed(tmp_path):
+    campaign_id = str(uuid4())
+    root = tmp_path / "campaign"
+    _link(root, campaign_id)
+    checker = _checker(tmp_path, Gallery([_release(campaign_id, 3)]))
+    checker.ignore_revision(root, 3)
+    result = checker.check(root)
+    assert result.status is UpdateStatus.UP_TO_DATE
+    assert result.ignored is True
+    assert not (root / ".gmcd" / "installation.json").exists()
+
+
+def test_unrelated_release_is_not_selected(tmp_path):
+    campaign_id = str(uuid4())
+    root = tmp_path / "campaign"
+    _link(root, campaign_id)
+    result = _checker(tmp_path, Gallery([_release(str(uuid4()), 99)])).check(root)
+    assert result.status is UpdateStatus.UP_TO_DATE
+
+
+def test_newer_release_after_switching_campaigns(tmp_path):
+    first_id, second_id = str(uuid4()), str(uuid4())
+    first, second = tmp_path / "first", tmp_path / "second"
+    _link(first, first_id, 4)
+    _link(second, second_id, 1)
+    gallery = Gallery([_release(first_id, 4), _release(second_id, 2)])
+    checker = _checker(tmp_path, gallery)
+    assert checker.check(first).status is UpdateStatus.UP_TO_DATE
+    switched = checker.check(second)
+    assert switched.status is UpdateStatus.UPDATE_AVAILABLE
+    assert switched.installed_revision == 1
+    assert switched.available_revision == 2
+    assert gallery.calls == [first_id, second_id]
+
+
+def test_check_interval_uses_per_installation_timestamp(tmp_path):
+    campaign_id = str(uuid4())
+    root = tmp_path / "campaign"
+    _link(root, campaign_id)
+    now = datetime(2026, 7, 26, tzinfo=timezone.utc)
+    gallery = Gallery([_release(campaign_id, 2)])
+    checker = _checker(tmp_path, gallery, now)
+    assert checker.check(root).checked_remote
+    second = checker.check(root, UpdateCheckSettings(interval_seconds=int(timedelta(days=1).total_seconds())))
+    assert not second.checked_remote
+    assert len(gallery.calls) == 1


### PR DESCRIPTION
### Motivation

- Provide a UI-independent service to detect newer campaign revisions by loading `.gmcd/sync.json` and comparing integer revisions strictly.  
- Respect per-installation settings for automatic checks, offline/disabled mode, check interval, and per-installation ignored revisions.  
- Integrate checks into the existing background/progress-task flow and marshal any Tkinter interactions back on the UI thread.  
- Prompt users non-modally when updates are available and preserve explicit confirmation before applying updates while allowing optional automatic download.

### Description

- Add `modules/generic/campaign_sync/update_checker.py` implementing `CampaignUpdateChecker`, typed `CampaignUpdateResult`, `UpdateCheckSettings`, and `UpdateStatus` with strict integer revision validation and `ignore_revision` support.  
- Add `modules/generic/campaign_sync/settings.py` for installation-local preferences (`CampaignUpdatePreferences`) and `modules/generic/campaign_sync/update_ui.py` providing a non-modal `CampaignUpdatePrompt` and `CampaignUpdateSettingsDialog`.  
- Extend `modules/generic/campaign_sync/metadata_store.py` with `InstallationStateStore.campaign_state` and `update_campaign_state` to persist `last_checked_at` and `ignored_revision` per local installation.  
- Harden `modules/generic/campaign_sync/models.py` to avoid coercing non-integer revision values and to enforce positive integer revisions.  
- Integrate the checker into `main_window.py` by creating a `CampaignUpdateChecker` instance, queuing checks via the existing `_run_progress_task` worker, marshalling UI updates with `after(0, ...)`, adding a settings entry and prompt handling, and extending `_run_progress_task` to accept an `on_success` callback for UI-safe completion handling.  

### Testing

- Ran unit tests for the checker with `pytest -q tests/generic/campaign_sync/test_update_checker.py` and the mocked scenarios (offline, malformed metadata, ignored revisions, unrelated releases, interval behavior, and switching campaigns) which passed.  
- Ran broader tests with `pytest -q tests/generic/campaign_sync tests/test_cross_campaign_asset_service.py` which completed successfully.  
- Verified bytecode/compilation with `python -m compileall -q modules/generic/campaign_sync main_window.py` which succeeded.  
- Note: collection of a main-window shortcut test was blocked by the environment shadowing `python-docx` (the local `docx` module prevents importing `docx.shared`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6656ac9b98832baea1df5e9d428990)