### PR TITLE
Embed read-only NPC relationship graph in GM Table scenario board

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/character_graph_view.py
+++ b/modules/scenarios/gm_table/scenario_board/character_graph_view.py
@@ -1,0 +1,61 @@
+"""Scenario-wizard styled character graph embedded in the GM scenario board."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import customtkinter as ctk
+
+from modules.scenarios.scenario_character_graph import ScenarioCharacterGraphEditor
+
+
+class ScenarioBoardCharacterGraph(ScenarioCharacterGraphEditor):
+    """A presentation-focused variant of the wizard's character graph."""
+
+    def init_toolbar(self) -> None:
+        """Replace editing actions with a compact viewing hint."""
+        toolbar = ctk.CTkFrame(self, fg_color="#172536", corner_radius=0)
+        toolbar.pack(fill="x")
+        ctk.CTkLabel(
+            toolbar,
+            text="NPC RELATIONSHIPS",
+            text_color="#f3f7fb",
+            font=ctk.CTkFont(size=12, weight="bold"),
+        ).pack(side="left", padx=12, pady=8)
+        ctk.CTkLabel(
+            toolbar,
+            text="Drag to inspect · Ctrl + wheel to zoom",
+            text_color="#9db4d1",
+            font=ctk.CTkFont(size=10),
+        ).pack(side="right", padx=12, pady=8)
+
+    def on_right_click(self, _event):
+        """Keep the board representation free of destructive context actions."""
+        return "break"
+
+    def open_character_editor(self, _event):
+        """Prevent the presentation-only board from opening an editable record."""
+        return "break"
+
+
+def create_scenario_character_graph(
+    master,
+    *,
+    graph_data: Mapping[str, Any],
+    wrappers: Mapping[str, object],
+) -> ScenarioBoardCharacterGraph | None:
+    """Create the graph when its data and required entity stores are available."""
+    if not graph_data.get("nodes"):
+        return None
+    required = ("NPCs", "PCs", "Factions")
+    if any(wrappers.get(key) is None for key in required):
+        return None
+    return ScenarioBoardCharacterGraph(
+        master,
+        npc_wrapper=wrappers["NPCs"],
+        pc_wrapper=wrappers["PCs"],
+        faction_wrapper=wrappers["Factions"],
+        graph_data=dict(graph_data),
+        background_style="scene_flow",
+        node_style="modern",
+    )

--- a/modules/scenarios/gm_table/scenario_board/models.py
+++ b/modules/scenarios/gm_table/scenario_board/models.py
@@ -53,6 +53,7 @@ class ScenarioBoardData:
     checkpoint: str
     scenes: tuple[ScenarioBoardScene, ...]
     linked_entities: dict[str, tuple[str, ...]]
+    character_graph: dict[str, Any]
 
 
 def _parse_serialized_payload(value: str) -> Any | None:
@@ -142,6 +143,32 @@ def normalize_list_field(value: Any) -> tuple[str, ...]:
         return tuple(items)
     text = _clean_text(value)
     return (text,) if text else ()
+
+
+def normalize_character_graph(value: Any) -> dict[str, Any]:
+    """Return a safe scenario character graph payload for display widgets."""
+    if isinstance(value, str):
+        value = _parse_serialized_payload(value)
+    if not isinstance(value, Mapping):
+        return {"nodes": [], "links": [], "shapes": []}
+
+    def mapping_list(key: str) -> list[dict[str, Any]]:
+        entries = value.get(key)
+        if not isinstance(entries, (list, tuple)):
+            return []
+        return [dict(entry) for entry in entries if isinstance(entry, Mapping)]
+
+    return {
+        "nodes": mapping_list("nodes"),
+        "links": mapping_list("links"),
+        "shapes": mapping_list("shapes"),
+        **({"tabs": mapping_list("tabs")} if isinstance(value.get("tabs"), list) else {}),
+        **(
+            {"active_tab_id": value["active_tab_id"]}
+            if value.get("active_tab_id")
+            else {}
+        ),
+    }
 
 
 def split_scene_title(scene_text: str, index: int) -> tuple[str, str]:
@@ -334,4 +361,5 @@ def build_scenario_board_data(
         checkpoint=first_text("Checkpoint", "Route", "Progression"),
         scenes=tuple(scenes),
         linked_entities=linked_entities,
+        character_graph=normalize_character_graph(item.get("ScenarioCharacterGraph")),
     )

--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -17,6 +17,9 @@ from modules.scenarios.gm_table.scenario_board.content import (
     build_directives,
     build_info_bands,
 )
