### PR TITLE
Add conflict-aware synchronized campaign publishing

### DIFF
--- a/docs/campaign_synchronization.md
+++ b/docs/campaign_synchronization.md
@@ -1,0 +1,43 @@
+# Campaign synchronization and gallery bundles
+
+GMCampaignDesigner deliberately exposes three different distribution formats:
+
+* **Manual asset-library bundles** contain selected entities and attachments.
+  Importing them merges the selected material into a campaign. They do not have
+  a campaign identity or revision and never participate in update checks.
+* **Synchronized campaign snapshots** contain one complete campaign, including
+  a transactionally consistent SQLite snapshot. They carry a campaign UUID,
+  parent revision, monotonically increasing revision, and content digest. They
+  are installed/replaced as a whole rather than merged.
+* **Image-library-only bundles** contain reusable image-library records. They
+  are manual bundles and must never trigger campaign update prompts.
+
+## Publication protocol
+
+`modules/generic/campaign_sync/publisher.py` is the sole publication path for a
+synchronized full campaign. It reads the installed campaign identity/revision,
+finds the latest remote revision for that exact UUID, and requires it to match
+the revision on which the local copy is based. If it does not match, publication
+stops until the remote update has been downloaded and reconciled.
+
+The publisher creates a consistent SQLite backup and complete bundle, assigns
+the next integer revision, embeds the campaign content SHA-256 digest, records
+the completed archive SHA-256 digest in release and installed metadata, and
+checks the remote revision again immediately before release creation. Local
+installed metadata and the local baseline advance only after release creation
+and post-publication verification succeed. A duplicate revision or a newer
+revision observed afterward marks the publication as **conflicted**; the
+application never silently chooses a winner.
+
+Enabling synchronization on a legacy campaign creates revision 1 and a UUID in
+`.gmcd/sync.json`. The same metadata is embedded in the synchronized bundle
+manifest, so installing the snapshot on another computer retains the campaign
+UUID. **Unlink this local copy** removes only the local link; it does not delete
+remote releases.
+
+## Concurrency limitation
+
+GitHub Releases has no atomic compare-and-swap or transactional revision
+allocator. Checking immediately before and after publication makes conflicts
+visible but leaves a small multi-writer race. Strict guarantees require a
+dedicated backend that allocates revisions transactionally.

--- a/main_window.py
+++ b/main_window.py
@@ -3774,10 +3774,9 @@ class MainWindow(ctk.CTk):
             )
             return
         publisher.select_campaign(matching_campaign)
-        # Defer until the publisher has rendered the selected campaign. Its
-        # existing full-campaign publication flow requests title, description,
-        # and a final explicit confirmation from the user.
-        publisher.after_idle(publisher.publish_selected_to_github)
+        # Full-campaign updates must use the optimistic revision publisher;
+        # the gallery action remains a merge-oriented manual asset feature.
+        publisher.after_idle(publisher.publish_campaign_update)
 
     def _save_remote_campaign_snapshot(self, root: Path, result) -> None:
         """Download/copy a remote revision without applying it to the campaign."""

--- a/modules/generic/campaign_sync/change_detector.py
+++ b/modules/generic/campaign_sync/change_detector.py
@@ -170,9 +170,17 @@ def _normalized_relative_path(value: str) -> str:
 
 
 def calculate_campaign_fingerprint(
-    campaign_root: Path, *, database_path: Optional[Path] = None
+    campaign_root: Path,
+    *,
+    database_path: Optional[Path] = None,
+    database_snapshot_path: Optional[Path] = None,
 ) -> str:
-    """Return the canonical SHA-256 of normalized paths and content hashes."""
+    """Return the canonical SHA-256 of normalized paths and content hashes.
+
+    ``database_snapshot_path`` lets a bundle producer hash the exact SQLite
+    backup that it will archive while retaining the live database's logical
+    relative path in the canonical digest.
+    """
     root = Path(campaign_root).expanduser().resolve()
     database = _database_path(root, database_path)
     try:
