### PR TITLE
Use full GM Table window area — remove outer gutters and corner radius

### DIFF
--- a/modules/scenarios/gm_table/layout/window_spacing.py
+++ b/modules/scenarios/gm_table/layout/window_spacing.py
@@ -1,0 +1,10 @@
+"""Outer spacing rules for the detached GM Table window."""
+
+from __future__ import annotations
+
+# The GM Table owns a dedicated, borderless top-level window.  Outer gutters only
+# reduce its usable desk area, so both primary rows should meet the window edges.
+WINDOW_EDGE_PADDING = 0
+TOOLBAR_CORNER_RADIUS = 0
+WORKSPACE_SECTION_GAP = 0
+WORKSPACE_CORNER_RADIUS = 0

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -14,6 +14,11 @@ from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
 from modules.scenarios.gm_table.drag_controller import GMTableDragController
 from modules.scenarios.gm_table.window_hit_testing import point_inside_map_tool
 from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
+from modules.scenarios.gm_table.layout.window_spacing import (
+    WINDOW_EDGE_PADDING,
+    WORKSPACE_CORNER_RADIUS,
+    WORKSPACE_SECTION_GAP,
+)
 from modules.scenarios.gm_table.panel_skins import (
     DESK_SPREAD_ACCENT_VARIANTS,
     resolve_panel_chrome,
@@ -1385,7 +1390,11 @@ class GMTableWorkspace(ctk.CTkFrame):
         on_reveal_requested: Callable[[str], None] | None = None,
         on_fixed_overlay_add_requested: Callable[[object], None] | None = None,
     ) -> None:
-        super().__init__(master, fg_color=TABLE_PALETTE["table_bg"], corner_radius=28)
+        super().__init__(
+            master,
+            fg_color=TABLE_PALETTE["table_bg"],
+            corner_radius=WORKSPACE_CORNER_RADIUS,
+        )
         self._build_panel = on_panel_build
         self._layout_changed_callback = on_layout_changed
         self._map_tool_window_provider = map_tool_window_provider
@@ -1425,11 +1434,17 @@ class GMTableWorkspace(ctk.CTkFrame):
         self.surface = ctk.CTkFrame(
             self,
             fg_color=TABLE_PALETTE["table_bg"],
-            corner_radius=24,
+            corner_radius=WORKSPACE_CORNER_RADIUS,
             border_width=1,
             border_color=TABLE_PALETTE["table_line"],
         )
-        self.surface.grid(row=0, column=0, sticky="nsew", padx=18, pady=(0, 10))
+        self.surface.grid(
+            row=0,
+            column=0,
+            sticky="nsew",
+            padx=WINDOW_EDGE_PADDING,
+            pady=(0, WORKSPACE_SECTION_GAP),
+        )
         self.surface.bind("<Configure>", self._on_surface_configure, add="+")
 
         self._desk_texture_canvas = tk.Canvas(
@@ -1533,11 +1548,17 @@ class GMTableWorkspace(ctk.CTkFrame):
         self.tray = ctk.CTkFrame(
             self,
             fg_color=TABLE_PALETTE["table_alt"],
-            corner_radius=20,
+            corner_radius=WORKSPACE_CORNER_RADIUS,
             border_width=1,
             border_color=TABLE_PALETTE["table_line"],
         )
-        self.tray.grid(row=1, column=0, sticky="ew", padx=18, pady=(0, 18))
+        self.tray.grid(
+            row=1,
+            column=0,
+            sticky="ew",
+            padx=WINDOW_EDGE_PADDING,
+            pady=(0, WINDOW_EDGE_PADDING),
+        )
         self.tray.grid_columnconfigure(1, weight=1)
 
         self.tray_label = ctk.CTkLabel(

--- a/modules/scenarios/gm_table_view.py
+++ b/modules/scenarios/gm_table_view.py
@@ -44,6 +44,10 @@ from modules.scenarios.gm_table.entity_media import has_displayable_entity_image
 from modules.scenarios.gm_table.handouts.page import GMTableHandoutsPage
 from modules.scenarios.gm_table.scenario_board import ScenarioBoardPanel, ScenarioBundle
 from modules.scenarios.gm_table.container_window import GMTableContainerPage
+from modules.scenarios.gm_table.layout.window_spacing import (
+    TOOLBAR_CORNER_RADIUS,
+    WINDOW_EDGE_PADDING,
+)
 from modules.scenarios.gm_table.pages import (
     GMTableAttachmentGallery,
     GMTableHostedPage,
@@ -299,7 +303,13 @@ class GMTableView(ctk.CTkFrame):
             on_reveal_requested=self._reveal_panel,
             on_fixed_overlay_add_requested=self._show_fixed_overlay_add_menu,
         )
-        self.workspace.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 18))
+        self.workspace.grid(
+            row=1,
+            column=0,
+            sticky="nsew",
+            padx=WINDOW_EDGE_PADDING,
+            pady=WINDOW_EDGE_PADDING,
+        )
 
         self.after_idle(self._restore_or_seed_layout)
 