+from modules.scenarios.gm_table.scenario_board.character_graph_view import (
+    create_scenario_character_graph,
+)
 from modules.scenarios.gm_table.scenario_board.entity_links import (
     add_entity_links,
     bind_full_width_wrap,
@@ -137,8 +140,44 @@ class ScenarioBoardPanel(ctk.CTkFrame):
             board.grid_columnconfigure(column, weight=1, uniform="board")
         row = self._add_info_bands(board, 0)
         row = self._add_directives(board, row)
+        row = self._add_character_graph(board, row)
         row = self._add_map_gallery(board, row)
         self._add_scene_grid(board, row)
+
+    def _add_character_graph(self, parent, row: int) -> int:
+        """Embed the saved scenario relationship graph using the wizard renderer."""
+        if not self._data.character_graph.get("nodes"):
+            return row
+        section = ctk.CTkFrame(
+            parent,
+            height=430,
+            fg_color=self._palette.surface,
+            corner_radius=0,
+            border_width=1,
+            border_color=self._palette.border,
+        )
+        section.grid(
+            row=row,
+            column=0,
+            columnspan=20,
+            sticky="ew",
+            padx=(0, 3),
+            pady=(0, 8),
+        )
+        section.grid_propagate(False)
+        section.grid_rowconfigure(0, weight=1)
+        section.grid_columnconfigure(0, weight=1)
+        graph = create_scenario_character_graph(
+            section,
+            graph_data=self._data.character_graph,
+            wrappers=self._wrappers,
+        )
+        if graph is None:
+            section.destroy()
+            return row
+        graph.grid(row=0, column=0, sticky="nsew")
+        self._character_graph = graph
+        return row + 1
 
     def _add_info_bands(self, parent, row: int) -> int:
         groups = build_info_bands(self._data)

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -14,6 +14,9 @@ from modules.helpers import theme_manager
 from modules.scenarios.gm_table.scenario_board.styles import (
     resolve_scenario_board_palette,
 )
+from modules.scenarios.gm_table.scenario_board.character_graph_view import (
+    ScenarioBoardCharacterGraph,
+)
 from modules.scenarios.gm_table.panel_skins import readable_text_color
 from modules.scenarios.gm_table.workspace import resolve_default_panel_size
 from modules.scenarios.gm_table_view import GMTableView
@@ -63,6 +66,50 @@ def test_build_scenario_board_data_extracts_scenes_sections_and_links() -> None:
     assert data.scenes[0].sections[0]["items"] == ["Meet the fixer"]
     assert data.linked_entities["NPCs"] == ("Fixer", "Captain")
     assert data.linked_entities["Places"] == ("Docks",)
+
+
+def test_build_scenario_board_data_normalizes_saved_character_graph() -> None:
+    """Scenario Board exposes wizard graph data even when SQLite returns JSON."""
+    data = build_scenario_board_data(
+        {
+            "Title": "Night Run",
+            "ScenarioCharacterGraph": (
+                '{"nodes":[{"tag":"npc_fixer","entity_type":"npc",'
+                '"entity_name":"Fixer","x":120,"y":160}],"links":[]}'
+            ),
+        }
+    )
+
+    assert data.character_graph["nodes"][0]["entity_name"] == "Fixer"
+    assert data.character_graph["links"] == []
+    assert data.character_graph["shapes"] == []
+
+
+def test_build_scenario_board_data_discards_malformed_graph_entries() -> None:
+    """Malformed persisted graph values must not crash the graph renderer."""
+    data = build_scenario_board_data(
+        {
+            "ScenarioCharacterGraph": {
+                "nodes": [None, "not-a-node", {"entity_name": "Fixer"}],
+                "links": "not-a-list",
+                "shapes": [42],
+            }
+        }
+    )
+
+    assert data.character_graph == {
+        "nodes": [{"entity_name": "Fixer"}],
+        "links": [],
+        "shapes": [],
+    }
+
+
+def test_scenario_board_character_graph_blocks_editing_gestures() -> None:
+    """The embedded graph is inspectable without exposing record editing actions."""
+    graph = ScenarioBoardCharacterGraph.__new__(ScenarioBoardCharacterGraph)
+
+    assert graph.on_right_click(None) == "break"
+    assert graph.open_character_editor(None) == "break"
 
 
 def test_build_scenario_board_data_decodes_serialized_rich_text_payloads() -> None:


### PR DESCRIPTION
### Motivation

- Surface the scenario NPC relationship graph on the GM Table scenario board using the same visual language as the scenario wizard so GMs can inspect relationships inline. 
- Keep the board presentation-only to avoid accidental edits while preserving panning/zoom gestures for inspection. 

### Description

- Added robust normalization of persisted character-graph payloads with `normalize_character_graph` and included a `character_graph` field on `ScenarioBoardData` so the UI can safely consume JSON or Python-literal stored graphs (`modules/scenarios/gm_table/scenario_board/models.py`).
- Implemented a presentation-only graph widget `ScenarioBoardCharacterGraph` that reuses the wizard renderer but blocks editing gestures, and `create_scenario_character_graph` factory that enforces required wrappers and visual style (`modules/scenarios/gm_table/scenario_board/character_graph_view.py`).
- Integrated the graph into the scenario board layout between directives and the map gallery with conditional rendering when graph data and wrappers are available (`modules/scenarios/gm_table/scenario_board/page.py`).
- Added unit tests covering graph normalization, tolerant handling of malformed persisted values, and read-only interaction behavior (`tests/scenarios/gm_table/test_scenario_board.py`).

### Testing

- Ran `pytest -q tests/scenarios/gm_table/test_scenario_board.py`, and the tests in that file passed.
- Verified module byte-compile with `python -m compileall` for the modified package, which succeeded.
- Broader test run of `pytest -q tests/scenarios/gm_table` passed except for two pre-existing real-Tk integration tests that could not start in the headless environment (no `$DISPLAY`), which is an environment limitation rather than a regression in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79fdbd9bf0832bae8e4b2df0c10055)