### PR TITLE
Anchor GM Table portrait crops to the top

### DIFF
--- a/modules/generic/detail_ui/portrait_fitting.py
+++ b/modules/generic/detail_ui/portrait_fitting.py
@@ -1,0 +1,18 @@
+"""Portrait-specific image fitting helpers for entity detail views."""
+
+from __future__ import annotations
+
+from PIL import Image, ImageOps
+
+
+PORTRAIT_CROP_CENTERING = (0.5, 0.0)
+
+
+def fit_portrait_to_frame(image: Image.Image, size: tuple[int, int]) -> Image.Image:
+    """Fill a portrait frame while preserving the top of oversized images."""
+    return ImageOps.fit(
+        image,
+        size,
+        method=Image.Resampling.LANCZOS,
+        centering=PORTRAIT_CROP_CENTERING,
+    )

--- a/modules/generic/entity_detail_factory.py
+++ b/modules/generic/entity_detail_factory.py
@@ -3,7 +3,7 @@
 import os
 import re
 import customtkinter as ctk
-from PIL import Image, ImageOps, ImageTk
+from PIL import Image, ImageTk
 from customtkinter import CTkImage, CTkLabel, CTkTextbox
 from modules.helpers.text_helpers import (
     deserialize_possible_json,
@@ -59,6 +59,7 @@ from modules.generic.detail_ui import (
     get_link_color,
     get_textbox_style,
 )
+from modules.generic.detail_ui.portrait_fitting import fit_portrait_to_frame
 from modules.generic.detail_ui.window_geometry import apply_fullscreen_top_left
 from modules.generic.entities.linking import resolve_entity_label, resolve_entity_slug
 from modules.generic.scene_indicator_payload import build_scene_indicator_payload
@@ -356,12 +357,7 @@ def _build_portrait_widget(parent, entity_type, entity, *, size):
         # Keep portrait widget resilient if this step fails.
         _portrait_debug(entity_type, entity, f"loading portrait image from '{resolved_portrait}'")
         img = Image.open(resolved_portrait).convert("RGBA")
-        framed_image = ImageOps.fit(
-            img,
-            size,
-            method=Image.Resampling.LANCZOS,
-            centering=(0.5, 0.5),
-        )
+        framed_image = fit_portrait_to_frame(img, size)
 
         portrait_shell = ctk.CTkFrame(parent, fg_color="transparent")
         portrait_shell.pack_propagate(False)

--- a/tests/generic/test_portrait_fitting.py
+++ b/tests/generic/test_portrait_fitting.py
@@ -1,0 +1,30 @@
+"""Tests for entity-detail portrait cropping."""
+
+from modules.generic.detail_ui import portrait_fitting
+
+
+def test_portrait_crop_is_anchored_to_top(monkeypatch) -> None:
+    captured = {}
+    expected = object()
+
+    def fake_fit(image, size, *, method, centering):
+        captured.update(
+            image=image,
+            size=size,
+            method=method,
+            centering=centering,
+        )
+        return expected
+
+    monkeypatch.setattr(portrait_fitting.ImageOps, "fit", fake_fit, raising=False)
+    source = object()
+
+    result = portrait_fitting.fit_portrait_to_frame(source, (320, 420))
+
+    assert result is expected
+    assert captured == {
+        "image": source,
+        "size": (320, 420),
+        "method": portrait_fitting.Image.Resampling.LANCZOS,
+        "centering": (0.5, 0.0),
+    }


### PR DESCRIPTION
### Motivation
- Entity portrait images in GM Table detail views were being center-cropped and sometimes cut off the subject's head when the source image was taller than the portrait frame, so cropping should preserve the top of portraits (i.e. "cut the feet").

### Description
- Add `modules/generic/detail_ui/portrait_fitting.py` with `fit_portrait_to_frame` that uses `ImageOps.fit` with a top-centered `centering=(0.5, 0.0)` to preserve heads.
- Replace the inline `ImageOps.fit(..., centering=(0.5, 0.5))` call in `modules/generic/entity_detail_factory.py` with the new `fit_portrait_to_frame` helper.
- Add `tests/generic/test_portrait_fitting.py` which verifies the helper calls `ImageOps.fit` with the expected top-centering and resampling method.

### Testing
- Ran `pytest tests/generic/test_portrait_fitting.py tests/generic/test_entity_detail_factory_window_focus.py` and all tests passed (`6 passed`).
- Byte-compiled the modified modules with `python -m compileall` and it completed without error.
- Automated repository checks executed during the rollout reported no issues affecting the changes introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71df81c408832b8b4febb119d98f81)