### PR TITLE
Fix Scenario Board resize feedback loop

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/entity_links.py
+++ b/modules/scenarios/gm_table/scenario_board/entity_links.py
@@ -51,9 +51,24 @@ def add_entity_links(
 
 
 def bind_full_width_wrap(label: ctk.CTkLabel, *, padding: int = 14) -> None:
-    """Keep a label's wrapping width synchronized with its scene card."""
+    """Keep a label's wrapping width synchronized with its containing card.
+
+    Listening to the label itself creates a feedback loop: changing ``wraplength``
+    changes the label's requested size, which emits another ``<Configure>`` event.
+    On content-heavy boards that loop can keep Tk's event queue busy indefinitely.
+    The card width is the stable value we actually want, so listen to the parent and
+    skip duplicate values instead.
+    """
+
+    parent = label.master
+    last_wraplength: int | None = None
 
     def update_wrap(event) -> None:
-        label.configure(wraplength=max(120, event.width - padding))
+        nonlocal last_wraplength
+        wraplength = max(120, event.width - padding)
+        if wraplength == last_wraplength:
+            return
+        last_wraplength = wraplength
+        label.configure(wraplength=wraplength)
 
-    label.bind("<Configure>", update_wrap, add="+")
+    parent.bind("<Configure>", update_wrap, add="+")

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -107,6 +107,39 @@ def test_build_scenario_board_data_accepts_plural_objectives_field() -> None:
     assert data.objective == "Rescue the archivist."
 
 
+def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
+    """Wrapping must not bind to the label and continuously resize itself."""
+    from modules.scenarios.gm_table.scenario_board.entity_links import (
+        bind_full_width_wrap,
+    )
+
+    class _Parent:
+        def bind(self, event_name, callback, *, add):
+            self.binding = (event_name, callback, add)
+
+    class _Label:
+        def __init__(self):
+            self.master = _Parent()
+            self.wraplengths = []
+
+        def bind(self, *_args, **_kwargs):
+            raise AssertionError("the resizable label must not observe itself")
+
+        def configure(self, *, wraplength):
+            self.wraplengths.append(wraplength)
+
+    label = _Label()
+    bind_full_width_wrap(label, padding=14)
+
+    event_name, callback, add = label.master.binding
+    assert (event_name, add) == ("<Configure>", "+")
+    callback(SimpleNamespace(width=300))
+    callback(SimpleNamespace(width=300))
+    callback(SimpleNamespace(width=360))
+
+    assert label.wraplengths == [286, 346]
+
+
 def test_scenario_board_rejects_non_positive_scene_state() -> None:
     """Persisted scene selection must continue to reject invalid indices."""
     from modules.scenarios.gm_table.scenario_board.page import ScenarioBoardPanel


### PR DESCRIPTION
### Motivation
- Fix a regression where the scenario board would vibrate, become very slow, and emit repeated Tkinter callback exceptions because changing a label's `wraplength` produced another `<Configure>` event on the same widget and flooded the event queue.

### Description
- Change `bind_full_width_wrap` in `modules/scenarios/gm_table/scenario_board/entity_links.py` to bind the parent's `<Configure>` event instead of the label, and track `last_wraplength` to skip duplicate updates.
- Expand the function docstring to document the feedback-loop cause and the chosen approach.
- Add `test_full_width_wrap_uses_parent_width_without_configure_feedback` to `tests/scenarios/gm_table/test_scenario_board.py` which asserts the label does not observe itself and that redundant identical parent widths are ignored.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_scenario_board.py -q` and the tests in that file passed.
- Ran the full test collection with `pytest -q`; collection reported pre-existing test isolation/collection errors unrelated to this change (the failure is not caused by the resize fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71046d6320832ba8e5e95cb97abe85)