### PR TITLE
Add scene grid layout and deterministic initial wraplength for scene cards

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/entity_links.py
+++ b/modules/scenarios/gm_table/scenario_board/entity_links.py
@@ -50,7 +50,12 @@ def add_entity_links(
         ).pack(fill="x", padx=5, pady=(0, 5))
 
 
-def bind_full_width_wrap(label: ctk.CTkLabel, *, padding: int = 14) -> None:
+def bind_full_width_wrap(
+    label: ctk.CTkLabel,
+    *,
+    padding: int = 14,
+    initial_wraplength: int = 320,
+) -> None:
     """Keep a label's wrapping width synchronized with its containing card.
 
     Listening to the label itself creates a feedback loop: changing ``wraplength``
@@ -61,7 +66,8 @@ def bind_full_width_wrap(label: ctk.CTkLabel, *, padding: int = 14) -> None:
     """
 
     parent = label.master
-    last_wraplength: int | None = None
+    last_wraplength: int | None = max(120, initial_wraplength)
+    label.configure(wraplength=last_wraplength)
 
     def update_wrap(event) -> None:
         nonlocal last_wraplength

--- a/modules/scenarios/gm_table/scenario_board/layout.py
+++ b/modules/scenarios/gm_table/scenario_board/layout.py
@@ -1,0 +1,49 @@
+"""Pure layout calculations for the Scenario Board scene grid."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SceneGridCell:
+    """Grid coordinates occupied by one scene card."""
+
+    row: int
+    column: int
+    columnspan: int
+
+
+def build_scene_grid_layout(
+    scene_count: int,
+    *,
+    columns: int = 20,
+    cards_per_row: int = 4,
+) -> tuple[SceneGridCell, ...]:
+    """Distribute scene cards, letting an incomplete row fill all columns."""
+    if scene_count <= 0:
+        return ()
+    if columns <= 0 or cards_per_row <= 0:
+        raise ValueError("columns and cards_per_row must be positive")
+
+    cells: list[SceneGridCell] = []
+    for row_start in range(0, scene_count, cards_per_row):
+        row_count = min(cards_per_row, scene_count - row_start)
+        base_span, extra_columns = divmod(columns, row_count)
+        column = 0
+        for position in range(row_count):
+            span = base_span + (1 if position < extra_columns else 0)
+            cells.append(
+                SceneGridCell(
+                    row=row_start // cards_per_row,
+                    column=column,
+                    columnspan=span,
+                )
+            )
+            column += span
+    return tuple(cells)
+
+
+def initial_scene_wraplength(columnspan: int, *, column_width: int = 45) -> int:
+    """Return a stable first-pass wrap length until Tk reports the card width."""
+    return max(120, columnspan * column_width - 14)

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -15,8 +15,11 @@ from modules.scenarios.gm_table.scenario_board.entity_links import (
     add_entity_links,
     bind_full_width_wrap,
 )
+from modules.scenarios.gm_table.scenario_board.layout import (
+    build_scene_grid_layout,
+    initial_scene_wraplength,
+)
 from modules.scenarios.gm_table.scenario_board.models import (
-    ScenarioBoardData,
     ScenarioBoardScene,
     build_scenario_board_data,
 )
@@ -241,8 +244,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 parent, text="No scenario content found.", text_color=BOARD_MUTED
             ).grid(row=row, column=0, columnspan=20, pady=20)
             return
-        for offset, scene in enumerate(self._data.scenes):
-            grid_row, column = row + offset // 4, (offset % 4) * 5
+        layout = build_scene_grid_layout(len(self._data.scenes))
+        for offset, (scene, cell) in enumerate(zip(self._data.scenes, layout)):
             card = ctk.CTkFrame(
                 parent,
                 fg_color=BOARD_SURFACE,
@@ -251,9 +254,9 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 border_color=SCENE_COLORS[offset % 4],
             )
             card.grid(
-                row=grid_row,
-                column=column,
-                columnspan=5,
+                row=row + cell.row,
+                column=cell.column,
+                columnspan=cell.columnspan,
                 sticky="nsew",
                 padx=(0, 3),
                 pady=(0, 6),
@@ -290,7 +293,10 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 font=ctk.CTkFont(size=14),
             )
             body_label.pack(fill="both", expand=True, padx=7, pady=7)
-            bind_full_width_wrap(body_label)
+            bind_full_width_wrap(
+                body_label,
+                initial_wraplength=initial_scene_wraplength(cell.columnspan),
+            )
 
     def _add_scene_entity_links(self, card, scene: ScenarioBoardScene) -> None:
         entries = (

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -129,7 +129,9 @@ def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
             self.wraplengths.append(wraplength)
 
     label = _Label()
-    bind_full_width_wrap(label, padding=14)
+    bind_full_width_wrap(label, padding=14, initial_wraplength=240)
+
+    assert label.wraplengths == [240]
 
     event_name, callback, add = label.master.binding
     assert (event_name, add) == ("<Configure>", "+")
@@ -137,7 +139,40 @@ def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
     callback(SimpleNamespace(width=300))
     callback(SimpleNamespace(width=360))
 
-    assert label.wraplengths == [286, 346]
+    assert label.wraplengths == [240, 286, 346]
+
+
+def test_scene_grid_layout_fills_incomplete_final_rows() -> None:
+    """The last row must use the full board instead of narrow empty columns."""
+    from modules.scenarios.gm_table.scenario_board.layout import (
+        build_scene_grid_layout,
+    )
+
+    five_scenes = build_scene_grid_layout(5)
+    assert [(cell.row, cell.column, cell.columnspan) for cell in five_scenes] == [
+        (0, 0, 5),
+        (0, 5, 5),
+        (0, 10, 5),
+        (0, 15, 5),
+        (1, 0, 20),
+    ]
+
+    seven_scenes = build_scene_grid_layout(7)
+    assert [(cell.row, cell.column, cell.columnspan) for cell in seven_scenes[4:]] == [
+        (1, 0, 7),
+        (1, 7, 7),
+        (1, 14, 6),
+    ]
+
+
+def test_initial_scene_wraplength_scales_with_card_span() -> None:
+    """A card gets a deterministic wrap width before its first resize event."""
+    from modules.scenarios.gm_table.scenario_board.layout import (
+        initial_scene_wraplength,
+    )
+
+    assert initial_scene_wraplength(5) == 211
+    assert initial_scene_wraplength(20) == 886
 
 
 def test_scenario_board_rejects_non_positive_scene_state() -> None:


### PR DESCRIPTION
### Motivation
- Make scene card placement predictable and allow incomplete final rows to fill the full board instead of leaving narrow empty columns.
- Provide a stable initial wrap length for scene card body labels so labels have a deterministic first-pass width and to avoid configure-event feedback loops.

### Description
- Added `modules/scenarios/gm_table/scenario_board/layout.py` with `SceneGridCell`, `build_scene_grid_layout`, and `initial_scene_wraplength` to compute grid positions and initial wrap lengths for scene cards.
- Updated `modules/scenarios/gm_table/scenario_board/page.py` to use `build_scene_grid_layout` for placing scene cards and to pass `initial_scene_wraplength` into `bind_full_width_wrap` for body labels.
- Modified `modules/scenarios/gm_table/scenario_board/entity_links.py` to add an `initial_wraplength` parameter to `bind_full_width_wrap`, initialize the label's `wraplength` to a stable value, and keep the parent-based configure binding to avoid feedback loops.
- Added and adjusted unit tests in `tests/scenarios/gm_table/test_scenario_board.py` to reflect the new behavior and to validate the grid layout and initial wraplength calculations.

### Testing
- Ran the scenario board unit tests in `tests/scenarios/gm_table/test_scenario_board.py` which include the updated `test_full_width_wrap_uses_parent_width_without_configure_feedback`, and new tests `test_scene_grid_layout_fills_incomplete_final_rows` and `test_initial_scene_wraplength_scales_with_card_span`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71061141dc832ba94a77a29ebfc951)