### PR TITLE
Replace 'Adversaries' band with 'Creatures' and centralize scenario-board content

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/content.py
+++ b/modules/scenarios/gm_table/scenario_board/content.py
@@ -1,0 +1,45 @@
+"""Presentation content for the scenario board's reference bands."""
+
+from __future__ import annotations
+
+from modules.scenarios.gm_table.scenario_board.models import ScenarioBoardData
+
+InfoBand = tuple[str, tuple[tuple[str, str], ...], str]
+ENTITY_ACTIONS = (
+    ("Open NPCs", "NPCs"),
+    ("Open Creatures", "Creatures"),
+    ("Open Places", "Places"),
+)
+
+
+def build_info_bands(data: ScenarioBoardData) -> tuple[InfoBand, ...]:
+    """Return the headings and entity links displayed above the scene grid."""
+    return (
+        ("OBJECTIVES", (), data.objective or data.summary),
+        (
+            "MAJOR NPCS",
+            tuple(("NPCs", name) for name in data.linked_entities.get("NPCs", ())),
+            "",
+        ),
+        (
+            "CREATURES",
+            tuple(
+                ("Creatures", name)
+                for name in data.linked_entities.get("Creatures", ())
+            ),
+            "",
+        ),
+        (
+            "FACTIONS",
+            tuple(
+                ("Factions", name)
+                for name in data.linked_entities.get("Factions", ())
+            ),
+            "",
+        ),
+        (
+            "PLACES",
+            tuple(("Places", name) for name in data.linked_entities.get("Places", ())),
+            "",
+        ),
+    )

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -11,6 +11,10 @@ from modules.scenarios.gm_table.scenario_board.bundle_service import (
     ScenarioBundle,
     resolve_scenario_bundle,
 )
+from modules.scenarios.gm_table.scenario_board.content import (
+    ENTITY_ACTIONS,
+    build_info_bands,
+)
 from modules.scenarios.gm_table.scenario_board.entity_links import (
     add_entity_links,
     bind_full_width_wrap,
@@ -99,12 +103,14 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             scrollbar_button_color=TABLE_PALETTE["table_chip"],
         )
         actions.grid(row=0, column=0, sticky="ew", pady=(0, 6))
+        entity_buttons = tuple(
+            (label, lambda entity_type=entity_type: self._open_entities(entity_type))
+            for label, entity_type in ENTITY_ACTIONS
+        )
         buttons = (
             ("Launch Scenario Bundle", self._launch_current_bundle),
             ("Open Scene Map", self._open_current_scene_map),
-            ("Open NPCs", lambda: self._open_entities("NPCs")),
-            ("Open Villain", lambda: self._open_entities("Villains")),
-            ("Open Places", lambda: self._open_entities("Places")),
+            *entity_buttons,
             ("Open World Map", self._open_world_map),
             ("Mark Scene Done", self._mark_current_scene_done),
         )
@@ -135,47 +141,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         self._add_scene_grid(board, row)
 
     def _add_info_bands(self, parent, row: int) -> int:
-        groups = (
-            ("OBJECTIVES", (), self._data.objective or self._data.summary),
-            (
-                "MAJOR NPCS",
-                tuple(
-                    ("NPCs", name)
-                    for name in self._data.linked_entities.get("NPCs", ())
-                ),
-                "",
-            ),
-            (
-                "ADVERSARIES",
-                (
-                    *(
-                        ("Villains", name)
-                        for name in self._data.linked_entities.get("Villains", ())
-                    ),
-                    *(
-                        ("Creatures", name)
-                        for name in self._data.linked_entities.get("Creatures", ())
-                    ),
-                ),
-                "",
-            ),
-            (
-                "FACTIONS",
-                tuple(
-                    ("Factions", name)
-                    for name in self._data.linked_entities.get("Factions", ())
-                ),
-                "",
-            ),
-            (
-                "PLACES",
-                tuple(
-                    ("Places", name)
-                    for name in self._data.linked_entities.get("Places", ())
-                ),
-                "",
-            ),
-        )
+        groups = build_info_bands(self._data)
         for column, (title, entries, plain_text) in enumerate(groups):
             cell = ctk.CTkFrame(
                 parent,

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -107,6 +107,28 @@ def test_build_scenario_board_data_accepts_plural_objectives_field() -> None:
     assert data.objective == "Rescue the archivist."
 
 
+def test_scenario_board_info_band_displays_creatures_instead_of_adversaries() -> None:
+    """The creature reference band must not include villain links."""
+    from modules.scenarios.gm_table.scenario_board.content import (
+        ENTITY_ACTIONS,
+        build_info_bands,
+    )
+
+    data = build_scenario_board_data(
+        {"Villains": ["The Fox"], "Creatures": ["Cave Drake"]}
+    )
+
+    creature_band = build_info_bands(data)[2]
+
+    assert creature_band == (
+        "CREATURES",
+        (("Creatures", "Cave Drake"),),
+        "",
+    )
+    assert ("Open Creatures", "Creatures") in ENTITY_ACTIONS
+    assert all(entity_type != "Villains" for _label, entity_type in ENTITY_ACTIONS)
+
+
 def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
     """Wrapping must not bind to the label and continuously resize itself."""
     from modules.scenarios.gm_table.scenario_board.entity_links import (


### PR DESCRIPTION
### Motivation
- The scenario board previously mixed different enemy types in an "Adversaries" band and used ad-hoc inline UI definitions, which made maintenance and behaviour changes error-prone. 
- The change centralizes presentation definitions and replaces the mixed adversary band with a dedicated creatures-only band so the UI reliably shows creature records and excludes villains.

### Description
- Add `modules/scenarios/gm_table/scenario_board/content.py` exporting `ENTITY_ACTIONS` and `build_info_bands` to centralize the reference-band configuration and entity actions. 
- Update `modules/scenarios/gm_table/scenario_board/page.py` to consume `ENTITY_ACTIONS` and `build_info_bands`, generate entity buttons dynamically, and use the centralized bands when building the board. 
- Replace the previous "Adversaries" band with a "CREATURES" band that lists only linked creatures and remove villain links from that band. 
- Add a regression test in `tests/scenarios/gm_table/test_scenario_board.py` to assert creatures are displayed in the new band and villain actions/links are excluded.

### Testing
- Ran `python -m pytest tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/gm_table/test_gm_table_view.py -q` and the test suite completed successfully (72 passed). 
- Ran `python -m compileall -q modules/scenarios/gm_table/scenario_board tests/scenarios/gm_table/test_scenario_board.py` which succeeded. 
- Performed a code diff/check for obvious issues and no problems were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717027e310832bb178a3a9cb8a1039)