### PR TITLE
Add campaign sync link diagnostics and orphaned-link recovery options

### DIFF
--- a/modules/generic/campaign_sync/publisher.py
+++ b/modules/generic/campaign_sync/publisher.py
@@ -49,6 +49,36 @@ class PublishOutcome(str, Enum):
     CONFLICTED = "conflicted"
 
 
+class CampaignSyncLinkState(str, Enum):
+    """Result of checking a local synchronization identity against GitHub."""
+
+    NEW_LOCAL_UNPUBLISHED = "new_local_unpublished"
+    MATCHED_REMOTE = "matched_remote"
+    REMOTE_AHEAD = "remote_ahead"
+    REMOTE_UNREACHABLE = "remote_unreachable"
+    INVALID_CREDENTIALS = "invalid_credentials"
+    ORPHANED_LOCAL_METADATA = "orphaned_local_metadata"
+
+
+@dataclass(frozen=True)
+class CampaignSyncDiagnostic:
+    state: CampaignSyncLinkState
+    repository: str
+    campaign_id: str
+    local_revision: int
+    remote_revision: Optional[int]
+    error: str = ""
+
+    def details(self) -> str:
+        remote = "unavailable" if self.remote_revision is None else str(self.remote_revision)
+        return (
+            f"Repository: {self.repository}\n"
+            f"Campaign ID: {self.campaign_id}\n"
+            f"Local revision: {self.local_revision}\n"
+            f"Remote revision: {remote}"
+        )
+
+
 @dataclass(frozen=True)
 class CampaignPublishResult:
     outcome: PublishOutcome
@@ -129,6 +159,49 @@ class CampaignPublisher:
             campaigns.pop(str(root), None)
             self.installation_store.write(state)
         return existed
