### PR TITLE
Add versioned incremental campaign delta bundles and apply/install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,12 @@ Detailed logs can help troubleshoot AI imports and other automated workflows. To
 4. Save the file and restart GMCampaignDesigner.
 
 When logging is enabled, runtime messages are written to the configured log file (for example, `logs/gmcampaigndesigner.log`), which you can inspect to see the AI payloads processed during imports.
+# Campaign synchronization snapshots
+
+Synchronized revision 1 and every periodic checkpoint are **full checkpoints**.
+Revisions between checkpoints are **incremental revisions**: they transfer a
+complete consistent SQLite snapshot plus only new or changed campaign files and
+deletion tombstones. Each incremental revision declares its required base
+revision and base content fingerprint; clients must apply the complete ordered
+chain or start from a compatible full checkpoint. Update screens show both the
+transfer size and required base revision.

--- a/modules/generic/campaign_sync/__init__.py
+++ b/modules/generic/campaign_sync/__init__.py
@@ -20,6 +20,7 @@ from .updater import (
     CampaignUpdateReceipt,
     CampaignUpdater,
 )
+from .delta_manifest import DeltaManifest, InventoryEntry
 
 __all__ = [
     "CampaignSyncMetadata",
@@ -37,4 +38,6 @@ __all__ = [
     "CampaignUpdateError",
     "CampaignUpdateReceipt",
     "CampaignUpdater",
+    "DeltaManifest",
+    "InventoryEntry",
 ]

--- a/modules/generic/campaign_sync/delta_applier.py
+++ b/modules/generic/campaign_sync/delta_applier.py
@@ -1,0 +1,56 @@
+"""Apply an authenticated delta payload to a staged campaign copy."""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from .delta_manifest import DeltaManifest, normalize_sync_path
+from .hashing import sha256_file
+
+
+def _safe_staging_path(staging: Path, relative: str) -> Path:
+    """Resolve a manifest path and reject traversal through existing symlinks."""
+    root = staging.resolve()
+    candidate = (root / normalize_sync_path(relative)).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"delta path escapes campaign root: {relative!r}") from exc
+    return candidate
+
+
+def clone_campaign(source: Path, destination: Path) -> None:
+    def copy(source_name: str, destination_name: str) -> str:
+        try:
+            os.link(source_name, destination_name)
+            return destination_name
+        except OSError:
+            return shutil.copy2(source_name, destination_name)
+    shutil.copytree(source, destination, copy_function=copy)
+
+
+def apply_delta(extracted: Path, staging: Path, delta: DeltaManifest, database_meta: dict) -> Path:
+    for relative in delta.tombstones:
+        target = _safe_staging_path(staging, relative)
+        if target.is_dir():
+            raise ValueError(f"delta tombstone names a directory: {relative}")
+        target.unlink(missing_ok=True)
+    for entry in delta.files:
+        source = extracted / "payload" / entry.path
+        if not source.is_file() or source.stat().st_size != entry.size or sha256_file(source) != entry.sha256:
+            raise ValueError(f"corrupted delta payload: {entry.path}")
+        target = _safe_staging_path(staging, entry.path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.unlink(missing_ok=True)  # detach a possible hard link to active
+        shutil.copy2(source, target)
+    source_db = extracted / str(database_meta["relative_path"])
+    if not source_db.is_file() or sha256_file(source_db) != str(database_meta["sha256"]):
+        raise ValueError("corrupted delta database snapshot")
+    file_name = normalize_sync_path(str(database_meta["file_name"]))
+    if "/" in file_name:
+        raise ValueError("delta database file_name must be a file name")
+    target_db = _safe_staging_path(staging, file_name)
+    target_db.unlink(missing_ok=True)  # never mutate the active database inode
+    shutil.copy2(source_db, target_db)
+    return target_db

--- a/modules/generic/campaign_sync/delta_builder.py
+++ b/modules/generic/campaign_sync/delta_builder.py
@@ -1,0 +1,58 @@
+"""Inventory creation and compact delta bundle construction."""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from .change_detector import _content_files
+from .delta_manifest import DeltaManifest, InventoryEntry
+from .hashing import sha256_file
+
+
+def build_inventory(root: Path, database_path: Path, *, database_snapshot_path: Path | None = None) -> tuple[InventoryEntry, ...]:
+    root, database_path = Path(root).resolve(), Path(database_path).resolve()
+    try:
+        database_relative = database_path.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError("campaign database must be inside the campaign root") from exc
+    db_source = Path(database_snapshot_path) if database_snapshot_path else database_path
+    entries = [InventoryEntry(database_relative, sha256_file(db_source), db_source.stat().st_size, "database")]
+    for relative, path in _content_files(root):
+        try:
+            path.resolve().relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"synchronized file escapes campaign root: {relative}") from exc
+        kind = "asset" if relative.startswith(("assets/", "world_maps/")) else "extra_file"
+        entries.append(InventoryEntry(relative, sha256_file(path), path.stat().st_size, kind))
+    return tuple(sorted(entries, key=lambda item: item.path))
+
+
+def compare_inventories(base: tuple[InventoryEntry, ...], current: tuple[InventoryEntry, ...]) -> tuple[tuple[InventoryEntry, ...], tuple[str, ...]]:
+    old = {x.path: x for x in base}; new = {x.path: x for x in current}
+    changed = tuple(x for path, x in sorted(new.items()) if x.file_type != "database" and old.get(path) != x)
+    deleted = tuple(sorted(path for path in old.keys() - new.keys() if old[path].file_type != "database"))
+    return changed, deleted
+
+
+def write_delta_bundle(archive: Path, root: Path, database_snapshot: Path, database_relative: str,
+                       sync: dict, base_revision: int, base_fingerprint: str,
+                       base_inventory: tuple[InventoryEntry, ...], current_inventory: tuple[InventoryEntry, ...]) -> dict:
+    changed, tombstones = compare_inventories(base_inventory, current_inventory)
+    delta = DeltaManifest(base_revision, base_fingerprint, changed, tombstones, current_inventory)
+    database_entry = next(x for x in current_inventory if x.file_type == "database")
+    manifest = {"version": sync["bundle_version"], "bundle_mode": "campaign_delta", "sync": sync,
+                "database": {"file_name": Path(database_relative).name, "relative_path": "database/campaign.db",
+                             "sha256": database_entry.sha256, "size": database_entry.size},
+                "delta": delta.to_dict(), "transfer_size": database_entry.size + sum(x.size for x in changed)}
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        bundle.write(database_snapshot, "database/campaign.db")
+        for entry in changed:
+            source = (root / entry.path).resolve()
+            try:
+                source.relative_to(root.resolve())
+            except ValueError as exc:
+                raise ValueError(f"delta payload escapes campaign root: {entry.path}") from exc
+            bundle.write(source, f"payload/{entry.path}")
+        bundle.writestr("manifest.json", json.dumps(manifest, indent=2))
+    return manifest

