### PR TITLE
Add dedicated 'Sync' top-level menu and extract shared menu models

### DIFF
--- a/modules/ui/menu/campaign_sync_menu.py
+++ b/modules/ui/menu/campaign_sync_menu.py
@@ -1,0 +1,30 @@
+"""Menu definition for campaign synchronization workflows."""
+
+from __future__ import annotations
+
+from modules.ui.menu.menu_models import MenuCommandSpec, MenuGroupSpec, TopLevelMenuSpec
+
+
+def build_campaign_sync_menu(app) -> TopLevelMenuSpec:
+    """Keep synchronization actions in a short, always-visible menu."""
+    return TopLevelMenuSpec(
+        label="Sync",
+        groups=[
+            MenuGroupSpec(
+                title="Campaign Synchronization",
+                helper="publish, update & reuse campaign content",
+                items=[
+                    MenuCommandSpec(
+                        "Campaign Update Settings",
+                        getattr(app, "open_campaign_update_settings", None),
+                        icon_key="campaign_updates",
+                    ),
+                    MenuCommandSpec(
+                        "Cross-campaign Asset Library",
+                        getattr(app, "open_cross_campaign_asset_library", None),
+                        icon_key="asset_library",
+                    ),
+                ],
+            ),
+        ],
+    )

--- a/modules/ui/menu/menu_models.py
+++ b/modules/ui/menu/menu_models.py
@@ -1,0 +1,34 @@
+"""Declarative models shared by the application menu builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass(slots=True)
+class MenuCommandSpec:
+    """One actionable entry in a menu group."""
+
+    label: str
+    command: Callable[[], None] | None = None
+    shortcut: str = ""
+    icon_key: str | None = None
+    kind: str = "command"
+
+
+@dataclass(slots=True)
+class MenuGroupSpec:
+    """A labelled collection of related menu commands."""
+
+    title: str
+    helper: str
+    items: list[MenuCommandSpec] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class TopLevelMenuSpec:
+    """A top-level navigation menu and its grouped commands."""
+
+    label: str
+    groups: list[MenuGroupSpec] = field(default_factory=list)

--- a/modules/ui/menu/menu_sections.py
+++ b/modules/ui/menu/menu_sections.py
@@ -1,33 +1,12 @@
 """Section definitions for menu."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from tkinter import messagebox
 from typing import Callable
 
 from modules.helpers.template_loader import list_manageable_entities
-
-
-@dataclass(slots=True)
-class MenuCommandSpec:
-    label: str
-    command: Callable[[], None] | None = None
-    shortcut: str = ""
-    icon_key: str | None = None
-    kind: str = "command"
-
-
-@dataclass(slots=True)
-class MenuGroupSpec:
-    title: str
-    helper: str
-    items: list[MenuCommandSpec] = field(default_factory=list)
-
-
-@dataclass(slots=True)
-class TopLevelMenuSpec:
-    label: str
-    groups: list[MenuGroupSpec] = field(default_factory=list)
+from modules.ui.menu.campaign_sync_menu import build_campaign_sync_menu
+from modules.ui.menu.menu_models import MenuCommandSpec, MenuGroupSpec, TopLevelMenuSpec
 
 
 def _command(label: str, command: Callable[[], None] | None, *, shortcut: str = "", icon_key: str | None = None) -> MenuCommandSpec:
@@ -90,7 +69,6 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                         _command("New Entity Type", app.open_new_entity_type_dialog, icon_key="new_entity_type"),
                         _command("Manage Systems", app.open_system_manager_dialog, icon_key="system_manager"),
                         _command("AI Settings", _optional_command(app, "open_ai_settings"), icon_key="system_manager"),
-                        _command("Cross-campaign Asset Library", app.open_cross_campaign_asset_library, icon_key="asset_library"),
                     ],
                 ),
                 MenuGroupSpec(
@@ -145,6 +123,7 @@ def build_menu_specs(app) -> list[TopLevelMenuSpec]:
                 ),
             ],
         ),
