### PR TITLE
Fix Scenario Board content font weight

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/entity_links.py
+++ b/modules/scenarios/gm_table/scenario_board/entity_links.py
@@ -35,7 +35,7 @@ def add_entity_links(
             fg_color="transparent",
             hover_color=palette.control_hover,
             text_color=palette.text,
-            font=ctk.CTkFont(size=font_size, weight="bold", underline=True),
+            font=ctk.CTkFont(size=font_size, underline=True),
             command=lambda kind=entity_type, value=name: (
                 callback(kind, value) if callable(callback) else None
             ),

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -28,7 +28,9 @@ from modules.scenarios.gm_table.scenario_board.models import (
     ScenarioBoardScene,
     build_scenario_board_data,
 )
-from modules.scenarios.gm_table.scenario_board.styles import resolve_scenario_board_palette
+from modules.scenarios.gm_table.scenario_board.styles import (
+    resolve_scenario_board_palette,
+)
 
 OpenEntityCallback = Callable[[str, str], None]
 OpenMapCallback = Callable[[str | None], None]
@@ -157,7 +159,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
                     text=plain_text,
                     justify="left",
                     text_color=self._palette.text,
-                    font=ctk.CTkFont(size=13, weight="bold"),
+                    font=ctk.CTkFont(size=13),
                 )
                 objective.pack(fill="x", padx=7, pady=(2, 7))
                 bind_full_width_wrap(objective)
@@ -197,7 +199,9 @@ class ScenarioBoardPanel(ctk.CTkFrame):
     def _add_scene_grid(self, parent, row: int) -> None:
         if not self._data.scenes:
             ctk.CTkLabel(
-                parent, text="No scenario content found.", text_color=self._palette.muted
+                parent,
+                text="No scenario content found.",
+                text_color=self._palette.muted,
             ).grid(row=row, column=0, columnspan=20, pady=20)
             return
         layout = build_scene_grid_layout(len(self._data.scenes))

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -160,6 +160,69 @@ def test_scenario_board_info_band_displays_creatures_instead_of_adversaries() ->
     assert all(entity_type != "Villains" for _label, entity_type in ENTITY_ACTIONS)
 
 
+def test_scenario_board_reference_content_uses_regular_weight(monkeypatch) -> None:
+    """Reference headings are bold without making their content bold too."""
+    from modules.scenarios.gm_table.scenario_board import entity_links, page
+
+    widgets = []
+
+    class _Widget:
+        def __init__(self, master=None, **kwargs):
+            self.master = master
+            self.options = kwargs
+            widgets.append(self)
+
+        def grid(self, **_kwargs):
+            return None
+
+        def pack(self, **_kwargs):
+            return None
+
+        def bind(self, *_args, **_kwargs):
+            return None
+
+        def configure(self, **kwargs):
+            self.options.update(kwargs)
+
+    monkeypatch.setattr(page.ctk, "CTkFrame", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkLabel", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkFont", lambda **kwargs: kwargs)
+    monkeypatch.setattr(entity_links.ctk, "CTkButton", _Widget)
+    monkeypatch.setattr(entity_links.ctk, "CTkLabel", _Widget)
+    monkeypatch.setattr(entity_links.ctk, "CTkFont", lambda **kwargs: kwargs)
+
+    panel = object.__new__(page.ScenarioBoardPanel)
+    panel._data = build_scenario_board_data(
+        {"Objectives": "Reach the throne.", "NPCs": ["Lysandra Malrec"]}
+    )
+    panel._palette = SimpleNamespace(
+        info_bands=("#111111",) * 5,
+        info_band_text_colors=("#FFFFFF",) * 5,
+        border="#333333",
+        text="#FFFFFF",
+        control_hover="#222222",
+    )
+    panel._open_entity_callback = None
+
+    panel._add_info_bands(_Widget(), 0)
+
+    heading = next(
+        widget for widget in widgets if widget.options.get("text") == "OBJECTIVES"
+    )
+    objective = next(
+        widget
+        for widget in widgets
+        if widget.options.get("text") == "Reach the throne."
+    )
+    npc = next(
+        widget for widget in widgets if widget.options.get("text") == "Lysandra Malrec"
+    )
+
+    assert heading.options["font"] == {"size": 11, "weight": "bold"}
+    assert objective.options["font"] == {"size": 13}
+    assert npc.options["font"] == {"size": 13, "underline": True}
+
+
 def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
     """Wrapping must not bind to the label and continuously resize itself."""
     from modules.scenarios.gm_table.scenario_board.entity_links import (


### PR DESCRIPTION
### Motivation
- Ensure only reference headings are bold while objective text and linked entity names render at regular weight for consistent typography.

### Description
- Remove the bold `weight` from entity link fonts so buttons use `ctk.CTkFont(size=font_size, underline=True)` in `modules/scenarios/gm_table/scenario_board/entity_links.py`.
- Render plain-text objectives with a regular font by changing the objective label to `ctk.CTkFont(size=13)` in `modules/scenarios/gm_table/scenario_board/page.py`.
- Add a regression test `test_scenario_board_reference_content_uses_regular_weight` in `tests/scenarios/gm_table/test_scenario_board.py` that asserts heading, objective, and entity link font options.
- Apply minor import/format tidying in `page.py` for clearer grouping of imports.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py` and all tests passed (20 passed).
- Ran `black --check modules/scenarios/gm_table/scenario_board/entity_links.py modules/scenarios/gm_table/scenario_board/page.py tests/scenarios/gm_table/test_scenario_board.py` which succeeded.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7180d475fc832b9c4c6e8cd392c3d7)