--- a/modules/generic/campaign_sync/delta_manifest.py
+++ b/modules/generic/campaign_sync/delta_manifest.py
@@ -1,0 +1,92 @@
+"""Versioned, content-addressed manifests for campaign delta bundles."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+DELTA_FORMAT_VERSION = 1
+
+
+def normalize_sync_path(value: str) -> str:
+    text = str(value).replace("\\", "/")
+    path = Path(text)
+    if (
+        not text
+        or path.is_absolute()
+        or path.drive
+        or text.startswith("//")
+        or any(part in ("", ".", "..") for part in path.parts)
+    ):
+        raise ValueError(f"invalid synchronized-content path: {value!r}")
+    return path.as_posix()
+
+
+@dataclass(frozen=True)
+class InventoryEntry:
+    path: str
+    sha256: str
+    size: int
+    file_type: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", normalize_sync_path(self.path))
+        digest = self.sha256.lower()
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            raise ValueError("invalid inventory SHA-256")
+        object.__setattr__(self, "sha256", digest)
+        if self.size < 0 or self.file_type not in {"database", "asset", "extra_file"}:
+            raise ValueError("invalid inventory entry")
+
+    @classmethod
+    def from_dict(cls, value: dict) -> "InventoryEntry":
+        return cls(str(value["path"]), str(value["sha256"]), int(value["size"]), str(value["file_type"]))
+
+
+@dataclass(frozen=True)
+class DeltaManifest:
+    base_revision: int
+    base_content_fingerprint: str
+    files: tuple[InventoryEntry, ...]
+    tombstones: tuple[str, ...]
+    inventory: tuple[InventoryEntry, ...]
+    version: int = DELTA_FORMAT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != DELTA_FORMAT_VERSION or self.base_revision < 1:
+            raise ValueError("unsupported delta manifest")
+        fingerprint = self.base_content_fingerprint.lower()
+        if len(fingerprint) != 64 or any(c not in "0123456789abcdef" for c in fingerprint):
+            raise ValueError("invalid base fingerprint")
+        object.__setattr__(self, "base_content_fingerprint", fingerprint)
+        files = inventory_map(self.files)
+        inventory = inventory_map(self.inventory)
+        object.__setattr__(self, "tombstones", tuple(normalize_sync_path(p) for p in self.tombstones))
+        if len(set(self.tombstones)) != len(self.tombstones):
+            raise ValueError("duplicate tombstone path")
+        if set(files) & set(self.tombstones):
+            raise ValueError("a delta path cannot be both changed and deleted")
+        if any(inventory.get(path) != entry for path, entry in files.items()):
+            raise ValueError("delta payload is inconsistent with its resulting inventory")
+
+    def to_dict(self) -> dict:
+        return {"version": self.version, "base_revision": self.base_revision,
+                "base_content_fingerprint": self.base_content_fingerprint,
+                "files": [asdict(x) for x in self.files], "tombstones": list(self.tombstones),
+                "inventory": [asdict(x) for x in self.inventory]}
+
+    @classmethod
+    def from_dict(cls, value: dict) -> "DeltaManifest":
+        return cls(int(value["base_revision"]), str(value["base_content_fingerprint"]),
+                   tuple(InventoryEntry.from_dict(x) for x in value.get("files", ())),
+                   tuple(str(x) for x in value.get("tombstones", ())),
+                   tuple(InventoryEntry.from_dict(x) for x in value.get("inventory", ())),
+                   int(value.get("version", 0)))
+
+
+def inventory_map(entries: Iterable[InventoryEntry]) -> dict[str, InventoryEntry]:
+    values = tuple(entries)
+    result = {entry.path: entry for entry in values}
+    if len(result) != len(values):
+        raise ValueError("duplicate inventory path")
+    return result

--- a/modules/generic/campaign_sync/models.py
+++ b/modules/generic/campaign_sync/models.py
@@ -42,11 +42,21 @@ class CampaignSyncMetadata:
     bundle_version: int
     change_summary: Optional[str] = None
     snapshot_mode: str = "full_campaign"
+    base_revision: Optional[int] = None
+    base_content_fingerprint: Optional[str] = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "campaign_id", _valid_uuid(self.campaign_id))
         object.__setattr__(self, "snapshot_sha256", _valid_sha256(self.snapshot_sha256))
         _validate_revision(self.revision, self.parent_revision)
+        if self.snapshot_mode not in {"full_campaign", "campaign_delta"}:
+            raise ValueError("snapshot_mode must be full_campaign or campaign_delta")
+        if self.snapshot_mode == "campaign_delta":
+            if self.base_revision != self.parent_revision or self.base_revision is None:
+                raise ValueError("delta base_revision must equal parent_revision")
+            if not self.base_content_fingerprint:
+                raise ValueError("delta requires base_content_fingerprint")
+            object.__setattr__(self, "base_content_fingerprint", _valid_sha256(self.base_content_fingerprint))
 
     def to_dict(self) -> Dict[str, Any]:
         return {key: value for key, value in asdict(self).items() if value is not None}
@@ -65,6 +75,8 @@ class CampaignSyncMetadata:
             bundle_version=int(value.get("bundle_version") or 0),
             change_summary=(str(value["change_summary"]) if value.get("change_summary") is not None else None),
             snapshot_mode=str(value.get("snapshot_mode") or "full_campaign"),
+            base_revision=value.get("base_revision"),
+            base_content_fingerprint=value.get("base_content_fingerprint"),
         )
 
 
@@ -79,11 +91,19 @@ class RemoteCampaignRevision:
     snapshot_mode: str
     published_at: Optional[str] = None
     change_summary: Optional[str] = None
+    base_revision: Optional[int] = None
+    base_content_fingerprint: Optional[str] = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "campaign_id", _valid_uuid(self.campaign_id))
         object.__setattr__(self, "snapshot_sha256", _valid_sha256(self.snapshot_sha256))
         _validate_revision(self.revision, self.parent_revision)
+        if self.snapshot_mode not in {"full_campaign", "campaign_delta"}:
+            raise ValueError("snapshot_mode must be full_campaign or campaign_delta")
+        if self.snapshot_mode == "campaign_delta":
+            if self.base_revision != self.parent_revision or self.base_revision is None or not self.base_content_fingerprint:
+                raise ValueError("delta release is missing its required base")
+            object.__setattr__(self, "base_content_fingerprint", _valid_sha256(self.base_content_fingerprint))
 
     @classmethod
     def from_dict(cls, value: Dict[str, Any]) -> "RemoteCampaignRevision":
@@ -95,4 +115,6 @@ class RemoteCampaignRevision:
             snapshot_mode=str(value.get("snapshot_mode") or "full_campaign"),
             published_at=(str(value["published_at"]) if value.get("published_at") else None),
             change_summary=(str(value["change_summary"]) if value.get("change_summary") else None),
+            base_revision=value.get("base_revision"),
+            base_content_fingerprint=value.get("base_content_fingerprint"),
         )

--- a/modules/generic/campaign_sync/publisher.py
+++ b/modules/generic/campaign_sync/publisher.py
@@ -10,6 +10,8 @@ import shutil
 import sqlite3
 import tempfile
 import time
+import json
+import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -27,6 +29,7 @@ from .change_detector import CampaignChangeDetector, calculate_campaign_fingerpr
 from .hashing import sha256_file
 from .metadata_store import CampaignSyncMetadataStore, InstallationStateStore
 from .models import CampaignSyncMetadata
+from .delta_builder import build_inventory, write_delta_bundle
 
 
 class CampaignPublishError(RuntimeError):
@@ -76,12 +79,14 @@ class CampaignPublisher:
         retry_attempts: int = 3,
         retry_delay: float = 0.05,
         sleeper: Callable[[float], None] = time.sleep,
+        checkpoint_interval: int = 10,
     ) -> None:
         self.gallery_client = gallery_client
         self.installation_store = installation_store or InstallationStateStore()
         self.retry_attempts = max(1, int(retry_attempts))
         self.retry_delay = max(0.0, float(retry_delay))
         self.sleeper = sleeper
+        self.checkpoint_interval = max(2, int(checkpoint_interval))
 
     def enable(self, campaign_root: Path, *, database_path: Optional[Path] = None) -> CampaignSyncMetadata:
         """Give a legacy campaign a durable UUID and initial revision.
