### PR TITLE
Limit scene map picker to linked maps

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+from tkinter import messagebox
 
 import customtkinter as ctk
 
@@ -326,9 +327,78 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             self._launch_bundle_callback(self._current_bundle())
 
     def _open_current_scene_map(self) -> None:
-        bundle = self._current_bundle()
+        map_names = self._scene_map_names()
+        if not map_names:
+            messagebox.showinfo(
+                "Open Scene Map",
+                "No map is linked to the current scenario or selected scene.",
+                parent=self,
+            )
+            return
+        if len(map_names) == 1:
+            self._select_scene_map(None, map_names[0])
+            return
+        self._open_scene_map_picker(map_names)
+
+    def _scene_map_names(self) -> tuple[str, ...]:
+        """Return unique, display-ready map names for the current scene bundle."""
+        names: list[str] = []
+        seen: set[str] = set()
+        for map_name in self._current_bundle().maps:
+            clean_name = str(map_name or "").strip()
+            key = clean_name.casefold()
+            if clean_name and key not in seen:
+                names.append(clean_name)
+                seen.add(key)
+        return tuple(names)
+
+    def _open_scene_map_picker(self, map_names: tuple[str, ...]) -> None:
+        """Show only the selected scene/scenario map links before opening one."""
+        if not callable(self._open_scene_map_callback):
+            return
+        selector = ctk.CTkToplevel(self)
+        selector.title("Open Scene Map")
+        selector.geometry("360x420")
+        selector.transient(self.winfo_toplevel())
+        selector.grab_set()
+        ctk.CTkLabel(
+            selector,
+            text="Choose a linked map to open:",
+            text_color=self._palette.text,
+            font=ctk.CTkFont(size=13, weight="bold"),
+        ).pack(fill="x", padx=12, pady=(12, 6))
+        list_frame = ctk.CTkScrollableFrame(
+            selector,
+            fg_color=self._palette.background,
+            scrollbar_button_color=self._palette.control,
+        )
+        list_frame.pack(fill="both", expand=True, padx=12, pady=(0, 12))
+        for map_name in map_names:
+            ctk.CTkButton(
+                list_frame,
+                text=map_name,
+                anchor="w",
+                fg_color=self._palette.control,
+                hover_color=self._palette.control_hover,
+                text_color=self._palette.control_text,
+                command=lambda name=map_name: self._select_scene_map(selector, name),
+            ).pack(fill="x", pady=(0, 6))
+        ctk.CTkButton(
+            selector,
+            text="Cancel",
+            fg_color=self._palette.surface,
+            hover_color=self._palette.control_hover,
+            text_color=self._palette.text,
+            command=selector.destroy,
+        ).pack(pady=(0, 12))
+
+    def _select_scene_map(self, selector: object, map_name: str) -> None:
+        """Close the linked-map picker and open the chosen map."""
+        destroy = getattr(selector, "destroy", None)
+        if callable(destroy):
+            destroy()
         if callable(self._open_scene_map_callback):
-            self._open_scene_map_callback(bundle.maps[0] if bundle.maps else None)
+            self._open_scene_map_callback(map_name)
 
     def _open_world_map(self) -> None:
         bundle = self._current_bundle()

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -481,6 +481,97 @@ def test_resolve_scenario_bundle_uses_scene_and_tolerant_wrapper_matches() -> No
     assert bundle.world_maps == ("Campaign World",)
 
 
