### PR TITLE
Remove duplicate entity names from GM Table panels

### DIFF
--- a/modules/generic/detail_ui/entity_layout.py
+++ b/modules/generic/detail_ui/entity_layout.py
@@ -127,6 +127,7 @@ def create_spotlight_panel(
     fallback_text: str = "No portrait linked yet.",
     accent_lines: Iterable[str] | None = None,
     prominent: bool = False,
+    show_title: bool = True,
 ):
     """Create spotlight panel."""
     palette = get_detail_palette()
@@ -142,9 +143,11 @@ def create_spotlight_panel(
     )
     card.pack(fill="x", pady=(0, 14))
 
-    header = ctk.CTkFrame(card, fg_color="transparent")
-    header.pack(fill="x", padx=18, pady=(18, 10))
-    create_chip(header, title, accent=True).pack(anchor="w")
+    if show_title or subtitle:
+        header = ctk.CTkFrame(card, fg_color="transparent")
+        header.pack(fill="x", padx=18, pady=(18, 10))
+    if show_title:
+        create_chip(header, title, accent=True).pack(anchor="w")
     if subtitle:
         ctk.CTkLabel(
             header,

--- a/modules/generic/detail_ui/theme.py
+++ b/modules/generic/detail_ui/theme.py
@@ -129,6 +129,7 @@ def create_hero_header(
     portrait_widget=None,
     portrait_builder=None,
     adaptive_wrap: bool = True,
+    show_title: bool = True,
 ):
     """Create hero header."""
     palette = get_detail_palette()
@@ -159,15 +160,17 @@ def create_hero_header(
     if meta_items:
         create_chip(badge_row, f"{len([item for item in meta_items if item])} signals").pack(side="left", padx=(8, 0))
 
-    title_label = ctk.CTkLabel(
-        text_col,
-        text=title,
-        font=ctk.CTkFont(size=28, weight="bold"),
-        text_color=palette["text"],
-        justify="left",
-        wraplength=820,
-    )
-    title_label.pack(anchor="w", fill="x", pady=(12, 8))
+    title_label = None
+    if show_title:
+        title_label = ctk.CTkLabel(
+            text_col,
+            text=title,
+            font=ctk.CTkFont(size=28, weight="bold"),
+            text_color=palette["text"],
+            justify="left",
+            wraplength=820,
+        )
+        title_label.pack(anchor="w", fill="x", pady=(12, 8))
 
     summary_label = None
     if summary:
@@ -179,7 +182,11 @@ def create_hero_header(
             justify="left",
             wraplength=760,
         )
-        summary_label.pack(anchor="w", fill="x")
+        summary_label.pack(
+            anchor="w",
+            fill="x",
+            pady=(12, 0) if not show_title else 0,
+        )
 
     if meta_items:
         # Continue with this path when meta items is set.
@@ -221,7 +228,8 @@ def create_hero_header(
             title_wrap = max(320, text_width - 8)
             summary_wrap = max(320, text_width - 8)
             try:
-                title_label.configure(wraplength=title_wrap)
+                if title_label is not None:
+                    title_label.configure(wraplength=title_wrap)
             except Exception:
                 pass
             if summary_label is not None:

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -1638,7 +1638,14 @@ def _replace_detail_frame(current_frame, updated_item, entity_type, open_entity_
     return replacement_frame
 
 @log_function
-def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity_callback=None):
+def create_scenario_detail_frame(
+    entity_type,
+    scenario_item,
+    master,
+    open_entity_callback=None,
+    *,
+    show_entity_name: bool = True,
+):
     """
     Build a scrollable detail view for a scenario with:
     1) A header zone (Title, Summary, Secrets)
@@ -1665,6 +1672,7 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
                 item,
                 parent,
                 open_entity_callback,
+                show_entity_name=show_entity_name,
             ),
         )
 
@@ -1787,6 +1795,7 @@ def create_scenario_detail_frame(entity_type, scenario_item, master, open_entity
         category=entity_type[:-1] if entity_type.endswith("s") else entity_type,
         summary=format_multiline_text(scenario_item.get("Summary", "")),
         meta_items=scenario_meta,
+        show_title=show_entity_name,
     )
     hero.pack(fill="x", padx=10, pady=(0, 12))
     # ——— BODY — prepare fields in the custom order ———
@@ -2245,6 +2254,7 @@ def create_entity_detail_frame(
     *,
     spotlight_only: bool = False,
     show_spotlight: bool = True,
+    show_entity_name: bool = True,
 ):
     """
     Routes Scenarios through our custom header/body and
@@ -2255,7 +2265,8 @@ def create_entity_detail_frame(
             entity_type,
             entity,
             master,
-            open_entity_callback
+            open_entity_callback,
+            show_entity_name=show_entity_name,
         )
 
     palette = get_detail_palette()
@@ -2276,6 +2287,7 @@ def create_entity_detail_frame(
                 open_entity_callback,
                 spotlight_only=spotlight_only,
                 show_spotlight=show_spotlight,
+                show_entity_name=show_entity_name,
             ),
         )
 
@@ -2400,6 +2412,7 @@ def create_entity_detail_frame(
             fallback_text=_spotlight_fallback(entity_type),
             accent_lines=spotlight_accent_lines,
             prominent=spotlight_primary,
+            show_title=show_entity_name,
         )
 
     if spotlight_only:
@@ -2407,19 +2420,23 @@ def create_entity_detail_frame(
 
     compact_header = ctk.CTkFrame(main_column, fg_color="transparent")
     compact_header.pack(fill="x", pady=(0, 14))
-    compact_title = ctk.CTkLabel(
-        compact_header,
-        text=f"{entity_label} · {category_label}",
-        font=ctk.CTkFont(size=17, weight="bold"),
-        text_color=palette["text"],
-        anchor="w",
-        justify="left",
-    )
-    compact_title.pack(fill="x", anchor="w")
+    if show_entity_name:
+        compact_title = ctk.CTkLabel(
+            compact_header,
+            text=f"{entity_label} · {category_label}",
+            font=ctk.CTkFont(size=17, weight="bold"),
+            text_color=palette["text"],
+            anchor="w",
+            justify="left",
+        )
+        compact_title.pack(fill="x", anchor="w")
 
     chip_row = ctk.CTkFrame(compact_header, fg_color="transparent")
     chip_row.pack(fill="x", pady=(8, 0))
-    create_chip(chip_row, str(entity_label), accent=True).pack(side="left", padx=(0, 8))
+    if show_entity_name:
+        create_chip(chip_row, str(entity_label), accent=True).pack(
+            side="left", padx=(0, 8)
+        )
 
     if primary_type:
         create_chip(chip_row, primary_type).pack(side="left", padx=(0, 8))

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -1870,6 +1870,7 @@ class GMTableView(ctk.CTkFrame):
                 open_entity_callback=self.open_entity_panel,
                 spotlight_only=False,
                 show_spotlight=False,
+                show_entity_name=False,
             )
             detail_frame.pack(fill="both", expand=True, padx=8, pady=(0, 8))
             return scrollable_host
@@ -1883,6 +1884,7 @@ class GMTableView(ctk.CTkFrame):
                 open_entity_callback=self.open_entity_panel,
                 spotlight_only=False,
                 show_spotlight=has_displayable_entity_image(item),
+                show_entity_name=False,
             )
             frame.pack(fill="both", expand=True)
             return frame
@@ -1893,6 +1895,7 @@ class GMTableView(ctk.CTkFrame):
             master=host,
             open_entity_callback=self.open_entity_panel,
             spotlight_only=True,
+            show_entity_name=False,
         )
         frame.grid(row=0, column=0, sticky="nsew")
         return frame

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -278,7 +278,10 @@ def test_build_entity_content_calls_detail_factory(monkeypatch) -> None:
     assert captured["item"] is expected_item
     assert captured["master"] is host
     assert captured["callback"] is callback