@@ -105,6 +110,11 @@ class CampaignPublisher:
         CampaignChangeDetector(self.installation_store).persist_baseline(
             root, fingerprint, database_path=database_path
         )
+        if database_path:
+            inventory = build_inventory(root, Path(database_path))
+            self.installation_store.update_campaign_state(
+                str(root), baseline_inventory=[entry.__dict__ for entry in inventory]
+            )
         return metadata
 
     def unlink(self, campaign_root: Path) -> bool:
@@ -162,21 +172,42 @@ class CampaignPublisher:
                 database_snapshot_path=database_snapshot,
             )
             published_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            state = self.installation_store.campaign_state(str(root))
+            from .delta_manifest import InventoryEntry
+            try:
+                baseline_inventory = tuple(InventoryEntry.from_dict(x) for x in state.get("baseline_inventory", ()))
+            except (KeyError, TypeError, ValueError):
+                baseline_inventory = ()
+            current_inventory = build_inventory(root, database, database_snapshot_path=database_snapshot)
+            is_checkpoint = revision == 1 or revision % self.checkpoint_interval == 0 or not baseline_inventory
+            snapshot_mode = "full_campaign" if is_checkpoint else "campaign_delta"
+            base_fingerprint = state.get("baseline_fingerprint") if snapshot_mode == "campaign_delta" else None
             metadata = CampaignSyncMetadata(
                 campaign_id=local.campaign_id, revision=revision,
                 parent_revision=(remote_revision or None), snapshot_sha256=content_digest,
                 published_at=published_at,
                 publisher_installation_id=self.installation_store.installation_id(),
                 bundle_version=BUNDLE_VERSION, change_summary=change_summary,
-                snapshot_mode="full_campaign",
+                snapshot_mode=snapshot_mode,
+                base_revision=remote_revision if snapshot_mode == "campaign_delta" else None,
+                base_content_fingerprint=base_fingerprint,
             )
             archive = temp_dir / f"{root.name}-r{revision}.zip"
