### PR TITLE
Normalize image asset paths across campaigns

### DIFF
--- a/db/migrate.py
+++ b/db/migrate.py
@@ -4,6 +4,7 @@
 import json
 import os
 import sqlite3
+import argparse
 from db import get_connection, initialize_db
 from modules.helpers.logging_helper import log_module_import
 
@@ -41,6 +42,17 @@ def migrate_table(json_file, table, columns):
     print(f"Migrated data from {json_file} to {table}")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image-assets-db")
+    parser.add_argument("--campaign-root")
+    args, _unknown = parser.parse_known_args()
+    if args.image_assets_db:
+        if not args.campaign_root:
+            parser.error("--campaign-root is required with --image-assets-db")
+        from db.migrations.image_asset_relative_paths import migrate_image_asset_paths
+        report = migrate_image_asset_paths(args.image_assets_db, args.campaign_root)
+        print(json.dumps(report.__dict__, ensure_ascii=False, indent=2))
+        raise SystemExit(0)
     initialize_db()
     
     # Migrate NPCs (fields based on npcs_template.json)

--- a/db/migrations/__init__.py
+++ b/db/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned and manually runnable database migrations."""

--- a/db/migrations/image_asset_relative_paths.py
+++ b/db/migrations/image_asset_relative_paths.py
@@ -1,0 +1,81 @@
+"""Idempotently migrate image_assets rows to campaign-relative references."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import shutil
+import sqlite3
+from pathlib import Path
+
+from modules.image_assets.paths import (
+    InvalidAssetReference,
+    normalize_asset_reference,
+    resolve_asset_reference,
+)
+
+
+@dataclass
+class MigrationReport:
+    updated: int = 0
+    unchanged: int = 0
+    issues: list[dict[str, str]] = field(default_factory=list)
+    backup_path: str = ""
+
+
+def migrate_image_asset_paths(database: str | Path, campaign_root: str | Path) -> MigrationReport:
+    """Migrate one campaign DB, preserving unconvertible rows and reporting them."""
+    db_path = Path(database).resolve()
+    root = Path(campaign_root).resolve()
+    report = MigrationReport()
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(image_assets)")}
+        if not columns:
+            return report
+        id_column = "AssetId" if "AssetId" in columns else "rowid"
+        fields = [name for name in (id_column, "Path", "RelativePath", "SourceRoot") if name == "rowid" or name in columns]
+        rows = connection.execute(f"SELECT {', '.join(fields)} FROM image_assets").fetchall()
+        updates: list[tuple[str, str, str, object]] = []
+        for row in rows:
+            values = dict(zip(fields, row))
+            identity = values[id_column]
+            candidates = [values.get("RelativePath"), values.get("Path")]
+            canonical = ""
+            failures: list[str] = []
+            for value in candidates:
+                if not str(value or "").strip():
+                    continue
+                try:
+                    canonical = normalize_asset_reference(str(value), root)
+                    break
+                except InvalidAssetReference as exc:
+                    failures.append(str(exc))
+            if not canonical:
+                report.issues.append({"asset_id": str(identity), "path": str(values.get("Path") or ""), "reason": "; ".join(failures) or "missing reference"})
+                continue
+            resolved = resolve_asset_reference(canonical, root)
+            if not resolved.is_file():
+                report.issues.append({
+                    "asset_id": str(identity),
+                    "path": canonical,
+                    "reason": "resolved file is missing",
+                })
+            desired = (canonical, canonical, "assets/image_library")
+            current = (str(values.get("Path") or ""), str(values.get("RelativePath") or ""), str(values.get("SourceRoot") or ""))
+            if current == desired:
+                report.unchanged += 1
+            else:
+                updates.append((*desired, identity))
+        if updates:
+            stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            backup = db_path.with_suffix(db_path.suffix + f".pre-image-paths-{stamp}.bak")
+            connection.commit()
+            shutil.copy2(db_path, backup)
+            report.backup_path = str(backup)
+            connection.executemany(
+                f"UPDATE image_assets SET Path=?, RelativePath=?, SourceRoot=? WHERE {id_column}=?",
+                updates,
+            )
+            connection.commit()
+            report.updated = len(updates)
+    return report