+
+    def diagnose_link(self, campaign_root: Path) -> CampaignSyncDiagnostic:
+        """Compare campaign-local metadata with the configured GitHub repository.
+
+        This method is deliberately read-only: in particular, an identity whose
+        releases disappeared is reported as orphaned and is never repaired by
+        silently changing its UUID or revision.
+        """
+        root = Path(campaign_root).resolve()
+        local = CampaignSyncMetadataStore(root).read()
+        if local is None:
+            raise CampaignNotLinkedError("This local campaign has no synchronization metadata.")
+        repository = str(getattr(self.gallery_client, "repo", "") or "(not configured)")
+        try:
+            remote = self.gallery_client.highest_revision(local.campaign_id)
+            remote_revision = self._revision(remote)
+        except Exception as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            state = (
+                CampaignSyncLinkState.INVALID_CREDENTIALS
+                if status in {401, 403}
+                else CampaignSyncLinkState.REMOTE_UNREACHABLE
+            )
+            return CampaignSyncDiagnostic(
+                state, repository, local.campaign_id, local.revision, None, str(exc)
+            )
+        if remote_revision == 0:
+            state = (
+                CampaignSyncLinkState.NEW_LOCAL_UNPUBLISHED
+                if local.revision == 1 and not local.published_at
+                else CampaignSyncLinkState.ORPHANED_LOCAL_METADATA
+            )
+        elif remote_revision == local.revision:
+            state = CampaignSyncLinkState.MATCHED_REMOTE
+        elif remote_revision > local.revision:
+            state = CampaignSyncLinkState.REMOTE_AHEAD
+        else:
+            # A remote history that ends before the local revision cannot prove
+            # that the local revision still exists, so treat it as orphaned.
+            state = CampaignSyncLinkState.ORPHANED_LOCAL_METADATA
+        return CampaignSyncDiagnostic(
+            state, repository, local.campaign_id, local.revision, remote_revision
+        )
 
     def publish(
         self,

--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -37,6 +37,8 @@ from modules.generic.github_gallery_client import (
 from modules.generic.campaign_sync.metadata_store import CampaignSyncMetadataStore
 from modules.generic.campaign_sync.publisher import (
     CampaignPublisher,
+    CampaignSyncDiagnostic,
+    CampaignSyncLinkState,
     PublishOutcome,
 )
 from modules.helpers.config_helper import ConfigHelper
@@ -677,13 +679,96 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         if not self.selected_campaign:
             messagebox.showwarning("No Source", "Select a source campaign first.")
             return
-        metadata = self.campaign_publisher.enable(
+        self.campaign_publisher.enable(
             self.selected_campaign.root, database_path=self.selected_campaign.db_path
         )
+        diagnostic = self.campaign_publisher.diagnose_link(self.selected_campaign.root)
+        if diagnostic.state is CampaignSyncLinkState.REMOTE_UNREACHABLE:
+            messagebox.showerror(
+                "Repository Unavailable",
+                f"The remote repository could not be queried.\n\n{diagnostic.details()}\n\n{diagnostic.error}",
+            )
+            return
+        if diagnostic.state is CampaignSyncLinkState.INVALID_CREDENTIALS:
+            messagebox.showerror(
+                "Invalid GitHub Credentials",
+                f"GitHub rejected the configured credentials.\n\n{diagnostic.details()}"
+                f"\n\n{diagnostic.error}",
+            )
+            return
+        if diagnostic.state is CampaignSyncLinkState.ORPHANED_LOCAL_METADATA:
+            self._resolve_orphaned_campaign_sync(diagnostic)
+            return
+        state_message = {
+            CampaignSyncLinkState.NEW_LOCAL_UNPUBLISHED:
+                "A new local link was created. It has not been published yet.",
+            CampaignSyncLinkState.MATCHED_REMOTE:
+                "The local link matches GitHub.",
+            CampaignSyncLinkState.REMOTE_AHEAD:
+                "The link is valid, and a newer revision is available on GitHub.",
+        }[diagnostic.state]
         messagebox.showinfo(
             "Synchronization Enabled",
-            f"Campaign ID: {metadata.campaign_id}\nInitial revision: {metadata.revision}",
+            f"{state_message}\n\n{diagnostic.details()}",
         )
+
+    def _resolve_orphaned_campaign_sync(
+        self, diagnostic: CampaignSyncDiagnostic
+    ) -> None:
+        """Offer only explicit, confirmed recovery paths for an orphaned link."""
+        prompt = (
+            "The local revision does not exist in the configured GitHub repository.\n\n"
+            f"{diagnostic.details()}\n\n"
+            "Choose an action:\n"
+            "1 - Select the correct GitHub repository\n"
+            "2 - Keep this local link without publishing\n"
+            "3 - Unlink and create a new campaign identity"
+        )
+        choice = simpledialog.askstring("Orphaned Synchronization Metadata", prompt, parent=self)
+        if choice is None:
+            return
+        choice = choice.strip()
+        if choice == "1":
+            repository = simpledialog.askstring(
+                "GitHub Repository", "Repository (owner/name):", parent=self
+            )
+            if not repository:
+                return
+            repository = repository.strip().strip("/")
+            if not messagebox.askyesno(
+                "Confirm Repository",
+                f"Query {repository} for Campaign ID\n{diagnostic.campaign_id}?",
+            ):
+                return
+            try:
+                self.gallery_client.set_repo(repository)
+            except ValueError as exc:
+                messagebox.showerror("Invalid Repository", str(exc))
+                return
+            ConfigHelper.set("Gallery", "github_repo", self.gallery_client.repo)
+            # Re-run the complete diagnostic; never alter local identity here.
+            self.enable_campaign_sync()
+        elif choice == "2":
+            if messagebox.askyesno(
+                "Keep Unpublished Link",
+                "Keep this Campaign ID and revision locally without publishing?",
+            ):
+                messagebox.showinfo(
+                    "Link Preserved", f"No metadata was changed.\n\n{diagnostic.details()}"
+                )
+        elif choice == "3":
+            if not messagebox.askyesno(
+                "Create New Campaign Identity",
+                "Permanently unlink this local copy and create a new Campaign ID? "
+                "The existing remote releases will not be changed.",
+            ):
+                return
+            campaign = self.selected_campaign
+            self.campaign_publisher.unlink(campaign.root)
+            self.campaign_publisher.enable(campaign.root, database_path=campaign.db_path)
+            self.enable_campaign_sync()
+        else:
+            messagebox.showwarning("Invalid Choice", "Enter 1, 2, or 3.")
 
     def publish_campaign_update(self):
         if not self.selected_campaign:

--- a/modules/generic/github_gallery_client.py
+++ b/modules/generic/github_gallery_client.py
@@ -119,6 +119,13 @@ class GithubGalleryClient:
         token_env = os.environ.get("GMCD_GALLERY_TOKEN", "").strip()
         self._token = token_config or token_env or None
 
+    def set_repo(self, repo: str) -> None:
+        """Select the repository used by subsequent gallery operations."""
+        normalized = str(repo).strip().strip("/")
+        if not re.fullmatch(r"[^/\s]+/[^/\s]+", normalized):
+            raise ValueError("GitHub repository must use the owner/repository format.")
+        self._repo = normalized
+
     # ----------------------------------------------------------------- Session
     def _create_session(self, *, auth: bool = False) -> requests.Session:
         """Create session."""

--- a/tests/generic/campaign_sync/test_link_diagnostic.py
+++ b/tests/generic/campaign_sync/test_link_diagnostic.py
@@ -1,0 +1,118 @@
+"""Diagnostics for campaign identities linked to GitHub releases."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from modules.generic.campaign_sync.metadata_store import CampaignSyncMetadataStore
+from modules.generic.campaign_sync.models import CampaignSyncMetadata
+from modules.generic.campaign_sync.publisher import (
+    CampaignPublisher,
+    CampaignSyncLinkState,
+)
+
+
+class DiagnosticGallery:
+    repo = "guild/campaigns"
+
+    def __init__(self, remote_revision=0, error=None):
+        self.remote_revision = remote_revision
+        self.error = error
+
+    def highest_revision(self, campaign_id):
+        if self.error:
+            raise self.error
+        if not self.remote_revision:
+            return None
+        return SimpleNamespace(campaign_id=campaign_id, revision=self.remote_revision)
+
+
+def write_local_revision(root, revision):
+    metadata = CampaignSyncMetadata(
+        campaign_id=str(uuid4()),
+        revision=revision,
+        parent_revision=revision - 1,
+        snapshot_sha256="a" * 64,
+        published_at="2026-07-28T00:00:00Z",
+        publisher_installation_id="installation",
+        bundle_version=1,
+    )
+    CampaignSyncMetadataStore(root).write(metadata)
+    return metadata
+
+
+@pytest.mark.parametrize(
+    ("local_revision", "remote_revision", "expected"),
+    [
+        (2, 0, CampaignSyncLinkState.ORPHANED_LOCAL_METADATA),
+        (2, 2, CampaignSyncLinkState.MATCHED_REMOTE),
+        (2, 3, CampaignSyncLinkState.REMOTE_AHEAD),
+    ],
+)
+def test_diagnostic_compares_local_and_remote_revisions(
+    tmp_path, local_revision, remote_revision, expected
+):
+    local = write_local_revision(tmp_path, local_revision)
+    diagnostic = CampaignPublisher(
+        DiagnosticGallery(remote_revision), retry_delay=0
+    ).diagnose_link(tmp_path)
+
+    assert diagnostic.state is expected
+    assert diagnostic.repository == "guild/campaigns"
+    assert diagnostic.campaign_id == local.campaign_id
+    assert diagnostic.local_revision == local_revision
+    assert diagnostic.remote_revision == remote_revision
+    assert "Repository: guild/campaigns" in diagnostic.details()
+    assert f"Campaign ID: {local.campaign_id}" in diagnostic.details()
+    assert f"Local revision: {local_revision}" in diagnostic.details()
+    assert f"Remote revision: {remote_revision}" in diagnostic.details()
+
+
+def test_diagnostic_distinguishes_network_failure(tmp_path):
+    write_local_revision(tmp_path, 2)
+    diagnostic = CampaignPublisher(
+        DiagnosticGallery(error=OSError("offline")), retry_delay=0
+    ).diagnose_link(tmp_path)
+
+    assert diagnostic.state is CampaignSyncLinkState.REMOTE_UNREACHABLE
+    assert diagnostic.remote_revision is None
+    assert "offline" in diagnostic.error
+
+
+def test_diagnostic_reports_invalid_remote_metadata_as_unreachable(tmp_path):
+    write_local_revision(tmp_path, 2)
+    gallery = DiagnosticGallery(remote_revision="invalid")
+
+    diagnostic = CampaignPublisher(gallery, retry_delay=0).diagnose_link(tmp_path)
+
+    assert diagnostic.state is CampaignSyncLinkState.REMOTE_UNREACHABLE
+    assert diagnostic.remote_revision is None
+    assert "invalid revision metadata" in diagnostic.error
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_diagnostic_distinguishes_invalid_credentials(tmp_path, status_code):
+    write_local_revision(tmp_path, 2)
+    error = RuntimeError("credentials rejected")
+    error.response = SimpleNamespace(status_code=status_code)
+    diagnostic = CampaignPublisher(
+        DiagnosticGallery(error=error), retry_delay=0
+    ).diagnose_link(tmp_path)
+
+    assert diagnostic.state is CampaignSyncLinkState.INVALID_CREDENTIALS
+    assert diagnostic.remote_revision is None
+
+
+def test_diagnostic_identifies_new_unpublished_local_link(tmp_path):
+    publisher = CampaignPublisher(DiagnosticGallery(), retry_delay=0)
+    local = CampaignSyncMetadata(
+        campaign_id=str(uuid4()), revision=1, parent_revision=None,
+        snapshot_sha256="a" * 64, published_at="",
+        publisher_installation_id="installation", bundle_version=1,
+    )
+    CampaignSyncMetadataStore(tmp_path).write(local)
+
+    diagnostic = publisher.diagnose_link(tmp_path)
+
+    assert local.revision == 1
+    assert diagnostic.state is CampaignSyncLinkState.NEW_LOCAL_UNPUBLISHED


### PR DESCRIPTION
### Motivation
- Ensure the UI only reports synchronization as enabled after comparing local `CampaignSyncMetadataStore(root).read().revision` with the repository's highest remote revision. 
- Distinguish and surface clear states for local/distant link validity including new unpublished, matched, remote-ahead, unreachable repo, invalid credentials, and orphaned local metadata. 
- Provide explicit, confirmed recovery choices for orphaned metadata rather than silently changing `campaign_id` or revision. 
- Make diagnostics actionable by displaying the repository queried, Campaign ID, local revision and remote revision.

### Description
- Add `CampaignSyncLinkState` and `CampaignSyncDiagnostic` datatypes and a read-only `CampaignPublisher.diagnose_link` method that compares the local metadata revision against `gallery_client.highest_revision`. 
- Update `enable_campaign_sync` in `CrossCampaignAssetLibraryWindow` to call `diagnose_link` before declaring sync enabled and to handle `REMOTE_UNREACHABLE`, `INVALID_CREDENTIALS`, `NEW_LOCAL_UNPUBLISHED`, `MATCHED_REMOTE`, and `REMOTE_AHEAD` explicitly. 
- Implement `_resolve_orphaned_campaign_sync` UI flow that prompts the user to (1) select and confirm a different GitHub repository, (2) keep the local link without publishing, or (3) unlink and create a new campaign identity, and ensure no automatic reset of `campaign_id` or revision occurs. 
- Add `GithubGalleryClient.set_repo` with validation for the `owner/repository` format. 
- Add tests in `tests/generic/campaign_sync/test_link_diagnostic.py` covering local/remote revision combos `2/0`, `2/2`, `2/3`, network failures, invalid remote metadata, HTTP auth errors (`401`/`403`), and the new-unpublished local link case.

### Testing
- Run compile check with `python -m compileall -q modules/generic/campaign_sync modules/generic/cross_campaign_asset_library.py modules/generic/github_gallery_client.py`, which succeeded. 
- Run targeted tests with `pytest -q tests/generic/campaign_sync`, which passed (63 passed). 
- Run the remaining generic tests with `pytest -q tests/generic --ignore=tests/generic/campaign_sync`, which passed (25 passed). 
- Ran `git diff --check` to validate no whitespace/conflict markers remain. 
- Note: a full `pytest -q` collection remained blocked by pre-existing test collection/isolation issues unrelated to these changes (duplicate module names and incomplete global mocks), while the modified areas' test suite passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68b10d3b70832badb4e0603f3e8b11)