+        build_campaign_sync_menu(app),
         TopLevelMenuSpec(
             label="GM Tools",
             groups=[

--- a/tests/ui/test_campaign_sync_menu.py
+++ b/tests/ui/test_campaign_sync_menu.py
@@ -1,0 +1,35 @@
+"""Contracts for the dedicated campaign synchronization menu."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from modules.ui.menu.campaign_sync_menu import build_campaign_sync_menu
+
+
+def test_sync_menu_keeps_campaign_sync_actions_together() -> None:
+    """Synchronization routes should not depend on a tall Campaign popup."""
+    def update_settings() -> None:
+        pass
+
+    def asset_library() -> None:
+        pass
+
+    menu = build_campaign_sync_menu(
+        SimpleNamespace(
+            open_campaign_update_settings=update_settings,
+            open_cross_campaign_asset_library=asset_library,
+        )
+    )
+
+    assert menu.label == "Sync"
+    assert len(menu.groups) == 1
+    assert menu.groups[0].title == "Campaign Synchronization"
+    assert [item.label for item in menu.groups[0].items] == [
+        "Campaign Update Settings",
+        "Cross-campaign Asset Library",
+    ]
+    assert [item.command for item in menu.groups[0].items] == [
+        update_settings,
+        asset_library,
+    ]

--- a/tests/ui/test_menu_sections_image_commands.py
+++ b/tests/ui/test_menu_sections_image_commands.py
@@ -59,6 +59,8 @@ def test_menu_sections_expose_image_library_commands() -> None:
     )
 
     specs = build_menu_specs(app)
+    sync_menu = next(menu for menu in specs if menu.label == "Sync")
+    sync_labels = [item.label for group in sync_menu.groups for item in group.items]
     campaign_menu = next(menu for menu in specs if menu.label == "Campaign")
     table_surfaces = next(group for group in campaign_menu.groups if group.title == "Table Surfaces")
     table_labels = [item.label for item in table_surfaces.items]
@@ -69,6 +71,7 @@ def test_menu_sections_expose_image_library_commands() -> None:
     live_labels = [item.label for item in live_tools.items]
 
     assert "GM Table" in table_labels
+    assert sync_labels == ["Campaign Update Settings", "Cross-campaign Asset Library"]
     assert "Import Image Directories…" in labels
     assert "Open Image Library" in labels
     assert "Ambiance Control" in live_labels


### PR DESCRIPTION
### Motivation

- The Campaign menu had grown taller than some displays, hiding synchronization actions inside a long popup, so a short always-visible top-level menu is needed to keep sync features accessible.
- The `Cross-campaign Asset Library` entry was duplicated in `File`, so it should be moved to a dedicated area to avoid redundancy.
- Menu dataclasses were duplicated in `menu_sections.py`, so extract them to a shared module to keep the architecture modular and avoid circular imports.

### Description

- Added `modules/ui/menu/campaign_sync_menu.py` which defines `build_campaign_sync_menu(app)` and provides a compact `Sync` top-level menu with `Campaign Update Settings` and `Cross-campaign Asset Library` commands.
- Introduced `modules/ui/menu/menu_models.py` containing `MenuCommandSpec`, `MenuGroupSpec`, and `TopLevelMenuSpec` dataclasses and reused them across menu builders.
- Updated `modules/ui/menu/menu_sections.py` to import and insert the `Sync` menu via `build_campaign_sync_menu(app)` and removed the duplicate `Cross-campaign Asset Library` entry from the `File` menu.
- Added `tests/ui/test_campaign_sync_menu.py` and updated `tests/ui/test_menu_sections_image_commands.py` to cover the new menu labels, ordering, and wiring.

### Testing

- Ran the new and updated unit tests `pytest -q tests/ui/test_campaign_sync_menu.py tests/ui/test_menu_sections_image_commands.py`, and they passed. 
- Ran a broader UI test suite which produced mostly green results (`115 passed, 11 skipped`) but two thumbnail tests failed due to a missing `Pillow` dependency in the headless environment. 
- Performed static checks with `ruff` and a byte-compile sanity check (`python -m compileall`), both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6860d197d0832bacdf93f6b9ff21c8)