+def test_open_scene_map_shows_only_linked_map_choices(monkeypatch) -> None:
+    """Open Scene Map should present only the current bundle's linked maps."""
+    from modules.scenarios.gm_table.scenario_board import page
+
+    opened = []
+    button_labels = []
+
+    class _Toplevel:
+        def __init__(self, _master):
+            self.destroyed = False
+
+        def title(self, _value):
+            pass
+
+        def geometry(self, _value):
+            pass
+
+        def transient(self, _value):
+            pass
+
+        def grab_set(self):
+            pass
+
+        def destroy(self):
+            self.destroyed = True
+
+    class _Widget:
+        def __init__(self, master=None, **kwargs):
+            self.master = master
+            self.options = kwargs
+            text = kwargs.get("text")
+            if text and text not in {"Choose a linked map to open:", "Cancel"}:
+                button_labels.append(text)
+
+        def pack(self, **_kwargs):
+            return None
+
+    monkeypatch.setattr(page.ctk, "CTkToplevel", _Toplevel)
+    monkeypatch.setattr(page.ctk, "CTkLabel", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkScrollableFrame", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkButton", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkFont", lambda **kwargs: kwargs)
+
+    panel = object.__new__(page.ScenarioBoardPanel)
+    panel._palette = SimpleNamespace(
+        text="#FFFFFF",
+        background="#111111",
+        control="#222222",
+        control_hover="#333333",
+        control_text="#EEEEEE",
+        surface="#444444",
+    )
+    panel._open_scene_map_callback = opened.append
+    panel.winfo_toplevel = lambda: None
+
+    panel._open_scene_map_picker(("Gallery Map", "Vault Map"))
+
+    assert button_labels == ["Gallery Map", "Vault Map"]
+    assert opened == []
+
+
+def test_open_current_scene_map_opens_single_map_without_picker() -> None:
+    """A single linked map should open directly without forcing a picker."""
+    from modules.scenarios.gm_table.scenario_board import page
+
+    opened = []
+    panel = object.__new__(page.ScenarioBoardPanel)
+    panel._open_scene_map_callback = opened.append
+    panel._current_bundle = lambda: SimpleNamespace(maps=(" Gallery Map ", "gallery map"))
+    panel._open_scene_map_picker = lambda _map_names: opened.append("picker")
+
+    panel._open_current_scene_map()
+
+    assert opened == ["Gallery Map"]
+
+
+def test_select_scene_map_opens_chosen_linked_map() -> None:
+    """Choosing from the linked-map picker should open that exact map."""
+    from modules.scenarios.gm_table.scenario_board import page
+
+    opened = []
+    selector = SimpleNamespace(destroyed=False)
+    selector.destroy = lambda: setattr(selector, "destroyed", True)
+    panel = object.__new__(page.ScenarioBoardPanel)
+    panel._open_scene_map_callback = opened.append
+
+    panel._select_scene_map(selector, "Vault Map")
+
+    assert selector.destroyed is True
+    assert opened == ["Vault Map"]
+
 def test_scenario_board_palette_follows_application_themes() -> None:
     """Board surfaces and controls should come from each application theme."""
     palettes = {}


### PR DESCRIPTION
### Motivation

- The previous "Open Scene Map" action exposed a global/all-maps selector instead of only maps linked to the current scenario/scene, making it hard to open the intended map quickly.
- The change scopes the UI to the current scenario bundle and provides a clearer UX: direct-open for a single linked map, a focused picker for multiple linked maps, and an informational dialog when none exist.

### Description

- Updated `ScenarioBoardPanel._open_current_scene_map` to derive choices from the current bundle via a new helper `._scene_map_names` and to show an info dialog when no linked maps exist.
- Added `._scene_map_names` to normalize, deduplicate (case-insensitive), and trim linked map names from `self._current_bundle().maps` and return them as a tuple.
- Implemented `._open_scene_map_picker` which builds a small top-level picker showing only the provided linked map names and wires each button to `._select_scene_map`.
- Modified `._select_scene_map` to close the picker (if present) and invoke `self._open_scene_map_callback` with the selected map name.
- Added regression tests in `tests/scenarios/gm_table/test_scenario_board.py` covering the picker UI, single-map direct open behavior (whitespace/case dedupe), and the selected-map callback.

### Testing

- Ran `pytest tests/scenarios/gm_table/test_scenario_board.py -q` and all tests passed (23 passed).
- Ran a quick compile check with `python -m compileall modules/scenarios/gm_table/scenario_board tests/scenarios/gm_table/test_scenario_board.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a735ba8f678832bad743cf5d883ac26)