### PR TITLE
Hide empty portrait zones in GM Table entity panels

### DIFF
--- a/modules/scenarios/gm_table/entity_media.py
+++ b/modules/scenarios/gm_table/entity_media.py
@@ -1,0 +1,20 @@
+"""Media visibility helpers for GM Table entity panels."""
+
+from __future__ import annotations
+
+from modules.helpers.config_helper import ConfigHelper
+from modules.helpers.portrait_helper import resolve_portrait_path
+
+
+def has_displayable_entity_image(
+    entity: dict, *, campaign_dir: str | None = None
+) -> bool:
+    """Return whether the entity has a portrait/image that can be displayed."""
+    if not isinstance(entity, dict):
+        return False
+
+    base_dir = campaign_dir or ConfigHelper.get_campaign_dir()
+    return any(
+        resolve_portrait_path(entity.get(field_name), base_dir) is not None
+        for field_name in ("Portrait", "Image")
+    )

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -38,6 +38,7 @@ from modules.scenarios.gm_table.attachments import (
     collect_entity_attachments,
     entity_has_attachments,
 )
+from modules.scenarios.gm_table.entity_media import has_displayable_entity_image
 from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
 from modules.scenarios.gm_table.scenario_board import ScenarioBoardPanel, ScenarioBundle
 from modules.scenarios.gm_table.container_window import GMTableContainerPage
@@ -1881,6 +1882,7 @@ class GMTableView(ctk.CTkFrame):
                 master=scrollable_host,
                 open_entity_callback=self.open_entity_panel,
                 spotlight_only=False,
+                show_spotlight=has_displayable_entity_image(item),
             )
             frame.pack(fill="both", expand=True)
             return frame

--- a/tests/scenarios/gm_table/test_entity_media.py
+++ b/tests/scenarios/gm_table/test_entity_media.py
@@ -1,0 +1,24 @@
+"""Tests for GM Table entity media visibility."""
+
+from modules.scenarios.gm_table.entity_media import has_displayable_entity_image
+
+
+def test_entity_without_portrait_or_image_has_no_displayable_media(tmp_path) -> None:
+    assert not has_displayable_entity_image({"Name": "No Portrait"}, campaign_dir=tmp_path)
+
+
+def test_entity_with_missing_portrait_has_no_displayable_media(tmp_path) -> None:
+    entity = {"Name": "Missing", "Portrait": "portraits/missing.png"}
+
+    assert not has_displayable_entity_image(entity, campaign_dir=tmp_path)
+
+
+def test_entity_with_existing_image_has_displayable_media(tmp_path) -> None:
+    image = tmp_path / "maps" / "location.png"
+    image.parent.mkdir()
+    image.write_bytes(b"image fixture")
+
+    assert has_displayable_entity_image(
+        {"Name": "Location", "Image": "maps/location.png"},
+        campaign_dir=tmp_path,
+    )

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -334,7 +334,10 @@ def test_build_object_entity_content_uses_scrollable_full_detail(monkeypatch) ->
     assert captured["item"] is expected_item
     assert captured["master"] is scroll_host
     assert captured["callback"] is callback
-    assert captured["kwargs"] == {"spotlight_only": False}
+    assert captured["kwargs"] == {
+        "spotlight_only": False,
+        "show_spotlight": False,
+    }
     assert frame.pack_calls == [{"fill": "both", "expand": True}]
 
 
@@ -411,6 +414,45 @@ def test_build_entity_content_with_attachments_hides_portrait_spotlight(
     assert captured["callback"] is callback
     assert captured["kwargs"] == {"spotlight_only": False, "show_spotlight": False}
     assert captured["gallery_kwargs"] == {"attachments": [attachment]}
+
+
+def test_build_entity_content_keeps_spotlight_for_existing_portrait(
+    monkeypatch, tmp_path
+) -> None:
+    """GM Table should retain the portrait zone when its image can be resolved."""
+    captured = {}
+
+    class _DummyFrame:
+        def pack(self, **_kwargs):
+            return None
+
+    portrait = tmp_path / "portrait.png"
+    portrait.write_bytes(b"image fixture")
+    item = {"Name": "Ari", "Portrait": str(portrait)}
+    view = GMTableView.__new__(GMTableView)
+    view._load_entity_item = lambda _entity_type, _name: item
+    view.open_entity_panel = lambda *_args, **_kwargs: None
+
+    monkeypatch.setattr(
+        gm_table_view_module, "build_scroll_host", lambda _host: object()
+    )
+
+    def _fake_factory(_entity_type, _item, **kwargs):
+        captured.update(kwargs)
+        return _DummyFrame()
+
+    monkeypatch.setattr(
+        gm_table_view_module, "create_entity_detail_frame", _fake_factory
+    )
+
+    GMTableView._build_entity_content(
+        view,
+        object(),
+        {"entity_type": "NPCs", "entity_name": "Ari"},
+    )
+
+    assert captured["spotlight_only"] is False
+    assert captured["show_spotlight"] is True
 
 
 def test_context_menu_handler_resolution_is_safe_without_gm_screen_api() -> None:


### PR DESCRIPTION
### Motivation

- Prevent empty portrait/image UI regions from appearing in GM Table entity detail panels when an entity has no resolvable portrait or image.
- Make the detail layout conditional on actual displayable media so attachment-backed or text-only entities do not show an empty spotlight area.

### Description

- Added a media helper `has_displayable_entity_image` in `modules/scenarios/gm_table/entity_media.py` that checks `Portrait`/`Image` fields and resolves them against the campaign directory.
- Updated `modules/scenarios/gm_table_view.py` to pass `show_spotlight=has_displayable_entity_image(item)` when building readable entity detail frames so the portrait/image zone is omitted when no media is present.
- Added unit tests `tests/scenarios/gm_table/test_entity_media.py` and extended `tests/scenarios/gm_table/test_gm_table_view.py` to cover missing, present, and resolved-image behaviors.

### Testing

- Ran targeted tests with `python -m pytest -q tests/scenarios/gm_table/test_entity_media.py tests/scenarios/gm_table/test_gm_table_view.py` and they passed (`60 passed`).
- Ran the `tests/scenarios/gm_table` suite which passed with `213 passed` and reported `2` graphical Tk tests could not run due to the headless `$DISPLAY` environment.
- Running the full test collection exposed pre-existing collection/stub conflicts during environment-wide `pytest` runs; the added tests themselves are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717392b6e8832b85aafba0921a1543)