### PR TITLE
Add transactional full-campaign synchronization updater

### DIFF
--- a/modules/generic/campaign_sync/__init__.py
+++ b/modules/generic/campaign_sync/__init__.py
@@ -2,15 +2,39 @@
 
 from .models import CampaignSyncMetadata, RemoteCampaignRevision
 from .change_detector import (
-    CampaignChangeDetector, CampaignChangeResult, CampaignChangeState,
-    calculate_campaign_fingerprint, create_campaign_backup_archive,
+    CampaignChangeDetector,
+    CampaignChangeResult,
+    CampaignChangeState,
+    calculate_campaign_fingerprint,
+    create_campaign_backup_archive,
 )
-from .update_checker import CampaignUpdateChecker, CampaignUpdateResult, UpdateCheckSettings, UpdateStatus
+from .update_checker import (
+    CampaignUpdateChecker,
+    CampaignUpdateResult,
+    UpdateCheckSettings,
+    UpdateStatus,
+)
+from .updater import (
+    CampaignUpdateCancelled,
+    CampaignUpdateError,
+    CampaignUpdateReceipt,
+    CampaignUpdater,
+)
 
 __all__ = [
-    "CampaignSyncMetadata", "RemoteCampaignRevision", "CampaignUpdateChecker",
-    "CampaignUpdateResult", "UpdateCheckSettings", "UpdateStatus",
-    "CampaignChangeDetector", "CampaignChangeResult", "CampaignChangeState",
+    "CampaignSyncMetadata",
+    "RemoteCampaignRevision",
+    "CampaignUpdateChecker",
+    "CampaignUpdateResult",
+    "UpdateCheckSettings",
+    "UpdateStatus",
+    "CampaignChangeDetector",
+    "CampaignChangeResult",
+    "CampaignChangeState",
     "calculate_campaign_fingerprint",
     "create_campaign_backup_archive",
+    "CampaignUpdateCancelled",
+    "CampaignUpdateError",
+    "CampaignUpdateReceipt",
+    "CampaignUpdater",
 ]

