### PR TITLE
Move GM Table desk controls to left

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -1467,7 +1467,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             border_width=1,
             border_color=TABLE_PALETTE["table_line"],
         )
-        self._nav_hud.place(relx=1.0, x=-18, y=18, anchor="ne")
+        self._nav_hud.place(relx=0.0, x=18, y=18, anchor="nw")
         self._nav_status = ctk.CTkLabel(
             self._nav_hud,
             text="Desk 100%",


### PR DESCRIPTION
### Motivation
- Move the desk (Home, Marks) floating HUD to the left edge of the GM Table surface to match the requested UI change.

### Description
- Updated the HUD placement in `modules/scenarios/gm_table/workspace.py` by changing `self._nav_hud.place(relx=1.0, x=-18, y=18, anchor="ne")` to `self._nav_hud.place(relx=0.0, x=18, y=18, anchor="nw")`, preserving the 18px inset while relocating from top-right to top-left.

### Testing
- Ran `python -m py_compile modules/scenarios/gm_table/workspace.py` (success) and `python -m pytest -q tests/scenarios/gm_table/test_workspace.py tests/scenarios/test_gm_table_middle_drag_hit_testing.py -k 'not mount_payload_widget'` which reported `54 passed, 2 deselected`, while a full `pytest` run recorded `54 passed` plus `2` display-dependent failures caused by missing `DISPLAY`/`Xvfb` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d89ecd624832bb64fd06daec7a7ab)