### PR TITLE
Show campaign map thumbnails on Scenario Board

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/map_cards.py
+++ b/modules/scenarios/gm_table/scenario_board/map_cards.py
@@ -9,9 +9,23 @@ from typing import Any, Mapping, Sequence
 import customtkinter as ctk
 from PIL import Image, ImageDraw
 
+from modules.helpers.config_helper import ConfigHelper
+
 _THUMBNAIL_SIZE = (176, 104)
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
-_IMAGE_KEYS = ("Image", "image", "Path", "path", "File", "file")
+_IMAGE_KEYS = (
+    "Image",
+    "image",
+    "ImagePath",
+    "image_path",
+    "MapImage",
+    "MapPath",
+    "RelativePath",
+    "Path",
+    "path",
+    "File",
+    "file",
+)
 _NAME_KEYS = ("Name", "Title", "Map", "MapName", "name", "title")
 _INFO_KEYS = ("Type", "Category", "Tags", "Kind", "Scale", "Grid", "Description")
 
@@ -141,9 +155,7 @@ def _resolve_image_path(image_path: str) -> Path | None:
     if not raw:
         return None
     path = Path(raw)
-    candidates = (
-        [path] if path.is_absolute() else [_PROJECT_ROOT / path, Path.cwd() / path]
-    )
+    candidates = [path] if path.is_absolute() else _relative_image_candidates(path)
     for candidate in candidates:
         try:
             resolved = candidate.resolve()
@@ -152,6 +164,24 @@ def _resolve_image_path(image_path: str) -> Path | None:
         if resolved.exists() and resolved.is_file():
             return resolved
     return None
+
+
+def _relative_image_candidates(path: Path) -> list[Path]:
+    """Return likely locations for a campaign-relative map image path."""
+    candidates: list[Path] = []
+    for root in (_campaign_root(), _PROJECT_ROOT, Path.cwd()):
+        candidate = root / path
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+
+
+def _campaign_root() -> Path:
+    """Return the active campaign directory without failing thumbnail rendering."""
+    try:
+        return Path(ConfigHelper.get_campaign_dir())
+    except Exception:
+        return Path.cwd()
 
 
 def _cover_image(image: Image.Image, size: tuple[int, int]) -> Image.Image:

--- a/tests/scenarios/gm_table/test_scenario_board_map_cards.py
+++ b/tests/scenarios/gm_table/test_scenario_board_map_cards.py
@@ -56,3 +56,41 @@ def test_build_map_cards_keeps_unresolved_map_names() -> None:
     assert len(cards) == 1
     assert cards[0].name == "Hidden Shrine"
     assert cards[0].size_label == "No image"
+
+
+def test_build_map_cards_resolves_campaign_relative_image_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    campaign_dir = tmp_path / "campaign"
+    image_path = campaign_dir / "assets" / "maps" / "vault.png"
+    image_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"fake image")
+
+    class _FakeImage:
+        width = 640
+        height = 480
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    opened_paths = []
+    monkeypatch.setattr(
+        map_cards.ConfigHelper, "get_campaign_dir", lambda: str(campaign_dir)
+    )
+    monkeypatch.setattr(
+        map_cards.Image,
+        "open",
+        lambda path: opened_paths.append(Path(path)) or _FakeImage(),
+    )
+
+    cards = build_map_cards(
+        ["Vault"],
+        _Wrapper([{"Name": "Vault", "ImagePath": "assets/maps/vault.png"}]),
+    )
+
+    assert cards[0].image_path == "assets/maps/vault.png"
+    assert cards[0].size_label == "640 × 480"
+    assert opened_paths == [image_path.resolve()]


### PR DESCRIPTION
### Motivation
- The Scenario Board's Maps section should display a miniature of each linked map image, resolving images stored inside the active campaign directory when records use campaign-relative paths. 

### Description
- Add support for common image fields (`ImagePath`, `image_path`, `MapImage`, `MapPath`, `RelativePath`) in `modules/scenarios/gm_table/scenario_board/map_cards.py` so linked maps can surface their real image values. 
- Resolve campaign-relative image locations by checking the active campaign directory via `ConfigHelper.get_campaign_dir()` and by adding helper functions `
_relative_image_candidates` and `_campaign_root` used by `_resolve_image_path`.
- Keep existing fallbacks to project root and current working directory and preserve the placeholder thumbnail behavior when no image is found.
- Add a regression test `test_build_map_cards_resolves_campaign_relative_image_path` to `tests/scenarios/gm_table/test_scenario_board_map_cards.py` that verifies campaign-relative thumbnail resolution.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py tests/scenarios/gm_table/test_scenario_board_map_cards.py`, all tests passed (`26 passed`).
- Ran focused map-card tests and the added regression case with `pytest -q tests/scenarios/gm_table/test_scenario_board_map_cards.py`, which passed (`3 passed`).
- Verified module byte-compile with `python -m compileall -q modules/scenarios/gm_table/scenario_board`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73646e8170832b93c834ebd1b61cec)