### PR TITLE
Expose campaign synchronization routes in the main sidebar

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1124,7 +1124,7 @@ class MainWindow(ctk.CTk):
         container = getattr(self, "sidebar_sections_container", None)
         if container is None:
             return
-        default_title = "Campaign Workshop"
+        default_title = "Campaign Entities"
 
         # Group buttons
         data_system = [
@@ -1133,12 +1133,18 @@ class MainWindow(ctk.CTk):
             SidebarItemSpec("customize_fields", "Customize Fields", self.open_custom_fields_editor),
             SidebarItemSpec("new_entity_type", "New Entity Type", self.open_new_entity_type_dialog),
             SidebarItemSpec("system_manager", "AI Settings", self.open_ai_settings),
-            SidebarItemSpec("campaign_updates", "Campaign Update Settings", self.open_campaign_update_settings),
             SidebarItemSpec("auto_improve", "Auto-improvement (Codex CLI)", self.open_auto_improve_panel),
             SidebarItemSpec("system_manager", "Manage Campaign Systems", self.open_system_manager_dialog),
             SidebarItemSpec("db_export", "Create Campaign Backup", self.prompt_campaign_backup),
             SidebarItemSpec("db_import", "Restore Campaign Backup", self.prompt_campaign_restore),
-            SidebarItemSpec("asset_library", "Cross-campaign Asset Library", self.open_cross_campaign_asset_library),
+        ]
+        campaign_synchronization = [
+            SidebarItemSpec("campaign_updates", "Campaign Update Settings", self.open_campaign_update_settings),
+            SidebarItemSpec(
+                "asset_library",
+                "Cross-campaign Asset Library",
+                self.open_cross_campaign_asset_library,
+            ),
         ]
 
         entity_buttons = []
@@ -1188,7 +1194,12 @@ class MainWindow(ctk.CTk):
 
         specs = [
             SidebarSectionSpec("Data & System", data_system, item_count=len(data_system), has_unresolved=not has_campaign_data),
-            SidebarSectionSpec("Campaign Workshop", entity_buttons, item_count=len(entity_buttons), updated_recently=recent_update),
+            SidebarSectionSpec(
+                "Campaign Synchronization",
+                campaign_synchronization,
+                item_count=len(campaign_synchronization),
+            ),
+            SidebarSectionSpec("Campaign Entities", entity_buttons, item_count=len(entity_buttons), updated_recently=recent_update),
             SidebarSectionSpec("Relations & Graphs", relations, item_count=len(relations)),
             SidebarSectionSpec("Utilities", utilities, item_count=len(utilities), has_critical=not has_campaign_data),
         ]

--- a/tests/ui/sidebar/test_main_window_sidebar_spec.py
+++ b/tests/ui/sidebar/test_main_window_sidebar_spec.py
@@ -1,0 +1,82 @@
+"""Static contracts for the main-window accordion sidebar."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+SOURCE_PATH = Path("main_window.py")
+MODULE_AST = ast.parse(SOURCE_PATH.read_text(encoding="utf-8-sig"))
+
+
+def _create_sidebar_method() -> ast.FunctionDef:
+    for node in MODULE_AST.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "MainWindow":
+            continue
+        for member in node.body:
+            if isinstance(member, ast.FunctionDef) and member.name == "create_accordion_sidebar":
+                return member
+    raise AssertionError("MainWindow.create_accordion_sidebar not found")
+
+
+def _assigned_list(method: ast.FunctionDef, variable_name: str) -> ast.List:
+    for node in method.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == variable_name for target in node.targets):
+            assert isinstance(node.value, ast.List)
+            return node.value
+    raise AssertionError(f"{variable_name} list not found")
+
+
+def _item_specs(items: ast.List) -> dict[str, tuple[str, str]]:
+    specs: dict[str, tuple[str, str]] = {}
+    for element in items.elts:
+        if not isinstance(element, ast.Call) or not element.args:
+            continue
+        label = ast.literal_eval(element.args[1])
+        command = element.args[2]
+        assert isinstance(command, ast.Attribute)
+        specs[label] = (ast.literal_eval(element.args[0]), command.attr)
+    return specs
+
+
+def test_synchronization_destinations_have_a_dedicated_sidebar_section() -> None:
+    """Both synchronization routes remain together and directly discoverable."""
+    method = _create_sidebar_method()
+    synchronization_items = _item_specs(_assigned_list(method, "campaign_synchronization"))
+
+    assert synchronization_items == {
+        "Campaign Update Settings": ("campaign_updates", "open_campaign_update_settings"),
+        "Cross-campaign Asset Library": (
+            "asset_library",
+            "open_cross_campaign_asset_library",
+        ),
+    }
+
+    synchronization_sections = [
+        call
+        for call in ast.walk(method)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == "SidebarSectionSpec"
+        and len(call.args) >= 2
+        and isinstance(call.args[0], ast.Constant)
+        and call.args[0].value == "Campaign Synchronization"
+    ]
+    assert len(synchronization_sections) == 1
+    section_items = synchronization_sections[0].args[1]
+    assert isinstance(section_items, ast.Name)
+    assert section_items.id == "campaign_synchronization"
+
+
+def test_entity_shortcuts_are_clearly_labelled_as_entities() -> None:
+    """The expandable entity-only section must not imply broader workshop tools."""
+    method = _create_sidebar_method()
+    string_literals = {
+        node.value for node in ast.walk(method) if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+    assert "Campaign Entities" in string_literals
+    assert "Campaign Workshop" not in string_literals


### PR DESCRIPTION
### Motivation

- Make synchronization actions (`Campaign Update Settings`, `Cross-campaign Asset Library`) directly discoverable from the main sidebar by grouping them under an explicit `Campaign Synchronization` section. 
- Avoid hiding synchronization destinations behind an ambiguously named entity-only header so users don't miss global sync tools. 
- Clarify the intent of the entity-only accordion by renaming it so its header clearly refers to entity shortcuts.

### Description

- Created a new `campaign_synchronization` list and moved/duplicated the `SidebarItemSpec` entries for `campaign_updates` and `asset_library` into it, leaving their handlers unchanged in `modules/generic/*` so runtime behavior is preserved. 
- Added a `SidebarSectionSpec("Campaign Synchronization", campaign_synchronization, ...)` to the sidebar spec and placed it before the entity section. 
- Renamed the previous entity-only section from `Campaign Workshop` to `Campaign Entities` and changed the `default_title` to `Campaign Entities` so entity shortcuts are still the default expanded section and are clearly labeled. 
- Added a static AST-based regression test `tests/ui/sidebar/test_main_window_sidebar_spec.py` that asserts the synchronization items exist, are grouped under `campaign_synchronization`, and verifies the renamed entity section is present while `Campaign Workshop` no longer appears.

### Testing

- Ran `pytest` for the new and related UI contract tests with `python -m pytest -q tests/ui/sidebar/test_main_window_sidebar_spec.py tests/test_main_window_launch_defaults.py` and the suite passed (`4 passed`).
- Verified syntax and bytecode with `python -m py_compile main_window.py tests/ui/sidebar/test_main_window_sidebar_spec.py` and `python -m compileall -q modules/ui/sidebar`, both succeeded. 
- Note: running a broader test command that includes `tests/test_main_window_update.py` failed during collection due to an environment dependency (`docx` resolved as a non-package and `docx.shared` could not be imported), which is an external test-environment issue and unrelated to the sidebar changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a685d1d677c832bbcbfbf9cf9510b69)