### PR TITLE
Redesign GM Table scenario board as a dense reference sheet

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/models.py
+++ b/modules/scenarios/gm_table/scenario_board/models.py
@@ -48,6 +48,9 @@ class ScenarioBoardData:
     status: str
     summary: str
     secrets: str
+    objective: str
+    pressure: str
+    checkpoint: str
     scenes: tuple[ScenarioBoardScene, ...]
     linked_entities: dict[str, tuple[str, ...]]
 
@@ -312,11 +315,21 @@ def build_scenario_board_data(
         entity_type: values for entity_type, values in linked_entities.items() if values
     }
 
+    def first_text(*keys: str) -> str:
+        for key in keys:
+            value = _clean_text(item.get(key))
+            if value:
+                return value
+        return ""
+
     return ScenarioBoardData(
         title=_clean_text(item.get("Title") or item.get("Name")) or "Untitled Scenario",
         status=_clean_text(item.get("Status")),
         summary=_clean_text(item.get("Summary")),
         secrets=_clean_text(item.get("Secrets")),
+        objective=first_text("Objective", "MainObjective", "Goal", "Goals"),
+        pressure=first_text("Pressure", "Stakes", "Threat", "Complications"),
+        checkpoint=first_text("Checkpoint", "Route", "Progression"),
         scenes=tuple(scenes),
         linked_entities=linked_entities,
     )

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -1,4 +1,4 @@
-"""Scenario board page for the GM Table."""
+"""Dense, live-session scenario sheet for the GM Table."""
 
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ from typing import Any
 
 import customtkinter as ctk
 
