### PR TITLE
Add safe campaign sync change detection

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -121,6 +121,11 @@ from modules.generic.campaign_sync.update_checker import (
     UpdateCheckSettings,
     UpdateStatus,
 )
+from modules.generic.campaign_sync.change_detector import (
+    CampaignChangeDetector,
+    CampaignChangeState,
+    create_campaign_backup_archive,
+)
 from modules.generic.campaign_sync.update_ui import (
     CampaignUpdatePrompt,
     CampaignUpdateSettingsDialog,
@@ -3719,8 +3724,82 @@ class MainWindow(ctk.CTk):
             on_ignore=lambda: self._campaign_update_checker.ignore_revision(
                 root, result.available_revision
             ),
+            on_backup_replace=lambda: self._backup_then_replace_campaign(root, result),
+            on_publish_local=lambda: self._publish_local_campaign_revision(root, result),
+            on_save_remote=lambda: self._save_remote_campaign_snapshot(root, result),
         )
         self._campaign_update_prompt = prompt
+
+    def _backup_then_replace_campaign(self, root: Path, result) -> None:
+        """Create a durable local archive before entering the replace flow."""
+        backup_dir = Path.home() / ".gmcd" / "campaign_backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        archive = backup_dir / f"{root.name}_before_r{result.available_revision}_{timestamp}.zip"
+        try:
+            create_campaign_backup_archive(root, archive)
+        except Exception as exc:
+            messagebox.showerror("Backup Failed", f"The campaign was not replaced.\n\n{exc}", parent=self)
+            return
+        messagebox.showinfo("Local Backup Created", f"Backup saved to:\n{archive}", parent=self)
+        self._confirm_campaign_update(root, result, allow_non_clean=True)
+
+    def _publish_local_campaign_revision(self, root: Path, result) -> None:
+        """Route a safe local-publication choice to the existing publisher."""
+        if result.conflict:
+            messagebox.showwarning(
+                "Campaign Conflict",
+                "Local and remote changes derive from the same parent revision. "
+                "Publishing over the remote revision is disabled.",
+                parent=self,
+            )
+            return
+        self.open_cross_campaign_asset_library()
+        publisher = self._asset_library_window
+        if publisher is None:
+            return
+        matching_campaign = next(
+            (
+                campaign
+                for campaign in publisher.source_campaigns
+                if campaign.root.resolve() == root.resolve()
+            ),
+            None,
+        )
+        if matching_campaign is None:
+            messagebox.showerror(
+                "Publish Local Campaign",
+                "The active campaign could not be selected in the publisher.",
+                parent=self,
+            )
+            return
+        publisher.select_campaign(matching_campaign)
+        # Defer until the publisher has rendered the selected campaign. Its
+        # existing full-campaign publication flow requests title, description,
+        # and a final explicit confirmation from the user.
+        publisher.after_idle(publisher.publish_selected_to_github)
+
+    def _save_remote_campaign_snapshot(self, root: Path, result) -> None:
+        """Download/copy a remote revision without applying it to the campaign."""
+        destination = filedialog.asksaveasfilename(
+            title="Save Remote Campaign Snapshot",
+            initialfile=f"{root.name}_remote_r{result.available_revision}.zip",
+            defaultextension=".zip",
+            filetypes=[("Zip Archives", "*.zip")],
+        )
+        if not destination:
+            return
+        cached = self._downloaded_campaign_updates.get((str(root), result.available_revision))
+        if cached is not None and cached.exists():
+            shutil.copy2(cached, destination)
+            return
+
+        def worker(progress):
+            return self._campaign_update_checker.gallery_client.download_bundle(
+                result.bundle, Path(destination), progress_callback=progress
+            )
+
+        self._run_progress_task("Saving Remote Campaign Snapshot", worker, None)
 
     def _download_campaign_update(self, root: Path, result, *, show_prompt: bool) -> None:
         temp_dir = Path(tempfile.mkdtemp(prefix="gmcd_campaign_update_"))
@@ -3739,7 +3818,25 @@ class MainWindow(ctk.CTk):
 
         self._run_progress_task("Downloading Campaign Update", worker, None, on_success=downloaded)
 
