### PR TITLE
Apply campaign publication settings immediately

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -422,7 +422,17 @@ class MainWindow(ctk.CTk):
 
     def open_campaign_update_settings(self):
         """Open installation-local automatic campaign update preferences."""
-        CampaignUpdateSettingsDialog(self)
+        CampaignUpdateSettingsDialog(self, on_saved=self._apply_campaign_update_preferences)
+
+    def _apply_campaign_update_preferences(self, preferences):
+        """Apply saved publication preferences to the running background service."""
+        coordinator = self._auto_publish_coordinator
+        coordinator.configure(
+            automatic=preferences.automatic_publication,
+            offline=preferences.offline,
+            idle_delay=preferences.publication_idle_seconds,
+            maximum_interval=preferences.publication_maximum_seconds,
+        )
 
     def register_tour_widget(self, screen: str, key: str, widget):
         """Register a guided-tour target widget by stable key."""

--- a/modules/generic/campaign_sync/auto_publish/coordinator.py
+++ b/modules/generic/campaign_sync/auto_publish/coordinator.py
@@ -78,6 +78,15 @@ class AutoPublishCoordinator:
     def set_offline(self, value: bool) -> None:
         self.offline = bool(value)
 
+    def configure(self, *, automatic: bool, offline: bool,
+                  idle_delay: float, maximum_interval: float) -> None:
+        """Apply publication preferences without requiring an application restart."""
+        scheduler = PublicationScheduler(idle_delay, maximum_interval)
+        with self._lock:
+            self.automatic = bool(automatic)
+            self.offline = bool(offline)
+            self.scheduler = scheduler
+
     def credentials_changed(self) -> None:
         for entry in self.outbox.entries():
             if entry.failure_category in (FailureCategory.CREDENTIALS.value, FailureCategory.AUTHENTICATION.value):

--- a/modules/generic/campaign_sync/update_ui.py
+++ b/modules/generic/campaign_sync/update_ui.py
@@ -92,8 +92,9 @@ class CampaignUpdatePrompt(ctk.CTkToplevel):
 
 
 class CampaignUpdateSettingsDialog(ctk.CTkToplevel):
-    def __init__(self, master) -> None:
+    def __init__(self, master, *, on_saved: Optional[Callable[[CampaignUpdatePreferences], None]] = None) -> None:
         super().__init__(master)
+        self._on_saved = on_saved
         self.title("Campaign Update Settings")
         self.geometry("560x470")
         self.resizable(False, False)
@@ -139,8 +140,11 @@ class CampaignUpdateSettingsDialog(ctk.CTkToplevel):
         except ValueError:
             self.error.configure(text="Use positive whole numbers; maximum must be at least the idle delay.")
             return
-        CampaignUpdatePreferences(
+        preferences = CampaignUpdatePreferences(
             self.checks.get(), hours, self.download.get(), self.offline.get(),
             self.auto_publish.get(), idle, maximum,
-        ).save()
+        )
+        preferences.save()
+        if self._on_saved is not None:
+            self._on_saved(preferences)
         self.destroy()

--- a/tests/generic/campaign_sync/test_auto_publish_coordinator.py
+++ b/tests/generic/campaign_sync/test_auto_publish_coordinator.py
@@ -1,0 +1,31 @@
+from queue import Queue
+
+from modules.generic.campaign_sync.auto_publish.coordinator import AutoPublishCoordinator
+
+
+class MemoryOutbox:
+    def entries(self):
+        return []
+
+
+class IdleWorker:
+    def __init__(self):
+        self.events = Queue()
+
+
+def test_configure_applies_saved_preferences_without_restart():
+    coordinator = AutoPublishCoordinator(MemoryOutbox(), IdleWorker())
+    try:
+        coordinator.configure(
+            automatic=False,
+            offline=True,
+            idle_delay=12,
+            maximum_interval=90,
+        )
+
+        assert coordinator.automatic is False
+        assert coordinator.offline is True
+        assert coordinator.scheduler.idle_delay == 12
+        assert coordinator.scheduler.maximum_interval == 90
+    finally:
+        coordinator.shutdown()


### PR DESCRIPTION
### Motivation

- Enabling "Automatically publish saved campaign changes" updated the saved preferences but did not update the running publication coordinator, so automatic publication didn't occur until restart.
- Enabling synchronization alone does not create a release; a linked campaign still needs to be saved and published (manually or automatically when due). 

### Description

- Add `AutoPublishCoordinator.configure(...)` to atomically refresh runtime flags and the `PublicationScheduler` without restarting the app. 
- Main window now opens `CampaignUpdateSettingsDialog` with an `on_saved` callback and applies saved preferences to the active coordinator via `_apply_campaign_update_preferences`. 
- `CampaignUpdateSettingsDialog` now accepts an optional `on_saved` callback, returns a `CampaignUpdatePreferences` instance from its save flow, and invokes the callback after persisting preferences. 
- Add a unit test `tests/generic/campaign_sync/test_auto_publish_coordinator.py` that verifies `configure` applies saved preferences at runtime.

### Testing

- Ran `python -m pytest -q tests/generic/campaign_sync` and observed the test suite pass (50 passed). 
- Ran `python -m pytest -q tests/generic/campaign_sync/test_auto_publish_coordinator.py` and the new test passed. 
- Verified bytecode compilation with `python -m compileall -q main_window.py modules/generic/campaign_sync tests/generic/campaign_sync/test_auto_publish_coordinator.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a687483f860832bbce582cd1c5a66a9)