-from modules.scenarios.gm_table.workspace import TABLE_PALETTE
 from modules.scenarios.gm_table.scenario_board.bundle_service import (
     ScenarioBundle,
     resolve_scenario_bundle,
@@ -17,6 +16,17 @@ from modules.scenarios.gm_table.scenario_board.models import (
     ScenarioBoardScene,
     build_scenario_board_data,
 )
+from modules.scenarios.gm_table.scenario_board.styles import (
+    BOARD_BACKGROUND,
+    BOARD_BORDER,
+    BOARD_MUTED,
+    BOARD_SURFACE,
+    BOARD_TEXT,
+    INFO_BAND_COLORS,
+    SCENE_COLORS,
+    SECTION_ACCENTS,
+)
+from modules.scenarios.gm_table.workspace import TABLE_PALETTE
 
 OpenEntityCallback = Callable[[str, str], None]
 OpenMapCallback = Callable[[str | None], None]
@@ -25,7 +35,7 @@ StateChangedCallback = Callable[[], None]
 
 
 class ScenarioBoardPanel(ctk.CTkFrame):
-    """Compact live-session board built from one scenario record."""
+    """Compact four-column scenario reference sheet with live controls."""
 
     def __init__(
         self,
@@ -42,77 +52,46 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         initial_state: dict[str, Any] | None = None,
         on_state_changed: StateChangedCallback | None = None,
     ) -> None:
-        super().__init__(master, fg_color="transparent")
+        super().__init__(master, fg_color=BOARD_BACKGROUND)
         self.scenario_name = str(scenario_name or "").strip()
         self._scenario_item = scenario_item if isinstance(scenario_item, dict) else {}
         self._open_entity_callback = open_entity_callback
         self._launch_bundle_callback = launch_bundle_callback
         self._open_scene_map_callback = open_scene_map_callback
         self._open_world_map_callback = open_world_map_callback
-        self._wrappers = wrappers or {}
-        self._map_wrapper = map_wrapper
+        self._wrappers, self._map_wrapper = wrappers or {}, map_wrapper
         self._on_state_changed = on_state_changed
         self._data = build_scenario_board_data(scenario_item)
         state = initial_state if isinstance(initial_state, dict) else {}
         self._completed_scenes = {
-            int(value)
-            for value in state.get("completed_scenes", [])
-            if str(value).isdigit()
+            int(v) for v in state.get("completed_scenes", []) if str(v).isdigit()
         }
         self._current_scene_index = self._coerce_scene_index(state.get("current_scene"))
         if self._current_scene_index is None and self._data.scenes:
             self._current_scene_index = self._data.scenes[0].index
         self._scene_buttons: dict[int, ctk.CTkButton] = {}
-        self._scene_status_label: ctk.CTkLabel | None = None
-
         self.grid_rowconfigure(1, weight=1)
         self.grid_columnconfigure(0, weight=1)
-        self._build_header()
-        self._build_scroll_body()
+        self._build_actions()  # Deliberately retain the original top controls.
+        self._build_board()
         self._refresh_scene_selection()
 
     def get_state(self) -> dict[str, Any]:
-        """Return persisted panel state."""
         return {
             "scenario_name": self.scenario_name or self._data.title,
             "current_scene": self._current_scene_index,
             "completed_scenes": sorted(self._completed_scenes),
         }
 
-    def _build_header(self) -> None:
-        header = ctk.CTkFrame(
+    def _build_actions(self) -> None:
+        actions = ctk.CTkScrollableFrame(
             self,
-            fg_color=TABLE_PALETTE["panel_alt"],
-            corner_radius=16,
-            border_width=1,
-            border_color=TABLE_PALETTE["panel_border"],
+            orientation="horizontal",
+            height=48,
+            fg_color=BOARD_BACKGROUND,
+            scrollbar_button_color=TABLE_PALETTE["table_chip"],
         )
-        header.grid(row=0, column=0, sticky="ew", pady=(0, 10))
-        header.grid_columnconfigure(0, weight=1)
-
-        title = self._data.title
-        if self._data.status:
-            title = f"{title}  •  {self._data.status}"
-        ctk.CTkLabel(
-            header,
-            text=title,
-            text_color=TABLE_PALETTE["text"],
-            font=ctk.CTkFont(size=18, weight="bold"),
-            anchor="w",
-        ).grid(row=0, column=0, sticky="ew", padx=14, pady=(10, 2))
-        self._scene_status_label = ctk.CTkLabel(
-            header,
-            text="Scenario Board",
-            text_color=TABLE_PALETTE["muted"],
-            font=ctk.CTkFont(size=12),
-            anchor="w",
-        )
-        self._scene_status_label.grid(
-            row=1, column=0, sticky="ew", padx=14, pady=(0, 8)
-        )
-
-        actions = ctk.CTkFrame(header, fg_color="transparent")
-        actions.grid(row=2, column=0, sticky="ew", padx=14, pady=(0, 12))
+        actions.grid(row=0, column=0, sticky="ew", pady=(0, 6))
         buttons = (
             ("Launch Scenario Bundle", self._launch_current_bundle),
             ("Open Scene Map", self._open_current_scene_map),
@@ -127,165 +106,192 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 actions,
                 text=text,
                 height=28,
+                width=120,
                 fg_color=TABLE_PALETTE["table_chip"],
                 hover_color="#283146",
-                text_color=TABLE_PALETTE["text"],
-                corner_radius=14,
+                text_color=BOARD_TEXT,
+                corner_radius=4,
                 command=command,
-            ).pack(side="left", padx=(0, 6), pady=(0, 6))
+            ).pack(side="left", padx=(0, 6))
 
-    def _build_scroll_body(self) -> None:
-        scroll = ctk.CTkScrollableFrame(
+    def _build_board(self) -> None:
+        board = ctk.CTkScrollableFrame(
             self,
-            fg_color="transparent",
+            fg_color=BOARD_BACKGROUND,
             scrollbar_button_color=TABLE_PALETTE["table_chip"],
-            scrollbar_button_hover_color=TABLE_PALETTE["accent"],
         )
-        scroll.grid(row=1, column=0, sticky="nsew")
-        scroll.grid_columnconfigure(0, weight=1)
-        row = 0
+        board.grid(row=1, column=0, sticky="nsew")
+        for column in range(20):
+            board.grid_columnconfigure(column, weight=1, uniform="board")
+        row = self._add_info_bands(board, 0)
+        row = self._add_directives(board, row)
+        row = self._add_checkpoint(board, row)
+        self._add_scene_grid(board, row)
 
-        row = self._add_text_card(scroll, row, "Summary", self._data.summary)
-        row = self._add_text_card(scroll, row, "Secrets", self._data.secrets)
-        row = self._add_entities_card(scroll, row, self._data)
-        row = self._add_scenes(scroll, row, self._data)
-
-        if row == 0:
+    def _add_info_bands(self, parent, row: int) -> int:
+        groups = (
+            ("PCS", self._data.linked_entities.get("PCs", ())),
+            ("MAJOR NPCS", self._data.linked_entities.get("NPCs", ())),
+            (
+                "ADVERSARIES",
+                (
+                    *self._data.linked_entities.get("Villains", ()),
+                    *self._data.linked_entities.get("Creatures", ()),
+                ),
+            ),
+            ("FACTIONS", self._data.linked_entities.get("Factions", ())),
+            (
+                "PLACES / CLUES",
+                (
+                    *self._data.linked_entities.get("Places", ()),
+                    *self._data.linked_entities.get("Clues", ()),
+                ),
+            ),
+        )
+        for column, (title, values) in enumerate(groups):
+            cell = ctk.CTkFrame(
+                parent,
+                fg_color=INFO_BAND_COLORS[column],
+                corner_radius=0,
+                border_width=1,
+                border_color=BOARD_BORDER,
+            )
+            cell.grid(
+                row=row, column=column * 4, columnspan=4, sticky="nsew", pady=(0, 8)
+            )
             ctk.CTkLabel(
-                scroll,
-                text="No scenario content found.",
-                text_color=TABLE_PALETTE["muted"],
-            ).grid(row=0, column=0, sticky="ew", padx=16, pady=16)
-
-    def _add_text_card(self, parent, row: int, title: str, text: str) -> int:
-        if not text:
-            return row
-        card = self._card(parent)
-        card.grid(row=row, column=0, sticky="ew", pady=(0, 10))
-        self._card_title(card, title).grid(
-            row=0, column=0, sticky="ew", padx=12, pady=(10, 4)
-        )
-        self._wrapped_label(card, text).grid(
-            row=1, column=0, sticky="ew", padx=12, pady=(0, 12)
-        )
-        return row + 1
-
-    def _add_entities_card(self, parent, row: int, data: ScenarioBoardData) -> int:
-        if not data.linked_entities:
-            return row
-        card = self._card(parent)
-        card.grid(row=row, column=0, sticky="ew", pady=(0, 10))
-        self._card_title(card, "Linked Entities").grid(
-            row=0, column=0, sticky="ew", padx=12, pady=(10, 4)
-        )
-        entity_row = 1
-        for entity_type, names in data.linked_entities.items():
+                cell,
+                text=title,
+                text_color=SCENE_COLORS[column % 4],
+                font=ctk.CTkFont(size=10, weight="bold"),
+            ).pack(pady=(7, 0))
             ctk.CTkLabel(
-                card,
-                text=entity_type,
-                text_color=TABLE_PALETTE["muted"],
+                cell,
+                text="\n".join(values) or "—",
+                text_color=BOARD_TEXT,
                 font=ctk.CTkFont(size=12, weight="bold"),
-                anchor="w",
-            ).grid(row=entity_row, column=0, sticky="ew", padx=12, pady=(6, 2))
-            entity_row += 1
-            chips = ctk.CTkFrame(card, fg_color="transparent")
-            chips.grid(row=entity_row, column=0, sticky="ew", padx=12, pady=(0, 2))
-            for name in names:
-                ctk.CTkButton(
-                    chips,
-                    text=name,
-                    height=26,
-                    fg_color=TABLE_PALETTE["table_chip"],
-                    hover_color="#283146",
-                    text_color=TABLE_PALETTE["text"],
-                    corner_radius=13,
-                    command=lambda et=entity_type, n=name: self._open_entity(et, n),
-                ).pack(side="left", padx=(0, 6), pady=(0, 6))
-            entity_row += 1
+            ).pack(padx=6, pady=(0, 7))
         return row + 1
 