@@ -180,7 +188,14 @@ def calculate_campaign_fingerprint(
     except ValueError as exc:
         raise ValueError("campaign database must be inside the campaign root") from exc
 
-    entries = [(_normalized_relative_path(database_relative), sqlite_snapshot_sha256(database))]
+    if database_snapshot_path is None:
+        database_digest = sqlite_snapshot_sha256(database)
+    else:
+        snapshot = Path(database_snapshot_path).expanduser().resolve()
+        if not snapshot.is_file():
+            raise FileNotFoundError(snapshot)
+        database_digest = sha256_file(snapshot)
+    entries = [(_normalized_relative_path(database_relative), database_digest)]
     entries.extend(
         (_normalized_relative_path(relative), sha256_file(path))
         for relative, path in _content_files(root)

--- a/modules/generic/campaign_sync/publisher.py
+++ b/modules/generic/campaign_sync/publisher.py
@@ -1,0 +1,292 @@
+"""Safe publication of versioned, complete campaign snapshots.
+
+Manual gallery bundles intentionally remain in ``cross_campaign_asset_library``.
+This module is the only route that may advance synchronized campaign state.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+from uuid import uuid4
+
+from modules.generic.cross_campaign_asset_service import (
+    BUNDLE_VERSION,
+    CampaignDatabase,
+    export_bundle,
+)
+
+from .change_detector import CampaignChangeDetector, calculate_campaign_fingerprint
+from .hashing import sha256_file
+from .metadata_store import CampaignSyncMetadataStore, InstallationStateStore
+from .models import CampaignSyncMetadata
+
+
+class CampaignPublishError(RuntimeError):
+    """Base class for synchronization publication failures."""
+
+
+class CampaignNotLinkedError(CampaignPublishError):
+    """Raised when publication is requested for a legacy/unlinked campaign."""
+
+
+class StaleParentError(CampaignPublishError):
+    """The remote campaign advanced since this local snapshot was installed."""
+
+
+class PublishOutcome(str, Enum):
+    PUBLISHED = "published"
+    CONFLICTED = "conflicted"
+
+
+@dataclass(frozen=True)
+class CampaignPublishResult:
+    outcome: PublishOutcome
+    revision: int
+    campaign_id: str
+    snapshot_sha256: str
+    release: object
+    conflict_message: Optional[str] = None
+
+    @property
+    def conflicted(self) -> bool:
+        return self.outcome is PublishOutcome.CONFLICTED
+
+
+class CampaignPublisher:
+    """Publish full snapshots with optimistic revision checks.
+
+    GitHub Releases has no compare-and-swap operation.  The checks immediately
+    before and after release creation narrow, but cannot eliminate, a race
+    between independent publishers.
+    """
+
+    def __init__(
+        self,
+        gallery_client,
+        *,
+        installation_store: Optional[InstallationStateStore] = None,
+        retry_attempts: int = 3,
+        retry_delay: float = 0.05,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.gallery_client = gallery_client
+        self.installation_store = installation_store or InstallationStateStore()
+        self.retry_attempts = max(1, int(retry_attempts))
+        self.retry_delay = max(0.0, float(retry_delay))
+        self.sleeper = sleeper
+
+    def enable(self, campaign_root: Path, *, database_path: Optional[Path] = None) -> CampaignSyncMetadata:
+        """Give a legacy campaign a durable UUID and initial revision.
+
+        The metadata lives inside the campaign and is therefore retained when
+        the snapshot is installed on another computer.
+        """
+        root = Path(campaign_root).resolve()
+        store = CampaignSyncMetadataStore(root)
+        existing = store.read()
+        if existing is not None:
+            return existing
+        fingerprint = calculate_campaign_fingerprint(root, database_path=database_path)
+        metadata = CampaignSyncMetadata(
+            campaign_id=str(uuid4()), revision=1, parent_revision=None,
+            snapshot_sha256=fingerprint, published_at="",
+            publisher_installation_id=self.installation_store.installation_id(),
+            bundle_version=BUNDLE_VERSION, snapshot_mode="full_campaign",
+        )
+        store.write(metadata)
+        CampaignChangeDetector(self.installation_store).persist_baseline(
+            root, fingerprint, database_path=database_path
+        )
+        return metadata
+
+    def unlink(self, campaign_root: Path) -> bool:
+        """Remove the shared link and machine-local baseline from this copy."""
+        root = Path(campaign_root).resolve()
+        store = CampaignSyncMetadataStore(root)
+        existed = store.path.exists()
+        store.path.unlink(missing_ok=True)
+        state = self.installation_store.read()
+        campaigns = state.get("campaign_sync")
+        if isinstance(campaigns, dict):
+            campaigns.pop(str(root), None)
+            self.installation_store.write(state)
+        return existed
+
+    def publish(
+        self,
+        campaign_root: Path,
+        *,
+        database_path: Optional[Path] = None,
+        title: Optional[str] = None,
+        description: str = "",
+        change_summary: Optional[str] = None,
+        progress_callback=None,
+    ) -> CampaignPublishResult:
+        root = Path(campaign_root).resolve()
+        local = CampaignSyncMetadataStore(root).read()
+        if local is None:
+            raise CampaignNotLinkedError(
+                "Enable synchronization before publishing this campaign."
+            )
+        database = self._database_path(root, database_path)
+        remote = self._retry(lambda: self.gallery_client.highest_revision(local.campaign_id))
+        remote_revision = self._revision(remote)
+        # A newly enabled revision 1 is an unpublished baseline.  Otherwise the
+        # installed revision is the parent on which local edits are based.
+        expected_parent = 0 if local.revision == 1 and not local.published_at else local.revision
+        if remote_revision != expected_parent:
+            raise StaleParentError(
+                f"Remote revision is {remote_revision}; this local copy is based on "
+                f"revision {expected_parent}. Download and reconcile the remote update first."
+            )
+
+        revision = remote_revision + 1
+        temp_dir = Path(tempfile.mkdtemp(prefix="campaign_sync_publish_"))
+        try:
+            # Use one SQLite backup for record extraction, the archived database,
+            # and the content digest.  Reading the live database independently
+            # for each of those steps could describe different transactions.
+            database_snapshot = temp_dir / database.name
+            self._create_database_snapshot(database, database_snapshot)
+            content_digest = calculate_campaign_fingerprint(
+                root,
+                database_path=database,
+                database_snapshot_path=database_snapshot,
+            )
+            published_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            metadata = CampaignSyncMetadata(
+                campaign_id=local.campaign_id, revision=revision,
+                parent_revision=(remote_revision or None), snapshot_sha256=content_digest,
+                published_at=published_at,
+                publisher_installation_id=self.installation_store.installation_id(),
+                bundle_version=BUNDLE_VERSION, change_summary=change_summary,
+                snapshot_mode="full_campaign",
+            )
+            archive = temp_dir / f"{root.name}-r{revision}.zip"
+            manifest = export_bundle(
+                archive, CampaignDatabase(root.name, root, database_snapshot), {},
+                include_database=True, include_systems=True,
+                sync_metadata=metadata, change_summary=change_summary,
+                progress_callback=progress_callback,
+            )
+            # The updater authenticates the downloaded ZIP against release
+            # metadata.  Keep the content digest embedded in the ZIP manifest,
+            # then publish/store the digest of the completed immutable archive.
+            # (A ZIP cannot embed its own hash without making that hash stale.)
+            digest = sha256_file(archive)
+            release_sync = dict(manifest["sync"])
+            release_sync["content_sha256"] = content_digest
+            release_sync["snapshot_sha256"] = digest
+            manifest["sync"] = release_sync
+            metadata = CampaignSyncMetadata(
+                campaign_id=metadata.campaign_id,
+                revision=metadata.revision,
+                parent_revision=metadata.parent_revision,
+                snapshot_sha256=digest,
+                published_at=metadata.published_at,
+                publisher_installation_id=metadata.publisher_installation_id,
+                bundle_version=metadata.bundle_version,
+                change_summary=metadata.change_summary,
+                snapshot_mode=metadata.snapshot_mode,
+            )
+
+            # GitHub has no compare-and-swap primitive, so make the second
+            # optimistic check as close as possible to release creation.
+            latest = self._retry(
+                lambda: self.gallery_client.highest_revision(local.campaign_id)
+            )
+            if self._revision(latest) != remote_revision:
+                raise StaleParentError(
+                    "The remote campaign changed while preparing the snapshot; "
+                    "retry after updating."
+                )
+            release = self.gallery_client.publish_bundle(
+                archive, manifest, title=title or root.name,
+                description=description, progress_callback=progress_callback,
+            )
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+        matches = self._matching_revisions(local.campaign_id, revision)
+        highest = self._retry(lambda: self.gallery_client.highest_revision(local.campaign_id))
+        duplicate = len(matches) > 1 or self._revision(highest) != revision
+        if duplicate:
+            return CampaignPublishResult(
+                PublishOutcome.CONFLICTED, revision, local.campaign_id, digest, release,
+                "A duplicate or newer revision was detected after publication. Reconcile manually; no local baseline was advanced.",
+            )
+
+        # Release and verification succeeded: only now advance installed state.
+        CampaignSyncMetadataStore(root).write(metadata)
+        CampaignChangeDetector(self.installation_store).persist_baseline(
+            root, digest, database_path=database
+        )
+        return CampaignPublishResult(
+            PublishOutcome.PUBLISHED, revision, local.campaign_id, digest, release
+        )
+
+    @staticmethod
+    def _create_database_snapshot(source_path: Path, destination_path: Path) -> None:
+        source = sqlite3.connect(
+            f"file:{source_path.resolve().as_posix()}?mode=ro", uri=True
+        )
+        destination = sqlite3.connect(str(destination_path))
+        try:
+            source.backup(destination)
+        finally:
+            destination.close()
+            source.close()
+
+    def _matching_revisions(self, campaign_id: str, revision: int) -> list[object]:
+        list_bundles = getattr(self.gallery_client, "list_bundles", None)
+        if not callable(list_bundles):
+            return []
+        bundles = self._retry(list_bundles)
+        return [
+            item for item in bundles
+            if getattr(item, "campaign_id", None) == campaign_id
+            and getattr(item, "revision", None) == revision
+        ]
+
+    def _retry(self, operation):
+        for attempt in range(self.retry_attempts):
+            try:
+                return operation()
+            except Exception:
+                if attempt + 1 >= self.retry_attempts:
+                    raise
+                self.sleeper(self.retry_delay * (2 ** attempt))
+
+    @staticmethod
+    def _revision(remote: object | None) -> int:
+        value = getattr(remote, "revision", 0) if remote is not None else 0
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise CampaignPublishError("Remote campaign has invalid revision metadata")
+        return value
+
+    @staticmethod
+    def _database_path(root: Path, value: Optional[Path]) -> Path:
+        if value is not None:
+            path = Path(value).resolve()
+        else:
+            candidates = list(root.glob("*.db"))
+            if len(candidates) != 1:
+                raise CampaignPublishError(f"Expected one campaign database, found {len(candidates)}")
+            path = candidates[0].resolve()
+        if not path.is_file() or root not in path.parents:
+            raise CampaignPublishError("Campaign database must be inside the campaign directory")
+        return path
+
+
+__all__ = [
+    "CampaignNotLinkedError", "CampaignPublishError", "CampaignPublishResult",
+    "CampaignPublisher", "PublishOutcome", "StaleParentError",
+]

--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -34,6 +34,11 @@ from modules.generic.github_gallery_client import (
     GalleryBundleSummary,
     GithubGalleryClient,
 )
+from modules.generic.campaign_sync.metadata_store import CampaignSyncMetadataStore
+from modules.generic.campaign_sync.publisher import (
+    CampaignPublisher,
+    PublishOutcome,
+)
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.checkbox_dialog import CheckboxDialog
 from modules.helpers.logging_helper import log_exception, log_info, log_warning
@@ -72,6 +77,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         }
 
         self.gallery_client = GithubGalleryClient()
+        self.campaign_publisher = CampaignPublisher(self.gallery_client)
         self._online_dialog: Optional["OnlineGalleryDialog"] = None
         self.active_campaign = get_active_campaign()
         self.source_campaigns: List[CampaignDatabase] = []
@@ -231,6 +237,23 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             command=self.configure_github_token,
         )
         self.github_token_btn.grid(row=0, column=8, padx=6, pady=6, sticky="ew")
+
+        sync_row = ctk.CTkFrame(self)
+        sync_row.grid(row=2, column=0, columnspan=2, sticky="ew", padx=10, pady=(0, 10))
+        for column_index in range(4):
+            sync_row.grid_columnconfigure(column_index, weight=1)
+        ctk.CTkButton(sync_row, text="Enable synchronization", command=self.enable_campaign_sync).grid(
+            row=0, column=0, padx=6, pady=6, sticky="ew"
+        )
+        ctk.CTkButton(sync_row, text="Publish campaign update", command=self.publish_campaign_update).grid(
+            row=0, column=1, padx=6, pady=6, sticky="ew"
+        )
+        ctk.CTkButton(sync_row, text="Check for updates", command=self.check_campaign_updates).grid(
+            row=0, column=2, padx=6, pady=6, sticky="ew"
+        )
+        ctk.CTkButton(sync_row, text="Unlink this local copy", command=self.unlink_campaign_sync).grid(
+            row=0, column=3, padx=6, pady=6, sticky="ew"
+        )
 
         self._update_publish_button_state()
 
@@ -593,22 +616,13 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             return
 
         selections = self._gather_selected_records()
-        publishing_full_campaign = False
         if not selections:
-            # Handle the branch where selections is unavailable.
-            if not messagebox.askyesno(
-                "Publish Entire Campaign",
-                "No assets are selected.\n\nDo you want to publish the entire campaign database, including all attachments?",
-            ):
-                return
-            selections = self._gather_all_records()
-            if not selections:
-                messagebox.showinfo(
-                    "Nothing to Publish",
-                    "The selected campaign does not contain any exportable assets.",
-                )
-                return
-            publishing_full_campaign = True
+            messagebox.showinfo(
+                "Select Manual Assets",
+                "This action publishes a manual asset-library bundle that can be merged. "
+                "Select assets, or use 'Publish campaign update' for a versioned complete snapshot.",
+            )
+            return
 
         default_title = self.selected_campaign.name or "Campaign Bundle"
         title = simpledialog.askstring(
@@ -636,28 +650,107 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         description = description.strip()
 
         include_random_tables = False
-        if not publishing_full_campaign:
-            random_tables_dialog = CheckboxDialog(
-                self,
-                title="Publish Options",
-                message="Do you want to include random tables files from this campaign?",
-                checkbox_label="Include random tables",
-                default=False,
-                confirm_label="Continue",
-                cancel_label="Cancel",
-            )
-            self.wait_window(random_tables_dialog)
-            if random_tables_dialog.result is None:
-                return
-            include_random_tables = bool(random_tables_dialog.result)
+        random_tables_dialog = CheckboxDialog(
+            self,
+            title="Publish Options",
+            message="Do you want to include random tables files from this campaign?",
+            checkbox_label="Include random tables",
+            default=False,
+            confirm_label="Continue",
+            cancel_label="Cancel",
+        )
+        self.wait_window(random_tables_dialog)
+        if random_tables_dialog.result is None:
+            return
+        include_random_tables = bool(random_tables_dialog.result)
 
         self._publish_bundle_to_github(
             selections=selections,
             title=title,
             description=description,
-            include_database=publishing_full_campaign,
+            include_database=False,
             include_random_tables=include_random_tables,
         )
+
+    def enable_campaign_sync(self):
+        if not self.selected_campaign:
+            messagebox.showwarning("No Source", "Select a source campaign first.")
+            return
+        metadata = self.campaign_publisher.enable(
+            self.selected_campaign.root, database_path=self.selected_campaign.db_path
+        )
+        messagebox.showinfo(
+            "Synchronization Enabled",
+            f"Campaign ID: {metadata.campaign_id}\nInitial revision: {metadata.revision}",
+        )
+
+    def publish_campaign_update(self):
+        if not self.selected_campaign:
+            messagebox.showwarning("No Source", "Select a source campaign first.")
+            return
+        if not self.gallery_client.can_publish:
+            messagebox.showerror("GitHub Token Required", "Configure a GitHub token before publishing.")
+            return
+        title = simpledialog.askstring(
+            "Campaign Update", "Release title:", initialvalue=self.selected_campaign.name, parent=self
+        )
+        if title is None:
+            return
+        summary = simpledialog.askstring("Change Summary", "What changed?", parent=self)
+        if summary is None:
+            return
+
+        campaign = self.selected_campaign
+
+        def worker(callback):
+            return self.campaign_publisher.publish(
+                campaign.root,
+                database_path=campaign.db_path,
+                title=title.strip() or campaign.name,
+                change_summary=summary.strip() or None,
+                progress_callback=callback,
+            )
+
+        def success(result):
+            if result.outcome is PublishOutcome.CONFLICTED:
+                messagebox.showwarning("Publication Conflict", result.conflict_message)
+            else:
+                messagebox.showinfo("Campaign Published", f"Revision {result.revision} was published.")
+            self._refresh_online_dialog()
+        self._run_progress_task(
+            "Publishing Campaign Update", worker, None, None, on_success=success
+        )
+
+    def check_campaign_updates(self):
+        if not self.selected_campaign:
+            messagebox.showwarning("No Source", "Select a source campaign first.")
+            return
+        callback = getattr(self.master, "_queue_campaign_update_check", None)
+        if (
+            callable(callback)
+            and self.selected_campaign.root.resolve()
+            == self.active_campaign.root.resolve()
+        ):
+            callback(force=True)
+        else:
+            messagebox.showinfo(
+                "Check for Updates",
+                "Select this campaign as the active campaign to check it.",
+            )
+
+    def unlink_campaign_sync(self):
+        if not self.selected_campaign:
+            messagebox.showwarning("No Source", "Select a source campaign first.")
+            return
+        if not CampaignSyncMetadataStore(self.selected_campaign.root).read():
+            messagebox.showinfo("Not Linked", "This local campaign is not synchronized.")
+            return
+        if messagebox.askyesno(
+            "Unlink Local Copy",
+            "Stop update checks for this local copy? Remote releases are unchanged.",
+        ):
+            self.campaign_publisher.unlink(self.selected_campaign.root)
+            messagebox.showinfo("Campaign Unlinked", "This local copy is no longer synchronized.")
 
     def publish_image_library_to_github(self):
         """Publish image library records from the selected campaign to GitHub."""

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Dict, Iterable, List, Optional, Tuple
-from uuid import uuid4
 
 from modules.audio.entity_audio import normalize_audio_reference
 from modules.generic.ambiance_wallpaper_bundle import (
@@ -31,12 +30,8 @@ from modules.generic.cross_campaign_gm_tables import (
     merge_gm_virtual_tables,
 )
 from modules.generic.generic_model_wrapper import GenericModelWrapper
-from modules.generic.campaign_sync.hashing import hash_campaign_snapshot
 from modules.generic.campaign_sync.change_detector import CampaignChangeDetector
-from modules.generic.campaign_sync.metadata_store import (
-    CampaignSyncMetadataStore,
-    InstallationStateStore,
-)
+from modules.generic.campaign_sync.metadata_store import CampaignSyncMetadataStore
 from modules.generic.campaign_sync.models import CampaignSyncMetadata
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.portrait_helper import (
@@ -712,6 +707,7 @@ def export_bundle(
     include_random_tables: bool = False,
     gm_virtual_tables: Optional[List[dict]] = None,
     change_summary: Optional[str] = None,
+    sync_metadata: Optional[CampaignSyncMetadata] = None,
     progress_callback=None,
 ) -> dict:
     """Export bundle."""
@@ -743,21 +739,9 @@ def export_bundle(
         "assets": [],
         "bundle_mode": "full_campaign" if include_database else "asset_bundle",
     }
-    if include_database:
-        sync_store = CampaignSyncMetadataStore(source_campaign.root)
-        previous_sync = sync_store.read()
-        revision = (previous_sync.revision + 1) if previous_sync else 1
-        sync_metadata = CampaignSyncMetadata(
-            campaign_id=(previous_sync.campaign_id if previous_sync else str(uuid4())),
-            revision=revision,
-            parent_revision=(previous_sync.revision if previous_sync else None),
-            snapshot_sha256=hash_campaign_snapshot(source_campaign.root),
-            published_at=manifest["created_at"],
-            publisher_installation_id=InstallationStateStore().installation_id(),
-            bundle_version=BUNDLE_VERSION,
-            change_summary=change_summary,
-            snapshot_mode="full_campaign",
-        )
+    if sync_metadata is not None:
+        if not include_database:
+            raise ValueError("Synchronized snapshots must include the campaign database")
         manifest["sync"] = sync_metadata.to_dict()
 
     assets_lookup: Dict[str, Path] = {}
@@ -872,8 +856,16 @@ def export_bundle(
                 db_dir = temp_root / "database"
                 db_dir.mkdir(parents=True, exist_ok=True)
                 db_destination = db_dir / source_campaign.db_path.name
-                shutil.copy2(source_campaign.db_path, db_destination)
-                stat = source_campaign.db_path.stat()
+                source = sqlite3.connect(
+                    f"file:{source_campaign.db_path.resolve().as_posix()}?mode=ro", uri=True
+                )
+                snapshot = sqlite3.connect(str(db_destination))
+                try:
+                    source.backup(snapshot)
+                finally:
+                    snapshot.close()
+                    source.close()
+                stat = db_destination.stat()
                 manifest["database"] = {
                     "file_name": source_campaign.db_path.name,
                     "relative_path": f"database/{source_campaign.db_path.name}",
@@ -901,16 +893,6 @@ def export_bundle(
                     continue
                 arcname = file_path.relative_to(temp_root).as_posix()
                 zf.write(file_path, arcname)
-
-        # Advance local state only after the complete snapshot was written.  A
-        # failed export must not consume a revision number.
-        if include_database:
-            sync_store.write(sync_metadata)
-            CampaignChangeDetector().persist_baseline(
-                source_campaign.root,
-                sync_metadata.snapshot_sha256,
-                database_path=source_campaign.db_path,
-            )
 
         _call_progress(progress_callback, "Export completed", 1.0)
     finally:

--- a/tests/generic/campaign_sync/test_publisher.py
+++ b/tests/generic/campaign_sync/test_publisher.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+from types import SimpleNamespace
+import sqlite3
+import zipfile
+import json
+import io
+
+import pytest
+
+from modules.generic.campaign_sync.metadata_store import InstallationStateStore
+from modules.generic.campaign_sync.hashing import sha256_file
+from modules.generic.campaign_sync.publisher import (
+    CampaignPublisher,
+    PublishOutcome,
+    StaleParentError,
+)
+
+
+class MockGallery:
+    def __init__(self):
+        self.releases = []
+        self.failures = 0
+        self.duplicate_on_publish = False
+
+    def highest_revision(self, campaign_id):
+        if self.failures:
+            self.failures -= 1
+            raise OSError("temporary API failure")
+        matches = [item for item in self.releases if item.campaign_id == campaign_id]
+        return max(matches, key=lambda item: item.revision, default=None)
+
+    def list_bundles(self):
+        return list(self.releases)
+
+    def publish_bundle(self, archive, manifest, **_kwargs):
+        sync = manifest["sync"]
+        archive_bytes = Path(archive).read_bytes()
+        release = SimpleNamespace(
+            **sync,
+            archive=Path(archive),
+            archive_sha256=sha256_file(Path(archive)),
+            archive_bytes=archive_bytes,
+        )
+        self.releases.append(release)
+        if self.duplicate_on_publish:
+            self.releases.append(SimpleNamespace(**sync))
+        return release
+
+
+@pytest.fixture
+def campaign(tmp_path):
+    root = tmp_path / "Campaign"
+    root.mkdir()
+    database = root / "campaign.db"
+    connection = sqlite3.connect(database)
+    connection.execute("CREATE TABLE notes (value TEXT)")
+    connection.execute("INSERT INTO notes VALUES ('one')")
+    connection.commit()
+    connection.close()
+    return root, database
+
+
+def _publisher(tmp_path, gallery, **kwargs):
+    store = InstallationStateStore(tmp_path / "installation.json")
+    return CampaignPublisher(gallery, installation_store=store, retry_delay=0, **kwargs)
+
+
+def test_successful_sequential_publication(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery)
+    identity = publisher.enable(root, database_path=database)
+
+    first = publisher.publish(root, database_path=database)
+    connection = sqlite3.connect(database)
+    connection.execute("INSERT INTO notes VALUES ('two')")
+    connection.commit()
+    connection.close()
+    second = publisher.publish(root, database_path=database)
+
+    assert first.outcome is PublishOutcome.PUBLISHED and first.revision == 1
+    assert second.outcome is PublishOutcome.PUBLISHED and second.revision == 2
+    assert second.campaign_id == identity.campaign_id
+
+
+def test_release_digest_authenticates_archive_and_bundle_retains_uuid(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery)
+    identity = publisher.enable(root, database_path=database)
+
+    result = publisher.publish(root, database_path=database)
+
+    assert result.snapshot_sha256 == result.release.archive_sha256
+    with zipfile.ZipFile(io.BytesIO(result.release.archive_bytes)) as archive:
+        manifest = json.loads(archive.read("manifest.json"))
+    assert manifest["sync"]["campaign_id"] == identity.campaign_id
+
+
+def test_stale_parent_is_rejected_before_release(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery)
+    identity = publisher.enable(root, database_path=database)
+    gallery.releases.append(SimpleNamespace(campaign_id=identity.campaign_id, revision=2))
+
+    with pytest.raises(StaleParentError, match="Download and reconcile"):
+        publisher.publish(root, database_path=database)
+    assert len(gallery.releases) == 1
+
+
+def test_duplicate_revision_is_reported_without_advancing_local_state(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery)
+    local = publisher.enable(root, database_path=database)
+    gallery.duplicate_on_publish = True
+
+    result = publisher.publish(root, database_path=database)
+
+    assert result.outcome is PublishOutcome.CONFLICTED
+    assert publisher.enable(root, database_path=database) == local
+
+
+def test_remote_lookup_retries_transient_failures(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    gallery.failures = 2
+    publisher = _publisher(tmp_path, gallery, retry_attempts=3)
+    publisher.enable(root, database_path=database)
+
+    assert publisher.publish(root, database_path=database).revision == 1
+
+
+def test_unrelated_releases_do_not_affect_revision(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    gallery.releases.append(SimpleNamespace(campaign_id="unrelated", revision=99))
+    publisher = _publisher(tmp_path, gallery)
+    publisher.enable(root, database_path=database)
+
+    assert publisher.publish(root, database_path=database).revision == 1

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -109,7 +109,7 @@ def test_export_bundle_raises_when_database_missing(tmp_path):
     assert not destination.exists()
 
 
-def test_full_campaign_export_persists_sync_identity_and_advances_revision(
+def test_manual_full_campaign_export_does_not_create_sync_identity(
     tmp_path, monkeypatch
 ):
     campaign_root = tmp_path / "campaign"
@@ -128,13 +128,9 @@ def test_full_campaign_export_persists_sync_identity_and_advances_revision(
         include_systems=False,
     )
 
-    assert first["sync"]["campaign_id"] == second["sync"]["campaign_id"]
-    assert first["sync"]["revision"] == 1
-    assert second["sync"]["revision"] == 2
-    assert second["sync"]["parent_revision"] == 1
-    stored = json.loads((campaign_root / ".gmcd" / "sync.json").read_text())
-    assert stored["campaign_id"] == first["sync"]["campaign_id"]
-    assert "Same display name" not in first["sync"].values()
+    assert first["bundle_mode"] == second["bundle_mode"] == "full_campaign"
+    assert "sync" not in first and "sync" not in second
+    assert not (campaign_root / ".gmcd" / "sync.json").exists()
 
 
 def test_collect_assets_includes_image_library_files(tmp_path):


### PR DESCRIPTION
### Motivation

- Provide a safe, versioned path for publishing full synchronized campaign snapshots that enforces parent-revision validation and preserves a durable campaign UUID across installs.
- Prevent accidental overwrites from concurrent publishers by detecting duplicate revisions and surfacing conflicts rather than silently choosing a winner. 
- Keep the existing manual gallery and image-library bundle workflows unchanged while exposing explicit UI actions for campaign synchronization. 

### Description

- Add a dedicated publisher `modules/generic/campaign_sync/publisher.py` implementing `CampaignPublisher` with: optimistic parent-revision checks, consistent SQLite snapshot creation, content/archive SHA-256 digests, retry logic, a post-publication duplicate-detection pass, and delayed local baseline advancement. 
- Extend fingerprinting to accept a `database_snapshot_path` via `calculate_campaign_fingerprint` so the archive and digest are computed from the same consistent SQLite backup. 
- Route full-campaign publications through the new publisher by adding UI actions and handlers: `Enable synchronization`, `Publish campaign update`, `Check for updates`, and `Unlink this local copy` (changes in `modules/generic/cross_campaign_asset_library.py` and `main_window.py`), while preserving manual asset-gallery publishing and image-library-only bundles. 
- Make `export_bundle` manifest-aware of `sync_metadata` and require snapshots to include the campaign database when `sync_metadata` is present, and update bundle database snapshotting to use SQLite `backup()` for consistency. 
- Add documentation `docs/campaign_synchronization.md` describing the three bundle types, publication protocol, and the remaining concurrency limitation with GitHub Releases. 
- Add mocked API tests `tests/generic/campaign_sync/test_publisher.py` covering successful sequential publishing, stale-parent rejection, duplicate revision detection, retry behavior, and unrelated-release isolation; and update a manual-bundle test to ensure manual exports do not implicitly create sync metadata. 

### Testing

- Ran `pytest -q tests/generic/campaign_sync tests/test_cross_campaign_asset_service.py` and the focused synchronization/gallery tests passed (reported as 70 passed). 
- Ran a broader targeted suite `pytest -q tests/generic/campaign_sync/test_gallery_revisions.py tests/generic/campaign_sync/test_update_checker.py tests/generic/campaign_sync/test_updater.py tests/generic/campaign_sync/test_publisher.py tests/test_cross_campaign_asset_service.py` which completed successfully for those suites (reported as 55 passed). 
- Verified bytecode compilation with `python -m compileall -q modules/generic/campaign_sync modules/generic/cross_campaign_asset_library.py modules/generic/cross_campaign_asset_service.py main_window.py` and ran `ruff` checks on new files without errors. 
- Note: a small multi-writer race remains due to GitHub Releases lacking an atomic compare-and-swap primitive; the publisher performs a second check immediately before release creation and flags conflicts if a duplicate/newer revision is observed after publication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a665f0faedc832b806a038d8ab58ca6)