--- a/modules/generic/cross_campaign_asset_service.py
+++ b/modules/generic/cross_campaign_asset_service.py
@@ -1773,15 +1773,11 @@ def _rewrite_record_paths(
                 replacement = replacements[value]
                 break
         if replacement:
-            relative_replacement = str(Path(replacement).as_posix())
+            from modules.image_assets.paths import normalize_asset_reference
+            relative_replacement = normalize_asset_reference(replacement, target_campaign_root)
             updated["RelativePath"] = relative_replacement
-            campaign_root = (
-                target_campaign_root.resolve()
-                if target_campaign_root
-                else _resolve_campaign_dir(None)
-            )
-            updated["Path"] = str((campaign_root / relative_replacement).resolve())
-            updated["SourceRoot"] = str(campaign_root)
+            updated["Path"] = relative_replacement
+            updated["SourceRoot"] = "assets/image_library"
 
     return updated
 

--- a/modules/generic/editor/window_components/asset_path_and_preview.py
+++ b/modules/generic/editor/window_components/asset_path_and_preview.py
@@ -1,6 +1,7 @@
 """Utilities for window components asset path and preview."""
 
 from modules.generic.editor.window_context import *
+from modules.image_assets.paths import resolve_asset_reference
 
 
 class GenericEditorWindowAssetPathAndPreview:
@@ -8,7 +9,7 @@ class GenericEditorWindowAssetPathAndPreview:
         """Ensure selected source path exists before copying."""
         if not src_path:
             return False
-        source = Path(src_path)
+        source = resolve_asset_reference(src_path) if not Path(src_path).is_absolute() else Path(src_path).resolve()
         if source.is_file():
             return True
         messagebox.showerror(
@@ -75,7 +76,7 @@ class GenericEditorWindowAssetPathAndPreview:
 
     def attach_image_from_library(self, image_result):
         """Attach image selected from image library."""
-        source_path = getattr(image_result, "path", image_result)
+        source_path = getattr(image_result, "resolved_path", "") or resolve_asset_reference(getattr(image_result, "path", image_result))
         self._attach_image_from_source(str(source_path))
     def _campaign_relative_path(self, path):
         """Internal helper for campaign relative path."""

--- a/modules/generic/editor/window_components/portrait_and_image_workflows.py
+++ b/modules/generic/editor/window_components/portrait_and_image_workflows.py
@@ -182,7 +182,8 @@ class GenericEditorWindowPortraitAndImageWorkflows:
         )
     def _attach_portrait_from_image_library(self, image_result):
         """Handle portrait attach callback from internal image library."""
-        source_path = str(getattr(image_result, "path", ""))
+        from modules.image_assets.paths import resolve_asset_reference
+        source_path = str(getattr(image_result, "resolved_path", "") or resolve_asset_reference(getattr(image_result, "path", "")))
         if not self._validate_asset_source(source_path, asset_label="Portrait"):
             return
         make_primary = not self.portrait_paths
@@ -325,7 +326,8 @@ class GenericEditorWindowPortraitAndImageWorkflows:
         )
     def _attach_image_from_image_library(self, image_result):
         """Handle image attach callback from internal image library."""
-        source_path = str(getattr(image_result, "path", ""))
+        from modules.image_assets.paths import resolve_asset_reference
+        source_path = str(getattr(image_result, "resolved_path", "") or resolve_asset_reference(getattr(image_result, "path", "")))
         if not self._validate_asset_source(source_path, asset_label="Image"):
             return
         copied = self.copy_and_resize_image(source_path)
@@ -581,7 +583,9 @@ class GenericEditorWindowPortraitAndImageWorkflows:
 
     def attach_portrait_from_library(self, image_result):
         """Attach portrait selected from image library."""
-        source_path = str(getattr(image_result, "path", image_result))
+        from modules.image_assets.paths import resolve_asset_reference
+        reference = getattr(image_result, "path", image_result)
+        source_path = str(getattr(image_result, "resolved_path", "") or resolve_asset_reference(reference))
         if not self._validate_asset_source(source_path, asset_label="Portrait"):
             return
         copied = self.copy_and_resize_portrait(source_path)

--- a/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
+++ b/modules/generic/portrait_manager/scenario_portrait_manager_dialog.py
@@ -274,8 +274,10 @@ class ScenarioPortraitManagerDialog(ctk.CTkToplevel):
         return None
 
     def _attach_from_library(self, image_result):
+        from modules.image_assets.paths import resolve_asset_reference
         entity = self._entity()
-        source = str(getattr(image_result, "path", image_result))
+        reference = getattr(image_result, "path", image_result)
+        source = str(getattr(image_result, "resolved_path", "") or resolve_asset_reference(reference))
         if entity and Path(source).is_file():
             self._save_paths(self._paths() + [copy_portrait_to_campaign(source, entity.name)])
 

--- a/modules/image_assets/paths.py
+++ b/modules/image_assets/paths.py
@@ -1,0 +1,90 @@
+"""Canonical, campaign-relative paths for image-library assets.
+
+Persisted references always use POSIX separators.  Absolute paths are accepted
+only as a temporary read-compatibility measure and are converted before writes.
+"""
+
+from __future__ import annotations
+
+import ntpath
+from pathlib import Path, PurePosixPath
+
+from modules.helpers.config_helper import ConfigHelper
+
+
+class InvalidAssetReference(ValueError):
+    """Raised when an asset reference could escape the active campaign."""
+
+
+def _campaign_root(campaign_dir: str | Path | None = None) -> Path:
+    return Path(campaign_dir or ConfigHelper.get_campaign_dir()).expanduser().resolve()
+
+
+def _looks_windows_absolute(value: str) -> bool:
+    return ntpath.isabs(value) or (len(value) > 2 and value[1] == ":" and value[2] in "\\/")
+
+
+def normalize_asset_reference(reference: str | Path, campaign_dir: str | Path | None = None) -> str:
+    """Return a safe canonical reference, converting legacy absolute values.
+
+    Legacy absolute references must either be below the active campaign or have
+    a recognisable ``assets/image_library`` suffix (for a moved campaign).
+    """
+    raw = str(reference or "").strip()
+    if not raw:
+        return ""
+    root = _campaign_root(campaign_dir)
+    windows_absolute = _looks_windows_absolute(raw)
+    candidate = Path(raw).expanduser()
+    normalized = raw.replace("\\", "/")
+    if candidate.is_absolute() or windows_absolute:
+        # A Windows value can be made relative normally when running on Windows.
+        if candidate.is_absolute():
+            try:
+                return make_campaign_relative(candidate, root)
+            except InvalidAssetReference:
+                # A campaign may have moved since this value was persisted.
+                # Only remap the managed image-library suffix; arbitrary
+                # absolute paths remain invalid.
+                pass
+        marker = "/assets/image_library/"
+        lowered = normalized.lower()
+        index = lowered.find(marker)
+        if index >= 0:
+            normalized = normalized[index + 1 :]
+        else:
+            raise InvalidAssetReference(f"absolute asset is outside campaign: {raw}")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    parts = PurePosixPath(normalized).parts
+    if not parts or any(part in ("", ".", "..") for part in parts):
+        raise InvalidAssetReference(f"invalid asset reference: {raw}")
+    return PurePosixPath(*parts).as_posix()
+
+
+def make_campaign_relative(path: str | Path, campaign_dir: str | Path | None = None) -> str:
+    """Convert an existing filesystem path below the campaign to a reference."""
+    root = _campaign_root(campaign_dir)
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        return normalize_asset_reference(candidate, root)
+    resolved = candidate.resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise InvalidAssetReference(f"asset is outside campaign: {path}") from exc
+    return normalize_asset_reference(relative, root)
+
+
+def resolve_asset_reference(reference: str | Path, campaign_dir: str | Path | None = None) -> Path:
+    """Resolve a persisted reference safely against the active campaign root."""
+    root = _campaign_root(campaign_dir)
+    canonical = normalize_asset_reference(reference, root)
+    if not canonical:
+        raise InvalidAssetReference("empty asset reference")
+    resolved = (root / Path(*PurePosixPath(canonical).parts)).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise InvalidAssetReference(f"asset resolves outside campaign: {reference}") from exc
+    return resolved