-    def _add_scenes(self, parent, row: int, data: ScenarioBoardData) -> int:
-        if not data.scenes:
-            return row
-        for scene in data.scenes:
-            card = self._card(parent)
-            card.grid(row=row, column=0, sticky="ew", pady=(0, 10))
-            card.grid_columnconfigure(1, weight=1)
+    def _add_directives(self, parent, row: int) -> int:
+        directives = (
+            ("OBJECTIVE", self._data.objective or self._data.summary, "objective"),
+            ("SECRET", self._data.secrets, "secret"),
+            ("PRESSURE", self._data.pressure or self._data.status, "pressure"),
+        )
+        spans = (7, 7, 6)
+        start = 0
+        for (title, value, accent), span in zip(directives, spans):
+            text = f"{title}  {value or '—'}"
+            ctk.CTkLabel(
+                parent,
+                text=text,
+                anchor="w",
+                justify="left",
+                wraplength=380,
+                fg_color=BOARD_SURFACE,
+                text_color=SECTION_ACCENTS[accent],
+                font=ctk.CTkFont(size=10, weight="bold"),
+                height=34,
+            ).grid(
+                row=row,
+                column=start,
+                columnspan=span,
+                sticky="nsew",
+                pady=(0, 8),
+                padx=(0, 2),
+            )
+            start += span
+        return row + 1
+
+    def _add_checkpoint(self, parent, row: int) -> int:
+        route = self._data.checkpoint or "  →  ".join(
+            f"{scene.index}. {scene.title}" for scene in self._data.scenes
+        )
+        ctk.CTkLabel(
+            parent,
+            text=route or "No scenes defined",
+            fg_color=BOARD_SURFACE,
+            text_color=BOARD_TEXT,
+            font=ctk.CTkFont(size=11, weight="bold"),
+            height=28,
+        ).grid(row=row, column=0, columnspan=20, sticky="ew", pady=(0, 12))
+        return row + 1
+
+    def _add_scene_grid(self, parent, row: int) -> None:
+        if not self._data.scenes:
+            ctk.CTkLabel(
+                parent, text="No scenario content found.", text_color=BOARD_MUTED
+            ).grid(row=row, column=0, columnspan=20, pady=20)
+            return
+        for offset, scene in enumerate(self._data.scenes):
+            grid_row, column = row + offset // 4, (offset % 4) * 5
+            card = ctk.CTkFrame(
+                parent,
+                fg_color=BOARD_SURFACE,
+                corner_radius=0,
+                border_width=1,
+                border_color=SCENE_COLORS[offset % 4],
+            )
+            card.grid(
+                row=grid_row,
+                column=column,
+                columnspan=5,
+                sticky="nsew",
+                padx=(0, 3),
+                pady=(0, 6),
+            )
             button = ctk.CTkButton(
                 card,
-                text=f"{scene.index}. {scene.title}",
-                height=30,
-                fg_color=TABLE_PALETTE["table_chip"],
-                hover_color="#283146",
-                text_color=TABLE_PALETTE["text"],
-                anchor="w",
+                text=f"{scene.index}. {scene.title.upper()}",
+                height=34,
+                corner_radius=0,
+                fg_color=SCENE_COLORS[offset % 4],
+                hover_color=SCENE_COLORS[offset % 4],
+                text_color="#09111d",
+                font=ctk.CTkFont(size=11, weight="bold"),
                 command=lambda idx=scene.index: self._set_current_scene(idx),
             )
