### PR TITLE
Open campaign scenarios in GM Table scenario boards

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -3143,6 +3143,12 @@ class MainWindow(ctk.CTk):
 
         existing_window = self._focus_gm_table_window(table_id)
         if existing_window is not None:
+            if scenario_name:
+                view = getattr(existing_window, "_gm_table_view", None)
+                if view is not None:
+                    view.after_idle(
+                        lambda: view.open_or_focus_scenario_board(scenario_name)
+                    )
             return existing_window
 
         try:
@@ -3190,7 +3196,7 @@ class MainWindow(ctk.CTk):
             self._register_gm_table_window(table_id, window, view)
             view.after_idle(view.log_workspace_opened)
             if scenario_name:
-                view.after_idle(lambda: view.open_entity_panel("Scenarios", scenario_name))
+                view.after_idle(lambda: view.open_or_focus_scenario_board(scenario_name))
             return window
         except Exception:
             self._close_gm_table_window(table_id)

--- a/modules/campaigns/ui/graphical_display/components/scenario_header.py
+++ b/modules/campaigns/ui/graphical_display/components/scenario_header.py
@@ -20,6 +20,7 @@ class ScenarioHeroStrip(ctk.CTkFrame):
         subtitle: str,
         count_chips: list[tuple[str, str]],
         on_edit: Callable[[], None],
+        on_open_gm_table: Callable[[], None] | None = None,
         on_open_gm_screen: Callable[[], None] | None = None,
         accent: str | None = None,
     ):
@@ -83,6 +84,18 @@ class ScenarioHeroStrip(ctk.CTkFrame):
         ).grid(row=0, column=0, padx=14, pady=(14, 8), sticky="ew")
         ctk.CTkButton(
             actions,
+            text="Open in GM Table",
+            command=on_open_gm_table,
+            state="normal" if on_open_gm_table else "disabled",
+            fg_color=DASHBOARD_THEME.button_fg,
+            hover_color=DASHBOARD_THEME.button_hover,
+            border_width=1,
+            border_color=DASHBOARD_THEME.card_border,
+            width=164,
+            height=38,
+        ).grid(row=1, column=0, padx=14, pady=(0, 8), sticky="ew")
+        ctk.CTkButton(
+            actions,
             text="Open in GM screen",
             command=on_open_gm_screen,
             state="normal" if on_open_gm_screen else "disabled",
@@ -92,7 +105,7 @@ class ScenarioHeroStrip(ctk.CTkFrame):
             border_color=DASHBOARD_THEME.card_border,
             width=164,
             height=38,
-        ).grid(row=1, column=0, padx=14, pady=(0, 14), sticky="ew")
+        ).grid(row=2, column=0, padx=14, pady=(0, 14), sticky="ew")
 
 
 class ScenarioIdentityPanel(ctk.CTkFrame):
@@ -106,6 +119,7 @@ class ScenarioIdentityPanel(ctk.CTkFrame):
         tags: list[str],
         progress_items: list[tuple[str, str]],
         on_edit: Callable[[], None],
+        on_open_gm_table: Callable[[], None] | None = None,
         on_open_gm_screen: Callable[[], None] | None = None,
     ):
         """Initialize the ScenarioIdentityPanel instance."""
@@ -163,6 +177,17 @@ class ScenarioIdentityPanel(ctk.CTkFrame):
         ).grid(row=0, column=0, padx=(0, 8))
         ctk.CTkButton(
             actions,
+            text="Open in GM Table",
+            command=on_open_gm_table,
+            state="normal" if on_open_gm_table else "disabled",
+            fg_color=DASHBOARD_THEME.button_fg,
+            hover_color=DASHBOARD_THEME.button_hover,
+            border_width=1,
+            border_color=DASHBOARD_THEME.card_border,
+            width=148,
+        ).grid(row=0, column=1, padx=(0, 8))
+        ctk.CTkButton(
+            actions,
             text="Open in GM screen",
             command=on_open_gm_screen,
             state="normal" if on_open_gm_screen else "disabled",
@@ -171,4 +196,4 @@ class ScenarioIdentityPanel(ctk.CTkFrame):
             border_width=1,
             border_color=DASHBOARD_THEME.card_border,
             width=148,
-        ).grid(row=0, column=1)
+        ).grid(row=0, column=2)

--- a/modules/campaigns/ui/graphical_display/panel.py
+++ b/modules/campaigns/ui/graphical_display/panel.py
@@ -17,6 +17,7 @@ from modules.helpers import theme_manager
 from modules.campaigns.services.poster_export import build_poster_theme_from_tokens, render_campaign_poster
 from modules.scenarios.gm_layout_manager import GMScreenLayoutManager
 from modules.scenarios.gm_screen_view import GMScreenView
