### PR TITLE
Make GM Table windows frameless and add close button in tools banner

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -3159,10 +3159,14 @@ class MainWindow(ctk.CTk):
 
         try:
             from modules.scenarios.gm_table_view import GMTableView
+            from modules.scenarios.gm_table.window_chrome import (
+                remove_native_window_decorations,
+            )
 
             window = ctk.CTkToplevel(self)
             window.title(f"GM Table - {table_name}")
             self._maximize_detached_window(window)
+            remove_native_window_decorations(window)
             self._focus_detached_window(window)
             try:
                 window.attributes("-topmost", True)
@@ -3192,6 +3196,7 @@ class MainWindow(ctk.CTk):
                 on_switch_table=lambda target_table_id: self.open_gm_table(
                     table_id=target_table_id
                 ),
+                on_close=_on_close,
                 root_app=self,
                 layout_store=layout_store,
             )

--- a/modules/scenarios/gm_table/window_chrome.py
+++ b/modules/scenarios/gm_table/window_chrome.py
@@ -1,0 +1,10 @@
+"""Window chrome helpers for detached GM Table workspaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def remove_native_window_decorations(window: Any) -> None:
+    """Hide the operating-system title bar around a detached GM Table window."""
+    window.overrideredirect(True)

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -136,6 +136,7 @@ class GMTableView(ctk.CTkFrame):
         table_id: str,
         table_name: str,
         on_switch_table=None,
+        on_close=None,
         root_app=None,
         layout_store: GMTableLayoutStore | None = None,
     ) -> None:
@@ -153,6 +154,7 @@ class GMTableView(ctk.CTkFrame):
         self._session_mid_var = tk.StringVar(value="1.0")
         self._session_end_var = tk.StringVar(value="2.0")
         self._on_switch_table = on_switch_table
+        self._on_close = on_close
         self._root_app = root_app
         self.layout_store = layout_store or GMTableLayoutStore()
         self._layout_settle_scheduler = LayoutSettleScheduler(self)
@@ -475,7 +477,27 @@ class GMTableView(ctk.CTkFrame):
             text_color=TABLE_PALETTE["text"],
             corner_radius=14,
             command=self.reset_table,
+        ).pack(side="left", padx=(0, 10))
+
+        ctk.CTkButton(
+            actions,
+            text="×",
+            width=34,
+            height=30,
+            fg_color=TABLE_PALETTE["danger"],
+            hover_color="#B91C1C",
+            text_color="#FFFFFF",
+            font=ctk.CTkFont(size=18, weight="bold"),
+            corner_radius=14,
+            command=self._close_window,
         ).pack(side="left")
+
+    def _close_window(self) -> None:
+        """Close this table through its owner so window tracking stays accurate."""
+        if self._on_close is not None:
+            self._on_close()
+            return
+        self.winfo_toplevel().destroy()
 
     def _activate_desk_annotation_tool(self, tool: str) -> None:
         """Arm a desk annotation tool immediately using inline toolbar styling."""

--- a/tests/test_calendar_dock_lifecycle.py
+++ b/tests/test_calendar_dock_lifecycle.py
@@ -193,6 +193,7 @@ class _FakeToplevel:
         self.protocol_callbacks = {}
         self.after_idle_callbacks = []
         self.destroy_calls = 0
+        self.overrideredirect_calls = []
         self._exists = True
 
     def winfo_exists(self):
@@ -231,6 +232,10 @@ class _FakeToplevel:
         """Handle attributes."""
         self.attributes_calls.append(args)
 
+    def overrideredirect(self, value):
+        """Record native window-decoration changes."""
+        self.overrideredirect_calls.append(value)
+
     def after_idle(self, callback):
         """Handle after idle."""
         self.after_idle_callbacks.append(callback)
@@ -267,6 +272,7 @@ class _FakeGMTableView:
         table_id,
         table_name,
         on_switch_table=None,
+        on_close=None,
         root_app,
         layout_store=None,
     ):
@@ -275,6 +281,7 @@ class _FakeGMTableView:
         self.table_id = table_id
         self.table_name = table_name
         self.on_switch_table = on_switch_table
+        self.on_close = on_close
         self.root_app = root_app
         self.layout_store = layout_store
         self.opened_entities = []
@@ -335,6 +342,7 @@ def test_open_gm_table_launches_detached_window_without_clearing_main_content(mo
     assert gm_window.title_text == "GM Table - Main"
     assert gm_window.geometry_calls[-1] == "1920x1080+0+0"
     assert gm_window.minsize_calls[-1] == (1600, 900)
+    assert gm_window.overrideredirect_calls == [True]
     assert gm_window.lift_calls == 1
     assert gm_window.focus_force_calls == 1
     assert gm_window.attributes_calls[0] == ("-topmost", True)
@@ -490,6 +498,8 @@ def test_gm_table_window_close_clears_tracked_references(monkeypatch):
 
     gm_window = MainWindow.open_gm_table(window, scenario_name="Storm Front")
     close_callback = gm_window.protocol_callbacks["WM_DELETE_WINDOW"]
+
+    assert window.current_gm_table.on_close is close_callback
 
     close_callback()
 


### PR DESCRIPTION
### Motivation

- Reclaim vertical space in detached GM Table windows by removing the native OS title bar.  
- Provide a compact, consistent way for users to close GM Table windows from the in-app toolbar while preserving existing lifecycle/cleanup logic.  

### Description

- Add `modules/scenarios/gm_table/window_chrome.py` with `remove_native_window_decorations(window)` which calls `window.overrideredirect(True)` to hide native decorations.  
- Call `remove_native_window_decorations(window)` when creating detached GM Table windows in `main_window.py` and pass an `on_close` callback into the `GMTableView` instance so closing goes through the existing tracked-window cleanup path.  
- Add a compact red `×` `CTkButton` to the GM Table tools banner in `modules/scenarios/gm_table_view.py` and implement `_close_window()` to call the passed `on_close` callback (or fall back to destroying the toplevel when no callback is provided).  
- Extend `tests/test_calendar_dock_lifecycle.py` to assert that `overrideredirect(True)` is invoked for detached windows and that the view's close path is wired to the window close callback.  

### Testing

- Ran bytecode/compile checks: `python -m compileall -q main_window.py modules/scenarios/gm_table_view.py modules/scenarios/gm_table/window_chrome.py tests/test_calendar_dock_lifecycle.py` which succeeded.  
- Ran static sanity check with `git diff --check` which reported no whitespace/merge issues.  
- Ran focused lifecycle harnesses and import-based checks that verify the frameless setup and close-callback wiring (these checks passed).  
- Attempted `pytest -q tests/test_calendar_dock_lifecycle.py` but test collection was blocked due to unavailable project dependencies (`python-docx`, `cryptography`) and network restrictions preventing package installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d8f590a88832baa45c105a3f79d90)