### PR TITLE
Adapt Scenario Board colors to the active application theme

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/entity_links.py
+++ b/modules/scenarios/gm_table/scenario_board/entity_links.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterable
 
 import customtkinter as ctk
 
-from modules.scenarios.gm_table.scenario_board.styles import BOARD_TEXT
+from modules.scenarios.gm_table.scenario_board.styles import ScenarioBoardPalette
 
 OpenEntityCallback = Callable[[str, str], None]
 
@@ -17,6 +17,7 @@ def add_entity_links(
     callback: OpenEntityCallback | None,
     *,
     font_size: int = 13,
+    palette: ScenarioBoardPalette,
 ) -> None:
     """Pack entity names as compact links that open their GM Table panels."""
     found = False
@@ -32,8 +33,8 @@ def add_entity_links(
             border_width=0,
             corner_radius=0,
             fg_color="transparent",
-            hover_color="#31415a",
-            text_color=BOARD_TEXT,
+            hover_color=palette.control_hover,
+            text_color=palette.text,
             font=ctk.CTkFont(size=font_size, weight="bold", underline=True),
             command=lambda kind=entity_type, value=name: (
                 callback(kind, value) if callable(callback) else None
@@ -45,7 +46,7 @@ def add_entity_links(
         ctk.CTkLabel(
             parent,
             text="—",
-            text_color=BOARD_TEXT,
+            text_color=palette.text,
             font=ctk.CTkFont(size=font_size),
         ).pack(fill="x", padx=5, pady=(0, 5))
 

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -27,17 +27,7 @@ from modules.scenarios.gm_table.scenario_board.models import (
     ScenarioBoardScene,
     build_scenario_board_data,
 )
-from modules.scenarios.gm_table.scenario_board.styles import (
-    BOARD_BACKGROUND,
-    BOARD_BORDER,
-    BOARD_MUTED,
-    BOARD_SURFACE,
-    BOARD_TEXT,
-    INFO_BAND_COLORS,
-    SCENE_COLORS,
-    SECTION_ACCENTS,
-)
-from modules.scenarios.gm_table.workspace import TABLE_PALETTE
+from modules.scenarios.gm_table.scenario_board.styles import resolve_scenario_board_palette
 
 OpenEntityCallback = Callable[[str, str], None]
 OpenMapCallback = Callable[[str | None], None]
@@ -63,7 +53,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         initial_state: dict[str, Any] | None = None,
         on_state_changed: StateChangedCallback | None = None,
     ) -> None:
-        super().__init__(master, fg_color=BOARD_BACKGROUND)
+        self._palette = resolve_scenario_board_palette()
+        super().__init__(master, fg_color=self._palette.background)
         self.scenario_name = str(scenario_name or "").strip()
         self._scenario_item = scenario_item if isinstance(scenario_item, dict) else {}
         self._open_entity_callback = open_entity_callback
@@ -99,8 +90,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             self,
             orientation="horizontal",
             height=48,
-            fg_color=BOARD_BACKGROUND,
-            scrollbar_button_color=TABLE_PALETTE["table_chip"],
+            fg_color=self._palette.background,
+            scrollbar_button_color=self._palette.control,
         )
         actions.grid(row=0, column=0, sticky="ew", pady=(0, 6))
         entity_buttons = tuple(
@@ -120,9 +111,9 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 text=text,
                 height=28,
                 width=120,
-                fg_color=TABLE_PALETTE["table_chip"],
-                hover_color="#283146",
-                text_color=BOARD_TEXT,
+                fg_color=self._palette.control,
+                hover_color=self._palette.control_hover,
+                text_color=self._palette.control_text,
                 corner_radius=4,
                 command=command,
             ).pack(side="left", padx=(0, 6))
@@ -130,8 +121,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
     def _build_board(self) -> None:
         board = ctk.CTkScrollableFrame(
             self,
-            fg_color=BOARD_BACKGROUND,
-            scrollbar_button_color=TABLE_PALETTE["table_chip"],
+            fg_color=self._palette.background,
+            scrollbar_button_color=self._palette.control,
         )
         board.grid(row=1, column=0, sticky="nsew")
         for column in range(20):
@@ -145,10 +136,10 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         for column, (title, entries, plain_text) in enumerate(groups):
             cell = ctk.CTkFrame(
                 parent,
-                fg_color=INFO_BAND_COLORS[column],
+                fg_color=self._palette.info_bands[column],
                 corner_radius=0,
                 border_width=1,
-                border_color=BOARD_BORDER,
+                border_color=self._palette.border,
             )
             cell.grid(
                 row=row, column=column * 4, columnspan=4, sticky="nsew", pady=(0, 8)
@@ -156,7 +147,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             ctk.CTkLabel(
                 cell,
                 text=title,
-                text_color=SCENE_COLORS[column % 4],
+                text_color=self._palette.scene_colors[column % 4],
                 font=ctk.CTkFont(size=10, weight="bold"),
             ).pack(pady=(7, 0))
             if plain_text:
@@ -164,13 +155,15 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                     cell,
                     text=plain_text,
                     justify="left",
-                    text_color=BOARD_TEXT,
+                    text_color=self._palette.text,
                     font=ctk.CTkFont(size=13, weight="bold"),
                 )
                 objective.pack(fill="x", padx=7, pady=(2, 7))
                 bind_full_width_wrap(objective)
             else:
-                add_entity_links(cell, entries, self._open_entity_callback)
+                add_entity_links(
+                    cell, entries, self._open_entity_callback, palette=self._palette
+                )
         return row + 1
 
     def _add_directives(self, parent, row: int) -> int:
@@ -189,8 +182,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 anchor="w",
                 justify="left",
                 wraplength=380,
-                fg_color=BOARD_SURFACE,
-                text_color=SECTION_ACCENTS[accent],
+                fg_color=self._palette.surface,
+                text_color=self._palette.section_accents[accent],
                 font=ctk.CTkFont(size=10, weight="bold"),
                 height=34,
             ).grid(
@@ -207,17 +200,17 @@ class ScenarioBoardPanel(ctk.CTkFrame):
     def _add_scene_grid(self, parent, row: int) -> None:
         if not self._data.scenes:
             ctk.CTkLabel(
-                parent, text="No scenario content found.", text_color=BOARD_MUTED
+                parent, text="No scenario content found.", text_color=self._palette.muted
             ).grid(row=row, column=0, columnspan=20, pady=20)
             return
         layout = build_scene_grid_layout(len(self._data.scenes))
         for offset, (scene, cell) in enumerate(zip(self._data.scenes, layout)):
             card = ctk.CTkFrame(
                 parent,
-                fg_color=BOARD_SURFACE,
+                fg_color=self._palette.surface,
                 corner_radius=0,
                 border_width=1,
-                border_color=SCENE_COLORS[offset % 4],
+                border_color=self._palette.scene_colors[offset % 4],
             )
             card.grid(
                 row=row + cell.row,
@@ -232,9 +225,10 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 text=f"{scene.index}. {scene.title.upper()}",
                 height=34,
                 corner_radius=0,
-                fg_color=SCENE_COLORS[offset % 4],
-                hover_color=SCENE_COLORS[offset % 4],
-                text_color="#09111d",
+                fg_color=self._palette.scene_colors[offset % 4],
+                # Keep the computed foreground/text contrast stable on hover.
+                hover_color=self._palette.scene_colors[offset % 4],
+                text_color=self._palette.scene_text_colors[offset % 4],
                 font=ctk.CTkFont(size=11, weight="bold"),
                 command=lambda idx=scene.index: self._set_current_scene(idx),
             )
@@ -255,7 +249,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                 text="\n\n".join(line for line in lines if line),
                 anchor="nw",
                 justify="left",
-                text_color=BOARD_TEXT,
+                text_color=self._palette.text,
                 font=ctk.CTkFont(size=14),
             )
             body_label.pack(fill="both", expand=True, padx=7, pady=7)
