### PR TITLE
Fix campaign publication change baseline

### DIFF
--- a/modules/generic/campaign_sync/publisher.py
+++ b/modules/generic/campaign_sync/publisher.py
@@ -227,7 +227,7 @@ class CampaignPublisher:
         # Release and verification succeeded: only now advance installed state.
         CampaignSyncMetadataStore(root).write(metadata)
         CampaignChangeDetector(self.installation_store).persist_baseline(
-            root, digest, database_path=database
+            root, content_digest, database_path=database
         )
         return CampaignPublishResult(
             PublishOutcome.PUBLISHED, revision, local.campaign_id, digest, release

--- a/tests/generic/campaign_sync/test_publisher.py
+++ b/tests/generic/campaign_sync/test_publisher.py
@@ -7,7 +7,14 @@ import io
 
 import pytest
 
-from modules.generic.campaign_sync.metadata_store import InstallationStateStore
+from modules.generic.campaign_sync.change_detector import (
+    CampaignChangeDetector,
+    CampaignChangeState,
+)
+from modules.generic.campaign_sync.metadata_store import (
+    CampaignSyncMetadataStore,
+    InstallationStateStore,
+)
 from modules.generic.campaign_sync.hashing import sha256_file
 from modules.generic.campaign_sync.publisher import (
     CampaignPublisher,
@@ -57,6 +64,9 @@ def campaign(tmp_path):
     connection.execute("INSERT INTO notes VALUES ('one')")
     connection.commit()
     connection.close()
+    asset = root / "assets" / "image_library" / "scene.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"original image")
     return root, database
 
 
@@ -92,9 +102,36 @@ def test_release_digest_authenticates_archive_and_bundle_retains_uuid(campaign, 
     result = publisher.publish(root, database_path=database)
 
     assert result.snapshot_sha256 == result.release.archive_sha256
+    assert CampaignSyncMetadataStore(root).read().snapshot_sha256 == result.release.archive_sha256
     with zipfile.ZipFile(io.BytesIO(result.release.archive_bytes)) as archive:
         manifest = json.loads(archive.read("manifest.json"))
     assert manifest["sync"]["campaign_id"] == identity.campaign_id
+
+
+@pytest.mark.parametrize("changed_content", ["database", "asset"])
+def test_publication_baseline_tracks_campaign_content(campaign, tmp_path, changed_content):
+    root, database = campaign
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery)
+    publisher.enable(root, database_path=database)
+
+    publisher.publish(root, database_path=database)
+
+    detector = CampaignChangeDetector(publisher.installation_store)
+    assert detector.detect(root, database_path=database).state is CampaignChangeState.CLEAN
+
+    if changed_content == "database":
+        connection = sqlite3.connect(database)
+        connection.execute("INSERT INTO notes VALUES ('locally changed')")
+        connection.commit()
+        connection.close()
+    else:
+        (root / "assets" / "image_library" / "scene.png").write_bytes(b"locally changed image")
+
+    assert (
+        detector.detect(root, database_path=database).state
+        is CampaignChangeState.LOCALLY_MODIFIED
+    )
 
 
 def test_stale_parent_is_rejected_before_release(campaign, tmp_path):


### PR DESCRIPTION
### Motivation

- Ensure the post-publication change-detection baseline represents the campaign content fingerprint rather than the ZIP archive digest so local change detection correctly flags database or asset edits.
- Continue recording the ZIP archive digest in synchronization metadata so downloaded snapshots can still be validated.
- Add regression coverage that a freshly published campaign is `CLEAN` and that subsequent local modifications make it `LOCALLY_MODIFIED`.

### Description

- Updated `CampaignPublisher.publish()` to call `CampaignChangeDetector.persist_baseline()` with the campaign `content_digest` instead of the ZIP archive `digest` while still writing `metadata` via `CampaignSyncMetadataStore.write()`.
- Kept storing the ZIP digest in `CampaignSyncMetadata.snapshot_sha256` so snapshot validation remains unchanged.
- Extended tests in `tests/generic/campaign_sync/test_publisher.py` to import `CampaignChangeDetector`, `CampaignChangeState`, and `CampaignSyncMetadataStore`, to create a sample asset in the `campaign` fixture, to assert the metadata `snapshot_sha256` matches the published archive digest, and to add a parameterized regression test that verifies `detect()` returns `CLEAN` immediately after publish and `LOCALLY_MODIFIED` after either a database row insertion or an asset file change.

### Testing

- Ran `pytest -q tests/generic/campaign_sync/test_publisher.py` and the tests passed (`8 passed`).
- Ran `pytest -q tests/generic/campaign_sync` and the suite passed (`49 passed`).
- Ran linter check with `ruff` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6866e14708832bac7ba3625b7d5a78)