### PR TITLE
Maximize GM Table tool panels on open

### DIFF
--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -90,6 +90,17 @@ ENTITY_TYPES = (
 
 TITLE_KEY_ENTITY_TYPES = {"Scenarios", "Informations", "Books"}
 MAP_PANEL_KINDS = {"world_map", "map_tool"}
+MAXIMIZED_OPEN_PANEL_KINDS = {
+    "campaign_dashboard",
+    "character_graph",
+    "map_tool",
+    "object_shelf",
+    "scenario_board",
+    "scenario_graph",
+    "scene_flow",
+    "whiteboard",
+    "world_map",
+}
 
 FIXED_OVERLAY_ADD_OPTIONS = (
     "Image from Library",
@@ -846,7 +857,22 @@ class GMTableView(ctk.CTkFrame):
         )
         target_workspace = workspace or self.workspace
         target_workspace.add_panel(definition, geometry=geometry)
+        self._maximize_panel_on_open(target_workspace, definition.panel_id, kind)
         return definition.panel_id
+
+    def _maximize_panel_on_open(
+        self, workspace: GMTableWorkspace, panel_id: str, kind: str
+    ) -> None:
+        """Maximize GM Table tool panels that need a full workspace by default."""
+        if kind not in MAXIMIZED_OPEN_PANEL_KINDS:
+            return
+        try:
+            workspace.snap_panel(panel_id, "maximize")
+        except Exception as exc:
+            log_warning(
+                f"Unable to maximize GM Table panel '{panel_id}' on open: {exc}",
+                func_name="GMTableView._maximize_panel_on_open",
+            )
 
     def _create_panel_in_workspace(
         self,

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import modules.generic.entity_detail_factory as entity_detail_factory
 import modules.scenarios.gm_table_view as gm_table_view_module
 from modules.scenarios.gm_table.workspace import resolve_default_panel_size
-from modules.scenarios.gm_table_view import GMTableView
+from modules.scenarios.gm_table_view import GMTableView, MAXIMIZED_OPEN_PANEL_KINDS
 
 
 def test_resolve_default_panel_size_prefers_large_scenario_panels() -> None:
@@ -28,6 +28,51 @@ def test_resolve_default_panel_size_opens_objects_readably() -> None:
     assert object_size == (960, 700)
     assert object_size[0] > npc_size[0]
     assert object_size[1] > npc_size[1]
+
+
+class _PanelCallWorkspace:
+    """Minimal workspace test double that records panel creation and snapping."""
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def add_panel(self, definition, *, geometry=None):
+        self.calls.append(("add", definition.panel_id, definition.kind, geometry))
+
+    def snap_panel(self, panel_id, mode):
+        self.calls.append(("snap", panel_id, mode))
+
+
+def test_create_panel_maximizes_selected_gm_table_tool_panels_on_open() -> None:
+    """New selected GM Table tool panels should enter the maximized layout."""
+    for kind in sorted(MAXIMIZED_OPEN_PANEL_KINDS):
+        workspace = _PanelCallWorkspace()
+        view = GMTableView.__new__(GMTableView)
+        view.workspace = workspace
+
+        panel_id = GMTableView._create_panel(
+            view,
+            kind,
+            kind.replace("_", " ").title(),
+            {},
+            geometry={"width": 900, "height": 640},
+        )
+
+        assert workspace.calls == [
+            ("add", panel_id, kind, {"width": 900, "height": 640}),
+            ("snap", panel_id, "maximize"),
+        ]
+
+
+def test_create_panel_leaves_regular_gm_table_panels_floating() -> None:
+    """Non-tool panels should keep their regular floating placement."""
+    workspace = _PanelCallWorkspace()
+    view = GMTableView.__new__(GMTableView)
+    view.workspace = workspace
+
+    panel_id = GMTableView._create_panel(view, "note", "Note", {"text": ""})
+
+    assert workspace.calls == [("add", panel_id, "note", None)]
 
 
 def test_load_entity_item_accepts_title_or_name_case_insensitively() -> None:


### PR DESCRIPTION
### Motivation
- Certain GM Table tools (map tool, world map, campaign board, whiteboard, graphs, scene flow, object shelf, scenario board) work best when occupying the full workspace and should open maximized by default.

### Description
- Added a centralized `MAXIMIZED_OPEN_PANEL_KINDS` set to list GM Table panel kinds that should open maximized. (`modules/scenarios/gm_table_view.py`)
- Updated panel creation to call a new helper `_maximize_panel_on_open(workspace, panel_id, kind)` which snaps qualifying panels to the workspace `"maximize"` layout and logs safely on error. (`modules/scenarios/gm_table_view.py`)
- Added unit tests using a small `_PanelCallWorkspace` test double to verify that all kinds in `MAXIMIZED_OPEN_PANEL_KINDS` are snapped to `"maximize"` on creation and that non-tool panels remain floating. (`tests/scenarios/gm_table/test_gm_table_view.py`)
- Modified files: `modules/scenarios/gm_table_view.py` and `tests/scenarios/gm_table/test_gm_table_view.py`.

### Testing
- Ran `pytest tests/scenarios/gm_table/test_gm_table_view.py -q` which passed (`61 passed`).
- Ran `python -m py_compile modules/scenarios/gm_table_view.py tests/scenarios/gm_table/test_gm_table_view.py` which succeeded.
- Ran the broader GM Table test suite with `python -m pytest tests/scenarios/gm_table -q` where most tests passed (`226 passed`) but 2 tests failed in the headless environment due to `TclError: no display name and no $DISPLAY environment variable` when creating a Tk root, which is an environment limitation rather than a regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73665ed974832b8dbf1b9f9f0e16d6)