### PR TITLE
Fix progress dialog lifecycle race for immediate workers

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -82,6 +82,7 @@ from modules.ui.ambiance.control_window import AmbianceControlWindow
 from modules.ui.ambiance.importer.dialog import AmbianceWallpaperImporterDialog
 from modules.ui.sidebar.accordion_sections import SidebarAccordion, SidebarItemSpec, SidebarSectionSpec
 from modules.ui.controllers import AIRunWindowController
+from modules.ui.windows.progress_dialog import ProgressDialogLifecycle
 from app.ui.help.guided_tour_entry import launch_guided_tour
 from app.ui.help.tour_widget_registry import TourWidgetRegistry
 from modules.events.ui.dock import CalendarDock
@@ -3602,6 +3603,7 @@ class MainWindow(ctk.CTk):
         progress_bar = ctk.CTkProgressBar(progress_win, mode="determinate")
         progress_bar.pack(fill="x", padx=20, pady=(0, 20))
         progress_bar.set(0.0)
+        lifecycle = ProgressDialogLifecycle(self, progress_win)
 
         def update(message: str, fraction: float) -> None:
             """Update the operation."""
@@ -3613,36 +3615,27 @@ class MainWindow(ctk.CTk):
                 except Exception:
                     progress_bar.set(0.0)
 
-            self.after(0, _apply)
-
-        def close_window():
-            """Close window."""
-            if progress_win.winfo_exists():
-                # Handle the branch where progress_win.winfo_exists().
-                try:
-                    progress_win.grab_release()
-                except Exception:
-                    pass
-                progress_win.destroy()
+            lifecycle.schedule_update(_apply)
 
         def handle_error(title: str, detail: str) -> None:
             """Handle handle error."""
-            close_window()
-            messagebox.showerror(title, detail)
+            lifecycle.close(lambda: messagebox.showerror(title, detail))
 
         success_callback = on_success
 
         def handle_success(result):
             """Handle success."""
-            close_window()
-            if success_callback:
-                success_callback(result)
-                return
-            detail = detail_builder(result) if detail_builder else None
-            message = success_message or "Operation completed."
-            if detail:
-                message = f"{message}\n\n{detail}"
-            messagebox.showinfo("Success", message)
+            def notify():
+                if success_callback:
+                    success_callback(result)
+                    return
+                detail = detail_builder(result) if detail_builder else None
+                message = success_message or "Operation completed."
+                if detail:
+                    message = f"{message}\n\n{detail}"
+                messagebox.showinfo("Success", message)
+
+            lifecycle.close(notify)
 
         def run_worker():
             """Run worker."""

--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -46,6 +46,7 @@ from modules.helpers.portrait_helper import primary_portrait
 from modules.helpers.secret_helper import decrypt_secret, encrypt_secret
 from modules.helpers.selection_dialog import SelectionDialog
 from modules.helpers.template_loader import load_entity_definitions, list_known_entities
+from modules.ui.windows.progress_dialog import ProgressDialogLifecycle
 
 
 class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
@@ -1523,6 +1524,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         bar = ctk.CTkProgressBar(progress_win, mode="determinate")
         bar.pack(fill="x", padx=20, pady=(0, 20))
         bar.set(0.0)
+        lifecycle = ProgressDialogLifecycle(self, progress_win)
 
         def update(message: str, fraction: float):
             """Update the operation."""
@@ -1535,40 +1537,31 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 except Exception:
                     bar.set(0.0)
 
-            self.after(0, apply)
-
-        def close():
-            """Close the operation."""
-            if progress_win.winfo_exists():
-                # Handle the branch where progress_win.winfo_exists().
-                try:
-                    progress_win.grab_release()
-                except Exception:
-                    pass
-                progress_win.destroy()
+            lifecycle.schedule_update(apply)
 
         def handle_success(result):
             """Handle handle success."""
-            close()
-            if on_success:
-                on_success(result)
-                return
-            if success_message:
-                detail = detail_builder(result) if detail_builder else None
-                message = (
-                    success_message if not detail else f"{success_message}\n\n{detail}"
-                )
-                messagebox.showinfo("Success", message)
+            def notify():
+                if on_success:
+                    on_success(result)
+                    return
+                if success_message:
+                    detail = detail_builder(result) if detail_builder else None
+                    message = (
+                        success_message if not detail else f"{success_message}\n\n{detail}"
+                    )
+                    messagebox.showinfo("Success", message)
+
+            lifecycle.close(notify)
 
         def handle_error(exc: Exception):
             """Handle handle error."""
-            close()
             details = str(exc).strip()
             if details:
                 message = f"{exc.__class__.__name__}: {details}"
             else:
                 message = repr(exc)