@@ -315,11 +325,17 @@ class GMTableView(ctk.CTkFrame):
         bar = ctk.CTkFrame(
             self,
             fg_color=TABLE_PALETTE["table_alt"],
-            corner_radius=26,
+            corner_radius=TOOLBAR_CORNER_RADIUS,
             border_width=1,
             border_color=TABLE_PALETTE["table_line"],
         )
-        bar.grid(row=0, column=0, sticky="ew", padx=18, pady=10)
+        bar.grid(
+            row=0,
+            column=0,
+            sticky="ew",
+            padx=WINDOW_EDGE_PADDING,
+            pady=WINDOW_EDGE_PADDING,
+        )
         bar.grid_columnconfigure(0, weight=1)
 
         title_frame = ctk.CTkFrame(bar, fg_color="transparent")

--- a/tests/scenarios/gm_table/test_gm_table_view.py
+++ b/tests/scenarios/gm_table/test_gm_table_view.py
@@ -6,8 +6,22 @@ from types import SimpleNamespace
 
 import modules.generic.entity_detail_factory as entity_detail_factory
 import modules.scenarios.gm_table_view as gm_table_view_module
+from modules.scenarios.gm_table.layout.window_spacing import (
+    TOOLBAR_CORNER_RADIUS,
+    WINDOW_EDGE_PADDING,
+    WORKSPACE_CORNER_RADIUS,
+    WORKSPACE_SECTION_GAP,
+)
 from modules.scenarios.gm_table.workspace import resolve_default_panel_size
 from modules.scenarios.gm_table_view import GMTableView, MAXIMIZED_OPEN_PANEL_KINDS
+
+
+def test_detached_table_content_uses_the_full_window_area() -> None:
+    """The toolbar and desk should not reserve unused outer window gutters."""
+    assert WINDOW_EDGE_PADDING == 0
+    assert TOOLBAR_CORNER_RADIUS == 0
+    assert WORKSPACE_SECTION_GAP == 0
+    assert WORKSPACE_CORNER_RADIUS == 0
 
 
 def test_resolve_default_panel_size_prefers_large_scenario_panels() -> None:


### PR DESCRIPTION
### Motivation

- The detached GM Table window had visible outer gutters and rounded outer corners that wasted usable desk area and created distracting empty space. 
- The goal is to let the toolbar and workspace reach the window edges so the table content uses the full available area.

### Description

- Centralized window-edge spacing and corner-radius rules in a new module `modules/scenarios/gm_table/layout/window_spacing.py` and set the defaults to remove outer gutters (`WINDOW_EDGE_PADDING = 0`, `TOOLBAR_CORNER_RADIUS = 0`, `WORKSPACE_SECTION_GAP = 0`, `WORKSPACE_CORNER_RADIUS = 0`).
- Updated `GMTableWorkspace` in `modules/scenarios/gm_table/workspace.py` to apply the new spacing and corner-radius constants for the workspace surface and tray, replacing hard-coded paddings and radii.
- Updated `GMTableView` in `modules/scenarios/gm_table_view.py` to apply the new spacing and toolbar corner-radius constants so the toolbar and workspace grids extend to the full window area.
- Added a small regression test `tests/scenarios/gm_table/test_gm_table_view.py` asserting the spacing and corner-radius constants are zero to prevent regressions.

### Testing

- Ran the targeted unit test file `pytest tests/scenarios/gm_table/test_gm_table_view.py` and the new assertions passed. 
- Ran the scenario GM Table test subset and collection smoke checks (module compile / pytest) and they completed without errors. 
- Ran `git diff --check` (style / whitespace checks) and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d957008f4832ba1aec7e58e88412d)