### PR TITLE
Fix scenario board text wrapping with display scaling

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/entity_links.py
+++ b/modules/scenarios/gm_table/scenario_board/entity_links.py
@@ -74,7 +74,18 @@ def bind_full_width_wrap(
 
     def update_wrap(event) -> None:
         nonlocal last_wraplength
-        wraplength = max(120, event.width - padding)
+        # ``<Configure>`` reports physical pixels, while CustomTkinter's
+        # ``wraplength`` option expects logical (pre-scaling) pixels and applies
+        # the widget scaling itself.  Passing the physical width back unchanged
+        # therefore makes the rendered line wider than its card whenever display
+        # scaling is above 100%, and the right-hand words are clipped rather than
+        # wrapped.  Convert through the widget's scaling helper when available;
+        # the fallback keeps this utility usable with regular Tk/test doubles.
+        reverse_scaling = getattr(label, "_reverse_widget_scaling", None)
+        logical_width = (
+            reverse_scaling(event.width) if callable(reverse_scaling) else event.width
+        )
+        wraplength = max(120, round(logical_width) - padding)
         if wraplength == last_wraplength:
             return
         last_wraplength = wraplength

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -279,6 +279,36 @@ def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
     assert label.wraplengths == [240, 286, 346]
 
 
+def test_full_width_wrap_accounts_for_customtkinter_display_scaling() -> None:
+    """Physical configure widths must be converted before CTk scales them again."""
+    from modules.scenarios.gm_table.scenario_board.entity_links import (
+        bind_full_width_wrap,
+    )
+
+    class _Parent:
+        def bind(self, _event_name, callback, *, add):
+            assert add == "+"
+            self.callback = callback
+
+    class _ScaledLabel:
+        def __init__(self):
+            self.master = _Parent()
+            self.wraplengths = []
+
+        def _reverse_widget_scaling(self, value):
+            return value / 1.25
+
+        def configure(self, *, wraplength):
+            self.wraplengths.append(wraplength)
+
+    label = _ScaledLabel()
+    bind_full_width_wrap(label, padding=14, initial_wraplength=240)
+    label.master.callback(SimpleNamespace(width=500))
+
+    # 500 physical pixels are 400 CTk logical pixels at 125% scaling.
+    assert label.wraplengths == [240, 386]
+
+
 def test_scene_grid_layout_fills_incomplete_final_rows() -> None:
     """The last row must use the full board instead of narrow empty columns."""
     from modules.scenarios.gm_table.scenario_board.layout import (


### PR DESCRIPTION
### Motivation
- The scene text on scenario cards was being clipped at display scalings >100% because `<Configure>` delivers physical pixels while CustomTkinter expects logical (pre-scaling) pixels for the `wraplength` option.
- Ensure labels receive a logical wrap width so lines wrap correctly instead of being cut off on high-DPI displays.

### Description
- Convert the physical `event.width` back to logical pixels before computing `wraplength` by calling a widget helper `label._reverse_widget_scaling` when present, with a fallback to the raw value for regular Tk/test doubles.
- Use `round(logical_width) - padding` and maintain a minimum wrap of `120` pixels before applying via `label.configure(wraplength=...)`.
- Preserve previous behavior of skipping duplicate wraplength updates to avoid feedback loops.
- Add a regression test `test_full_width_wrap_accounts_for_customtkinter_display_scaling` that simulates a 125% scaling helper and verifies the computed wraplength for a 500 physical-pixel width.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py` and the test suite for that file passed (`24 passed`).
- Ran the broader scenario tests with `pytest -q tests/scenarios/gm_table` which passed except for two display-dependent Tk tests that failed due to no graphical display in the environment (`227 passed, 2 display-dependent failures`).
- Ran `python -m compileall` on the modified modules and `git diff --check`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76c4d5e30c832b869f860c00b2eba7)