@@ -273,7 +267,13 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         if entries:
             links = ctk.CTkFrame(card, fg_color="transparent", corner_radius=0)
             links.pack(fill="x", padx=2, pady=(4, 0))
-            add_entity_links(links, entries, self._open_entity_callback, font_size=12)
+            add_entity_links(
+                links,
+                entries,
+                self._open_entity_callback,
+                font_size=12,
+                palette=self._palette,
+            )
 
     def _current_scene(self) -> ScenarioBoardScene | None:
         return next(

--- a/modules/scenarios/gm_table/scenario_board/styles.py
+++ b/modules/scenarios/gm_table/scenario_board/styles.py
@@ -1,22 +1,81 @@
-"""Visual tokens for the dense GM Table scenario sheet."""
+"""Theme-aware visual tokens for the dense GM Table scenario sheet."""
 
 from __future__ import annotations
 
-from modules.scenarios.gm_table.workspace import TABLE_PALETTE
+from dataclasses import dataclass
 
-BOARD_BACKGROUND = "#0b1423"
-BOARD_SURFACE = "#17263a"
-BOARD_BORDER = "#53728d"
-BOARD_TEXT = TABLE_PALETTE["text"]
-BOARD_MUTED = "#9fb5c9"
+from modules.helpers import theme_manager
+from modules.scenarios.gm_table.panel_skins import readable_text_color
 
-INFO_BAND_COLORS = ("#1d425b", "#253a55", "#5b2437", "#1d4c3d", "#574821")
-SCENE_COLORS = ("#61bfdf", "#e8c552", "#dc5a66", "#5ac08d")
 
-SECTION_ACCENTS = {
-    "objective": "#59c6ec",
-    "secret": "#b787f4",
-    "pressure": "#f1bc38",
-    "transition": "#5ac08d",
-}
+def _mix(first: str, second: str, ratio: float) -> str:
+    """Blend two six-digit hex colours without adding a UI dependency."""
+    amount = max(0.0, min(1.0, ratio))
+    first_rgb = tuple(int(first[index : index + 2], 16) for index in (1, 3, 5))
+    second_rgb = tuple(int(second[index : index + 2], 16) for index in (1, 3, 5))
+    channels = (
+        round(left * (1.0 - amount) + right * amount)
+        for left, right in zip(first_rgb, second_rgb, strict=True)
+    )
+    return "#" + "".join(f"{channel:02X}" for channel in channels)
 
+
+@dataclass(frozen=True, slots=True)
+class ScenarioBoardPalette:
+    """Resolved colours used by one Scenario Board instance."""
+
+    background: str
+    surface: str
+    border: str
+    text: str
+    muted: str
+    control: str
+    control_hover: str
+    control_text: str
+    info_bands: tuple[str, ...]
+    scene_colors: tuple[str, ...]
+    scene_text_colors: tuple[str, ...]
+    section_accents: dict[str, str]
+
+
+def resolve_scenario_board_palette(theme: str | None = None) -> ScenarioBoardPalette:
+    """Build a board palette from the application's active theme tokens."""
+    tokens = theme_manager.get_tokens(theme)
+    background = tokens["panel_bg"]
+    surface = tokens["panel_alt_bg"]
+    accent = tokens["button_fg"]
+    control = tokens["accent_button_fg"]
+    control_hover = tokens["accent_button_hover"]
+
+    scene_colors = tuple(
+        _mix(accent, target, ratio)
+        for target, ratio in (
+            ("#FFFFFF", 0.12),
+            ("#FFFFFF", 0.28),
+            (surface, 0.18),
+            ("#FFFFFF", 0.42),
+        )
+    )
+    info_bands = tuple(
+        _mix(surface, accent, ratio) for ratio in (0.16, 0.22, 0.28, 0.34, 0.40)
+    )
+    text = "#F4F7FB"
+    return ScenarioBoardPalette(
+        background=background,
+        surface=surface,
+        border=_mix(surface, accent, 0.52),
+        text=text,
+        muted=_mix(text, surface, 0.38),
+        control=control,
+        control_hover=control_hover,
+        control_text=readable_text_color(control),
+        info_bands=info_bands,
+        scene_colors=scene_colors,
+        scene_text_colors=tuple(readable_text_color(color) for color in scene_colors),
+        section_accents={
+            "objective": scene_colors[0],
+            "secret": scene_colors[1],
+            "pressure": scene_colors[3],
+            "transition": scene_colors[2],
+        },
+    )

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -10,6 +10,10 @@ from modules.scenarios.gm_table.scenario_board import (
     resolve_scenario_bundle,
     split_scene_title,
 )
+from modules.helpers import theme_manager
+from modules.scenarios.gm_table.scenario_board.styles import (
+    resolve_scenario_board_palette,
+)
 from modules.scenarios.gm_table.workspace import resolve_default_panel_size
 from modules.scenarios.gm_table_view import GMTableView
 
@@ -354,3 +358,26 @@ def test_resolve_scenario_bundle_uses_scene_and_tolerant_wrapper_matches() -> No
     assert bundle.places == ("Grand Gallery",)
     assert bundle.maps == ("Gallery Map",)
     assert bundle.world_maps == ("Campaign World",)
+
+
+def test_scenario_board_palette_follows_application_themes() -> None:
+    """Board surfaces and controls should come from each application theme."""
+    palettes = {}
+    for theme in (
+        theme_manager.THEME_DEFAULT,
+        theme_manager.THEME_MEDIEVAL,
+        theme_manager.THEME_SF,
+    ):
+        tokens = theme_manager.get_tokens(theme)
+        palette = resolve_scenario_board_palette(theme)
+        palettes[theme] = palette
+
+        assert palette.background == tokens["panel_bg"]
+        assert palette.surface == tokens["panel_alt_bg"]
+        assert palette.control == tokens["accent_button_fg"]
+        assert palette.control_hover == tokens["accent_button_hover"]
+        assert len(palette.info_bands) == 5
+        assert len(palette.scene_colors) == 4
+
+    assert len({palette.background for palette in palettes.values()}) == 3
+    assert len({palette.scene_colors for palette in palettes.values()}) == 3


### PR DESCRIPTION
### Motivation
- The Scenario Board used hard-coded colours that did not follow the application's active theme, producing incorrect visuals versus other UI components.
- Centralise and derive visual tokens from the application theme so boards follow the same palette and maintain readable contrast across themes.

### Description
- Add a frozen `ScenarioBoardPalette` dataclass and `resolve_scenario_board_palette` in `modules/scenarios/gm_table/scenario_board/styles.py` with a `_mix` helper to compute info-band and scene colours from theme tokens. 
- Update `ScenarioBoardPanel` in `modules/scenarios/gm_table/scenario_board/page.py` to resolve the palette at init and use palette values for background, surface, borders, controls, scrollbars, info bands, directives, scene cards, and body text. 
- Update `modules/scenarios/gm_table/scenario_board/entity_links.py` to accept a `palette` argument and use themed `control_hover` and `text` colours for entity link states. 
- Add a regression test `test_scenario_board_palette_follows_application_themes` in `tests/scenarios/gm_table/test_scenario_board.py` to verify palettes for default, medieval, and science-fiction themes produce distinct expected tokens.

### Testing
- Ran `python -m pytest tests/scenarios/gm_table/test_scenario_board.py -q` and all tests in that file passed (`17 passed`).
- Ran `python -m pytest tests/scenarios/gm_table -q -k 'not mount_payload_widget'` and the selected suite passed (`209 passed, 2 deselected`).
- Ran `python -m compileall -q modules/scenarios/gm_table/scenario_board tests/scenarios/gm_table/test_scenario_board.py` and `ruff check modules/scenarios/gm_table/scenario_board tests/scenarios/gm_table/test_scenario_board.py` with no issues, and `git diff --check` produced no warnings.
- UI/Tk tests could not be fully exercised because the environment lacks a display (`$DISPLAY`) and no virtual display tooling was available, so some UI initialization tests were not run in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7170fa73b8832b96303fad7ef8041b)