### PR TITLE
Add MAPS gallery to Scenario Board and open maps in MapTool with fit-height sizing

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/map_cards.py
+++ b/modules/scenarios/gm_table/scenario_board/map_cards.py
@@ -1,0 +1,179 @@
+"""Map card helpers for Scenario Board panels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import customtkinter as ctk
+from PIL import Image, ImageDraw
+
+_THUMBNAIL_SIZE = (176, 104)
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_IMAGE_KEYS = ("Image", "image", "Path", "path", "File", "file")
+_NAME_KEYS = ("Name", "Title", "Map", "MapName", "name", "title")
+_INFO_KEYS = ("Type", "Category", "Tags", "Kind", "Scale", "Grid", "Description")
+
+
+@dataclass(frozen=True)
+class ScenarioBoardMapCard:
+    """Display data for one linked map card."""
+
+    name: str
+    subtitle: str = ""
+    details: str = ""
+    image_path: str = ""
+    size_label: str = ""
+
+
+def build_map_cards(
+    map_names: Sequence[str], map_wrapper: object | None
+) -> tuple[ScenarioBoardMapCard, ...]:
+    """Resolve linked map names into thumbnail-card data."""
+    records = _load_map_records(map_wrapper)
+    lookup = _build_record_lookup(records)
+    cards: list[ScenarioBoardMapCard] = []
+    seen: set[str] = set()
+    for raw_name in map_names:
+        name = str(raw_name or "").strip()
+        key = name.casefold()
+        if not name or key in seen:
+            continue
+        seen.add(key)
+        record = lookup.get(key, {})
+        image_path = _first_value(record, _IMAGE_KEYS)
+        cards.append(
+            ScenarioBoardMapCard(
+                name=_first_value(record, _NAME_KEYS) or name,
+                subtitle=_first_info(record),
+                details=_description_excerpt(record),
+                image_path=image_path,
+                size_label=_image_size_label(image_path),
+            )
+        )
+    return tuple(cards)
+
+
+def create_map_thumbnail(
+    image_path: str, *, size: tuple[int, int] = _THUMBNAIL_SIZE
+) -> ctk.CTkImage:
+    """Create a CTk thumbnail for a map image or a styled placeholder."""
+    image = _load_image(image_path) or _placeholder_image(size)
+    image = _cover_image(image, size)
+    return ctk.CTkImage(light_image=image, dark_image=image, size=size)
+
+
+def _load_map_records(map_wrapper: object | None) -> list[Mapping[str, Any]]:
+    load_items = getattr(map_wrapper, "load_items", None)
+    if not callable(load_items):
+        return []
+    try:
+        items = load_items()
+    except Exception:
+        return []
+    return (
+        [item for item in items if isinstance(item, Mapping)]
+        if isinstance(items, list)
+        else []
+    )
+
+
+def _build_record_lookup(
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    lookup: dict[str, Mapping[str, Any]] = {}
+    for record in records:
+        for key in _NAME_KEYS:
+            alias = str(record.get(key) or "").strip()
+            if alias:
+                lookup.setdefault(alias.casefold(), record)
+    return lookup
+
+
+def _first_value(record: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = str(record.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _first_info(record: Mapping[str, Any]) -> str:
+    values = []
+    for key in _INFO_KEYS[:-1]:
+        value = str(record.get(key) or "").strip()
+        if value:
+            values.append(value)
+    return " • ".join(values[:2])
+
+
+def _description_excerpt(record: Mapping[str, Any], *, limit: int = 92) -> str:
+    text = str(record.get("Description") or "").strip().replace("\n", " ")
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 1].rstrip()}…"
+
+
+def _image_size_label(image_path: str) -> str:
+    path = _resolve_image_path(image_path)
+    if path is None:
+        return "No image"
+    try:
+        with Image.open(path) as image:
+            return f"{image.width} × {image.height}"
+    except Exception:
+        return "Image unavailable"
+
+
+def _load_image(image_path: str) -> Image.Image | None:
+    path = _resolve_image_path(image_path)
+    if path is None:
+        return None
+    try:
+        return Image.open(path).convert("RGBA")
+    except Exception:
+        return None
+
+
+def _resolve_image_path(image_path: str) -> Path | None:
+    raw = str(image_path or "").strip()
+    if not raw:
+        return None
+    path = Path(raw)
+    candidates = (
+        [path] if path.is_absolute() else [_PROJECT_ROOT / path, Path.cwd() / path]
+    )
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            resolved = candidate
+        if resolved.exists() and resolved.is_file():
+            return resolved
+    return None
+
+
+def _cover_image(image: Image.Image, size: tuple[int, int]) -> Image.Image:
+    target_w, target_h = size
+    image = image.copy()
+    image.thumbnail(
+        size,
+        Image.Resampling.LANCZOS if hasattr(Image, "Resampling") else Image.LANCZOS,
+    )
+    canvas = Image.new("RGBA", size, (24, 28, 38, 255))
+    x = (target_w - image.width) // 2
+    y = (target_h - image.height) // 2
+    canvas.alpha_composite(image, (x, y))
+    return canvas
+
+
+def _placeholder_image(size: tuple[int, int]) -> Image.Image:
+    image = Image.new("RGBA", size, (31, 35, 48, 255))
+    draw = ImageDraw.Draw(image)
+    w, h = size
+    for offset in range(-h, w, 18):
+        draw.line((offset, h, offset + h, 0), fill=(47, 54, 74, 255), width=2)
+    draw.rectangle((1, 1, w - 2, h - 2), outline=(91, 107, 139, 255), width=2)
+    draw.text((w // 2 - 28, h // 2 - 6), "MAP", fill=(178, 190, 214, 255))
+    return image

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -25,6 +25,10 @@ from modules.scenarios.gm_table.scenario_board.layout import (
     build_scene_grid_layout,
     initial_scene_wraplength,
 )
+from modules.scenarios.gm_table.scenario_board.map_cards import (
+    build_map_cards,
+    create_map_thumbnail,
+)
 from modules.scenarios.gm_table.scenario_board.models import (
     ScenarioBoardScene,
     build_scenario_board_data,
@@ -133,6 +137,7 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             board.grid_columnconfigure(column, weight=1, uniform="board")
         row = self._add_info_bands(board, 0)
         row = self._add_directives(board, row)
+        row = self._add_map_gallery(board, row)
         self._add_scene_grid(board, row)
 
     def _add_info_bands(self, parent, row: int) -> int:
@@ -196,6 +201,111 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             )
             start += span
         return row + 1
+
+    def _add_map_gallery(self, parent, row: int) -> int:
+        """Render linked scenario maps as clickable thumbnail cards."""
+        map_cards = build_map_cards(self._scene_map_names(), self._map_wrapper)
+        if not map_cards:
+            return row
+
+        section = ctk.CTkFrame(
+            parent,
+            fg_color=self._palette.surface,
+            corner_radius=0,
+            border_width=1,
+            border_color=self._palette.border,
+        )
+        section.grid(
+            row=row,
+            column=0,
+            columnspan=20,
+            sticky="ew",
+            padx=(0, 3),
+            pady=(0, 8),
+        )
+        header = ctk.CTkFrame(section, fg_color="transparent")
+        header.pack(fill="x", padx=8, pady=(7, 4))
+        ctk.CTkLabel(
+            header,
+            text="MAPS",
+            text_color=self._palette.control_text,
+            font=ctk.CTkFont(size=11, weight="bold"),
+        ).pack(side="left")
+        ctk.CTkLabel(
+            header,
+            text="Click a map to open it in MapTool",
+            text_color=self._palette.muted,
+            font=ctk.CTkFont(size=10),
+        ).pack(side="left", padx=(10, 0))
+
+        gallery = ctk.CTkScrollableFrame(
+            section,
+            orientation="horizontal",
+            height=186,
+            fg_color="transparent",
+            scrollbar_button_color=self._palette.control,
+        )
+        gallery.pack(fill="x", padx=6, pady=(0, 8))
+        self._map_card_images = getattr(self, "_map_card_images", [])
+        self._map_card_images.clear()
+        for card in map_cards:
+            self._add_map_card(gallery, card)
+        return row + 1
+
+    def _add_map_card(self, parent, card) -> None:
+        tile = ctk.CTkFrame(
+            parent,
+            width=192,
+            height=166,
+            fg_color=self._palette.background,
+            corner_radius=8,
+            border_width=1,
+            border_color=self._palette.control,
+        )
+        tile.pack(side="left", padx=(0, 8), pady=2)
+        tile.pack_propagate(False)
+        tile.configure(cursor="hand2")
+
+        thumbnail = create_map_thumbnail(card.image_path)
+        self._map_card_images.append(thumbnail)
+        image_label = ctk.CTkLabel(
+            tile, text="", image=thumbnail, width=176, height=104
+        )
+        image_label.pack(padx=8, pady=(8, 3))
+        image_label.configure(cursor="hand2")
+
+        title_label = ctk.CTkLabel(
+            tile,
+            text=card.name,
+            text_color=self._palette.text,
+            font=ctk.CTkFont(size=12, weight="bold"),
+            wraplength=176,
+            justify="left",
+            anchor="w",
+        )
+        title_label.pack(fill="x", padx=8)
+        title_label.configure(cursor="hand2")
+
+        info_parts = [
+            part for part in (card.subtitle, card.size_label, card.details) if part
+        ]
+        info_label = ctk.CTkLabel(
+            tile,
+            text=" · ".join(info_parts[:2]) or "MapTool ready",
+            text_color=self._palette.muted,
+            font=ctk.CTkFont(size=10),
+            wraplength=176,
+            justify="left",
+            anchor="w",
+        )
+        info_label.pack(fill="x", padx=8, pady=(1, 6))
+        info_label.configure(cursor="hand2")
+
+        def _open_map(_event=None, map_name=card.name):
+            self._select_scene_map(None, map_name)
+
+        for widget in (tile, image_label, title_label, info_label):
+            widget.bind("<Button-1>", _open_map)
 
     def _add_scene_grid(self, parent, row: int) -> None:
         if not self._data.scenes:

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import tkinter as tk
+from pathlib import Path
 from tkinter import filedialog, messagebox
 from uuid import uuid4
 
 import customtkinter as ctk
+from PIL import Image
 
 from modules.books.pdf_viewer_panel import PDFViewerFrame
 from modules.characters.character_graph_editor import CharacterGraphEditor
@@ -1085,7 +1087,18 @@ class GMTableView(ctk.CTkFrame):
             panel_id = str(records[-1]["panel_id"])
             self.workspace.bring_to_front(panel_id)
             payload = records[-1]["payload"]
-            if target_map and hasattr(payload, "open_map_by_name"):
+            if target_map and hasattr(payload, "fit_mode"):
+                payload.fit_mode = "Height"
+                payload._fit_initialized = False
+            if target_map and hasattr(payload, "open_map_by_name_when_ready"):
+                try:
+                    payload.open_map_by_name_when_ready(target_map, apply_fit=True)
+                except Exception as exc:
+                    log_exception(
+                        f"Unable to load map '{target_map}' in existing GM Table map tool panel: {exc}",
+                        func_name="GMTableView._focus_or_open_map_tool_panel",
+                    )
+            elif target_map and hasattr(payload, "open_map_by_name"):
                 try:
                     payload.open_map_by_name(target_map)
                 except Exception as exc:
@@ -1097,8 +1110,79 @@ class GMTableView(ctk.CTkFrame):
         return self._create_panel(
             "map_tool",
             "Map Tool",
-            self._panel_state(map_name=target_map),
+            self._panel_state(map_name=target_map, fit_mode="Height"),
+            geometry=self._map_tool_opening_geometry(target_map),
         )
+
+    def _map_tool_opening_geometry(self, map_name: str | None) -> dict | None:
+        """Size new MapTool panels so height-fit displays the whole map."""
+        image_size = self._map_image_size(map_name)
+        if image_size is None:
+            return None
+        image_width, image_height = image_size
+        if image_width <= 0 or image_height <= 0:
+            return None
+        default_width, default_height = resolve_default_panel_size("map_tool")
+        target_height = default_height
+        aspect_width = int(target_height * (image_width / image_height)) + 28
+        target_width = max(default_width, min(1400, aspect_width))
+        return {"width": target_width, "height": target_height}
+
+    def _map_image_size(self, map_name: str | None) -> tuple[int, int] | None:
+        """Return the backing image size for a campaign map name."""
+        target = self._normalize_entity_name(map_name)
+        if not target:
+            return None
+        try:
+            records = self.map_wrapper.load_items()
+        except Exception:
+            return None
+        for record in records if isinstance(records, list) else []:
+            if not isinstance(record, dict):
+                continue
+            aliases = {
+                self._normalize_entity_name(record.get(key))
+                for key in ("Name", "Title", "Map", "MapName")
+            }
+            if target not in aliases:
+                continue
+            path = self._resolve_campaign_media_path(self._first_map_image_value(record))
+            if path is None:
+                return None
+            try:
+                with Image.open(path) as image:
+                    return image.width, image.height
+            except Exception:
+                return None
+        return None
+
+    @staticmethod
+    def _first_map_image_value(record: dict) -> object:
+        """Return the first supported image path field from a map record."""
+        for key in ("Image", "image", "Path", "path", "File", "file"):
+            value = record.get(key)
+            if str(value or "").strip():
+                return value
+        return ""
+
+    @staticmethod
+    def _resolve_campaign_media_path(value: object) -> Path | None:
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        path = Path(raw)
+        project_root = Path(__file__).resolve().parents[2]
+        candidates = (
+            [path] if path.is_absolute() else [project_root / path, Path.cwd() / path]
+        )
+        for candidate in candidates:
+            try:
+                resolved = candidate.resolve()
+            except Exception:
+                resolved = candidate
+            if resolved.exists() and resolved.is_file():
+                return resolved
+        return None
 
     def open_or_focus_world_map(self, map_name: str | None = None) -> str | None:
         """Public Scenario Board helper for opening or focusing the world map panel."""
@@ -1772,8 +1856,20 @@ class GMTableView(ctk.CTkFrame):
             self._templates["Maps"],
             root_app=self._root_app or self,
         )
+        fit_mode = str(state.get("fit_mode") or "Height").title()
+        if fit_mode in {"Contain", "Width", "Height"}:
+            controller.fit_mode = fit_mode
+            controller._fit_initialized = False
         map_name = state.get("map_name")
-        if map_name and hasattr(controller, "open_map_by_name"):
+        if map_name and hasattr(controller, "open_map_by_name_when_ready"):
+            try:
+                controller.open_map_by_name_when_ready(map_name, apply_fit=True)
+            except Exception as exc:
+                log_exception(
+                    f"Unable to restore map tool map '{map_name}' in GM Table panel: {exc}",
+                    func_name="GMTableView._build_map_tool_content",
+                )
+        elif map_name and hasattr(controller, "open_map_by_name"):
             try:
                 controller.open_map_by_name(map_name)
             except Exception as exc:

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -767,6 +767,58 @@ def test_focus_or_open_map_tool_panel_reuses_existing_panel_for_active_scene() -
     assert opened == ["front:tool-panel", "Harbor"]
 
 
+def test_focus_or_open_map_tool_panel_leaves_existing_fit_when_no_target_map() -> None:
+    """Focusing MapTool without a selected map should not override the user's fit mode."""
+    payload = SimpleNamespace(fit_mode="Width", open_map_by_name=lambda _map: None)
+    workspace = SimpleNamespace(
+        get_active_panel_id=lambda **_kwargs: None,
+        get_panel_definition=lambda _panel_id: None,
+        get_panel_payload=lambda _panel_id: None,
+        list_panels=lambda **kwargs: (
+            [{"panel_id": "tool-panel", "payload": payload}]
+            if kwargs.get("kinds") == {"map_tool"}
+            else []
+        ),
+        bring_to_front=lambda _panel_id: None,
+    )
+    view = GMTableView.__new__(GMTableView)
+    view.scenario = {}
+    view.workspace = workspace
+
+    panel_id = GMTableView._focus_or_open_map_tool_panel(view)
+
+    assert panel_id == "tool-panel"
+    assert payload.fit_mode == "Width"
+
+
+def test_map_tool_opening_geometry_supports_path_image_field(tmp_path, monkeypatch) -> None:
+    """MapTool height-fit sizing should resolve the same path fields used by map cards."""
+    image_path = tmp_path / "wide-map.png"
+    image_path.write_bytes(b"fake image")
+
+    class _FakeImage:
+        width = 1200
+        height = 400
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(gm_table_view_module.Image, "open", lambda _path: _FakeImage())
+    view = GMTableView.__new__(GMTableView)
+    view.map_wrapper = SimpleNamespace(
+        load_items=lambda: [{"Name": "Wide Map", "Path": str(image_path)}]
+    )
+
+    _default_width, default_height = resolve_default_panel_size("map_tool")
+
+    assert GMTableView._map_tool_opening_geometry(view, "wide map") == {
+        "width": 1400,
+        "height": default_height,
+    }
+
 def test_resolve_tabletop_context_queries_panel_list_once_when_no_active_panel() -> (
     None
 ):