--- a/modules/generic/campaign_sync/updater.py
+++ b/modules/generic/campaign_sync/updater.py
@@ -1,0 +1,384 @@
+"""Transactional installation of complete synchronized campaign snapshots.
+
+This module deliberately does not use ``cross_campaign_asset_service.apply_import``.
+That function is a merge-oriented, manual import facility; synchronization must
+replace the complete snapshot so that remote deletions remain deletions.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from modules.generic.cross_campaign_asset_service import (
+    BUNDLE_VERSION,
+    _safe_extract_zip,
+)
+from modules.helpers import backup_helper
+
+from .change_detector import CampaignChangeDetector, calculate_campaign_fingerprint
+from .hashing import sha256_file
+from .metadata_store import CampaignSyncMetadataStore, InstallationStateStore
+from .models import CampaignSyncMetadata
+
+ProgressCallback = Callable[[str, float], None]
+CancelCallback = Callable[[], bool]
+LifecycleCallback = Callable[[], None]
+
+
+class CampaignUpdateError(RuntimeError):
+    """The synchronized snapshot could not be installed safely."""
+
+
+class CampaignUpdateCancelled(CampaignUpdateError):
+    """Cancellation requested before the replacement transaction began."""
+
+
+@dataclass(frozen=True)
+class CampaignUpdateReceipt:
+    campaign_root: Path
+    revision: int
+    backup_path: Path
+    baseline_fingerprint: str
+
+
+def _noop() -> None:
+    return None
+
+
+def _manifest_path(root: Path, value: object, *, label: str) -> Path:
+    text = str(value or "").replace("\\", "/")
+    candidate = (root / text).resolve()
+    if not text or Path(text).is_absolute():
+        raise CampaignUpdateError(f"Invalid {label} path: {text!r}")
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as exc:
+        raise CampaignUpdateError(f"Invalid {label} path: {text!r}") from exc
+    return candidate
+
+
+def _iter_declared_files(manifest: dict) -> Iterable[tuple[str, dict]]:
+    database = manifest.get("database")
+    if isinstance(database, dict):
+        yield str(database.get("relative_path") or ""), database
+    for meta in (manifest.get("entities") or {}).values():
+        if isinstance(meta, dict):
+            yield str(meta.get("data_path") or ""), meta
+    for key in ("systems", "world_maps"):
+        meta = manifest.get(key)
+        if isinstance(meta, dict):
+            yield str(meta.get("data_path") or meta.get("path") or ""), meta
+    for key in ("assets", "extra_files"):
+        for meta in manifest.get(key) or ():
+            if isinstance(meta, dict):
+                yield str(meta.get("bundle_path") or ""), meta
+
+
+def _validate_declared_hashes(extracted: Path, manifest: dict) -> None:
+    """Validate every manifest entry that declares a SHA-256 digest."""
+    for relative, meta in _iter_declared_files(manifest):
+        expected = meta.get("sha256") or meta.get("checksum_sha256")
+        if not expected:
+            continue
+        path = _manifest_path(extracted, relative, label="declared file")
+        if not path.is_file():
+            raise CampaignUpdateError(f"Declared bundle file is missing: {relative}")
+        if sha256_file(path).lower() != str(expected).lower():
+            raise CampaignUpdateError(f"SHA-256 mismatch for bundle file: {relative}")
+
+
+def _copy_payload(extracted: Path, staging: Path, manifest: dict) -> Path:
+    """Materialize the full-bundle transport layout as a campaign directory."""
+    database = manifest["database"]
+    source_db = _manifest_path(
+        extracted, database.get("relative_path"), label="database"
+    )
+    if not source_db.is_file():
+        raise CampaignUpdateError("Bundle database entry does not exist")
+    db_name = str(database.get("file_name") or source_db.name)
+    if Path(db_name).name != db_name:
+        raise CampaignUpdateError("Invalid database file name")
+    staging.mkdir()
+    target_db = staging / db_name
+    shutil.copy2(source_db, target_db)
+
+    for entry in manifest.get("assets") or ():
+        if not isinstance(entry, dict):
+            continue
+        source = _manifest_path(extracted, entry.get("bundle_path"), label="asset")
+        destination = _manifest_path(
+            staging, entry.get("original_path"), label="asset destination"
+        )
+        if source.is_file():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+    for entry in manifest.get("extra_files") or ():
+        if not isinstance(entry, dict):
+            continue
+        source = _manifest_path(extracted, entry.get("bundle_path"), label="extra file")
+        destination = _manifest_path(
+            staging, entry.get("relative_path"), label="extra destination"
+        )
+        if not source.is_file():
+            raise CampaignUpdateError(f"Declared extra file is missing: {source.name}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    return target_db
+
+
+def _validate_sqlite(path: Path) -> None:
+    try:
+        connection = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+        try:
+            result = connection.execute("PRAGMA quick_check").fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        raise CampaignUpdateError(
+            f"Unable to open bundled campaign database: {exc}"
+        ) from exc
+    if not result or result[0] != "ok":
+        raise CampaignUpdateError("Bundled campaign database failed SQLite validation")
+
+
+def _preserve_local_settings(
+    active: Path, staging: Path, relative_paths: Iterable[Path]
+) -> None:
+    """Copy only explicitly documented local files, filtering Gallery secrets."""
+    for relative in relative_paths:
+        relative = Path(relative)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise CampaignUpdateError(
+                f"Invalid machine-local settings path: {relative}"
+            )
+        source, destination = active / relative, staging / relative
+        if not source.is_file():
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.name.lower() == "settings.ini":
+            parser = configparser.ConfigParser()
+            parser.read(source, encoding="utf-8")
+            if parser.has_section("Gallery"):
+                for option in tuple(parser.options("Gallery")):
+                    if "token" in option.lower() or "credential" in option.lower():
+                        parser.remove_option("Gallery", option)
+            with destination.open("w", encoding="utf-8") as handle:
+                parser.write(handle)
+        else:
+            shutil.copy2(source, destination)
+
+
+class CampaignUpdater:
+    """Download, validate, and atomically replace one active campaign."""
+
+    def __init__(
+        self,
+        gallery_client,
+        *,
+        installation_store: Optional[InstallationStateStore] = None,
+        backup_creator: Optional[Callable[[Path], object]] = None,
+        quiesce: LifecycleCallback = _noop,
+        reopen: LifecycleCallback = _noop,
+        local_settings: Iterable[Path] = (),
+        replace: Callable[[os.PathLike, os.PathLike], None] = os.replace,
+    ) -> None:
+        self.gallery_client = gallery_client
+        self.installation_store = installation_store or InstallationStateStore()
+        self.backup_creator = backup_creator or backup_helper.create_backup_archive
+        self.quiesce = quiesce
+        self.reopen = reopen
+        self.local_settings = tuple(local_settings)
+        self.replace = replace
+
+    def install(
+        self,
+        campaign_root: Path,
+        release,
+        *,
+        progress: Optional[ProgressCallback] = None,
+        cancelled: Optional[CancelCallback] = None,
+    ) -> CampaignUpdateReceipt:
+        active = Path(campaign_root).expanduser().resolve()
+        current = CampaignSyncMetadataStore(active).read()
+        if current is None:
+            raise CampaignUpdateError("Campaign is not linked for synchronization")
+        expected_mode = str(getattr(release, "snapshot_mode", "") or "").lower()
+        if expected_mode and expected_mode != "full_campaign":
+            raise CampaignUpdateError(
+                "Asset-only bundles cannot be synchronized automatically"
+            )
+
+        def report(message: str, fraction: float) -> None:
+            if progress:
+                progress(message, fraction)
+
+        def check_cancel() -> None:
+            if cancelled and cancelled():
+                raise CampaignUpdateCancelled("Campaign update cancelled")
+
+        parent = active.parent
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        backup = parent / f"{active.name}.backup-{stamp}.zip"
+        rollback = parent / f".{active.name}.rollback-{stamp}"
+        staging = parent / f".{active.name}.staging-{stamp}"
+        replacement_started = False
+        with tempfile.TemporaryDirectory(prefix="gmcd_sync_download_") as temp_name:
+            archive = Path(temp_name) / "campaign.zip"
+            check_cancel()
+            report("Downloading campaign snapshot…", 0.05)
+            self.gallery_client.download_bundle(
+                release, archive, progress_callback=progress
+            )
+            check_cancel()
+            expected_archive_hash = str(
+                getattr(release, "snapshot_sha256", "") or ""
+            ).lower()
+            if (
+                not expected_archive_hash
+                or sha256_file(archive) != expected_archive_hash
+            ):
+                raise CampaignUpdateError(
+                    "Downloaded archive SHA-256 does not match release metadata"
+                )
+
+            extracted = Path(temp_name) / "extracted"
+            extracted.mkdir()
+            try:
+                with zipfile.ZipFile(archive) as bundle:
+                    _safe_extract_zip(bundle, extracted)
+            except (zipfile.BadZipFile, ValueError) as exc:
+                raise CampaignUpdateError(f"Invalid campaign ZIP: {exc}") from exc
+            manifest_path = extracted / "manifest.json"
+            if not manifest_path.is_file():
+                raise CampaignUpdateError("Bundle manifest missing")
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if manifest.get("version") != BUNDLE_VERSION:
+                raise CampaignUpdateError(
+                    f"Unsupported bundle version: {manifest.get('version')}"
+                )
+            if manifest.get("bundle_mode") != "full_campaign" or not isinstance(
+                manifest.get("database"), dict
+            ):
+                raise CampaignUpdateError(
+                    "Asset-only bundles cannot be synchronized automatically"
+                )
+            sync = CampaignSyncMetadata.from_dict(manifest.get("sync") or {})
+            if sync.bundle_version != BUNDLE_VERSION:
+                raise CampaignUpdateError("Incompatible synchronized bundle version")
+            release_campaign = str(
+                getattr(release, "campaign_id", "") or sync.campaign_id
+            )
+            release_revision = getattr(release, "revision", sync.revision)
+            release_parent = getattr(release, "parent_revision", sync.parent_revision)
+            if (
+                sync.campaign_id != current.campaign_id
+                or release_campaign != current.campaign_id
+            ):
+                raise CampaignUpdateError(
+                    "Campaign ID does not match the active campaign"
+                )
+            if sync.revision != release_revision or sync.revision <= current.revision:
+                raise CampaignUpdateError(
+                    "Bundle revision does not match the selected release"
+                )
+            if (
+                sync.parent_revision != current.revision
+                or release_parent != current.revision
+            ):
+                raise CampaignUpdateError(
+                    "Bundle parent revision does not match the installed revision"
+                )
+            _validate_declared_hashes(extracted, manifest)
+            check_cancel()
+            report("Creating safety backup…", 0.55)
+            try:
+                self.backup_creator(backup)
+            except Exception as exc:
+                raise CampaignUpdateError(
+                    f"Unable to create campaign backup: {exc}"
+                ) from exc
+            check_cancel()
+            if staging.exists() or rollback.exists():
+                raise CampaignUpdateError("Update staging location already exists")
+            target_db = _copy_payload(extracted, staging, manifest)
+            _validate_sqlite(target_db)
+            _preserve_local_settings(active, staging, self.local_settings)
+            CampaignSyncMetadataStore(staging).write(sync)
+            check_cancel()
+            report("Preparing campaign replacement…", 0.9)
+            self.quiesce()
+            replacement_started = True
+            try:
+                self.replace(active, rollback)
+                try:
+                    self.replace(staging, active)
+                except Exception:
+                    self.replace(rollback, active)
+                    raise
+                try:
+                    self.reopen()
+                    baseline = calculate_campaign_fingerprint(
+                        active, database_path=active / target_db.name
+                    )
+                    CampaignChangeDetector(self.installation_store).persist_baseline(
+                        active, baseline, database_path=active / target_db.name
+                    )
+                    self.installation_store.update_campaign_state(
+                        str(active), installed_revision=sync.revision
+                    )
+                except Exception as exc:
+                    failed = parent / f".{active.name}.failed-{stamp}"
+                    self.replace(active, failed)
+                    self.replace(rollback, active)
+                    try:
+                        self.reopen()
+                    finally:
+                        shutil.rmtree(failed, ignore_errors=True)
+                    raise CampaignUpdateError(
+                        f"Campaign reopen failed; previous campaign restored: {exc}"
+                    ) from exc
+                shutil.rmtree(rollback)
+                return CampaignUpdateReceipt(active, sync.revision, backup, baseline)
+            except CampaignUpdateError:
+                raise
+            except Exception as exc:
+                if rollback.exists() and not active.exists():
+                    self.replace(rollback, active)
+                    try:
+                        self.reopen()
+                    except Exception:
+                        pass
+                elif active.exists():
+                    # The first rename can fail after the lifecycle was
+                    # quiesced; resume the untouched campaign in that case.
+                    try:
+                        self.reopen()
+                    except Exception:
+                        pass
+                raise CampaignUpdateError(
+                    f"Atomic campaign replacement failed: {exc}"
+                ) from exc
+            finally:
+                if staging.exists():
+                    shutil.rmtree(staging, ignore_errors=True)
+                # No progress/cancellation callbacks are consulted after
+                # replacement_started becomes true: commit or rollback only.
+                _ = replacement_started
+
+
+__all__ = [
+    "CampaignUpdateCancelled",
+    "CampaignUpdateError",
+    "CampaignUpdateReceipt",
+    "CampaignUpdater",
+]

--- a/tests/generic/campaign_sync/test_updater.py
+++ b/tests/generic/campaign_sync/test_updater.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from modules.generic.campaign_sync.metadata_store import (
+    CampaignSyncMetadataStore,
+    InstallationStateStore,
+)
+from modules.generic.campaign_sync.models import CampaignSyncMetadata
+from modules.generic.campaign_sync.updater import CampaignUpdateError, CampaignUpdater
+
+
+def _metadata(
+    campaign_id: str, revision: int, parent: int | None, digest: str = "0" * 64
+):
+    return CampaignSyncMetadata(
+        campaign_id=campaign_id,
+        revision=revision,
+        parent_revision=parent,
+        snapshot_sha256=digest,
+        published_at="2026-07-26T00:00:00Z",
+        publisher_installation_id="computer-a",
+        bundle_version=1,
+    )
+
+
+def _campaign(
+    path: Path, campaign_id: str, revision: int = 1, value: str = "old"
+) -> Path:
+    path.mkdir()
+    database = path / "campaign.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE items (value TEXT)")
+        connection.execute("INSERT INTO items VALUES (?)", (value,))
+    (path / "assets").mkdir()
+    (path / "assets" / "obsolete.txt").write_text("delete me", encoding="utf-8")
+    CampaignSyncMetadataStore(path).write(
+        _metadata(campaign_id, revision, revision - 1 or None)
+    )
+    return path
+
+
+def _bundle(
+    tmp_path: Path,
+    campaign_id: str,
+    *,
+    revision=2,
+    parent=1,
+    version=1,
+    mode="full_campaign",
+    member_name=None,
+) -> tuple[Path, object]:
+    source = tmp_path / f"source-{uuid4().hex}"
+    source.mkdir()
+    database = source / "new.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE items (value TEXT)")
+        connection.execute("INSERT INTO items VALUES ('new')")
+    asset = source / "new.txt"
+    asset.write_text("new asset", encoding="utf-8")
+    manifest = {
+        "version": version,
+        "bundle_mode": mode,
+        "database": {
+            "file_name": "campaign.db",
+            "relative_path": "database/campaign.db",
+            "sha256": hashlib.sha256(database.read_bytes()).hexdigest(),
+        },
+        "assets": [
+            {
+                "bundle_path": "payload/new.txt",
+                "original_path": "assets/new.txt",
+                "sha256": hashlib.sha256(asset.read_bytes()).hexdigest(),
+            }
+        ],
+        "sync": _metadata(campaign_id, revision, parent).to_dict(),
+    }
+    archive = tmp_path / f"bundle-{uuid4().hex}.zip"
+    with zipfile.ZipFile(archive, "w") as bundle:
+        bundle.writestr(member_name or "manifest.json", json.dumps(manifest))
+        bundle.write(database, "database/campaign.db")
+        bundle.write(asset, "payload/new.txt")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    release = SimpleNamespace(
+        campaign_id=campaign_id,
+        revision=revision,
+        parent_revision=parent,
+        snapshot_sha256=digest,
+        snapshot_mode=mode,
+    )
+    return archive, release
+
+
+class Client:
+    def __init__(self, archive: Path, failure: Exception | None = None):
+        self.archive, self.failure = archive, failure
+
+    def download_bundle(self, release, destination, progress_callback=None):
+        destination.write_bytes(
+            self.archive.read_bytes()[:20]
+            if self.failure
+            else self.archive.read_bytes()
+        )
+        if self.failure:
+            raise self.failure
+        return destination
+
+
+def _updater(tmp_path, archive, **kwargs):
+    store = InstallationStateStore(tmp_path / "installation.json")
+
+    def backup(path):
+        Path(path).write_bytes(b"backup")
+
+    return CampaignUpdater(
+        Client(archive),
+        installation_store=store,
+        backup_creator=kwargs.pop("backup_creator", backup),
+        **kwargs,
+    )
+
+
+def test_interrupted_download_does_not_replace_campaign(tmp_path):
+    campaign_id, active = str(uuid4()), None
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id)
+    updater = CampaignUpdater(
+        Client(archive, IOError("interrupted")), backup_creator=lambda p: None
+    )
+    with pytest.raises(IOError, match="interrupted"):
+        updater.install(active, release)
+    assert (active / "assets" / "obsolete.txt").exists()
+
+
+def test_checksum_mismatch_is_rejected(tmp_path):
+    campaign_id = str(uuid4())
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id)
+    release.snapshot_sha256 = "f" * 64
+    with pytest.raises(CampaignUpdateError, match="archive SHA-256"):
+        _updater(tmp_path, archive).install(active, release)
+
+
+def test_invalid_zip_path_is_rejected(tmp_path):
+    campaign_id = str(uuid4())
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id, member_name="../manifest.json")
+    with pytest.raises(CampaignUpdateError, match="Invalid campaign ZIP"):
+        _updater(tmp_path, archive).install(active, release)
+
+
+@pytest.mark.parametrize(
+    ("campaign_override", "version", "mode", "message"),
+    [
+        (True, 1, "full_campaign", "Campaign ID"),
+        (False, 99, "full_campaign", "Unsupported bundle version"),
+        (False, 1, "asset_bundle", "Asset-only"),
+    ],
+)
+def test_invalid_bundle_identity_version_and_mode(
+    tmp_path, campaign_override, version, mode, message
+):
+    campaign_id = str(uuid4())
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(
+        tmp_path,
+        str(uuid4()) if campaign_override else campaign_id,
+        version=version,
+        mode=mode,
+    )
+    if campaign_override:
+        release.campaign_id = campaign_id
+    with pytest.raises(CampaignUpdateError, match=message):
+        _updater(tmp_path, archive).install(active, release)
+
+
+def test_backup_failure_prevents_quiesce_and_replacement(tmp_path):
+    campaign_id = str(uuid4())
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id)
+    quiesced = []
+
+    def fail(_):
+        raise OSError("disk full")
+
+    with pytest.raises(CampaignUpdateError, match="backup"):
+        _updater(
+            tmp_path,
+            archive,
+            backup_creator=fail,
+            quiesce=lambda: quiesced.append(True),
+        ).install(active, release)
+    assert not quiesced and (active / "assets" / "obsolete.txt").exists()
+
+
+def test_first_rename_failure_leaves_active_campaign(tmp_path):
+    campaign_id = str(uuid4())
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id)
+
+    def fail(source, destination):
+        raise OSError("rename denied")
+
+    with pytest.raises(CampaignUpdateError, match="replacement failed"):
+        _updater(tmp_path, archive, replace=fail).install(active, release)
+    assert (active / "assets" / "obsolete.txt").exists()
+
+
+def test_database_reopen_failure_restores_previous_campaign(tmp_path):
+    campaign_id = str(uuid4())
+    active = _campaign(tmp_path / "campaign", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id)
+    calls = []
+
+    def reopen():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("UI database rejected")
+
+    with pytest.raises(CampaignUpdateError, match="previous campaign restored"):
+        _updater(tmp_path, archive, reopen=reopen).install(active, release)
+    assert len(calls) == 2
+    assert (active / "assets" / "obsolete.txt").read_text() == "delete me"
+    assert not list(tmp_path.glob(".campaign.rollback-*"))
+
+
+def test_two_computer_full_snapshot_integration(tmp_path):
+    campaign_id = str(uuid4())
+    computer_a = _campaign(tmp_path / "computer-a", campaign_id)
+    computer_b = _campaign(tmp_path / "computer-b", campaign_id)
+    archive, release = _bundle(tmp_path, campaign_id)
+    receipt = _updater(tmp_path, archive).install(computer_b, release)
+    assert receipt.revision == 2 and receipt.backup_path.is_file()
+    assert not (computer_b / "assets" / "obsolete.txt").exists()
+    assert (computer_b / "assets" / "new.txt").read_text() == "new asset"
+    with sqlite3.connect(computer_b / "campaign.db") as connection:
+        assert connection.execute("SELECT value FROM items").fetchone()[0] == "new"
+    assert CampaignSyncMetadataStore(computer_b).read().revision == 2
+    assert CampaignSyncMetadataStore(computer_a).read().revision == 1


### PR DESCRIPTION
### Motivation

- Provide a dedicated, atomic installation path for full-campaign synchronized snapshots instead of using the manual/merge-oriented import flow. 
- Ensure synchronized updates are safe by verifying archive integrity, manifest contents, declared file hashes, and SQLite integrity before replacing the active campaign. 
- Make updates recoverable by creating backups, quiescing the app, and supporting deterministic rollback on failure while preserving documented local machine settings (but never copying credentials).

### Description

- Add a new transactional updater `modules/generic/campaign_sync/updater.py` which implements download into a temporary directory, SHA-256 archive verification, safe ZIP extraction, manifest and bundle-version validation, declared-file hash checks, and rejection of asset-only bundles. 
- Implement staging-on-same-filesystem extraction, creation of a timestamped safety backup using `modules/helpers/backup_helper.py`, SQLite validation, and selective preservation of documented local settings with Gallery credential filtering. 
- Perform an atomic replacement by renaming the active campaign to a rollback location and moving staging into the active path while quiescing UI/database connections, then reinitialize database/views, persist the installed revision and baseline fingerprint, and delete rollback only after successful reopen. 
- Export updater types from the package via `modules/generic/campaign_sync/__init__.py` and add `tests/generic/campaign_sync/test_updater.py` with failure-injection and an integration scenario; keep this flow separate from `apply_import` (manual import remains unchanged).

### Testing

- Ran `pytest -q tests/generic/campaign_sync` and the added test-suite completed successfully. 
- Tests include injected-failure scenarios for interrupted downloads, checksum mismatch, invalid ZIP paths, wrong campaign ID, incompatible bundle versions/modes, backup failure, rename failure, and database reopen failure which all behaved as expected. 
- A two-computer integration test using temporary campaign directories verified that a full snapshot replaces the receiving campaign (removing remote deletions), updates the DB, and records the installed revision. 
- All automated tests for the new updater passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a665d6a56f4832b95b19b7d3ac74758)