-            button.grid(
-                row=0, column=0, sticky="ew", padx=12, pady=(10, 4), columnspan=2
-            )
+            button.pack(fill="x")
             self._scene_buttons[scene.index] = button
-            inner_row = 1
-            if scene.intro_text:
-                self._wrapped_label(card, scene.intro_text).grid(
-                    row=inner_row,
-                    column=0,
-                    columnspan=2,
-                    sticky="ew",
-                    padx=12,
-                    pady=(0, 8),
-                )
-                inner_row += 1
-            inner_row = self._add_scene_entities(card, inner_row, scene)
+            entities = self._scene_entity_text(scene)
+            body = scene.intro_text or scene.body
+            lines = [entities, body]
             for section in scene.sections:
-                inner_row = self._add_scene_section(card, inner_row, section)
-            row += 1
-        return row
+                section_text = "\n".join(
+                    f"• {item}" for item in section.get("items") or ()
+                )
+                lines.append(
+                    f"{str(section.get('title') or '').upper()}\n{section_text}".strip()
+                )
+            ctk.CTkLabel(
+                card,
+                text="\n\n".join(line for line in lines if line),
+                anchor="nw",
+                justify="left",
+                wraplength=235,
+                text_color=BOARD_TEXT,
+                font=ctk.CTkFont(size=10),
+            ).pack(fill="both", expand=True, padx=7, pady=7)
 