--- a/tests/scenarios/gm_table/test_scenario_board_map_cards.py
+++ b/tests/scenarios/gm_table/test_scenario_board_map_cards.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from modules.scenarios.gm_table.scenario_board import map_cards
+from modules.scenarios.gm_table.scenario_board.map_cards import build_map_cards
+
+
+class _Wrapper:
+    def __init__(self, records):
+        self._records = records
+
+    def load_items(self):
+        return self._records
+
+
+def test_build_map_cards_resolves_record_metadata_and_image_size(
+    tmp_path: Path, monkeypatch
+) -> None:
+    image_path = tmp_path / "warehouse.png"
+    image_path.write_bytes(b"fake image")
+
+    class _FakeImage:
+        width = 320
+        height = 180
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(map_cards.Image, "open", lambda _path: _FakeImage())
+    wrapper = _Wrapper(
+        [
+            {
+                "Name": "Old Warehouse",
+                "Image": str(image_path),
+                "Type": "Battlemap",
+                "Category": "Urban",
+                "Description": "A dockside warehouse with loading bays and upper offices.",
+            }
+        ]
+    )
+
+    cards = build_map_cards(["old warehouse"], wrapper)
+
+    assert len(cards) == 1
+    assert cards[0].name == "Old Warehouse"
+    assert cards[0].subtitle == "Battlemap • Urban"
+    assert cards[0].size_label == "320 × 180"
+    assert "dockside warehouse" in cards[0].details
+
+
+def test_build_map_cards_keeps_unresolved_map_names() -> None:
+    cards = build_map_cards(["Hidden Shrine"], _Wrapper([]))
+
+    assert len(cards) == 1
+    assert cards[0].name == "Hidden Shrine"
+    assert cards[0].size_label == "No image"