-    def _confirm_campaign_update(self, root: Path, result) -> None:
+    def _confirm_campaign_update(
+        self, root: Path, result, *, allow_non_clean: bool = False
+    ) -> None:
+        # The campaign can change while a prompt is open or an archive is
+        # downloading.  Revalidate at the destructive boundary rather than
+        # relying on the earlier update-check result.
+        if not allow_non_clean:
+            local_changes = CampaignChangeDetector(
+                self._campaign_update_checker.installation_store
+            ).detect(root)
+            if local_changes.state is not CampaignChangeState.CLEAN:
+                messagebox.showwarning(
+                    "Campaign Changed",
+                    "The campaign is no longer known to match the installed revision. "
+                    "Use the backup-and-replace option or save the remote snapshot separately.",
+                    parent=self,
+                )
+                self._queue_campaign_update_check(force=True)
+                return
         if not messagebox.askyesno(
             "Apply Campaign Update",
             f"Apply revision {result.available_revision} to '{result.campaign_name}' now?",

--- a/modules/generic/campaign_sync/__init__.py
+++ b/modules/generic/campaign_sync/__init__.py
@@ -1,9 +1,16 @@
 """Campaign synchronization identity, revisions, and snapshot utilities."""
 
 from .models import CampaignSyncMetadata, RemoteCampaignRevision
+from .change_detector import (
+    CampaignChangeDetector, CampaignChangeResult, CampaignChangeState,
+    calculate_campaign_fingerprint, create_campaign_backup_archive,
+)
 from .update_checker import CampaignUpdateChecker, CampaignUpdateResult, UpdateCheckSettings, UpdateStatus
 
 __all__ = [
     "CampaignSyncMetadata", "RemoteCampaignRevision", "CampaignUpdateChecker",
     "CampaignUpdateResult", "UpdateCheckSettings", "UpdateStatus",
+    "CampaignChangeDetector", "CampaignChangeResult", "CampaignChangeState",
+    "calculate_campaign_fingerprint",
+    "create_campaign_backup_archive",
 ]

--- a/modules/generic/campaign_sync/change_detector.py
+++ b/modules/generic/campaign_sync/change_detector.py
@@ -1,0 +1,248 @@
+"""Canonical campaign fingerprints and conservative local-change detection.
+
+Only content that participates in a full-campaign synchronization is included.
+Sync bookkeeping and SQLite's transient sidecar files are deliberately excluded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Iterable, Optional
+
+from modules.generic.cross_campaign_bundle_extras import collect_full_campaign_extra_files
+
+from .hashing import sha256_file
+from .metadata_store import InstallationStateStore
+
+_CONTENT_DIRECTORIES = (Path("assets"), Path("world_maps"))
+_SQLITE_SIDECARS = ("-journal", "-shm", "-wal")
+_TRANSIENT_NAMES = {".DS_Store", "Thumbs.db"}
+_TRANSIENT_SUFFIXES = (".tmp", ".temp", ".part", ".swp", "~")
+
+
+class CampaignChangeState(str, Enum):
+    CLEAN = "clean"
+    LOCALLY_MODIFIED = "locally_modified"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class CampaignChangeResult:
+    state: CampaignChangeState
+    current_fingerprint: Optional[str] = None
+    baseline_fingerprint: Optional[str] = None
+    error: Optional[str] = None
+
+    @property
+    def allows_one_click_replacement(self) -> bool:
+        return self.state is CampaignChangeState.CLEAN
+
+
+def _is_transient(path: Path) -> bool:
+    name = path.name
+    return (
+        name in _TRANSIENT_NAMES
+        or name.startswith(".~")
+        or name.endswith(_SQLITE_SIDECARS)
+        or any(name.endswith(suffix) for suffix in _TRANSIENT_SUFFIXES)
+    )
+
+
+def _database_path(root: Path, database_path: Optional[Path]) -> Path:
+    if database_path is not None:
+        candidate = Path(database_path)
+        return (root / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+    candidates = sorted(
+        (item.resolve() for item in root.glob("*.db") if item.is_file()),
+        key=lambda item: item.name,
+    )
+    if len(candidates) != 1:
+        raise ValueError(f"expected one campaign database in {root}, found {len(candidates)}")
+    return candidates[0]
+
+
+def sqlite_snapshot_sha256(database_path: Path) -> str:
+    """Hash a transactionally consistent SQLite backup, never the live file."""
+    source_path = Path(database_path).resolve()
+    if not source_path.is_file():
+        raise FileNotFoundError(source_path)
+    descriptor, snapshot_name = tempfile.mkstemp(prefix="gmcd_fingerprint_", suffix=".db")
+    os.close(descriptor)
+    snapshot = Path(snapshot_name)
+    try:
+        source = sqlite3.connect(f"file:{source_path.as_posix()}?mode=ro", uri=True)
+        destination = sqlite3.connect(str(snapshot))
+        try:
+            source.backup(destination)
+        finally:
+            destination.close()
+            source.close()
+        return sha256_file(snapshot)
+    finally:
+        snapshot.unlink(missing_ok=True)
+
+
+def create_campaign_backup_archive(
+    campaign_root: Path,
+    destination: Path,
+    *,
+    database_path: Optional[Path] = None,
+) -> Path:
+    """Create a zip backup whose database member is a consistent snapshot.
+
+    ``shutil.make_archive`` must not be pointed at a live campaign directly:
+    copying a database while SQLite is writing can produce a corrupt backup.
+    Stage the ordinary files first, then place a SQLite-backup copy of the
+    database into the staged tree before creating the archive.
+    """
+    root = Path(campaign_root).expanduser().resolve()
+    database = _database_path(root, database_path)
+    try:
+        database_relative = database.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("campaign database must be inside the campaign root") from exc
+
+    destination = Path(destination).expanduser().resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gmcd_campaign_backup_") as temp_name:
+        staged = Path(temp_name) / root.name
+
+        def ignore(directory: str, names: list[str]) -> set[str]:
+            directory_path = Path(directory).resolve()
+            ignored: set[str] = set()
+            for name in names:
+                candidate = directory_path / name
+                if candidate == database or (
+                    directory_path == database.parent
+                    and name.startswith(database.name)
+                    and name[len(database.name):] in _SQLITE_SIDECARS
+                ):
+                    ignored.add(name)
+            return ignored
+
+        shutil.copytree(root, staged, ignore=ignore)
+        staged_database = staged / database_relative
+        staged_database.parent.mkdir(parents=True, exist_ok=True)
+        source = sqlite3.connect(f"file:{database.as_posix()}?mode=ro", uri=True)
+        snapshot = sqlite3.connect(staged_database)
+        try:
+            source.backup(snapshot)
+        finally:
+            snapshot.close()
+            source.close()
+
+        archive_base = destination.with_suffix("") if destination.suffix.lower() == ".zip" else destination
+        archive = Path(shutil.make_archive(str(archive_base), "zip", root_dir=staged))
+        if archive != destination:
+            shutil.move(str(archive), destination)
+        return destination
+
+
+def _content_files(root: Path) -> Iterable[tuple[Path, str]]:
+    found: dict[str, Path] = {}
+    for directory in _CONTENT_DIRECTORIES:
+        base = root / directory
+        if not base.is_dir():
+            continue
+        for item in base.rglob("*"):
+            if item.is_file() and not _is_transient(item):
+                found[item.relative_to(root).as_posix()] = item
+    for item, relative in collect_full_campaign_extra_files(root):
+        if item.is_file() and not _is_transient(item):
+            found[Path(relative).as_posix()] = item
+    return sorted(found.items(), key=lambda pair: pair[0])
+
+
+def _normalized_relative_path(value: str) -> str:
+    """Normalize and validate a path before it becomes part of the digest."""
+    normalized = value.replace("\\", "/")
+    path = Path(normalized)
+    if path.is_absolute() or any(part in ("", ".", "..") for part in path.parts):
+        raise ValueError(f"invalid synchronized-content path: {value!r}")
+    return path.as_posix()
+
+
+def calculate_campaign_fingerprint(
+    campaign_root: Path, *, database_path: Optional[Path] = None
+) -> str:
+    """Return the canonical SHA-256 of normalized paths and content hashes."""
+    root = Path(campaign_root).expanduser().resolve()
+    database = _database_path(root, database_path)
+    try:
+        database_relative = database.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError("campaign database must be inside the campaign root") from exc
+
+    entries = [(_normalized_relative_path(database_relative), sqlite_snapshot_sha256(database))]
+    entries.extend(
+        (_normalized_relative_path(relative), sha256_file(path))
+        for relative, path in _content_files(root)
+    )
+    digest = hashlib.sha256()
+    for relative, file_digest in sorted(entries, key=lambda pair: pair[0]):
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(bytes.fromhex(file_digest))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+class CampaignChangeDetector:
+    """Compare campaign content with the last installed/published baseline."""
+
+    def __init__(self, installation_store: Optional[InstallationStateStore] = None) -> None:
+        self.installation_store = installation_store or InstallationStateStore()
+
+    @staticmethod
+    def installation_key(campaign_root: Path) -> str:
+        return str(Path(campaign_root).expanduser().resolve())
+
+    def persist_baseline(
+        self, campaign_root: Path, fingerprint: Optional[str] = None, *, database_path: Optional[Path] = None
+    ) -> str:
+        value = fingerprint or calculate_campaign_fingerprint(campaign_root, database_path=database_path)
+        if len(value) != 64:
+            raise ValueError("campaign fingerprint must be a SHA-256 hexadecimal digest")
+        try:
+            bytes.fromhex(value)
+        except ValueError as exc:
+            raise ValueError("campaign fingerprint must be a SHA-256 hexadecimal digest") from exc
+        self.installation_store.update_campaign_state(
+            self.installation_key(campaign_root), baseline_fingerprint=value
+        )
+        return value
+
+    def detect(self, campaign_root: Path, *, database_path: Optional[Path] = None) -> CampaignChangeResult:
+        baseline = self.installation_store.campaign_state(
+            self.installation_key(campaign_root)
+        ).get("baseline_fingerprint")
+        if not isinstance(baseline, str) or len(baseline) != 64:
+            return CampaignChangeResult(CampaignChangeState.UNKNOWN)
+        try:
+            current = calculate_campaign_fingerprint(campaign_root, database_path=database_path)
+        # Fingerprinting is a safety gate.  An unexpected implementation or
+        # filesystem failure must fail closed instead of enabling replacement.
+        except Exception as exc:
+            return CampaignChangeResult(
+                CampaignChangeState.UNKNOWN, baseline_fingerprint=baseline, error=str(exc)
+            )
+        state = (
+            CampaignChangeState.CLEAN
+            if current == baseline
+            else CampaignChangeState.LOCALLY_MODIFIED
+        )
+        return CampaignChangeResult(state, current, baseline)
+
+
+__all__ = [
+    "CampaignChangeDetector", "CampaignChangeResult", "CampaignChangeState",
+    "calculate_campaign_fingerprint", "create_campaign_backup_archive",
+    "sqlite_snapshot_sha256",
+]

--- a/modules/generic/campaign_sync/hashing.py
+++ b/modules/generic/campaign_sync/hashing.py
@@ -15,14 +15,7 @@ def sha256_file(path: Path) -> str:
 
 
 def hash_campaign_snapshot(campaign_root: Path) -> str:
-    """Hash names and contents, excluding local sync bookkeeping."""
-    root = Path(campaign_root).resolve()
-    digest = hashlib.sha256()
-    for path in sorted((item for item in root.rglob("*") if item.is_file()), key=lambda item: item.relative_to(root).as_posix()):
-        relative = path.relative_to(root).as_posix()
-        if relative.startswith(".gmcd/"):
-            continue
-        digest.update(relative.encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(bytes.fromhex(sha256_file(path)))
-    return digest.hexdigest()
+    """Compatibility wrapper for the canonical synchronized-content hash."""
+    from .change_detector import calculate_campaign_fingerprint
+
+    return calculate_campaign_fingerprint(campaign_root)

--- a/modules/generic/campaign_sync/update_checker.py
+++ b/modules/generic/campaign_sync/update_checker.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from .metadata_store import CampaignSyncMetadataStore, InstallationStateStore
+from .change_detector import CampaignChangeDetector, CampaignChangeState
 
 
 class UpdateStatus(str, Enum):
@@ -40,6 +41,8 @@ class CampaignUpdateResult:
     checked_remote: bool = False
     ignored: bool = False
     error: Optional[str] = None
+    local_change_state: CampaignChangeState = CampaignChangeState.UNKNOWN
+    conflict: bool = False
 
 
 class CampaignUpdateChecker:
@@ -131,6 +134,17 @@ class CampaignUpdateChecker:
         available = revision > metadata.revision
         ignored = available and ignored_revision == revision
         status = UpdateStatus.UPDATE_AVAILABLE if available and not ignored else UpdateStatus.UP_TO_DATE
+        local_changes = CampaignChangeDetector(self.installation_store).detect(root)
+        remote_parent = getattr(remote, "parent_revision", None)
+        if remote_parent is None:
+            remote_metadata = getattr(remote, "metadata", {})
+            sync_value = remote_metadata.get("sync", {}) if isinstance(remote_metadata, dict) else {}
+            remote_parent = sync_value.get("parent_revision") if isinstance(sync_value, dict) else None
+        conflict = (
+            available
+            and local_changes.state is CampaignChangeState.LOCALLY_MODIFIED
+            and remote_parent == metadata.revision
+        )
         summary = getattr(remote, "change_summary", None)
         if not summary:
             remote_metadata = getattr(remote, "metadata", {})
@@ -147,6 +161,8 @@ class CampaignUpdateChecker:
             bundle=remote,
             checked_remote=True,
             ignored=ignored,
+            local_change_state=local_changes.state,
+            conflict=conflict,
         )
 
     def ignore_revision(self, campaign_root: Path, revision: int) -> None:

--- a/modules/generic/campaign_sync/update_ui.py
+++ b/modules/generic/campaign_sync/update_ui.py
@@ -4,22 +4,26 @@ from __future__ import annotations
 
 import tkinter as tk
 from datetime import datetime
-from typing import Callable
+from typing import Callable, Optional
 
 import customtkinter as ctk
 
 from .settings import CampaignUpdatePreferences
 from .update_checker import CampaignUpdateResult
+from .change_detector import CampaignChangeState
 
 
 class CampaignUpdatePrompt(ctk.CTkToplevel):
     """Non-modal prompt: the rest of the application remains usable."""
 
     def __init__(self, master, result: CampaignUpdateResult, *, on_update: Callable[[], None],
-                 on_later: Callable[[], None], on_ignore: Callable[[], None]) -> None:
+                 on_later: Callable[[], None], on_ignore: Callable[[], None],
+                 on_backup_replace: Optional[Callable[[], None]] = None,
+                 on_publish_local: Optional[Callable[[], None]] = None,
+                 on_save_remote: Optional[Callable[[], None]] = None) -> None:
         super().__init__(master)
         self.title("Campaign update available")
-        self.geometry("560x390")
+        self.geometry("680x500")
         self.resizable(False, False)
         self.transient(master)
         self.protocol("WM_DELETE_WINDOW", self._later)
@@ -41,16 +45,44 @@ class CampaignUpdatePrompt(ctk.CTkToplevel):
             details.append(f"Publisher: {result.publisher}")
         if result.change_summary:
             details.extend(("", "Changes:", result.change_summary))
+        if result.conflict:
+            details.extend((
+                "", "Conflict: local and remote changes derive from the same parent revision.",
+                "Nothing will be merged or overwritten automatically.",
+            ))
+        elif result.local_change_state is CampaignChangeState.LOCALLY_MODIFIED:
+            details.extend(("", "Local content has changed since the installed revision."))
+        elif result.local_change_state is CampaignChangeState.UNKNOWN:
+            details.extend(("", "Local change state is unknown; a safe one-click replacement is disabled."))
         ctk.CTkLabel(self, text="\n".join(details), justify="left", anchor="nw",
                      wraplength=500).pack(fill="both", expand=True, padx=28, pady=12)
         buttons = ctk.CTkFrame(self, fg_color="transparent")
         buttons.pack(fill="x", padx=20, pady=(8, 20))
-        ctk.CTkButton(buttons, text="Update now", command=lambda: self._choose(on_update)).pack(side="left")
-        ctk.CTkButton(buttons, text="Later", command=self._later).pack(side="left", padx=10)
-        ctk.CTkButton(buttons, text="Ignore this revision", command=lambda: self._choose(on_ignore)).pack(side="right")
+        if result.local_change_state is CampaignChangeState.CLEAN:
+            ctk.CTkButton(buttons, text="Replace with update", command=lambda: self._choose(on_update)).pack(side="left")
+        else:
+            ctk.CTkButton(
+                buttons, text="Back up local and replace",
+                command=lambda: self._choose(on_backup_replace),
+                state="normal" if on_backup_replace else "disabled",
+            ).pack(side="left")
+            ctk.CTkButton(
+                buttons, text="Publish local as new revision",
+                command=lambda: self._choose(on_publish_local),
+                state="normal" if on_publish_local and not result.conflict else "disabled",
+            ).pack(side="left", padx=8)
+            ctk.CTkButton(
+                buttons, text="Save remote separately",
+                command=lambda: self._choose(on_save_remote),
+                state="normal" if on_save_remote else "disabled",
+            ).pack(side="left")
+        ctk.CTkButton(buttons, text="Cancel", command=self._later).pack(side="right", padx=8)
+        ctk.CTkButton(buttons, text="Ignore", command=lambda: self._choose(on_ignore)).pack(side="right")
         self.lift()
 
-    def _choose(self, callback: Callable[[], None]) -> None:
+    def _choose(self, callback: Optional[Callable[[], None]]) -> None:
+        if callback is None:
+            return
         self.destroy()
         callback()
 

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -32,6 +32,7 @@ from modules.generic.cross_campaign_gm_tables import (
 )
 from modules.generic.generic_model_wrapper import GenericModelWrapper
 from modules.generic.campaign_sync.hashing import hash_campaign_snapshot
+from modules.generic.campaign_sync.change_detector import CampaignChangeDetector
 from modules.generic.campaign_sync.metadata_store import (
     CampaignSyncMetadataStore,
     InstallationStateStore,
@@ -905,6 +906,11 @@ def export_bundle(
         # failed export must not consume a revision number.
         if include_database:
             sync_store.write(sync_metadata)
+            CampaignChangeDetector().persist_baseline(
+                source_campaign.root,
+                sync_metadata.snapshot_sha256,
+                database_path=source_campaign.db_path,
+            )
 
         _call_progress(progress_callback, "Export completed", 1.0)
     finally:
@@ -1603,6 +1609,16 @@ def install_full_campaign_bundle(
             )
 
         install_wallpaper_bundle(temp_dir, target_root, manifest)
+
+        sync_value = manifest.get("sync")
+        if isinstance(sync_value, dict):
+            sync_metadata = CampaignSyncMetadata.from_dict(sync_value)
+            CampaignSyncMetadataStore(target_root).write(sync_metadata)
+            # Compute this installation's baseline from what was actually
+            # restored rather than trusting archive metadata alone.
+            CampaignChangeDetector().persist_baseline(
+                target_root, database_path=db_destination
+            )
 
         campaign_name = str(
             manifest.get("source_campaign", {}).get("name") or target_dir.name

--- a/tests/generic/campaign_sync/test_change_detector.py
+++ b/tests/generic/campaign_sync/test_change_detector.py
@@ -1,0 +1,103 @@
+import sqlite3
+import zipfile
+
+import pytest
+
+from modules.generic.campaign_sync.change_detector import (
+    CampaignChangeDetector,
+    CampaignChangeState,
+    calculate_campaign_fingerprint,
+    create_campaign_backup_archive,
+)
+from modules.generic.campaign_sync.metadata_store import InstallationStateStore
+
+
+@pytest.fixture
+def campaign(tmp_path):
+    root = tmp_path / "campaign"
+    root.mkdir()
+    connection = sqlite3.connect(root / "campaign.db")
+    connection.execute("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)")
+    connection.execute("INSERT INTO notes(body) VALUES ('original')")
+    connection.commit()
+    connection.close()
+    files = {
+        "image": root / "assets/image_library/scene.png",
+        "attachment": root / "assets/attachments/handout.pdf",
+        "gm_table": root / "gm_table_layouts.json",
+        "extra": root / "static/data/random_tables.json",
+    }
+    for path, value in zip(files.values(), (b"image", b"attachment", b"[]", b"{}")):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(value)
+    return root, files
+
+
+def _detector(tmp_path, root):
+    detector = CampaignChangeDetector(
+        InstallationStateStore(tmp_path / "installation.json")
+    )
+    detector.persist_baseline(root)
+    assert detector.detect(root).state is CampaignChangeState.CLEAN
+    return detector
+
+
+def test_database_mutation_marks_campaign_dirty(tmp_path, campaign):
+    root, _ = campaign
+    detector = _detector(tmp_path, root)
+    connection = sqlite3.connect(root / "campaign.db")
+    connection.execute("INSERT INTO notes(body) VALUES ('changed')")
+    connection.commit()
+    connection.close()
+    assert detector.detect(root).state is CampaignChangeState.LOCALLY_MODIFIED
+
+
+@pytest.mark.parametrize("file_key", ["image", "attachment", "gm_table", "extra"])
+def test_synchronized_file_mutation_marks_campaign_dirty(tmp_path, campaign, file_key):
+    root, files = campaign
+    detector = _detector(tmp_path, root)
+    files[file_key].write_bytes(files[file_key].read_bytes() + b"changed")
+    assert detector.detect(root).state is CampaignChangeState.LOCALLY_MODIFIED
+
+
+def test_transient_and_sync_metadata_do_not_change_fingerprint(campaign):
+    root, _ = campaign
+    baseline = calculate_campaign_fingerprint(root)
+    transient = root / "assets/image_library/upload.tmp"
+    transient.write_bytes(b"in progress")
+    sync = root / ".gmcd/sync.json"
+    sync.parent.mkdir()
+    sync.write_text('{"revision": 999}', encoding="utf-8")
+    (root / "campaign.db-wal").write_bytes(b"transient")
+    assert calculate_campaign_fingerprint(root) == baseline
+
+
+def test_repeated_sqlite_snapshots_are_deterministic(campaign):
+    root, _ = campaign
+    assert calculate_campaign_fingerprint(root) == calculate_campaign_fingerprint(root)
+
+
+def test_missing_baseline_and_fingerprint_failure_are_unknown(tmp_path, campaign):
+    root, _ = campaign
+    store = InstallationStateStore(tmp_path / "installation.json")
+    detector = CampaignChangeDetector(store)
+    assert detector.detect(root).state is CampaignChangeState.UNKNOWN
+    detector.persist_baseline(root)
+    (root / "campaign.db").unlink()
+    result = detector.detect(root)
+    assert result.state is CampaignChangeState.UNKNOWN
+    assert result.error
+
+
+def test_backup_archive_contains_readable_sqlite_snapshot(tmp_path, campaign):
+    root, _ = campaign
+    archive = create_campaign_backup_archive(root, tmp_path / "backup.zip")
+    restored = tmp_path / "restored"
+    with zipfile.ZipFile(archive) as bundle:
+        bundle.extractall(restored)
+    connection = sqlite3.connect(restored / "campaign.db")
+    try:
+        assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        assert connection.execute("SELECT body FROM notes").fetchall() == [("original",)]
+    finally:
+        connection.close()


### PR DESCRIPTION
### Motivation

- Provide a canonical, deterministic fingerprint for synchronized campaigns that covers the database and all synchronized content while excluding transient and sync bookkeeping files. 
- Prevent accidental data loss by detecting local modifications and gating destructive one-click replacement behind an explicit safety workflow. 
- Ensure exports/installs persist a baseline fingerprint from the actual restored snapshot so later comparisons are accurate. 

### Description

- Add `modules/generic/campaign_sync/change_detector.py` which implements `calculate_campaign_fingerprint`, `sqlite_snapshot_sha256`, `create_campaign_backup_archive`, and `CampaignChangeDetector` to compute and persist canonical SHA-256 fingerprints based on SQLite snapshots plus sorted normalized relative paths and per-file SHA-256s. 
- Integrate the detector: make `modules/generic/campaign_sync/hashing.py` delegate to the new canonical function, use `CampaignChangeDetector` in `modules/generic/campaign_sync/update_checker.py` to classify local state and detect same-parent conflicts, and persist baselines from `export_bundle` and `install_full_campaign_bundle` in `modules/generic/cross_campaign_asset_service.py`. 
- Extend the UI logic in `modules/generic/campaign_sync/update_ui.py` and `main_window.py` to surface clean/modified/unknown states, disable silent replacement on conflicts, and provide explicit choices: cancel, backup-and-replace, publish-local (when permitted), or save remote snapshot separately. 
- Add unit tests in `tests/generic/campaign_sync/test_change_detector.py` that mutate the database, image, GM-table, and extra-file independently and assert the detector marks the campaign dirty, plus tests that transient files and sync metadata do not affect the fingerprint and that backup archives contain a valid SQLite snapshot. 

### Testing

- Ran `pytest -q tests/generic/campaign_sync tests/test_cross_campaign_asset_service.py` with the targeted tests, resulting in `54 passed` for those suites. 
- Verified byte-compile with `python -m compileall -q modules/generic/campaign_sync modules/generic/cross_campaign_asset_service.py main_window.py` and checked style errors with `git diff --check`. 
- Noted that a full `pytest -q` run is blocked in this environment by unrelated collection issues and missing GUI/dependency mocks, so broader test collection produced environment-specific collection errors and skipped tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a665a5aab8c832bb5684c9cd2197640)