### PR TITLE
Improve GM scenario board heading visibility

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -147,8 +147,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             ctk.CTkLabel(
                 cell,
                 text=title,
-                text_color=self._palette.scene_colors[column % 4],
-                font=ctk.CTkFont(size=10, weight="bold"),
+                text_color=self._palette.info_band_text_colors[column],
+                font=ctk.CTkFont(size=11, weight="bold"),
             ).pack(pady=(7, 0))
             if plain_text:
                 objective = ctk.CTkLabel(

--- a/modules/scenarios/gm_table/scenario_board/styles.py
+++ b/modules/scenarios/gm_table/scenario_board/styles.py
@@ -33,6 +33,7 @@ class ScenarioBoardPalette:
     control_hover: str
     control_text: str
     info_bands: tuple[str, ...]
+    info_band_text_colors: tuple[str, ...]
     scene_colors: tuple[str, ...]
     scene_text_colors: tuple[str, ...]
     section_accents: dict[str, str]
@@ -70,6 +71,9 @@ def resolve_scenario_board_palette(theme: str | None = None) -> ScenarioBoardPal
         control_hover=control_hover,
         control_text=readable_text_color(control),
         info_bands=info_bands,
+        info_band_text_colors=tuple(
+            readable_text_color(color) for color in info_bands
+        ),
         scene_colors=scene_colors,
         scene_text_colors=tuple(readable_text_color(color) for color in scene_colors),
         section_accents={

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -14,6 +14,7 @@ from modules.helpers import theme_manager
 from modules.scenarios.gm_table.scenario_board.styles import (
     resolve_scenario_board_palette,
 )
+from modules.scenarios.gm_table.panel_skins import readable_text_color
 from modules.scenarios.gm_table.workspace import resolve_default_panel_size
 from modules.scenarios.gm_table_view import GMTableView
 
@@ -213,6 +214,16 @@ def test_scenario_board_rejects_non_positive_scene_state() -> None:
 def test_scenario_board_has_dedicated_default_panel_size() -> None:
     """The scenario board should open as a large planning panel."""
     assert resolve_default_panel_size("scenario_board") == (900, 680)
+
+
+def test_info_band_titles_use_readable_text_for_each_background() -> None:
+    """Reference-band headings must remain legible across every app theme."""
+    for theme in ("default", "medieval", "sf"):
+        palette = resolve_scenario_board_palette(theme)
+
+        assert palette.info_band_text_colors == tuple(
+            readable_text_color(background) for background in palette.info_bands
+        )
 
 
 def test_handle_add_option_routes_scenario_board_to_scenario_picker() -> None:


### PR DESCRIPTION
### Motivation

- The scenario board information-band titles (Objectives, Factions, etc.) were not sufficiently legible against their backgrounds and needed higher contrast and slightly larger typography.

### Description

- Add `info_band_text_colors` to `ScenarioBoardPalette` and compute it with `readable_text_color` for each `info_bands` background in `modules/scenarios/gm_table/scenario_board/styles.py`.
- Use the new `palette.info_band_text_colors` for the info-band title `text_color` in `modules/scenarios/gm_table/scenario_board/page.py` and increase the title font size from 10 to 11.
- Add a regression test `test_info_band_titles_use_readable_text_for_each_background` in `tests/scenarios/gm_table/test_scenario_board.py` to assert the palette produces readable title colors across the `default`, `medieval`, and `sf` themes.

### Testing

- Ran `python -m pytest tests/scenarios/gm_table/test_scenario_board.py -q` and the focused tests passed (`18 passed`).
- Ran the broader suite `python -m pytest tests/scenarios/gm_table -q --ignore=tests/scenarios/gm_table/test_workspace.py && python -m pytest tests/scenarios/gm_table/test_workspace.py -q -k 'not mount_payload_widget_grids_direct_child_widget and not mount_payload_widget_preserves_existing_geometry_manager'` and it passed (`214 passed`, `2` display-dependent tests deselected).
- Headless environment run of `python -m pytest tests/scenarios/gm_table -q` shows GUI display-dependent tests failing when `$DISPLAY` is unavailable (`214 passed, 2 failed`) which is an unrelated environment limitation.
- Ran `python -m compileall -q modules/scenarios/gm_table/scenario_board tests/scenarios/gm_table/test_scenario_board.py` and `git diff --check`, both succeeded; automated contrast verification reports a minimum title contrast of `8.25:1` across the tested themes, exceeding the WCAG `4.5:1` threshold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717bbbe6a8832bb6e47029fa732424)