+from modules.scenarios.gm_table.navigation import open_scenario_in_main_gm_table
 
 from .components import (
     CampaignOverviewHero,
@@ -575,6 +576,7 @@ class CampaignGraphPanel(ctk.CTkFrame):
 
         subtitle = f"{arc.name} • Scenario {self._selected_scenario_index + 1} of {len(arc.scenarios)}"
         gm_callback = (lambda n=scenario.title: self._open_scenario_gm_screen(n)) if scenario.record_exists else None
+        table_callback = (lambda n=scenario.title: self._open_scenario_gm_table(n)) if scenario.record_exists else None
 
         ScenarioHeroStrip(
             card,
@@ -587,6 +589,7 @@ class CampaignGraphPanel(ctk.CTkFrame):
                 ("villains", str(scenario.linked_villains_count)),
             ],
             on_edit=lambda n=scenario.title: self._open_scenario(n),
+            on_open_gm_table=table_callback,
             on_open_gm_screen=gm_callback,
         ).grid(row=0, column=0, sticky="ew", padx=14, pady=(14, 10))
 
@@ -615,6 +618,7 @@ class CampaignGraphPanel(ctk.CTkFrame):
                 ("status", scenario.status),
             ],
             on_edit=lambda n=scenario.title: self._open_scenario(n),
+            on_open_gm_table=table_callback,
             on_open_gm_screen=gm_callback,
         ).grid(row=0, column=0, sticky="ew", pady=(0, 12))
 
@@ -823,6 +827,7 @@ class CampaignGraphPanel(ctk.CTkFrame):
         self._clear_container(left_column)
 
         gm_callback = (lambda n=scenario.title: self._open_scenario_gm_screen(n)) if scenario.record_exists else None
+        table_callback = (lambda n=scenario.title: self._open_scenario_gm_table(n)) if scenario.record_exists else None
         ScenarioHeroStrip(
             primary,
             title=scenario.title,
@@ -834,6 +839,7 @@ class CampaignGraphPanel(ctk.CTkFrame):
                 ("villains", str(scenario.linked_villains_count)),
             ],
             on_edit=lambda n=scenario.title: self._open_scenario(n),
+            on_open_gm_table=table_callback,
             on_open_gm_screen=gm_callback,
         ).grid(row=0, column=0, sticky="ew")
 
@@ -851,6 +857,7 @@ class CampaignGraphPanel(ctk.CTkFrame):
                 ("status", scenario.status),
             ],
             on_edit=lambda n=scenario.title: self._open_scenario(n),
+            on_open_gm_table=table_callback,
             on_open_gm_screen=gm_callback,
         ).grid(row=0, column=0, sticky="ew", pady=(0, 12))
 
@@ -1131,6 +1138,15 @@ class CampaignGraphPanel(ctk.CTkFrame):
                 messagebox.showerror("GM screen", f"Unable to open the GM screen for '{scenario_name}':\n{exc}", parent=self.winfo_toplevel())
 
         open_scenario_in_embedded_gm_screen(self, scenario_name, fallback=_fallback)
+
+    def _open_scenario_gm_table(self, scenario_name: str) -> None:
+        """Open a scenario board on the primary GM Table."""
+        if not open_scenario_in_main_gm_table(self, scenario_name):
+            messagebox.showerror(
+                "GM Table",
+                "The main GM Table could not be opened from this window.",
+                parent=self.winfo_toplevel(),
+            )
 
     def _open_entity(self, entity_type: str, entity_name: str) -> None:
         """Open entity."""

--- a/modules/scenarios/gm_screen/dashboard/campaign_dashboard_panel.py
+++ b/modules/scenarios/gm_screen/dashboard/campaign_dashboard_panel.py
@@ -39,12 +39,14 @@ class CampaignDashboardPanel(ctk.CTkFrame):
         *,
         wrappers: dict,
         open_entity_callback: Callable[[str, str], None],
+        open_scenario_board_callback: Callable[[str], None] | None = None,
         **kwargs,
     ):
         """Initialize the CampaignDashboardPanel instance."""
         super().__init__(master, fg_color=DASHBOARD_THEME.panel_bg, **kwargs)
         self.wrappers = wrappers or {}
         self.open_entity_callback = open_entity_callback
+        self.open_scenario_board_callback = open_scenario_board_callback
 
         self._campaign_catalog = load_campaign_entities(self.wrappers)
         self._campaign_options, self._option_to_campaign = build_campaign_option_index(self._campaign_catalog)
@@ -336,12 +338,19 @@ class CampaignDashboardPanel(ctk.CTkFrame):
                 arc_field = CampaignArcField(
                     block,
                     raw_value=field.get("value"),
-                    open_scenario_callback=lambda scenario_name: self.open_entity_callback("Scenarios", scenario_name),
+                    open_scenario_callback=self._open_scenario,
                 )
                 arc_field.grid(row=1, column=0, sticky="ew", padx=10, pady=(0, 8))
             else:
                 self._render_read_only_field(block, field.get("value"), query)
             row += 1