-    def _add_scene_entities(self, parent, row: int, scene: ScenarioBoardScene) -> int:
+    @staticmethod
+    def _scene_entity_text(scene: ScenarioBoardScene) -> str:
         parts = []
         for label, values in (
-            ("NPCs", scene.npcs),
-            ("Villains", scene.villains),
-            ("Places", scene.places),
-            ("Maps", scene.maps),
+            ("NPCS", scene.npcs),
+            ("ADVERSARIES", scene.villains),
+            ("PLACES", scene.places),
+            ("MAPS", scene.maps),
         ):
             if values:
                 parts.append(f"{label}: {', '.join(values)}")
-        if not parts:
-            return row
-        self._wrapped_label(
-            parent, "  •  ".join(parts), text_color=TABLE_PALETTE["muted"]
-        ).grid(row=row, column=0, columnspan=2, sticky="ew", padx=12, pady=(0, 8))
-        return row + 1
-
-    def _add_scene_section(self, parent, row: int, section: dict[str, Any]) -> int:
-        title = f"{section.get('emoji', '')} {section.get('title', '')}".strip()
-        ctk.CTkLabel(
-            parent,
-            text=title,
-            text_color=TABLE_PALETTE["accent"],
-            font=ctk.CTkFont(size=12, weight="bold"),
-            anchor="w",
-        ).grid(row=row, column=0, columnspan=2, sticky="ew", padx=12, pady=(4, 2))
-        items = section.get("items") or []
-        text = (
-            "\n".join(f"• {item}" for item in items)
-            if items
-            else str(section.get("raw_text") or "").strip()
-        )
-        if text:
-            self._wrapped_label(parent, text).grid(
-                row=row + 1, column=0, columnspan=2, sticky="ew", padx=18, pady=(0, 4)
-            )
-            return row + 2
-        return row + 1
+        return "\n".join(parts)
 
     def _current_scene(self) -> ScenarioBoardScene | None:
-        for scene in self._data.scenes:
-            if scene.index == self._current_scene_index:
-                return scene
-        return self._data.scenes[0] if self._data.scenes else None
+        return next(
+            (s for s in self._data.scenes if s.index == self._current_scene_index),
+            self._data.scenes[0] if self._data.scenes else None,
+        )
 
     def _current_bundle(self) -> ScenarioBundle:
         return resolve_scenario_bundle(
@@ -304,48 +310,27 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         if self._current_scene_index is None:
             return
         self._completed_scenes.add(self._current_scene_index)
-        next_scene = next(
+        self._current_scene_index = next(
             (
-                scene.index
-                for scene in self._data.scenes
-                if scene.index not in self._completed_scenes
+                s.index
+                for s in self._data.scenes
+                if s.index not in self._completed_scenes
             ),
-            None,
+            self._current_scene_index,
         )
-        if next_scene is not None:
-            self._current_scene_index = next_scene
         self._refresh_scene_selection()
         self._notify_state_changed()
 
     def _refresh_scene_selection(self) -> None:
         for index, button in self._scene_buttons.items():
-            done = index in self._completed_scenes
-            current = index == self._current_scene_index
-            prefix = "✓ " if done else ("▶ " if current else "")
-            scene = next(
-                (
-                    candidate
-                    for candidate in self._data.scenes
-                    if candidate.index == index
-                ),
-                None,
-            )
-            if scene is not None:
-                button.configure(
-                    text=f"{prefix}{scene.index}. {scene.title}",
-                    fg_color=(
-                        TABLE_PALETTE["accent_soft"]
-                        if current
-                        else TABLE_PALETTE["table_chip"]
-                    ),
+            scene = next((s for s in self._data.scenes if s.index == index), None)
+            if scene:
+                marker = (
+                    "✓ "
+                    if index in self._completed_scenes
+                    else ("▶ " if index == self._current_scene_index else "")
                 )
-        scene = self._current_scene()
-        if self._scene_status_label is not None:
-            if scene is None:
-                text = "Scenario Board"
-            else:
-                text = f"Current scene: {scene.index}. {scene.title}  •  Done: {len(self._completed_scenes)}/{len(self._data.scenes)}"
-            self._scene_status_label.configure(text=text)
+                button.configure(text=f"{marker}{scene.index}. {scene.title.upper()}")
 
     def _launch_current_bundle(self) -> None:
         if callable(self._launch_bundle_callback):
@@ -353,29 +338,25 @@ class ScenarioBoardPanel(ctk.CTkFrame):
 
     def _open_current_scene_map(self) -> None:
         bundle = self._current_bundle()
-        map_name = bundle.maps[0] if bundle.maps else None
         if callable(self._open_scene_map_callback):
-            self._open_scene_map_callback(map_name)
+            self._open_scene_map_callback(bundle.maps[0] if bundle.maps else None)
 
     def _open_world_map(self) -> None:
         bundle = self._current_bundle()
-        map_name = bundle.world_maps[0] if bundle.world_maps else None
         if callable(self._open_world_map_callback):
-            self._open_world_map_callback(map_name)
+            self._open_world_map_callback(
+                bundle.world_maps[0] if bundle.world_maps else None
+            )
 
     def _open_entities(self, entity_type: str) -> None:
         bundle = self._current_bundle()
-        names = {
+        for name in {
             "NPCs": bundle.npcs,
             "Villains": bundle.villains,
             "Places": bundle.places,
-        }.get(entity_type, ())
-        for name in names:
-            self._open_entity(entity_type, name)
-
-    def _open_entity(self, entity_type: str, name: str) -> None:
-        if callable(self._open_entity_callback):
-            self._open_entity_callback(entity_type, name)
+        }.get(entity_type, ()):
+            if callable(self._open_entity_callback):
+                self._open_entity_callback(entity_type, name)
 
     def _notify_state_changed(self) -> None:
         if callable(self._on_state_changed):
@@ -388,51 +369,3 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         except (TypeError, ValueError):
             return None
         return index if index > 0 else None
-
-    @staticmethod
-    def _wrapped_label(
-        parent,
-        text: str,
-        *,
-        text_color: str | None = None,
-        horizontal_padding: int = 36,
-    ) -> ctk.CTkLabel:
-        """Create a label whose wrap length follows the available card width."""
-        label = ctk.CTkLabel(
-            parent,
-            text=text,
-            text_color=text_color or TABLE_PALETTE["text"],
-            justify="left",
-            wraplength=760,
-            anchor="w",
-        )
-
-        def update_wraplength(event=None) -> None:
-            width = getattr(event, "width", 0) or parent.winfo_width()
-            label.configure(wraplength=max(240, width - horizontal_padding))
-
-        parent.bind("<Configure>", update_wraplength, add="+")
-        label.after_idle(update_wraplength)
-        return label
-
-    @staticmethod
-    def _card(parent) -> ctk.CTkFrame:
-        card = ctk.CTkFrame(
-            parent,
-            fg_color=TABLE_PALETTE["panel_alt"],
-            corner_radius=14,
-            border_width=1,
-            border_color=TABLE_PALETTE["panel_border"],
-        )
-        card.grid_columnconfigure(0, weight=1)
-        return card
-
-    @staticmethod
-    def _card_title(parent, text: str) -> ctk.CTkLabel:
-        return ctk.CTkLabel(
-            parent,
-            text=text,
-            text_color=TABLE_PALETTE["text"],
-            font=ctk.CTkFont(size=14, weight="bold"),
-            anchor="w",
-        )

--- a/modules/scenarios/gm_table/scenario_board/styles.py
+++ b/modules/scenarios/gm_table/scenario_board/styles.py
@@ -1,0 +1,22 @@
+"""Visual tokens for the dense GM Table scenario sheet."""
+
+from __future__ import annotations
+
+from modules.scenarios.gm_table.workspace import TABLE_PALETTE
+
+BOARD_BACKGROUND = "#0b1423"
+BOARD_SURFACE = "#17263a"
+BOARD_BORDER = "#53728d"
+BOARD_TEXT = TABLE_PALETTE["text"]
+BOARD_MUTED = "#9fb5c9"
+
+INFO_BAND_COLORS = ("#1d425b", "#253a55", "#5b2437", "#1d4c3d", "#574821")
+SCENE_COLORS = ("#61bfdf", "#e8c552", "#dc5a66", "#5ac08d")
+
+SECTION_ACCENTS = {
+    "objective": "#59c6ec",
+    "secret": "#b787f4",
+    "pressure": "#f1bc38",
+    "transition": "#5ac08d",
+}
+

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -84,6 +84,31 @@ def test_build_scenario_board_data_decodes_serialized_rich_text_payloads() -> No
     assert data.scenes[1].title == "Inline Scene"
     assert data.scenes[1].body == "Scene from JSON payload."
 
+
+def test_build_scenario_board_data_prepares_reference_sheet_directives() -> None:
+    """Dense board bands accept both current and legacy scenario field names."""
+    data = build_scenario_board_data(
+        {
+            "MainObjective": "Reach the flooded clinic.",
+            "Stakes": "The suspect escapes at dawn.",
+            "Route": "Checkpoint → Refuge → Clinic → Train",
+        }
+    )
+
+    assert data.objective == "Reach the flooded clinic."
+    assert data.pressure == "The suspect escapes at dawn."
+    assert data.checkpoint == "Checkpoint → Refuge → Clinic → Train"
+
+
+def test_scenario_board_rejects_non_positive_scene_state() -> None:
+    """Persisted scene selection must continue to reject invalid indices."""
+    from modules.scenarios.gm_table.scenario_board.page import ScenarioBoardPanel
+
+    assert ScenarioBoardPanel._coerce_scene_index(-1) is None
+    assert ScenarioBoardPanel._coerce_scene_index(0) is None
+    assert ScenarioBoardPanel._coerce_scene_index("2") == 2
+
+
 def test_scenario_board_has_dedicated_default_panel_size() -> None:
     """The scenario board should open as a large planning panel."""
     assert resolve_default_panel_size("scenario_board") == (900, 680)


### PR DESCRIPTION
### Motivation

- Refresh the GM Table scenario board UI to match the provided screenshot as a dense reference sheet while preserving the original action buttons at the top and removing the previous title and the short descriptive line underneath.

### Description

- Rework the scenario board panel in `modules/scenarios/gm_table/scenario_board/page.py` to remove the old header and label, retain the top action buttons, and replace the scroll card layout with a dense four-column reference layout implemented via `_build_actions`, `_build_board`, `_add_info_bands`, `_add_directives`, `_add_checkpoint`, and `_add_scene_grid`.
- Move visual tokens and colors into a new `modules/scenarios/gm_table/scenario_board/styles.py` module and update `page.py` to import these constants for consistent styling.
- Extend the normalized data model in `modules/scenarios/gm_table/scenario_board/models.py` by adding `objective`, `pressure`, and `checkpoint` fields and a `first_text` helper to accept legacy aliases when building `ScenarioBoardData`.
- Update scene card presentation: scene buttons now use colored headers, uppercase titles, compact scene bodies, and an entities summary helper `_scene_entity_text`, and action callbacks were simplified to inline behavior.
- Add and update unit tests in `tests/scenarios/gm_table/test_scenario_board.py` to cover the new directive fields and the scene index coercion behavior.

### Testing

- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py` and the scenario-board tests passed successfully.
- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/gm_table/test_gm_table_view.py` and the targeted suite passed (reported 67 tests in that run).
- Ran `python -m compileall -q modules/scenarios/gm_table/scenario_board` to verify import-time correctness and it succeeded.
- Ran `git diff --check` and `git status --short` to confirm style/working-tree sanity; checks reported no local problems; full `pytest -q` collection was not completed due to unrelated, preexisting global test-suite issues preventing full-suite collection in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70fd494990832b9a3e3db1ab93cfce)