### PR TITLE
Check campaign updates at launch (force immediate sync)

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -291,7 +291,10 @@ class MainWindow(ctk.CTk):
         self.after(400, self.open_audio_bar)
         self.after(600, lambda: self._queue_update_check(force=True))
         self.after(800, self._auto_open_campaign_overview)
-        self.after(1000, self._queue_campaign_update_check)
+        # Launch checks intentionally bypass the elapsed-time gate.  The
+        # configured interval still governs later automatic checks, while the
+        # enabled/offline preferences remain enforced by the checker.
+        self.after(1000, lambda: self._queue_campaign_update_check(force=True))
 
     def _on_campaign_data_saved(self, database_path=None) -> None:
         """Mark linked campaign content dirty after its database commit succeeds."""

--- a/tests/test_main_window_launch_defaults.py
+++ b/tests/test_main_window_launch_defaults.py
@@ -50,6 +50,39 @@ def test_main_window_schedules_campaign_overview_on_launch() -> None:
     raise AssertionError("MainWindow.__init__ no longer schedules the campaign overview at launch")
 
 
+def test_main_window_forces_campaign_update_check_on_launch() -> None:
+    """The launch check must not be suppressed by the recurring interval."""
+    init_method = _get_method("__init__")
+
+    for node in ast.walk(init_method):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "after"
+            and len(node.args) == 2
+        ):
+            continue
+        delay_arg, callback_arg = node.args
+        if not (
+            isinstance(delay_arg, ast.Constant)
+            and delay_arg.value == 1000
+            and isinstance(callback_arg, ast.Lambda)
+            and isinstance(callback_arg.body, ast.Call)
+            and isinstance(callback_arg.body.func, ast.Attribute)
+            and callback_arg.body.func.attr == "_queue_campaign_update_check"
+        ):
+            continue
+        if any(
+            keyword.arg == "force"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in callback_arg.body.keywords
+        ):
+            return
+
+    raise AssertionError("MainWindow.__init__ no longer forces an update check at launch")
+
+
 def test_gm_screen_auto_open_alias_points_to_campaign_overview() -> None:
     """Verify that GM screen auto open alias points to campaign overview."""
     alias_method = _get_method("_auto_open_gm_screen_if_available")


### PR DESCRIPTION
### Motivation

- Ensure the client performs a campaign synchronization check immediately at startup in addition to the configured recurring checks so users see updates right after launch.

### Description

- Call `self.after(1000, lambda: self._queue_campaign_update_check(force=True))` in `main_window.py` so the launch check bypasses the elapsed-time gate while preserving normal interval behavior.
- Add `test_main_window_forces_campaign_update_check_on_launch` to `tests/test_main_window_launch_defaults.py` to assert that the `__init__` schedules a forced update check at 1000 ms.

### Testing

- Ran `pytest -q tests/test_main_window_launch_defaults.py tests/generic/campaign_sync/test_update_checker.py` and the focused test set passed (14 tests) successfully.
- Verified syntax with `python -m py_compile main_window.py tests/test_main_window_launch_defaults.py` which completed without errors.
- Running the full test suite with `pytest -q` exposed unrelated, pre-existing collection errors in other tests that did not affect the focused changes (these failures are outside the scope of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68c645c1e8832bb774f091f9a311eb)