+
+    def _open_scenario(self, scenario_name: str) -> None:
+        """Open an arc scenario in the host's preferred scenario view."""
+        if callable(self.open_scenario_board_callback):
+            self.open_scenario_board_callback(scenario_name)
+            return
+        self.open_entity_callback("Scenarios", scenario_name)
 
     def _render_session_prep_view(self, visible_fields: list[dict], query: str) -> None:
         """Render session prep view."""

--- a/modules/scenarios/gm_table/navigation.py
+++ b/modules/scenarios/gm_table/navigation.py
@@ -1,0 +1,26 @@
+"""Navigation helpers for opening scenarios on the primary GM Table."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def find_gm_table_launcher(widget: Any) -> Any | None:
+    """Return the nearest widget/root exposing the GM Table launcher API."""
+    current = widget
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        if callable(getattr(current, "open_gm_table", None)):
+            return current
+        current = getattr(current, "master", None)
+    return None
+
+
+def open_scenario_in_main_gm_table(widget: Any, scenario_name: str) -> bool:
+    """Open *scenario_name* in a Scenario Board on the primary GM Table."""
+    launcher = find_gm_table_launcher(widget)
+    if launcher is None:
+        return False
+    launcher.open_gm_table(scenario_name=scenario_name)
+    return True

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1743,6 +1743,7 @@ class GMTableView(ctk.CTkFrame):
             host,
             wrappers=self.wrappers,
             open_entity_callback=self.open_entity_panel,
+            open_scenario_board_callback=self.open_or_focus_scenario_board,
         )
         widget.grid(row=0, column=0, sticky="nsew")
         return widget
@@ -1959,7 +1960,7 @@ class GMTableView(ctk.CTkFrame):
     @staticmethod
     def _uses_readable_entity_detail(entity_type: str | None) -> bool:
         """Return whether GM Table panels should show full text details."""
-        return entity_type == "Objects"
+        return entity_type not in {None, "Books", "Puzzles", "Scenarios"}
 
     def _build_puzzle_display_content(self, host, state: dict):
         """Build the puzzle display page."""


### PR DESCRIPTION
### Motivation

- Add a direct "Open in GM Table" action to scenario headers so users can open a scenario into the GM Table Main board without switching to the GM Screen. 
- Make Campaign Dashboard arc links open the Scenario Board on the GM Table instead of a generic scenario entity panel for a smoother GM workflow. 
- Ensure entities opened from the Scenario Board use the full, scrollable detail presentation (portrait + text) for most entity types.

### Description

- Added "Open in GM Table" buttons to the scenario header and identity panel and wired optional callbacks (`modules/campaigns/ui/graphical_display/components/scenario_header.py`).
- Implemented a small GM Table navigation helper with `find_gm_table_launcher` and `open_scenario_in_main_gm_table` to locate the app launcher and open the scenario on the Main GM Table (`modules/scenarios/gm_table/navigation.py`).
- Hooked the Campaign Graph / Campaign Dashboard flows to call the new navigation helper via a new `_open_scenario_gm_table` entry point and callback plumbing (`modules/campaigns/ui/graphical_display/panel.py`, `modules/scenarios/gm_screen/dashboard/campaign_dashboard_panel.py`, `modules/scenarios/gm_table_view.py`).
- Updated `MainWindow.open_gm_table` to focus an existing GM Table window or open a new one and then open/focus the requested Scenario Board via `open_or_focus_scenario_board`, and updated `GMTableView` to request scenario-boards and to treat most entity types as full readable detail panels (`main_window.py`, `modules/scenarios/gm_table_view.py`).

### Testing

- Ran focused unit tests `python -m pytest -q tests/scenarios/gm_table/test_gm_table_view.py tests/scenarios/gm_table/test_scenario_board.py` which passed (`65 passed`).
- Ran broader test sets `python -m pytest -q tests/test_campaign_dashboard_data.py tests/campaigns/test_graphical_display_data.py tests/test_campaign_overview_launch_layout.py tests/test_arcs_read_only_preview.py tests/test_arc_selector_cards.py tests/scenarios/gm_screen/test_entity_field_scrollbars.py` which passed (`15 passed`) and `python -m pytest -q tests/campaigns/ui/test_campaign_graph_panel.py` which passed (`8 passed`).
- Performed static verification with `python -m compileall` on edited modules and ran `git diff --check` and `git status` which were clean. 
- Noted environment-limited warnings: `tests/test_calendar_dock_lifecycle.py` could not be collected due to missing `python-docx`, and `tests/campaigns/ui/test_campaign_graph_pills.py` had two fixture-related failures due to a mocked theme missing expected fields, and desktop UI screenshot verification could not be performed in this headless environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e17c3fd60832b940c369481ba360e)