### PR TITLE
Remove duplicate OBJECTIVE directive from Scenario Board

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/content.py
+++ b/modules/scenarios/gm_table/scenario_board/content.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from modules.scenarios.gm_table.scenario_board.models import ScenarioBoardData
 
 InfoBand = tuple[str, tuple[tuple[str, str], ...], str]
+Directive = tuple[str, str, str]
 ENTITY_ACTIONS = (
     ("Open NPCs", "NPCs"),
     ("Open Creatures", "Creatures"),
@@ -42,4 +43,12 @@ def build_info_bands(data: ScenarioBoardData) -> tuple[InfoBand, ...]:
             tuple(("Places", name) for name in data.linked_entities.get("Places", ())),
             "",
         ),
+    )
+
+
+def build_directives(data: ScenarioBoardData) -> tuple[Directive, ...]:
+    """Return the non-duplicated scenario directives below the reference bands."""
+    return (
+        ("SECRET", data.secrets, "secret"),
+        ("PRESSURE", data.pressure or data.status, "pressure"),
     )

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -13,6 +13,7 @@ from modules.scenarios.gm_table.scenario_board.bundle_service import (
 )
 from modules.scenarios.gm_table.scenario_board.content import (
     ENTITY_ACTIONS,
+    build_directives,
     build_info_bands,
 )
 from modules.scenarios.gm_table.scenario_board.entity_links import (
@@ -167,12 +168,8 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         return row + 1
 
     def _add_directives(self, parent, row: int) -> int:
-        directives = (
-            ("OBJECTIVE", self._data.objective or self._data.summary, "objective"),
-            ("SECRET", self._data.secrets, "secret"),
-            ("PRESSURE", self._data.pressure or self._data.status, "pressure"),
-        )
-        spans = (7, 7, 6)
+        directives = build_directives(self._data)
+        spans = (10, 10)
         start = 0
         for (title, value, accent), span in zip(directives, spans):
             text = f"{title}  {value or '—'}"

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -112,6 +112,32 @@ def test_build_scenario_board_data_accepts_plural_objectives_field() -> None:
     assert data.objective == "Rescue the archivist."
 
 
+def test_scenario_board_displays_objective_only_in_reference_band() -> None:
+    """The compact directive row must not repeat the objective reference band."""
+    from modules.scenarios.gm_table.scenario_board.content import (
+        build_directives,
+        build_info_bands,
+    )
+
+    data = build_scenario_board_data(
+        {
+            "Objectives": "Rescue the archivist.",
+            "Secrets": "The archive is compromised.",
+            "Stakes": "The evidence will be destroyed.",
+        }
+    )
+
+    assert build_info_bands(data)[0] == (
+        "OBJECTIVES",
+        (),
+        "Rescue the archivist.",
+    )
+    assert build_directives(data) == (
+        ("SECRET", "The archive is compromised.", "secret"),
+        ("PRESSURE", "The evidence will be destroyed.", "pressure"),
+    )
+
+
 def test_scenario_board_info_band_displays_creatures_instead_of_adversaries() -> None:
     """The creature reference band must not include villain links."""
     from modules.scenarios.gm_table.scenario_board.content import (


### PR DESCRIPTION
### Motivation

- The scenario board showed the objectives twice (once in the reference band and again as a compact directive), causing redundant information and UI clutter.
- Simplify the reference row and keep the compact directive row focused on non-objective directives to improve clarity.

### Description

- Added `build_directives` in `modules/scenarios/gm_table/scenario_board/content.py` to return only the non-duplicated directives (`SECRET`, `PRESSURE`).
- Updated `ScenarioBoardPanel._add_directives` in `modules/scenarios/gm_table/scenario_board/page.py` to use `build_directives` and adjusted directive column spans from `(7, 7, 6)` to `(10, 10)` for an even 20-column layout.
- Updated imports to reference `build_directives` where needed.
- Added `test_scenario_board_displays_objective_only_in_reference_band` to `tests/scenarios/gm_table/test_scenario_board.py` to assert the objective is shown only in the `OBJECTIVES` band and not in the compact directives.

### Testing

- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py` and the updated test passed.
- Ran the `gm_table` test suite with `pytest -q tests/scenarios/gm_table` and it passed in this environment (note: some Tkinter UI tests may be skipped in headless CI if `$DISPLAY` is unset).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717deb13d4832b891b440e0869f438)