### PR DESCRIPTION
### Motivation

- Provide a clickable gallery of linked campaign maps on the Scenario Board so GMs can quickly open scene maps from the scenario UI.  
- When a map is opened from the gallery, ensure the MapTool window displays the whole map by default in a `fit height` mode and size new panels to match the map aspect ratio.

### Description

- Added a helper module `modules/scenarios/gm_table/scenario_board/map_cards.py` that resolves linked map records, reads metadata, generates thumbnails (with styled placeholder fallback), and exposes `build_map_cards` and `create_map_thumbnail`.  
- Updated `modules/scenarios/gm_table/scenario_board/page.py` to render a `MAPS` gallery before the scene grid and to show each map as a clickable card (thumbnail, title, metadata, size label), routing clicks to open the map.  
- Enhanced `modules/scenarios/gm_table_view.py` to reuse/focus an existing MapTool panel when available, set the panel `fit_mode` to height when opening a targeted map, attempt to open maps via `open_map_by_name_when_ready` (if available), and compute initial geometry for new MapTool panels so height-fit displays the whole map using the backing image size.  
- Implemented image-path resolution helpers that accept the same keys used by the cards (`Image`, `image`, `Path`, `path`, `File`, `file`) so sizing and thumbnails use consistent fields.  
- Added unit tests for map-card construction and thumbnail sizing and regressions for MapTool focus/open behavior under supported image fields in `tests/scenarios/gm_table/test_scenario_board_map_cards.py` and updates in `tests/scenarios/gm_table/test_gm_table_view.py`.

### Testing

- Ran `pytest tests/scenarios/gm_table/test_scenario_board_map_cards.py -q` and it passed.  
- Ran `pytest tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/gm_table/test_scenario_board_map_cards.py tests/scenarios/gm_table/test_gm_table_view.py -q` and the test suite covering the modified areas passed (84 tests).  
- Verified Python compilation with `python -m compileall modules/scenarios/gm_table/scenario_board modules/scenarios/gm_table_view.py` and `python3 -m py_compile` checks for the modified modules, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7360130030832bbe4ae4251f31918c)