-    assert captured["kwargs"] == {"spotlight_only": True}
+    assert captured["kwargs"] == {
+        "spotlight_only": True,
+        "show_entity_name": False,
+    }
     assert captured["grid"] == {"row": 0, "column": 0, "sticky": "nsew"}
 
 
@@ -337,6 +340,7 @@ def test_build_object_entity_content_uses_scrollable_full_detail(monkeypatch) ->
     assert captured["kwargs"] == {
         "spotlight_only": False,
         "show_spotlight": False,
+        "show_entity_name": False,
     }
     assert frame.pack_calls == [{"fill": "both", "expand": True}]
 
@@ -412,7 +416,11 @@ def test_build_entity_content_with_attachments_hides_portrait_spotlight(
     assert captured["item"] is expected_item
     assert captured["master"] is scroll_host
     assert captured["callback"] is callback
-    assert captured["kwargs"] == {"spotlight_only": False, "show_spotlight": False}
+    assert captured["kwargs"] == {
+        "spotlight_only": False,
+        "show_spotlight": False,
+        "show_entity_name": False,
+    }
     assert captured["gallery_kwargs"] == {"attachments": [attachment]}
 
 
@@ -453,6 +461,7 @@ def test_build_entity_content_keeps_spotlight_for_existing_portrait(
 
     assert captured["spotlight_only"] is False
     assert captured["show_spotlight"] is True
+    assert captured["show_entity_name"] is False
 
 
 def test_context_menu_handler_resolution_is_safe_without_gm_screen_api() -> None:


### PR DESCRIPTION
### Motivation

- Prevent duplicate display of an entity's title/name inside entity-content panels because the window top banner already shows the name.
- Make the detail UI components reusable by adding an explicit visibility control for title chips/labels so other callers can opt-out of in-panel titles.

### Description

- Added `show_title`/`show_entity_name` parameters to the shared UI builders `create_spotlight_panel` and `create_hero_header`, and propagated a `show_entity_name` flag through `create_entity_detail_frame` and `create_scenario_detail_frame` to control in-panel title rendering.
- Suppressed the compact header title chip/label and the spotlight/hero title when `show_entity_name` is set to `False` while preserving category chips and other metadata.
- Updated GM Table content builder to pass `show_entity_name=False` in all GM Table entity-content paths (spotlight-only, readable detail, attachment-backed, portrait-backed) so the top-banner name is the single source of truth.
- Updated unit tests in `tests/scenarios/gm_table/test_gm_table_view.py` to assert the new `show_entity_name` parameter is propagated as expected.

### Testing

- Ran `python -m pytest tests/scenarios/gm_table/test_gm_table_view.py -q` and the test suite completed successfully. 
- Ran `python -m pytest tests/generic -q` and the generic tests completed successfully. 
- Ran `python -m compileall -q modules/generic modules/scenarios tests/scenarios/gm_table` to verify modules compile without syntax errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71774e44c8832b88874ac98eb7220a)