--- a/modules/image_assets/repository.py
+++ b/modules/image_assets/repository.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any, Iterable
 
 from modules.generic.generic_model_wrapper import GenericModelWrapper
+from modules.image_assets.paths import InvalidAssetReference, normalize_asset_reference
 
 
 class ImageAssetsRepository:
@@ -22,6 +23,7 @@ class ImageAssetsRepository:
 
     def upsert_by_hash_or_path(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Create or update an asset using hash first, then path fallback."""
+        payload = self._normalize_payload(payload)
         existing = self._find_existing(
             hash_value=str(payload.get("Hash") or "").strip(),
             path=str(payload.get("Path") or "").strip(),
@@ -46,6 +48,7 @@ class ImageAssetsRepository:
 
     def replace_by_path(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Replace the existing row for a path, or create it when absent."""
+        payload = self._normalize_payload(payload)
         path = str(payload.get("Path") or "").strip()
         existing = self._find_existing_by_path(path) if path else None
 
@@ -68,12 +71,12 @@ class ImageAssetsRepository:
 
     def delete_stale_files(self, active_paths: Iterable[str]) -> int:
         """Delete rows that no longer map to known file paths."""
-        normalized = {str(path).strip() for path in active_paths if str(path).strip()}
+        normalized = {self._normalized_path(path) for path in active_paths if str(path).strip()}
         items = self.list_all()
         kept: list[dict[str, Any]] = []
         stale_count = 0
         for item in items:
-            row_path = str(item.get("Path") or "").strip()
+            row_path = self._normalized_path(item.get("Path"))
             if row_path and row_path in normalized:
                 kept.append(item)
             elif row_path:
@@ -118,13 +121,32 @@ class ImageAssetsRepository:
 
     def _find_existing_by_path(self, path: str) -> dict[str, Any] | None:
         """Find one row by exact path."""
-        normalized_path = str(path or "").strip()
+        normalized_path = self._normalized_path(path)
         if not normalized_path:
             return None
         for item in self.list_all():
-            if str(item.get("Path") or "").strip() == normalized_path:
+            if self._normalized_path(item.get("Path")) == normalized_path:
                 return item
         return None
+
+    @staticmethod
+    def _normalized_path(path: object) -> str:
+        try:
+            return normalize_asset_reference(str(path or ""))
+        except InvalidAssetReference:
+            return str(path or "").strip().replace("\\", "/")
+
+    @classmethod
+    def _normalize_payload(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(payload)
+        # Writes are deliberately strict.  The lenient helper above exists
+        # solely so legacy rows remain comparable until the migration runs.
+        path = normalize_asset_reference(str(payload.get("Path") or ""))
+        if path:
+            normalized["Path"] = path
+            normalized["RelativePath"] = path
+        normalized["SourceRoot"] = "assets/image_library"
+        return normalized
 
     @staticmethod
     def _apply_search(

--- a/modules/image_assets/services/import_service.py
+++ b/modules/image_assets/services/import_service.py
@@ -6,10 +6,13 @@ from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Iterable
+import shutil
 
 from PIL import Image, UnidentifiedImageError
 
 from modules.image_assets.repository import ImageAssetsRepository
+from modules.image_assets.paths import make_campaign_relative, normalize_asset_reference
+from modules.helpers.config_helper import ConfigHelper
 from modules.image_assets.services.import_options import ImageDirectoryImportOptions
 from modules.image_assets.search.indexing import (
     build_search_tokens,
@@ -90,12 +93,19 @@ class ImageAssetImportService:
             update_existing_files=update_existing_files,
         )
         normalized_roots = self._normalize_roots(paths)
+        campaign_root = Path(ConfigHelper.get_campaign_dir()).resolve()
         existing_items = self.repository.list_all()
-        existing_by_path = {
-            str(item.get("Path") or "").strip(): item
-            for item in existing_items
-            if str(item.get("Path") or "").strip()
-        }
+        existing_by_path: dict[str, dict] = {}
+        for item in existing_items:
+            raw_path = str(item.get("Path") or "").strip()
+            if not raw_path:
+                continue
+            try:
+                existing_by_path[normalize_asset_reference(raw_path, campaign_root)] = item
+            except ValueError:
+                # Temporary lookup support for an old external absolute value;
+                # the row is rewritten to the managed relative destination.
+                existing_by_path[str(Path(raw_path).expanduser().resolve())] = item
 
         roots_missing: list[str] = []
         scanned_files = 0
@@ -125,16 +135,22 @@ class ImageAssetImportService:
                 scanned_files += 1
                 discovered_candidates += 1
 
-                abs_path = str(file_path.resolve())
-                existing = existing_by_path.get(abs_path)
+                source_path = file_path.resolve()
+                try:
+                    stored_path = make_campaign_relative(source_path, campaign_root)
+                    managed_path = source_path
+                except ValueError:
+                    managed_path = self._copy_external_asset(source_path, root_path, campaign_root)
+                    stored_path = make_campaign_relative(managed_path, campaign_root)
+                existing = existing_by_path.get(stored_path) or existing_by_path.get(str(source_path))
 
                 try:
-                    file_size = file_path.stat().st_size
-                    content_hash = self._compute_sha256(file_path)
+                    file_size = managed_path.stat().st_size
+                    content_hash = self._compute_sha256(managed_path)
                 except OSError as exc:
                     errors.append(
                         AssetImportError(
-                            path=abs_path, reason=f"stat/hash failed: {exc}"
+                            path=str(source_path), reason=f"stat/hash failed: {exc}"
                         )
                     )
                     continue
@@ -162,11 +178,11 @@ class ImageAssetImportService:
                 height: int | None = None
                 if not unchanged:
                     try:
-                        width, height = self._read_dimensions(file_path)
+                        width, height = self._read_dimensions(managed_path)
                     except (OSError, UnidentifiedImageError) as exc:
                         errors.append(
                             AssetImportError(
-                                path=abs_path, reason=f"metadata read failed: {exc}"
+                                path=str(source_path), reason=f"metadata read failed: {exc}"
                             )
                         )
                         continue
@@ -186,11 +202,9 @@ class ImageAssetImportService:
                 )
                 searchable_blob = build_searchable_blob(
                     name=stem,
-                    path=abs_path,
-                    relative_path=self._compute_relative(
-                        file_path=file_path, root_path=root_path
-                    ),
-                    source_root=str(root_path.resolve()),
+                    path=stored_path,
+                    relative_path=stored_path,
+                    source_root="assets/image_library",
                     extension=file_path.suffix.lower().lstrip("."),
                     tags=tags,
                     name_normalized=name_normalized,
@@ -200,11 +214,9 @@ class ImageAssetImportService:
 
                 payload = {
                     "Name": stem,
-                    "Path": abs_path,
-                    "RelativePath": self._compute_relative(
-                        file_path=file_path, root_path=root_path
-                    ),
-                    "SourceRoot": str(root_path.resolve()),
+                    "Path": stored_path,
+                    "RelativePath": stored_path,
+                    "SourceRoot": "assets/image_library",
                     "SourceFolderName": file_path.parent.name,
                     "Extension": file_path.suffix.lower().lstrip("."),
                     "Width": width,
@@ -222,7 +234,7 @@ class ImageAssetImportService:
                     if existing
                     else self.repository.upsert_by_hash_or_path(payload)
                 )
-                existing_by_path[abs_path] = saved
+                existing_by_path[stored_path] = saved
                 seen_keys.add(dedupe_key)
 
                 if existing:
@@ -295,6 +307,36 @@ class ImageAssetImportService:
             return str(file_path.resolve().relative_to(root_path.resolve()))
         except ValueError:
             return file_path.name
+
+    @classmethod
+    def _copy_external_asset(cls, source: Path, source_root: Path, campaign_root: Path) -> Path:
+        """Copy an external file into the managed library without overwriting."""
+        folder = cls._safe_component(source_root.name or "imported")
+        try:
+            tail = source.relative_to(source_root.resolve())
+        except ValueError:
+            tail = Path(source.name)
+        destination = campaign_root / "assets" / "image_library" / folder / tail
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            if destination.stat().st_size == source.stat().st_size and cls._compute_sha256(destination) == cls._compute_sha256(source):
+                return destination
+            counter = 2
+            while True:
+                candidate = destination.with_name(f"{destination.stem}_{counter}{destination.suffix}")
+                if candidate.exists() and candidate.stat().st_size == source.stat().st_size and cls._compute_sha256(candidate) == cls._compute_sha256(source):
+                    return candidate
+                if not candidate.exists():
+                    destination = candidate
+                    break
+                counter += 1
+        shutil.copy2(source, destination)
+        return destination
+
+    @staticmethod
+    def _safe_component(value: str) -> str:
+        cleaned = "".join(char if char.isalnum() or char in "-_" else "_" for char in value).strip("_")
+        return cleaned or "imported"
 
     @staticmethod
     def _as_optional_int(value: object) -> int | None:

--- a/modules/image_assets/services/search_service.py
+++ b/modules/image_assets/services/search_service.py
@@ -8,6 +8,11 @@ from typing import Any, Literal
 
 from modules.image_assets.repository import ImageAssetsRepository
 from modules.image_assets.search.dto import ImageAssetSearchResultDTO
+from modules.image_assets.paths import (
+    InvalidAssetReference,
+    normalize_asset_reference,
+    resolve_asset_reference,
+)
 from modules.image_assets.search.indexing import (
     build_searchable_blob,
     normalize_extension,
@@ -251,11 +256,16 @@ class ImageAssetSearchService:
         if not searchable_blob:
             searchable_blob = self._compose_searchable_blob(item, tags=tags, search_tokens=search_tokens)
 
+        stored_value = str(item.get("RelativePath") or item.get("Path") or "")
+        try:
+            stored_path = normalize_asset_reference(stored_value)
+        except ValueError:
+            stored_path = stored_value.replace("\\", "/")
         return {
             "asset_id": str(item.get("AssetId") or ""),
             "name": str(item.get("Name") or ""),
-            "path": str(item.get("Path") or ""),
-            "relative_path": str(item.get("RelativePath") or ""),
+            "path": stored_path,
+            "relative_path": stored_path,
             "source_root": str(item.get("SourceRoot") or ""),
             "source_folder_name": str(item.get("SourceFolderName") or ""),
             "extension": str(item.get("Extension") or ""),
@@ -284,12 +294,18 @@ class ImageAssetSearchService:
 
     @staticmethod
     def _to_dto(row: dict[str, Any]) -> ImageAssetSearchResultDTO:
-        preview_path = str(row.get("path") or "")
+        stored_path = str(row.get("path") or "")
+        try:
+            preview_path = str(resolve_asset_reference(stored_path)) if stored_path else ""
+        except InvalidAssetReference:
+            # Preserve malformed legacy data for diagnostics, but never hand an
+            # unsafe database value to a filesystem consumer.
+            preview_path = ""
         return ImageAssetSearchResultDTO(
             asset_id=str(row.get("asset_id") or ""),
             name=str(row.get("name") or ""),
             preview_path=preview_path,
-            path=preview_path,
+            path=stored_path,
             relative_path=str(row.get("relative_path") or ""),
             source_root=str(row.get("source_root") or ""),
             source_folder_name=str(row.get("source_folder_name") or ""),

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -917,6 +917,8 @@ class GMTableView(ctk.CTkFrame):
 
     def _add_image_to_fixed_overlay_from_library_result(self, image_result) -> None:
         """Create a fixed-overlay image item from an image-library selection."""
+        # Keep the canonical campaign-relative reference in workspace state;
+        # panel renderers resolve it only when accessing the filesystem.
         image_path = str(getattr(image_result, "path", "") or "").strip()
         if not image_path:
             messagebox.showerror("GM Table", "The selected image has no usable path.")

--- a/modules/ui/image_library/browser_panel.py
+++ b/modules/ui/image_library/browser_panel.py
@@ -13,6 +13,7 @@ from typing import Callable, Iterable
 import customtkinter as ctk
 
 from modules.ui.image_library.result_card import ImageResult, ImageResultCard
+from modules.image_assets.paths import resolve_asset_reference
 from modules.ui.image_library.thumbnail_cache import ThumbnailCache, ThumbnailPlaceholderFactory
 from modules.ui.image_library.toolbar import ImageLibraryToolbar, SORT_OPTIONS, ToolbarState
 from modules.ui.image_library.editor.image_editor_dialog import ImageEditorDialog
@@ -381,7 +382,7 @@ class ImageBrowserPanel(ctk.CTkFrame):
             card = ImageResultCard(
                 self._items_frame,
                 item=item,
-                image=self._load_ctk_thumb(item.path, thumb_size),
+                image=self._load_ctk_thumb(item.resolved_path or item.path, thumb_size),
                 display_mode=display_mode,
                 on_open=self._open_callback,
                 on_view=self._view_callback,
@@ -409,10 +410,10 @@ class ImageBrowserPanel(ctk.CTkFrame):
     def _resolve_thumbnail_path(path: str) -> str:
         """Resolve image-library thumbnails the same way preview resolves portraits."""
         try:
-            resolved = resolve_portrait_path(path, ConfigHelper.get_campaign_dir())
+            resolved = str(resolve_asset_reference(path))
         except Exception:
             resolved = None
-        return resolved or str(Path(path).expanduser())
+        return resolved or ""
 
     def _clear_rendered_cards(self) -> None:
         """Remove currently rendered widgets and image references."""
@@ -451,7 +452,7 @@ class ImageBrowserPanel(ctk.CTkFrame):
 
         ImageEditorDialog(
             self,
-            self._context_item.path,
+            self._context_item.resolved_path or str(resolve_asset_reference(self._context_item.path)),
             on_saved=_refresh_after_save,
             use_transient=False,
             modal=False,
@@ -472,9 +473,7 @@ class ImageBrowserPanel(ctk.CTkFrame):
         """Default view behavior matching app image preview flow."""
         if not item.path:
             return
-        resolved = item.path
-        if not os.path.isabs(resolved):
-            resolved = str(Path(resolved).expanduser())
+        resolved = item.resolved_path or str(resolve_asset_reference(item.path))
         show_portrait(resolved, title=item.name)
 
 

--- a/modules/ui/image_library/dialogs/library_browser_dialog.py
+++ b/modules/ui/image_library/dialogs/library_browser_dialog.py
@@ -81,6 +81,7 @@ class ImageLibraryBrowserDialog(ctk.CTkToplevel):
                 modified_ts=0.0,
                 subtitle=row.relative_path or row.source_root,
                 source_folder_name=row.source_folder_name,
+                resolved_path=row.preview_path,
             )
             for row in rows
         ]

--- a/modules/ui/image_library/result_card.py
+++ b/modules/ui/image_library/result_card.py
@@ -17,6 +17,12 @@ class ImageResult:
     modified_ts: float = 0.0
     subtitle: str = ""
     source_folder_name: str = ""
+    resolved_path: str = ""
+
+    @property
+    def filesystem_path(self) -> str:
+        """Absolute transient path for filesystem access."""
+        return self.resolved_path
 
 
 class ImageResultCard(ctk.CTkFrame):

--- a/tests/image_assets/test_import_dedupe.py
+++ b/tests/image_assets/test_import_dedupe.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from modules.image_assets.services.import_service import ImageAssetImportService
+from modules.image_assets.paths import normalize_asset_reference
+
+
+@pytest.fixture(autouse=True)
+def _active_campaign(tmp_path: Path, monkeypatch):
+    """Treat each test's temporary directory as the active campaign root."""
+    monkeypatch.setattr(
+        "modules.image_assets.services.import_service.ConfigHelper.get_campaign_dir",
+        lambda: str(tmp_path),
+    )
 
 
 class _FakeRepository:
@@ -17,7 +29,13 @@ class _FakeRepository:
     def upsert_by_hash_or_path(self, payload: dict) -> dict:
         existing = None
         for row in self.items:
-            if row.get("Path") == payload.get("Path"):
+            try:
+                paths_match = normalize_asset_reference(row.get("Path", "")) == payload.get("Path")
+            except ValueError:
+                paths_match = str(row.get("Path", "")).replace("\\", "/").endswith(
+                    str(payload.get("Path", ""))
+                )
+            if paths_match:
                 existing = row
                 break
         if existing is None:
@@ -167,3 +185,50 @@ def test_import_directories_can_leave_existing_paths_unchanged(
     assert repository.items[0]["Name"] == "Old Hero"
     assert repository.items[0]["Hash"] == "old-hash"
     assert repository.items[0]["Tags"] == ["custom"]
+
+
+def test_external_import_is_copied_and_only_relative_paths_are_persisted(tmp_path, monkeypatch):
+    campaign = tmp_path / "campaign"
+    campaign.mkdir()
+    external = tmp_path / "external" / "ships"
+    external.mkdir(parents=True)
+    (external / "xwing.png").write_bytes(b"xwing")
+    monkeypatch.setattr(
+        "modules.image_assets.services.import_service.ConfigHelper.get_campaign_dir",
+        lambda: str(campaign),
+    )
+    repository = _FakeRepository()
+    service = ImageAssetImportService(repository=repository)
+    monkeypatch.setattr(service, "_read_dimensions", lambda _path: (64, 64))
+
+    summary = service.import_directories([str(tmp_path / "external")], recursive=True, reindex_changed_only=True)
+
+    assert summary.imported_new == 1
+    row = repository.items[0]
+    assert row["Path"] == row["RelativePath"] == "assets/image_library/external/ships/xwing.png"
+    assert row["SourceRoot"] == "assets/image_library"
+    assert not Path(row["Path"]).is_absolute()
+    assert (campaign / row["Path"]).read_bytes() == b"xwing"
+
+
+def test_external_import_collision_does_not_overwrite_different_file(tmp_path, monkeypatch):
+    campaign = tmp_path / "campaign"
+    destination = campaign / "assets" / "image_library" / "external" / "ship.png"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"old")
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "ship.png").write_bytes(b"new")
+    monkeypatch.setattr(
+        "modules.image_assets.services.import_service.ConfigHelper.get_campaign_dir",
+        lambda: str(campaign),
+    )
+    repository = _FakeRepository()
+    service = ImageAssetImportService(repository=repository)
+    monkeypatch.setattr(service, "_read_dimensions", lambda _path: (64, 64))
+
+    service.import_directories([str(external)], recursive=False, reindex_changed_only=True)
+
+    assert destination.read_bytes() == b"old"
+    assert (destination.parent / "ship_2.png").read_bytes() == b"new"
+    assert repository.items[0]["Path"] == "assets/image_library/external/ship_2.png"

--- a/tests/image_assets/test_path_migration.py
+++ b/tests/image_assets/test_path_migration.py
@@ -1,0 +1,56 @@
+"""Tests for the idempotent image-assets path migration."""
+
+import sqlite3
+from pathlib import Path
+
+from db.migrations.image_asset_relative_paths import migrate_image_asset_paths
+
+
+def _database(path: Path, rows: list[tuple[str, str, str, str]]) -> Path:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "CREATE TABLE image_assets (AssetId TEXT PRIMARY KEY, Path TEXT, RelativePath TEXT, SourceRoot TEXT)"
+        )
+        connection.executemany("INSERT INTO image_assets VALUES (?, ?, ?, ?)", rows)
+    return path
+
+
+def test_migration_handles_moved_windows_and_relative_rows_idempotently(tmp_path):
+    campaign = tmp_path / "moved-campaign"
+    campaign.mkdir()
+    db = _database(tmp_path / "Velaris.db", [
+        ("windows", r"D:\Velaris\assets\image_library\ships\xwing.png", "", r"D:\Velaris"),
+        ("relative", "assets\\image_library\\maps\\world.png", "assets/image_library/maps/world.png", "old"),
+    ])
+
+    first = migrate_image_asset_paths(db, campaign)
+    second = migrate_image_asset_paths(db, campaign)
+
+    assert first.updated == 2
+    assert Path(first.backup_path).is_file()
+    assert second.updated == 0
+    assert second.unchanged == 2
+    with sqlite3.connect(db) as connection:
+        rows = connection.execute(
+            "SELECT Path, RelativePath, SourceRoot FROM image_assets ORDER BY AssetId"
+        ).fetchall()
+    assert rows == [
+        ("assets/image_library/maps/world.png",) * 2 + ("assets/image_library",),
+        ("assets/image_library/ships/xwing.png",) * 2 + ("assets/image_library",),
+    ]
+
+
+def test_migration_reports_and_preserves_external_or_missing_reference(tmp_path):
+    db = _database(tmp_path / "Velaris.db", [
+        ("external", "/outside/image.png", "", "/outside"),
+        ("missing", "", "", ""),
+    ])
+
+    report = migrate_image_asset_paths(db, tmp_path / "campaign")
+
+    assert report.updated == 0
+    assert {issue["asset_id"] for issue in report.issues} == {"external", "missing"}
+    with sqlite3.connect(db) as connection:
+        assert connection.execute("SELECT Path, RelativePath FROM image_assets ORDER BY AssetId").fetchall() == [
+            ("/outside/image.png", ""), ("", "")
+        ]

--- a/tests/image_assets/test_paths.py
+++ b/tests/image_assets/test_paths.py
@@ -1,0 +1,44 @@
+"""Security and portability tests for image-library path references."""
+
+from pathlib import Path
+
+import pytest
+
+from modules.image_assets.paths import (
+    InvalidAssetReference,
+    make_campaign_relative,
+    normalize_asset_reference,
+    resolve_asset_reference,
+)
+
+
+def test_reference_round_trip_is_independent_of_working_directory(tmp_path, monkeypatch):
+    campaign = tmp_path / "campaign"
+    asset = campaign / "assets" / "image_library" / "objects" / "17_xwing.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"image")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    reference = make_campaign_relative(asset, campaign)
+
+    assert reference == "assets/image_library/objects/17_xwing.png"
+    assert resolve_asset_reference(reference, campaign) == asset.resolve()
+
+
+@pytest.mark.parametrize("reference", ["../secret.png", "assets/../secret.png", ""])
+def test_resolver_rejects_unsafe_or_empty_references(tmp_path, reference):
+    with pytest.raises(InvalidAssetReference):
+        resolve_asset_reference(reference, tmp_path)
+
+
+def test_moved_windows_library_reference_is_read_compatibly(tmp_path):
+    assert normalize_asset_reference(
+        r"D:\old\campaign\assets\image_library\ships\xwing.png", tmp_path
+    ) == "assets/image_library/ships/xwing.png"
+
+
+def test_arbitrary_external_absolute_reference_is_rejected(tmp_path):
+    with pytest.raises(InvalidAssetReference):
+        normalize_asset_reference(str(Path("/outside/file.png")), tmp_path)

--- a/tests/image_assets/test_search_filtering.py
+++ b/tests/image_assets/test_search_filtering.py
@@ -94,3 +94,23 @@ def test_search_images_filters_by_source_folder_name() -> None:
 
     assert total == 1
     assert [row.asset_id for row in rows] == ["2"]
+
+
+def test_search_result_keeps_stored_reference_separate_from_resolved_preview(tmp_path, monkeypatch) -> None:
+    campaign = tmp_path / "campaign"
+    campaign.mkdir()
+    monkeypatch.setattr(
+        "modules.image_assets.paths.ConfigHelper.get_campaign_dir", lambda: str(campaign)
+    )
+    reference = "assets/image_library/objects/xwing.png"
+    service = ImageAssetSearchService(repository=_FakeRepository([{
+        "AssetId": "17", "Name": "X-Wing", "Path": reference,
+        "RelativePath": reference, "Extension": "png",
+    }]))
+
+    rows, total = service.search_images(limit=10)
+
+    assert total == 1
+    assert rows[0].path == reference
+    assert rows[0].relative_path == reference
+    assert rows[0].preview_path == str((campaign / reference).resolve())

--- a/tests/test_cross_campaign_asset_service.py
+++ b/tests/test_cross_campaign_asset_service.py
@@ -212,8 +212,11 @@ def test_rewrite_record_paths_updates_image_library_fields(tmp_path):
     )
 
     assert updated["RelativePath"] == replacement
-    assert updated["Path"] == str((target_campaign_root / replacement).resolve())
-    assert updated["SourceRoot"] == str(target_campaign_root)
+    assert updated["Path"] == replacement
+    assert updated["SourceRoot"] == "assets/image_library"
+    assert not Path(updated["Path"]).is_absolute()
+    assert not Path(updated["RelativePath"]).is_absolute()
+    assert not Path(updated["SourceRoot"]).is_absolute()
 
 
 def test_export_bundle_full_campaign_includes_image_assets_even_without_selection(

--- a/tests/test_image_assets_repository.py
+++ b/tests/test_image_assets_repository.py
@@ -32,7 +32,7 @@ def test_upsert_by_hash_or_path_updates_existing_record():
     created = repository.upsert_by_hash_or_path(
         {
             "Name": "Map",
-            "Path": "/tmp/map.png",
+            "Path": "assets\\image_library\\map.png",
             "Hash": "abc",
             "Extension": ".png",
         }
@@ -40,7 +40,7 @@ def test_upsert_by_hash_or_path_updates_existing_record():
     updated = repository.upsert_by_hash_or_path(
         {
             "Name": "Map v2",
-            "Path": "/tmp/map.png",
+            "Path": "assets/image_library/map.png",
             "Hash": "abc",
             "Extension": ".png",
         }
@@ -49,20 +49,23 @@ def test_upsert_by_hash_or_path_updates_existing_record():
     assert len(wrapper.items) == 1
     assert updated["AssetId"] == created["AssetId"]
     assert wrapper.items[0]["Name"] == "Map v2"
+    assert wrapper.items[0]["Path"] == "assets/image_library/map.png"
+    assert wrapper.items[0]["RelativePath"] == "assets/image_library/map.png"
+    assert wrapper.items[0]["SourceRoot"] == "assets/image_library"
 
 
 def test_delete_stale_files_keeps_only_active_paths():
     wrapper = _FakeWrapper()
     wrapper.items = [
-        {"AssetId": "1", "Path": "/a.png"},
-        {"AssetId": "2", "Path": "/b.png"},
+        {"AssetId": "1", "Path": "assets\\image_library\\a.png"},
+        {"AssetId": "2", "Path": "assets/image_library/b.png"},
     ]
     repository = ImageAssetsRepository(wrapper=wrapper)
 
-    removed = repository.delete_stale_files(["/a.png"])
+    removed = repository.delete_stale_files(["assets/image_library/a.png"])
 
     assert removed == 1
-    assert [item["Path"] for item in wrapper.items] == ["/a.png"]
+    assert [item["Path"] for item in wrapper.items] == ["assets\\image_library\\a.png"]
 
 
 def test_list_paginated_supports_search_and_paging():
@@ -100,13 +103,13 @@ def test_replace_by_path_updates_path_match_without_hash_collision():
     wrapper.items = [
         {
             "AssetId": "same-hash",
-            "Path": "/tmp/original.png",
+            "Path": "assets/image_library/original.png",
             "Hash": "abc",
             "Name": "Original",
         },
         {
             "AssetId": "target",
-            "Path": "/tmp/target.png",
+            "Path": "assets\\image_library\\target.png",
             "Hash": "old",
             "Name": "Target",
         },
@@ -115,7 +118,7 @@ def test_replace_by_path_updates_path_match_without_hash_collision():
 
     updated = repository.replace_by_path(
         {
-            "Path": "/tmp/target.png",
+            "Path": "assets/image_library/target.png",
             "Hash": "abc",
             "Name": "Target Replacement",
         }

--- a/tests/ui/image_library/test_editor_attach_callbacks.py
+++ b/tests/ui/image_library/test_editor_attach_callbacks.py
@@ -56,7 +56,13 @@ def test_attach_portrait_from_library_stores_campaign_relative_path(monkeypatch,
         lambda _src: str(campaign_dir / "assets" / "portraits" / "npc_portrait.png"),
     )
 
-    editor.attach_portrait_from_library(ImageResult(path=str(source), name="portrait"))
+    editor.attach_portrait_from_library(
+        ImageResult(
+            path="assets/image_library/portraits/portrait.png",
+            resolved_path=str(source),
+            name="portrait",
+        )
+    )
 
     assert editor.captured_portrait_paths == ["assets/portraits/npc_portrait.png"]
     assert editor.field_widgets["Portrait"] == "assets/portraits/npc_portrait.png"
@@ -81,6 +87,12 @@ def test_attach_image_from_library_stores_campaign_relative_path(monkeypatch, tm
         lambda _src: str(campaign_dir / "assets" / "images" / "map_images" / "battlemap.png"),
     )
 
-    editor.attach_image_from_library(ImageResult(path=str(source), name="map"))
+    editor.attach_image_from_library(
+        ImageResult(
+            path="assets/image_library/maps/map.png",
+            resolved_path=str(source),
+            name="map",
+        )
+    )
 
     assert editor.field_widgets["Image"] == "assets/images/map_images/battlemap.png"


### PR DESCRIPTION
### Motivation

- Centralize and enforce a campaign-relative, POSIX canonical format for image-library references to avoid portability bugs caused by absolute paths and OS separators.
- Ensure filesystem access always resolves references against the active campaign root and never persists absolute paths back to the DB.
- Provide an idempotent migration to convert legacy absolute/Windows paths and produce diagnostics for unconvertible rows.
- Make UI and attachment flows use resolved transient paths only at access time to prevent CWD- or process-dependent failures.

### Description

- Add `modules/image_assets/paths.py` with `normalize_asset_reference()`, `make_campaign_relative()`, `resolve_asset_reference()` and `InvalidAssetReference` to centralize canonicalization and safe resolution. 
- Update `modules/image_assets/services/import_service.py` to detect images already inside the campaign, copy external images into `assets/image_library/<source>/...` while preserving structure, handle collisions safely, compute dedupe keys using normalized references, and persist only canonical relative references. 
- Update `modules/image_assets/repository.py` to normalize paths for lookups and writes, keep dedupe-by-hash/size behavior, and provide strict payload normalization that guarantees `Path`/`RelativePath` are campaign-relative and POSIX. 
- Change search and projection in `modules/image_assets/services/search_service.py` and `modules/image_assets/search/dto.py` to distinguish stored (relative) references from resolved preview paths, compute `preview_path` via the resolver but never persist resolved absolutes, and expose stored reference in search DTOs. 
- Adapt UI and browser components (`modules/ui/image_library/*`) to carry both the stored reference and a transient `resolved_path` for filesystem operations and thumbnail loading, and ensure thumbnails/previews use the central resolver. 
- Fix attachment and editor workflows (`modules/generic/editor/*`, `modules/generic/portrait_manager/*`, `modules/scenarios/gm_table_view.py`) to always resolve DB references before validating, copying, or calling `shutil.copy*`, and to persist only campaign-relative paths on entity attachments. 
- Update cross-campaign transfer logic (`modules/generic/cross_campaign_asset_service.py`) to write canonical relative `Path`/`RelativePath` and set `SourceRoot` to a relative reference (`assets/image_library`) instead of campaign absolute paths. 
- Add idempotent migration `db/migrations/image_asset_relative_paths.py` and wire it into `db/migrate.py` with a CLI entry (`--image-assets-db`/`--campaign-root`) that makes a backup before rewriting rows and reports issues for unconvertible or missing assets. 
- Add and update tests under `tests/` for import dedupe, path normalization, migration, repository behavior, search projections, UI attach callbacks, cross-campaign rewriting and other regressions (new tests: `tests/image_assets/test_paths.py`, `tests/image_assets/test_path_migration.py`, plus updates to multiple existing tests). 

### Testing

- Ran targeted test suites: `pytest -q tests/image_assets tests/test_image_assets_repository.py` (20 passed) and `pytest -q tests/image_assets` (17 passed). 
- UI/attachment and editor-related tests: `pytest -q tests/ui/image_library/test_editor_attach_callbacks.py tests/generic/editor tests/generic/portrait_manager` (18 passed). 
- Verified byte-compilation with `python -m compileall -q modules db tests` and ran `git diff --check` without new whitespace errors. 
- Notes: one cross-campaign targeted test remains blocked during collection by a pre-existing import cycle, and browser thumbnail tests are blocked by the test environment PIL stub missing `PIL.Image.new` (these are documented in the test notes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6df97b0d20832bb71478000f769694)