-            manifest = export_bundle(
-                archive, CampaignDatabase(root.name, root, database_snapshot), {},
-                include_database=True, include_systems=True,
-                sync_metadata=metadata, change_summary=change_summary,
-                progress_callback=progress_callback,
-            )
+            if snapshot_mode == "campaign_delta":
+                manifest = write_delta_bundle(
+                    archive, root, database_snapshot, database.relative_to(root).as_posix(),
+                    metadata.to_dict(), remote_revision, str(base_fingerprint),
+                    baseline_inventory, current_inventory,
+                )
+            else:
+                manifest = export_bundle(
+                    archive, CampaignDatabase(root.name, root, database_snapshot), {},
+                    include_database=True, include_systems=True,
+                    sync_metadata=metadata, change_summary=change_summary,
+                    progress_callback=progress_callback,
+                )
+                manifest["content_inventory"] = [entry.__dict__ for entry in current_inventory]
+                self._replace_archive_manifest(archive, manifest)
             # The updater authenticates the downloaded ZIP against release
             # metadata.  Keep the content digest embedded in the ZIP manifest,
             # then publish/store the digest of the completed immutable archive.
@@ -196,6 +227,8 @@ class CampaignPublisher:
                 bundle_version=metadata.bundle_version,
                 change_summary=metadata.change_summary,
                 snapshot_mode=metadata.snapshot_mode,
+                base_revision=metadata.base_revision,
+                base_content_fingerprint=metadata.base_content_fingerprint,
             )
 
             # GitHub has no compare-and-swap primitive, so make the second
@@ -229,6 +262,10 @@ class CampaignPublisher:
         CampaignChangeDetector(self.installation_store).persist_baseline(
             root, content_digest, database_path=database
         )
+        self.installation_store.update_campaign_state(
+            str(root), installed_revision=revision,
+            baseline_inventory=[entry.__dict__ for entry in current_inventory],
+        )
         return CampaignPublishResult(
             PublishOutcome.PUBLISHED, revision, local.campaign_id, digest, release
         )
@@ -244,6 +281,19 @@ class CampaignPublisher:
         finally:
             destination.close()
             source.close()
+
+    @staticmethod
+    def _replace_archive_manifest(archive: Path, manifest: dict) -> None:
+        """Rewrite the generated ZIP so inventory is part of the immutable revision."""
+        replacement = archive.with_suffix(".rewritten.zip")
+        with zipfile.ZipFile(archive, "r") as source, zipfile.ZipFile(
+            replacement, "w", compression=zipfile.ZIP_DEFLATED
+        ) as destination:
+            for info in source.infolist():
+                if info.filename != "manifest.json":
+                    destination.writestr(info, source.read(info.filename))
+            destination.writestr("manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        replacement.replace(archive)
 
     def _matching_revisions(self, campaign_id: str, revision: int) -> list[object]:
         list_bundles = getattr(self.gallery_client, "list_bundles", None)

--- a/modules/generic/campaign_sync/update_checker.py
+++ b/modules/generic/campaign_sync/update_checker.py
@@ -43,6 +43,9 @@ class CampaignUpdateResult:
     error: Optional[str] = None
     local_change_state: CampaignChangeState = CampaignChangeState.UNKNOWN
     conflict: bool = False
+    snapshot_mode: str = "full_campaign"
+    transfer_size: Optional[int] = None
+    required_base_revision: Optional[int] = None
 
 
 class CampaignUpdateChecker:
@@ -163,6 +166,9 @@ class CampaignUpdateChecker:
             ignored=ignored,
             local_change_state=local_changes.state,
             conflict=conflict,
+            snapshot_mode=str(getattr(remote, "snapshot_mode", "full_campaign")),
+            transfer_size=getattr(remote, "transfer_size", None),
+            required_base_revision=getattr(remote, "base_revision", None),
         )
 
     def ignore_revision(self, campaign_root: Path, revision: int) -> None:

--- a/modules/generic/campaign_sync/update_ui.py
+++ b/modules/generic/campaign_sync/update_ui.py
@@ -40,7 +40,12 @@ class CampaignUpdatePrompt(ctk.CTkToplevel):
             f"Installed revision: {result.installed_revision}",
             f"Available revision: {result.available_revision}",
             f"Published: {published}",
+            f"Snapshot: {'Full checkpoint' if result.snapshot_mode == 'full_campaign' else 'Incremental revision'}",
         ]
+        if result.transfer_size is not None:
+            details.append(f"Transfer size: {result.transfer_size / (1024 * 1024):.1f} MiB")
+        if result.required_base_revision is not None:
+            details.append(f"Required base revision: {result.required_base_revision}")
         if result.publisher:
             details.append(f"Publisher: {result.publisher}")
         if result.change_summary:

