### PR TITLE
Fix CTkToplevel teardown callback errors

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -32,7 +32,10 @@ from PIL import Image
 # Modular helper imports
 from modules.helpers.window_helper import position_window_at_top
 from modules.helpers import theme_manager
-from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch
+from modules.helpers.customtkinter_compat import (
+    apply_ctk_button_after_cleanup_patch,
+    apply_ctk_toplevel_after_cleanup_patch,
+)
 from modules.helpers.template_loader import (
     load_template,
     load_entity_definitions,
@@ -155,6 +158,7 @@ log_module_import(__name__)
 def configure_ui_defaults() -> None:
     """Apply global CustomTkinter defaults explicitly at app startup."""
     apply_ctk_button_after_cleanup_patch(ctk)
+    apply_ctk_toplevel_after_cleanup_patch(ctk)
     ctk.set_appearance_mode("Dark")
     theme_manager.apply_theme(theme_manager.get_theme())
 

--- a/modules/helpers/customtkinter_compat.py
+++ b/modules/helpers/customtkinter_compat.py
@@ -61,3 +61,57 @@ def apply_ctk_button_after_cleanup_patch(ctk_module: Any) -> None:
     button_cls.destroy = _safe_destroy
     button_cls._gm_after_cleanup_patch = True
     log_debug("Applied CTkButton after-cleanup compatibility patch")
+
+
+def apply_ctk_toplevel_after_cleanup_patch(ctk_module: Any) -> None:
+    """Cancel pending ``CTkToplevel`` callbacks before destroying the window.
+
+    On Windows, CustomTkinter temporarily withdraws a toplevel while changing
+    its title-bar colour and schedules a callback that calls ``deiconify``.
+    Destroying the window before that callback runs leaves the callback queued,
+    causing a ``TclError: bad window path name``.  Track callbacks registered on
+    each toplevel and cancel the outstanding ones during teardown.
+    """
+
+    toplevel_cls = getattr(ctk_module, "CTkToplevel", None)
+    if toplevel_cls is None:
+        return
+    if getattr(toplevel_cls, "_gm_after_cleanup_patch", False):
+        return
+
+    original_after = toplevel_cls.after
+    original_after_cancel = toplevel_cls.after_cancel
+    original_destroy = toplevel_cls.destroy
+
+    def _tracked_after(self: Any, ms: int, callback: Any = None, *args: Any) -> Any:
+        callback_id = original_after(self, ms, callback, *args)
+        if callback is not None and callback_id:
+            tracked = getattr(self, "_gm_tracked_after_ids", None)
+            if tracked is None:
+                tracked = set()
+                setattr(self, "_gm_tracked_after_ids", tracked)
+            tracked.add(callback_id)
+        return callback_id
+
+    def _tracked_after_cancel(self: Any, callback_id: Any) -> None:
+        tracked = getattr(self, "_gm_tracked_after_ids", None)
+        if tracked is not None:
+            tracked.discard(callback_id)
+        original_after_cancel(self, callback_id)
+
+    def _safe_destroy(self: Any) -> Any:
+        tracked = tuple(getattr(self, "_gm_tracked_after_ids", ()))
+        for callback_id in tracked:
+            try:
+                original_after_cancel(self, callback_id)
+            except Exception:
+                pass
+        if hasattr(self, "_gm_tracked_after_ids"):
+            self._gm_tracked_after_ids.clear()
+        return original_destroy(self)
+
+    toplevel_cls.after = _tracked_after
+    toplevel_cls.after_cancel = _tracked_after_cancel
+    toplevel_cls.destroy = _safe_destroy
+    toplevel_cls._gm_after_cleanup_patch = True
+    log_debug("Applied CTkToplevel after-cleanup compatibility patch")

--- a/tests/helpers/test_customtkinter_compat.py
+++ b/tests/helpers/test_customtkinter_compat.py
@@ -1,4 +1,7 @@
-from modules.helpers.customtkinter_compat import apply_ctk_button_after_cleanup_patch
+from modules.helpers.customtkinter_compat import (
+    apply_ctk_button_after_cleanup_patch,
+    apply_ctk_toplevel_after_cleanup_patch,
+)
 
 
 class _FakeButton:
@@ -22,6 +25,14 @@ class _FakeButton:
 
 class _FakeCTK:
     CTkButton = _FakeButton
+
+
+class _FakeToplevel(_FakeButton):
+    pass
+
+
+class _FakeToplevelCTK:
+    CTkToplevel = _FakeToplevel
 
 
 def test_patch_cancels_pending_after_callbacks_on_destroy():
@@ -48,3 +59,27 @@ def test_patch_is_idempotent():
     button.after_cancel(callback_id)
 
     assert button.after_cancel_calls.count(callback_id) == 1
+
+
+def test_toplevel_patch_cancels_titlebar_callback_before_destroy():
+    apply_ctk_toplevel_after_cleanup_patch(_FakeToplevelCTK)
+
+    window = _FakeToplevelCTK.CTkToplevel()
+    callback_id = window.after(5, window.destroy)
+
+    result = window.destroy()
+
+    assert result == "destroyed"
+    assert window.destroy_calls == 1
+    assert callback_id in window.after_cancel_calls
+
+
+def test_toplevel_patch_is_idempotent():
+    apply_ctk_toplevel_after_cleanup_patch(_FakeToplevelCTK)
+    apply_ctk_toplevel_after_cleanup_patch(_FakeToplevelCTK)
+
+    window = _FakeToplevelCTK.CTkToplevel()
+    callback_id = window.after(5, lambda: None)
+    window.after_cancel(callback_id)
+
+    assert window.after_cancel_calls.count(callback_id) == 1


### PR DESCRIPTION
### Motivation
- Prevent `TclError: bad window path name` raised when CustomTkinter schedules a delayed `deiconify()` callback on a `CTkToplevel` that was destroyed before the callback ran.

### Description
- Add `apply_ctk_toplevel_after_cleanup_patch(ctk_module)` in `modules/helpers/customtkinter_compat.py` which tracks `after` callback IDs on `CTkToplevel` instances and cancels them during `destroy`.
- Patch overrides `after`, `after_cancel`, and `destroy` on `CTkToplevel` and stores tracked IDs in `_gm_tracked_after_ids` to safely clear outstanding callbacks.
- Enable the new toplevel patch during app startup by calling `apply_ctk_toplevel_after_cleanup_patch(ctk)` in `main_window.configure_ui_defaults()` alongside the existing button patch.
- Add regression tests in `tests/helpers/test_customtkinter_compat.py` to verify callback cancellation on destroy and idempotent patch application for `CTkToplevel`.

### Testing
- Ran `pytest -q tests/helpers/test_customtkinter_compat.py`, which executed the compatibility tests and all tests passed (4 passed).
- Compiled changed modules with `python -m compileall -q modules/helpers/customtkinter_compat.py main_window.py tests/helpers/test_customtkinter_compat.py` with no syntax errors.
- Performed repository checks with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a666b040ae4832ba7dc0b0ac26e38f3)