### PR TITLE
Include linked Villains in Major NPCs list and render them red

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/content.py
+++ b/modules/scenarios/gm_table/scenario_board/content.py
@@ -19,7 +19,16 @@ def build_info_bands(data: ScenarioBoardData) -> tuple[InfoBand, ...]:
         ("OBJECTIVES", (), data.objective or data.summary),
         (
             "MAJOR NPCS",
-            tuple(("NPCs", name) for name in data.linked_entities.get("NPCs", ())),
+            (
+                *(
+                    ("NPCs", name)
+                    for name in data.linked_entities.get("NPCs", ())
+                ),
+                *(
+                    ("Villains", name)
+                    for name in data.linked_entities.get("Villains", ())
+                ),
+            ),
             "",
         ),
         (

--- a/modules/scenarios/gm_table/scenario_board/entity_links.py
+++ b/modules/scenarios/gm_table/scenario_board/entity_links.py
@@ -34,7 +34,9 @@ def add_entity_links(
             corner_radius=0,
             fg_color="transparent",
             hover_color=palette.control_hover,
-            text_color=palette.text,
+            text_color=(
+                palette.villain_text if entity_type == "Villains" else palette.text
+            ),
             font=ctk.CTkFont(size=font_size, underline=True),
             command=lambda kind=entity_type, value=name: (
                 callback(kind, value) if callable(callback) else None

--- a/modules/scenarios/gm_table/scenario_board/styles.py
+++ b/modules/scenarios/gm_table/scenario_board/styles.py
@@ -28,6 +28,7 @@ class ScenarioBoardPalette:
     surface: str
     border: str
     text: str
+    villain_text: str
     muted: str
     control: str
     control_hover: str
@@ -66,6 +67,7 @@ def resolve_scenario_board_palette(theme: str | None = None) -> ScenarioBoardPal
         surface=surface,
         border=_mix(surface, accent, 0.52),
         text=text,
+        villain_text="#FF5C5C",
         muted=_mix(text, surface, 0.38),
         control=control,
         control_hover=control_hover,

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -138,19 +138,29 @@ def test_scenario_board_displays_objective_only_in_reference_band() -> None:
     )
 
 
-def test_scenario_board_info_band_displays_creatures_instead_of_adversaries() -> None:
-    """The creature reference band must not include villain links."""
+def test_scenario_board_info_band_displays_villains_with_major_npcs() -> None:
+    """Villains belong with major NPCs without leaking into the creature band."""
     from modules.scenarios.gm_table.scenario_board.content import (
         ENTITY_ACTIONS,
         build_info_bands,
     )
 
     data = build_scenario_board_data(
-        {"Villains": ["The Fox"], "Creatures": ["Cave Drake"]}
+        {
+            "NPCs": ["Captain Vale"],
+            "Villains": ["The Fox"],
+            "Creatures": ["Cave Drake"],
+        }
     )
 
     creature_band = build_info_bands(data)[2]
+    major_npc_band = build_info_bands(data)[1]
 
+    assert major_npc_band == (
+        "MAJOR NPCS",
+        (("NPCs", "Captain Vale"), ("Villains", "The Fox")),
+        "",
+    )
     assert creature_band == (
         "CREATURES",
         (("Creatures", "Cave Drake"),),
@@ -193,13 +203,18 @@ def test_scenario_board_reference_content_uses_regular_weight(monkeypatch) -> No
 
     panel = object.__new__(page.ScenarioBoardPanel)
     panel._data = build_scenario_board_data(
-        {"Objectives": "Reach the throne.", "NPCs": ["Lysandra Malrec"]}
+        {
+            "Objectives": "Reach the throne.",
+            "NPCs": ["Lysandra Malrec"],
+            "Villains": ["The Red Queen"],
+        }
     )
     panel._palette = SimpleNamespace(
         info_bands=("#111111",) * 5,
         info_band_text_colors=("#FFFFFF",) * 5,
         border="#333333",
         text="#FFFFFF",
+        villain_text="#FF5C5C",
         control_hover="#222222",
     )
     panel._open_entity_callback = None
@@ -217,10 +232,16 @@ def test_scenario_board_reference_content_uses_regular_weight(monkeypatch) -> No
     npc = next(
         widget for widget in widgets if widget.options.get("text") == "Lysandra Malrec"
     )
+    villain = next(
+        widget for widget in widgets if widget.options.get("text") == "The Red Queen"
+    )
 
     assert heading.options["font"] == {"size": 11, "weight": "bold"}
     assert objective.options["font"] == {"size": 13}
     assert npc.options["font"] == {"size": 13, "underline": True}
+    assert npc.options["text_color"] == "#FFFFFF"
+    assert villain.options["font"] == {"size": 13, "underline": True}
+    assert villain.options["text_color"] == "#FF5C5C"
 
 
 def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:


### PR DESCRIPTION
### Motivation

- Ensure villains linked to a scenario appear alongside major NPCs in the Scenario Board so GMs see all relevant human adversaries in one place.

### Description

- Update `build_info_bands` to append `Villains` entries into the `MAJOR NPCS` band so villains show in the same list as NPCs (file `modules/scenarios/gm_table/scenario_board/content.py`).
- Add a `villain_text` colour token (`#FF5C5C`) to the `ScenarioBoardPalette` and expose it from `resolve_scenario_board_palette` (file `modules/scenarios/gm_table/scenario_board/styles.py`).
- Change `add_entity_links` to render entries of type `Villains` using `palette.villain_text` while keeping other entity names in the regular `palette.text` colour (file `modules/scenarios/gm_table/scenario_board/entity_links.py`).
- Add/adjust unit tests to verify villains are listed with major NPCs, do not appear in the creature band, and render with the villain colour (file `tests/scenarios/gm_table/test_scenario_board.py`).

### Testing

- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py` and all tests passed (20 tests).
- Ran Python bytecode compilation on the modified package with `python -m compileall` and it completed successfully.
- Ran `git diff --check` to ensure no whitespace/git-diff issues and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71d294f8ac832b99f37dd3b074e44e)