--- a/modules/generic/campaign_sync/updater.py
+++ b/modules/generic/campaign_sync/updater.py
@@ -29,6 +29,9 @@ from .change_detector import CampaignChangeDetector, calculate_campaign_fingerpr
 from .hashing import sha256_file
 from .metadata_store import CampaignSyncMetadataStore, InstallationStateStore
 from .models import CampaignSyncMetadata
+from .delta_applier import apply_delta, clone_campaign
+from .delta_builder import build_inventory
+from .delta_manifest import DeltaManifest, InventoryEntry
 
 ProgressCallback = Callable[[str, float], None]
 CancelCallback = Callable[[], bool]
@@ -165,6 +168,9 @@ def _preserve_local_settings(
         if not source.is_file():
             continue
         destination.parent.mkdir(parents=True, exist_ok=True)
+        # Delta staging may use hard links. Detach before filtering or copying
+        # so staging can never mutate the still-active campaign.
+        destination.unlink(missing_ok=True)
         if source.name.lower() == "settings.ini":
             parser = configparser.ConfigParser()
             parser.read(source, encoding="utf-8")
@@ -213,7 +219,7 @@ class CampaignUpdater:
         if current is None:
             raise CampaignUpdateError("Campaign is not linked for synchronization")
         expected_mode = str(getattr(release, "snapshot_mode", "") or "").lower()
-        if expected_mode and expected_mode != "full_campaign":
+        if expected_mode and expected_mode not in {"full_campaign", "campaign_delta"}:
             raise CampaignUpdateError(
                 "Asset-only bundles cannot be synchronized automatically"
             )
@@ -266,13 +272,16 @@ class CampaignUpdater:
                 raise CampaignUpdateError(
                     f"Unsupported bundle version: {manifest.get('version')}"
                 )
-            if manifest.get("bundle_mode") != "full_campaign" or not isinstance(
-                manifest.get("database"), dict
-            ):
+            bundle_mode = manifest.get("bundle_mode")
+            if bundle_mode not in {"full_campaign", "campaign_delta"} or not isinstance(manifest.get("database"), dict):
                 raise CampaignUpdateError(
                     "Asset-only bundles cannot be synchronized automatically"
                 )
             sync = CampaignSyncMetadata.from_dict(manifest.get("sync") or {})
+            if sync.snapshot_mode != bundle_mode:
+                raise CampaignUpdateError("Bundle mode does not match synchronization metadata")
+            if expected_mode and expected_mode != bundle_mode:
+                raise CampaignUpdateError("Selected release mode does not match the downloaded bundle")
             if sync.bundle_version != BUNDLE_VERSION:
                 raise CampaignUpdateError("Incompatible synchronized bundle version")
             release_campaign = str(
@@ -291,13 +300,28 @@ class CampaignUpdater:
                 raise CampaignUpdateError(
                     "Bundle revision does not match the selected release"
                 )
-            if (
-                sync.parent_revision != current.revision
-                or release_parent != current.revision
+            if bundle_mode == "campaign_delta" and (
+                sync.parent_revision != current.revision or release_parent != current.revision
             ):
                 raise CampaignUpdateError(
                     "Bundle parent revision does not match the installed revision"
                 )
+            delta = None
+            if bundle_mode == "campaign_delta":
+                try:
+                    delta = DeltaManifest.from_dict(manifest.get("delta") or {})
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise CampaignUpdateError(f"Invalid delta manifest: {exc}") from exc
+                baseline = self.installation_store.campaign_state(str(active)).get("baseline_fingerprint")
+                if (
+                    sync.base_revision != current.revision
+                    or delta.base_revision != current.revision
+                    or sync.base_content_fingerprint != baseline
+                    or delta.base_content_fingerprint != baseline
+                ):
+                    raise CampaignUpdateError(
+                        "Delta base revision or content fingerprint does not match the installed campaign"
+                    )
             _validate_declared_hashes(extracted, manifest)
             check_cancel()
             report("Creating safety backup…", 0.55)
@@ -310,9 +334,38 @@ class CampaignUpdater:
             check_cancel()
             if staging.exists() or rollback.exists():
                 raise CampaignUpdateError("Update staging location already exists")
-            target_db = _copy_payload(extracted, staging, manifest)
+            if delta is None:
+                target_db = _copy_payload(extracted, staging, manifest)
+            else:
+                clone_campaign(active, staging)
+                try:
+                    target_db = apply_delta(extracted, staging, delta, manifest["database"])
+                except ValueError as exc:
+                    raise CampaignUpdateError(str(exc)) from exc
             _validate_sqlite(target_db)
             _preserve_local_settings(active, staging, self.local_settings)
+            try:
+                inventory_data = (
+                    delta.inventory if delta is not None else
+                    tuple(InventoryEntry.from_dict(item) for item in manifest.get("content_inventory", ()))
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise CampaignUpdateError(f"Invalid content inventory: {exc}") from exc
+            if inventory_data:
+                actual_inventory = build_inventory(staging, target_db, database_snapshot_path=target_db)
+                if actual_inventory != inventory_data:
+                    raise CampaignUpdateError("Reconstructed campaign inventory does not match the publisher")
+            expected_content = str((manifest.get("sync") or {}).get("snapshot_sha256") or "")
+            staged_fingerprint = calculate_campaign_fingerprint(
+                staging, database_path=target_db, database_snapshot_path=target_db
+            )
+            # Legacy full bundles did not carry an inventory and used this
+            # field only for transport metadata. New versioned snapshots do,
+            # and can therefore enforce publisher/reconstruction identity.
+            if inventory_data and staged_fingerprint != expected_content:
+                raise CampaignUpdateError(
+                    "Reconstructed campaign fingerprint does not match the publisher"
+                )
             CampaignSyncMetadataStore(staging).write(sync)
             check_cancel()
             report("Preparing campaign replacement…", 0.9)
@@ -327,14 +380,13 @@ class CampaignUpdater:
                     raise
                 try:
                     self.reopen()
-                    baseline = calculate_campaign_fingerprint(
-                        active, database_path=active / target_db.name
-                    )
+                    baseline = staged_fingerprint
                     CampaignChangeDetector(self.installation_store).persist_baseline(
                         active, baseline, database_path=active / target_db.name
                     )
                     self.installation_store.update_campaign_state(
-                        str(active), installed_revision=sync.revision
+                        str(active), installed_revision=sync.revision,
+                        baseline_inventory=[entry.__dict__ for entry in inventory_data],
                     )
                 except Exception as exc:
                     failed = parent / f".{active.name}.failed-{stamp}"
@@ -374,6 +426,24 @@ class CampaignUpdater:
                 # No progress/cancellation callbacks are consulted after
                 # replacement_started becomes true: commit or rollback only.
                 _ = replacement_started
+
+    def install_chain(self, campaign_root: Path, releases: Iterable[object], **kwargs) -> list[CampaignUpdateReceipt]:
+        """Install a strictly ordered compatible chain, never skipping a delta base."""
+        ordered = sorted(releases, key=lambda item: getattr(item, "revision", 0))
+        receipts: list[CampaignUpdateReceipt] = []
+        for release in ordered:
+            current = CampaignSyncMetadataStore(campaign_root).read()
+            if current is None:
+                raise CampaignUpdateError("Campaign is not linked for synchronization")
+            revision = getattr(release, "revision", None)
+            if revision <= current.revision:
+                continue
+            mode = str(getattr(release, "snapshot_mode", "full_campaign"))
+            base = getattr(release, "base_revision", getattr(release, "parent_revision", None))
+            if mode == "campaign_delta" and base != current.revision:
+                raise CampaignUpdateError("Delta chain is incomplete or based on an unrelated revision")
+            receipts.append(self.install(campaign_root, release, **kwargs))
+        return receipts
 
 
 __all__ = [

--- a/modules/generic/github_gallery_client.py
+++ b/modules/generic/github_gallery_client.py
@@ -54,6 +54,9 @@ class GalleryBundleSummary:
     parent_revision: Optional[int] = None
     snapshot_sha256: str = ""
     snapshot_mode: str = ""
+    base_revision: Optional[int] = None
+    base_content_fingerprint: str = ""
+    transfer_size: Optional[int] = None
 
     @property
     def display_title(self) -> str:
@@ -388,6 +391,8 @@ class GithubGalleryClient:
         parent_revision = None
         snapshot_sha256 = ""
         snapshot_mode = ""
+        base_revision = None
+        base_content_fingerprint = ""
         if isinstance(metadata, dict):
             # Handle the branch where isinstance(metadata, dict).
             description = str(metadata.get("description") or "")
@@ -411,6 +416,8 @@ class GithubGalleryClient:
                 parent_revision = remote_revision.parent_revision
                 snapshot_sha256 = remote_revision.snapshot_sha256
                 snapshot_mode = remote_revision.snapshot_mode
+                base_revision = remote_revision.base_revision
+                base_content_fingerprint = remote_revision.base_content_fingerprint or ""
 
         summary = GalleryBundleSummary(
             release_id=int(release.get("id") or 0),
@@ -436,6 +443,9 @@ class GithubGalleryClient:
             parent_revision=parent_revision,
             snapshot_sha256=snapshot_sha256,
             snapshot_mode=snapshot_mode,
+            base_revision=base_revision,
+            base_content_fingerprint=base_content_fingerprint,
+            transfer_size=int((metadata.get("transfer_size") if isinstance(metadata, dict) else 0) or asset.get("size") or 0),
         )
         if not summary.download_url:
             raise RuntimeError("Bundle asset missing download URL")
@@ -531,6 +541,8 @@ class GithubGalleryClient:
                     "bundle_version",
                     "change_summary",
                     "snapshot_mode",
+                    "base_revision",
+                    "base_content_fingerprint",
                 )
                 if sync_entry.get(key) is not None
             }

--- a/tests/generic/campaign_sync/test_delta_bundles.py
+++ b/tests/generic/campaign_sync/test_delta_bundles.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from modules.generic.campaign_sync.change_detector import calculate_campaign_fingerprint
+from modules.generic.campaign_sync.delta_applier import apply_delta, clone_campaign
+from modules.generic.campaign_sync.delta_builder import (
+    build_inventory,
+    compare_inventories,
+    write_delta_bundle,
+)
+from modules.generic.campaign_sync.delta_manifest import DeltaManifest, InventoryEntry
+from modules.generic.campaign_sync.hashing import sha256_file
+from modules.generic.campaign_sync.metadata_store import CampaignSyncMetadataStore
+from modules.generic.campaign_sync.models import CampaignSyncMetadata
+from modules.generic.campaign_sync.updater import (
+    CampaignUpdateError,
+    CampaignUpdateReceipt,
+    CampaignUpdater,
+)
+
+
+def _database(path: Path, value: str) -> Path:
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE content (value TEXT)")
+        connection.execute("INSERT INTO content VALUES (?)", (value,))
+    return path
+
+
+def _campaign(root: Path, value: str = "one") -> Path:
+    root.mkdir()
+    database = _database(root / "campaign.db", value)
+    (root / "assets").mkdir()
+    (root / "assets" / "changed.bin").write_bytes(b"old")
+    (root / "assets" / "deleted.bin").write_bytes(b"delete")
+    (root / "world_maps").mkdir()
+    (root / "world_maps" / "renamed-old.png").write_bytes(b"map")
+    return database
+
+
+def test_inventory_diff_tracks_content_not_timestamps_and_models_rename(tmp_path):
+    root = tmp_path / "campaign"
+    database = _campaign(root)
+    before = build_inventory(root, database, database_snapshot_path=database)
+    changed = root / "assets" / "changed.bin"
+    old_stat = changed.stat()
+    changed.write_bytes(b"new")
+    os.utime(changed, (old_stat.st_atime, old_stat.st_mtime))
+    (root / "assets" / "new.bin").write_bytes(b"new file")
+    (root / "assets" / "deleted.bin").unlink()
+    (root / "world_maps" / "renamed-old.png").rename(
+        root / "world_maps" / "renamed-new.png"
+    )
+
+    after = build_inventory(root, database, database_snapshot_path=database)
+    files, tombstones = compare_inventories(before, after)
+
+    assert {entry.path for entry in files} == {
+        "assets/changed.bin",
+        "assets/new.bin",
+        "world_maps/renamed-new.png",
+    }
+    assert set(tombstones) == {
+        "assets/deleted.bin",
+        "world_maps/renamed-old.png",
+    }
+    assert all(len(entry.sha256) == 64 and entry.size >= 0 for entry in after)
+    assert {entry.file_type for entry in after} >= {"database", "asset"}
+
+
+def test_delta_reconstruction_matches_inventory_and_canonical_fingerprint(tmp_path):
+    active = tmp_path / "active"
+    active_db = _campaign(active)
+    baseline = build_inventory(active, active_db, database_snapshot_path=active_db)
+    base_fingerprint = calculate_campaign_fingerprint(
+        active, database_path=active_db, database_snapshot_path=active_db
+    )
+
+    publisher = tmp_path / "publisher"
+    shutil.copytree(active, publisher)
+    (publisher / "assets" / "changed.bin").write_bytes(b"replacement")
+    (publisher / "assets" / "deleted.bin").unlink()
+    (publisher / "assets" / "new.bin").write_bytes(b"new")
+    publisher_db = publisher / "campaign.db"
+    with sqlite3.connect(publisher_db) as connection:
+        connection.execute("INSERT INTO content VALUES ('two')")
+    current = build_inventory(publisher, publisher_db, database_snapshot_path=publisher_db)
+    fingerprint = calculate_campaign_fingerprint(
+        publisher, database_path=publisher_db, database_snapshot_path=publisher_db
+    )
+    archive = tmp_path / "delta.zip"
+    manifest = write_delta_bundle(
+        archive,
+        publisher,
+        publisher_db,
+        "campaign.db",
+        {"bundle_version": 1, "snapshot_sha256": fingerprint},
+        1,
+        base_fingerprint,
+        baseline,
+        current,
+    )
+    extracted = tmp_path / "extracted"
+    with zipfile.ZipFile(archive) as bundle:
+        bundle.extractall(extracted)
+    staging = tmp_path / "staging"
+    clone_campaign(active, staging)
+    delta = DeltaManifest.from_dict(manifest["delta"])
+
+    target_db = apply_delta(extracted, staging, delta, manifest["database"])
+
+    assert build_inventory(staging, target_db, database_snapshot_path=target_db) == current
+    assert calculate_campaign_fingerprint(
+        staging, database_path=target_db, database_snapshot_path=target_db
+    ) == fingerprint
+    assert not (staging / "assets" / "deleted.bin").exists()
+    assert (staging / "assets" / "changed.bin").read_bytes() == b"replacement"
+    # Hard-link staging must not mutate the currently installed campaign.
+    assert (active / "assets" / "changed.bin").read_bytes() == b"old"
+
+
+def test_delta_rejects_corrupted_payload_and_traversal(tmp_path):
+    payload = tmp_path / "payload.bin"
+    payload.write_bytes(b"expected")
+    entry = InventoryEntry("assets/file.bin", sha256_file(payload), 8, "asset")
+    delta = DeltaManifest(1, "a" * 64, (entry,), (), (entry,))
+    extracted = tmp_path / "extracted"
+    (extracted / "payload" / "assets").mkdir(parents=True)
+    (extracted / "payload" / "assets" / "file.bin").write_bytes(b"corrupt!")
+    database = _database(extracted / "db.sqlite", "new")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    with pytest.raises(ValueError, match="corrupted delta payload"):
+        apply_delta(
+            extracted,
+            staging,
+            delta,
+            {"relative_path": "db.sqlite", "sha256": sha256_file(database), "file_name": "campaign.db"},
+        )
+    with pytest.raises(ValueError, match="invalid synchronized-content path"):
+        InventoryEntry("../escape", "a" * 64, 1, "asset")
+    with pytest.raises(ValueError, match="invalid synchronized-content path"):
+        DeltaManifest(1, "a" * 64, (), ("assets/../../escape",), ())
+
+
+def test_delta_manifest_static_contract_is_versioned_and_requires_exact_base():
+    entry = InventoryEntry("assets/a", "b" * 64, 3, "asset")
+    manifest = DeltaManifest(7, "c" * 64, (entry,), (), (entry,))
+
+    serialized = json.loads(json.dumps(manifest.to_dict()))
+
+    assert serialized["version"] == 1
+    assert serialized["base_revision"] == 7
+    assert serialized["base_content_fingerprint"] == "c" * 64
+    assert serialized["inventory"][0] == {
+        "path": "assets/a",
+        "sha256": "b" * 64,
+        "size": 3,
+        "file_type": "asset",
+    }
+    with pytest.raises(ValueError, match="unsupported delta manifest"):
+        DeltaManifest.from_dict({**serialized, "version": 2})
+
+
+def test_install_chain_rejects_missing_delta_and_can_fall_back_to_full_checkpoint(tmp_path, monkeypatch):
+    root = tmp_path / "campaign"
+    root.mkdir()
+    campaign_id = "12345678-1234-5678-1234-567812345678"
+
+    def write_revision(revision: int) -> None:
+        CampaignSyncMetadataStore(root).write(
+            CampaignSyncMetadata(
+                campaign_id,
+                revision,
+                revision - 1 or None,
+                "a" * 64,
+                "2026-07-28T00:00:00Z",
+                "publisher",
+                1,
+            )
+        )
+
+    write_revision(1)
+    updater = CampaignUpdater(object(), backup_creator=lambda _: None)
+    installed: list[int] = []
+
+    def install(_root, release, **_kwargs):
+        installed.append(release.revision)
+        write_revision(release.revision)
+        return CampaignUpdateReceipt(root, release.revision, tmp_path / "backup.zip", "b" * 64)
+
+    monkeypatch.setattr(updater, "install", install)
+    delta3 = type("Release", (), {"revision": 3, "snapshot_mode": "campaign_delta", "base_revision": 2})()
+    with pytest.raises(CampaignUpdateError, match="incomplete"):
+        updater.install_chain(root, [delta3])
+
+    checkpoint = type("Release", (), {"revision": 5, "snapshot_mode": "full_campaign", "base_revision": None})()
+    delta6 = type("Release", (), {"revision": 6, "snapshot_mode": "campaign_delta", "base_revision": 5})()
+    receipts = updater.install_chain(root, [delta6, checkpoint])
+
+    assert [receipt.revision for receipt in receipts] == [5, 6]
+    assert installed == [5, 6]


### PR DESCRIPTION
### Motivation

- Reduce transfer size for intermediate revisions by shipping only changed/new assets and tombstones while keeping a transactionally consistent SQLite snapshot for safety.
- Ensure delta application is deterministic and safe by using per-revision content inventories with normalized paths and SHA-256 hashes instead of timestamps, and by requiring exact base revision/fingerprint contracts.
- Provide robust updater behavior that validates delta ancestry, stages replacements via hard-links or copies, and never applies a delta to an unrelated base.
- Improve observability for users by distinguishing full checkpoints from incremental revisions in the UI and README.

### Description

- Added a versioned delta manifest and inventory model in `modules/generic/campaign_sync/delta_manifest.py` with path normalization, `InventoryEntry`, `DeltaManifest`, and validation utilities. 
- Implemented inventory creation and compact delta bundle construction in `modules/generic/campaign_sync/delta_builder.py`, including `build_inventory`, `compare_inventories`, and `write_delta_bundle` which packages changed files, tombstones, and a complete SQLite snapshot. 
- Implemented delta application and safe staging helpers in `modules/generic/campaign_sync/delta_applier.py`, including hard-link copy fallback, path traversal protections, payload integrity checks, tombstone processing, and SQLite snapshot installation. 
- Extended synchronization metadata in `modules/generic/campaign_sync/models.py` to include `snapshot_mode` (`full_campaign`|`campaign_delta`), `base_revision`, and `base_content_fingerprint`, and added defensive validation for delta releases. 
- Updated publisher logic in `modules/generic/campaign_sync/publisher.py` to keep initial/periodic checkpoint revisions as full snapshots and to emit incremental delta bundles for intermediate revisions; the publisher now persists the content inventory and baseline state where applicable. 
- Updated updater logic in `modules/generic/campaign_sync/updater.py` to recognize delta bundles, require matching campaign ID/revision/base fingerprint, reconstruct staging by cloning the installed campaign and applying the delta (changed files, tombstones, SQLite snapshot), validate reconstructed inventory and fingerprint, and provide `install_chain` to apply ordered delta chains or fallback to full checkpoints. 
- Added UI/documentation changes to display whether a revision is a full checkpoint or incremental and to show transfer size and required base revision, and updated `README.md` to explain the checkpoint vs incremental behavior. 
- Added unit and static contract tests in `tests/generic/campaign_sync/test_delta_bundles.py` covering changed/new/deleted/renamed files, SHA-256 detection, tombstones, corrupted payloads, traversal protection, exact-base requirements, delta chains, fallback to full checkpoints, and canonical fingerprint reconstruction. 

### Testing

- Ran `pytest -q tests/generic/campaign_sync` which passed: 55 passed (1.36s). 
- Ran `python -m compileall -q modules/generic/campaign_sync tests/generic/campaign_sync` which succeeded with no syntax errors. 
- Ran repository checks such as `git diff --check` which reported no issues for the modified files. 
- Noted that running full repository `pytest -q` is blocked by unrelated pre-existing test isolation issues in other parts of the repo, so only the synchronization test-suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6879fdbcc0832bb43395a1ae8b5707)