-            messagebox.showerror("Operation Failed", message)
+            lifecycle.close(lambda: messagebox.showerror("Operation Failed", message))
 
         def run():
             """Run the operation."""

--- a/modules/ui/windows/__init__.py
+++ b/modules/ui/windows/__init__.py
@@ -1,0 +1,2 @@
+"""Reusable window lifecycle helpers."""
+

--- a/modules/ui/windows/progress_dialog.py
+++ b/modules/ui/windows/progress_dialog.py
@@ -1,0 +1,102 @@
+"""Lifecycle coordination for progress toplevels.
+
+CustomTkinter schedules some platform-specific toplevel initialization after the
+window is constructed.  An unusually fast worker can otherwise destroy the Tcl
+window before those callbacks run (most visibly on Windows).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Optional
+
+
+class ProgressDialogLifecycle:
+    """Keep a progress toplevel valid until its initialization has settled."""
+
+    def __init__(self, owner, window, *, minimum_lifetime_ms: int = 250) -> None:
+        self.owner = owner
+        self.window = window
+        self.minimum_lifetime_ms = max(0, minimum_lifetime_ms)
+        self.closing = False
+        self.destroyed = False
+        self._created_at = time.monotonic()
+        self._after_ids: set[object] = set()
+        self._close_after_id: Optional[object] = None
+        self._completion_claimed = False
+
+    def window_exists(self) -> bool:
+        """Return whether Tcl still owns the window without leaking Tcl errors."""
+        if self.destroyed:
+            return False
+        try:
+            return bool(self.window.winfo_exists())
+        except Exception:
+            return False
+
+    def can_update(self) -> bool:
+        """Return whether an application callback may still touch the dialog."""
+        return not self.closing and self.window_exists()
+
+    def schedule_update(self, callback: Callable[[], None]) -> bool:
+        """Schedule a guarded UI update, ignoring progress arriving after close."""
+        # Progress callbacks normally arrive on a worker thread.  Do not call
+        # any Tk method here; the guarded event-loop callback performs the Tcl
+        # existence check on the UI thread.
+        if self.closing or self.destroyed:
+            return False
+
+        token: dict[str, object] = {}
+
+        def guarded() -> None:
+            after_id = token.get("id")
+            if after_id is not None:
+                self._after_ids.discard(after_id)
+            if self.can_update():
+                callback()
+
+        after_id = self.owner.after(0, guarded)
+        token["id"] = after_id
+        self._after_ids.add(after_id)
+        return True
+
+    def close(self, on_closed: Optional[Callable[[], None]] = None) -> bool:
+        """Claim completion once and destroy safely after the minimum lifetime."""
+        if self._completion_claimed:
+            return False
+        self._completion_claimed = True
+        self.closing = True
+        self._cancel_updates()
+
+        elapsed_ms = int((time.monotonic() - self._created_at) * 1000)
+        delay_ms = max(0, self.minimum_lifetime_ms - elapsed_ms)
+        self._close_after_id = self.owner.after(
+            delay_ms, lambda: self._destroy_and_notify(on_closed)
+        )
+        return True
+
+    def _cancel_updates(self) -> None:
+        for after_id in tuple(self._after_ids):
+            try:
+                self.owner.after_cancel(after_id)
+            except Exception:
+                pass
+            finally:
+                self._after_ids.discard(after_id)
+
+    def _destroy_and_notify(self, on_closed: Optional[Callable[[], None]]) -> None:
+        self._close_after_id = None
+        self._cancel_updates()
+        if self.window_exists():
+            try:
+                self.window.grab_release()
+            except Exception:
+                pass
+            if self.window_exists():
+                try:
+                    self.window.destroy()
+                except Exception:
+                    pass
+        self.destroyed = True
+        if on_closed is not None:
+            on_closed()

--- a/tests/ui/windows/test_progress_dialog.py
+++ b/tests/ui/windows/test_progress_dialog.py
@@ -1,0 +1,111 @@
+"""Regression tests for short-lived CustomTkinter progress dialogs."""
+
+from __future__ import annotations
+
+import heapq
+
+from modules.ui.windows.progress_dialog import ProgressDialogLifecycle
+
+
+class FakeOwner:
+    def __init__(self) -> None:
+        self.now = 0
+        self._next_id = 0
+        self._callbacks = []
+        self.cancelled = set()
+
+    def after(self, delay, callback):
+        self._next_id += 1
+        after_id = f"after-{self._next_id}"
+        heapq.heappush(self._callbacks, (self.now + delay, self._next_id, after_id, callback))
+        return after_id
+
+    def after_cancel(self, after_id):
+        self.cancelled.add(after_id)
+
+    def run_next(self):
+        while self._callbacks:
+            due, _, after_id, callback = heapq.heappop(self._callbacks)
+            if after_id in self.cancelled:
+                continue
+            self.now = due
+            callback()
+            return True
+        return False
+
+    def run_all(self):
+        while self.run_next():
+            pass
+
+
+class FakeToplevel:
+    def __init__(self, owner: FakeOwner, *, delayed_setup: bool = True) -> None:
+        self.owner = owner
+        self.exists = True
+        self.calls = []
+        self.invalid_calls = []
+        if delayed_setup:
+            self.owner.after(200, self.deiconify)
+            self.owner.after(200, self.focus_force)
+
+    def winfo_exists(self):
+        return self.exists
+
+    def _record(self, operation):
+        if not self.exists:
+            self.invalid_calls.append(operation)
+        else:
+            self.calls.append(operation)
+
+    def configure(self, **_kwargs):
+        self._record("configure")
+
+    def deiconify(self):
+        self._record("deiconify")
+
+    def focus_force(self):
+        self._record("focus")
+
+    def grab_release(self):
+        self._record("grab_release")
+
+    def destroy(self):
+        self._record("destroy")
+        self.exists = False
+
+
+def test_immediate_worker_completion_keeps_dialog_alive_for_delayed_setup():
+    owner = FakeOwner()
+    window = FakeToplevel(owner)
+    lifecycle = ProgressDialogLifecycle(owner, window)
+    completions = []
+    progress_callback = lambda: lifecycle.schedule_update(
+        lambda: window.configure(text="late")
+    )
+
+    # Model a worker which reports progress and returns before the event loop runs.
+    progress_callback()
+    assert lifecycle.close(lambda: completions.append("success"))
+    assert not lifecycle.close(lambda: completions.append("duplicate"))
+
+    # A worker reporting again after completion must not enqueue another UI update.
+    assert progress_callback() is False
+    owner.run_all()
+
+    assert window.calls == ["deiconify", "focus", "grab_release", "destroy"]
+    assert window.invalid_calls == []
+    assert completions == ["success"]
+    assert lifecycle.closing is True
+    assert lifecycle.destroyed is True
+
+
+def test_guarded_update_rechecks_tcl_window_before_touching_widgets():
+    owner = FakeOwner()
+    window = FakeToplevel(owner, delayed_setup=False)
+    lifecycle = ProgressDialogLifecycle(owner, window, minimum_lifetime_ms=0)
+
+    assert lifecycle.schedule_update(lambda: window.configure(text="progress"))
+    window.exists = False  # Simulate destruction outside the lifecycle.
+    owner.run_all()
+
+    assert window.invalid_calls == []


### PR DESCRIPTION
### Motivation
- Prevent a race where a short background worker can destroy a newly created `customtkinter.CTkToplevel` before CustomTkinter finishes its delayed Windows title-bar setup.
- Centralize dialog-lifecycle logic in a reusable helper to avoid proliferating window-state complexity in `main_window.py` and to apply the same fix to other windows.
- Add a deterministic regression that simulates an immediately-completing worker plus delayed UI callbacks to ensure late updates are ignored safely.

### Description
- Add a `ProgressDialogLifecycle` helper in `modules/ui/windows/progress_dialog.py` that tracks `closing`/`destroyed` state, guards scheduled UI updates with `winfo_exists()`, cancels `after` callbacks, enforces a minimum lifetime, releases grabs before destroy, and ensures completion callbacks run only once.
- Refactor `MainWindow._run_progress_task` to use `ProgressDialogLifecycle` for `schedule_update` and `close` instead of calling `after`/`destroy` directly (file: `main_window.py`).
- Apply the same lifecycle protection to `CrossCampaignAssetLibraryWindow._run_progress_task` (file: `modules/generic/cross_campaign_asset_library.py`).
- Add `modules/ui/windows/__init__.py` and regression tests in `tests/ui/windows/test_progress_dialog.py` that exercise immediate completion, late progress callbacks, duplicate completion attempts, and simulated external destruction.

### Testing
- Ran `pytest -q tests/ui/windows/test_progress_dialog.py`, which passed (2 tests).
- Ran `python -m compileall -q modules/ui/windows/progress_dialog.py main_window.py modules/generic/cross_campaign_asset_library.py tests/ui/windows/test_progress_dialog.py`, which succeeded.
- Attempted a broader test collection (`pytest -q tests/ui/windows/test_progress_dialog.py tests/test_main_window_update.py tests/test_cross_campaign_asset_service.py`) which is blocked by unrelated environment/pre-existing repository issues (missing `docx` package stub and a separate circular import) and therefore did not complete end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a685e550e9c832b938209073d9eaeac)