### PR TITLE
Add force_full_checkpoint option and explicit "Publish full campaign" UI action

### DIFF
--- a/modules/generic/campaign_sync/auto_publish/coordinator.py
+++ b/modules/generic/campaign_sync/auto_publish/coordinator.py
@@ -41,7 +41,9 @@ class AutoPublishCoordinator:
         self._stopped = False
 
     def mark_dirty(self, *, campaign_id: str, campaign_name: str, campaign_root: Path,
-                   database_path: Path, expected_parent_revision: int, when: Optional[float] = None) -> None:
+                   database_path: Path, expected_parent_revision: int,
+                   force_full_checkpoint: bool = False,
+                   when: Optional[float] = None) -> None:
         """Record a *successfully saved* campaign mutation."""
         now = self.clock() if when is None else when
         with self._lock:
@@ -50,6 +52,7 @@ class AutoPublishCoordinator:
             self.outbox.upsert(OutboxEntry(
                 campaign_id, campaign_name, Path(campaign_root).resolve(), Path(database_path).resolve(),
                 expected_parent_revision, first, now,
+                force_full_checkpoint=force_full_checkpoint,
             ))
             if campaign_id in self._inflight:
                 self._dirty_during_flight.add(campaign_id)
@@ -114,13 +117,19 @@ class AutoPublishCoordinator:
     def _prepare_and_run(self, entry: OutboxEntry, force: bool) -> None:
         try:
             detected = self.detector.detect(entry.campaign_root, database_path=entry.database_path)
-            if detected.state is CampaignChangeState.CLEAN:
+            if detected.state is CampaignChangeState.CLEAN and not entry.force_full_checkpoint:
                 self.outbox.remove(entry.campaign_id)
                 self.events.put(WorkerEvent(str(uuid4()), entry.campaign_id, 1, EventKind.SUCCESS,
                                             SyncState.SYNCHRONIZED, "No changes to publish", 1.0,
                                             terminal=True))
                 return
-            if detected.state is not CampaignChangeState.LOCALLY_MODIFIED:
+            if (
+                detected.state is not CampaignChangeState.LOCALLY_MODIFIED
+                and not (
+                    entry.force_full_checkpoint
+                    and detected.state is CampaignChangeState.CLEAN
+                )
+            ):
                 raise RuntimeError(detected.error or "Campaign change state is unknown")
             revision = entry.expected_parent_revision + 1
             title = f"{entry.campaign_name} — Revision {revision}"
@@ -130,6 +139,7 @@ class AutoPublishCoordinator:
                 str(uuid4()), entry.campaign_id, entry.campaign_name, entry.campaign_root,
                 entry.database_path, entry.expected_parent_revision, entry.first_dirty_at,
                 entry.last_dirty_at, title, summary, detected.current_fingerprint,
+                entry.force_full_checkpoint,
             )
             self.worker.run(job)
         except BaseException as error:

--- a/modules/generic/campaign_sync/auto_publish/models.py
+++ b/modules/generic/campaign_sync/auto_publish/models.py
@@ -44,6 +44,7 @@ class PublicationJob:
     title: str
     summary: str
     fingerprint: Optional[str] = None
+    force_full_checkpoint: bool = False
 
 
 @dataclass(frozen=True)
@@ -59,6 +60,7 @@ class OutboxEntry:
     next_attempt_at: float = 0.0
     failure_category: Optional[str] = None
     failure_message: Optional[str] = None
+    force_full_checkpoint: bool = False
 
     def updated(self, **changes: Any) -> "OutboxEntry":
         return replace(self, **changes)
@@ -83,6 +85,7 @@ class OutboxEntry:
             next_attempt_at=max(0.0, float(value.get("next_attempt_at", 0))),
             failure_category=value.get("failure_category") or None,
             failure_message=value.get("failure_message") or None,
+            force_full_checkpoint=bool(value.get("force_full_checkpoint", False)),
         )
 
 

--- a/modules/generic/campaign_sync/auto_publish/outbox.py
+++ b/modules/generic/campaign_sync/auto_publish/outbox.py
@@ -56,6 +56,9 @@ class DurableOutbox:
                     next_attempt_at=previous.next_attempt_at,
                     failure_category=previous.failure_category,
                     failure_message=previous.failure_message,
+                    force_full_checkpoint=(
+                        previous.force_full_checkpoint or entry.force_full_checkpoint
+                    ),
                 )
             self._entries[entry.campaign_id] = entry
             self._persist()

--- a/modules/generic/campaign_sync/auto_publish/worker.py
+++ b/modules/generic/campaign_sync/auto_publish/worker.py
@@ -45,6 +45,7 @@ class PublicationWorker:
                 job.campaign_root, database_path=job.database_path,
                 title=job.title, description=job.summary,
                 change_summary=job.summary, progress_callback=progress,
+                force_full_checkpoint=job.force_full_checkpoint,
             )
             if result.outcome is PublishOutcome.CONFLICTED:
                 emit(EventKind.CONFLICT, SyncState.CONFLICT,

--- a/modules/generic/campaign_sync/publisher.py
+++ b/modules/generic/campaign_sync/publisher.py
@@ -212,6 +212,7 @@ class CampaignPublisher:
         description: str = "",
         change_summary: Optional[str] = None,
         progress_callback=None,
+        force_full_checkpoint: bool = False,
     ) -> CampaignPublishResult:
         root = Path(campaign_root).resolve()
         local = CampaignSyncMetadataStore(root).read()
@@ -252,7 +253,12 @@ class CampaignPublisher:
             except (KeyError, TypeError, ValueError):
                 baseline_inventory = ()
             current_inventory = build_inventory(root, database, database_snapshot_path=database_snapshot)
-            is_checkpoint = revision == 1 or revision % self.checkpoint_interval == 0 or not baseline_inventory
+            is_checkpoint = (
+                force_full_checkpoint
+                or revision == 1
+                or revision % self.checkpoint_interval == 0
+                or not baseline_inventory
+            )
             snapshot_mode = "full_campaign" if is_checkpoint else "campaign_delta"
             base_fingerprint = state.get("baseline_fingerprint") if snapshot_mode == "campaign_delta" else None
             metadata = CampaignSyncMetadata(

--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -215,7 +215,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.reload_btn.grid(row=0, column=4, padx=6, pady=6, sticky="ew")
         self.publish_btn = ctk.CTkButton(
             button_row,
-            text="Publish to GitHub…",
+            text="Publish selected assets to GitHub…",
             command=self.publish_selected_to_github,
         )
         self.publish_btn.grid(row=0, column=5, padx=6, pady=6, sticky="ew")
@@ -243,7 +243,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
 
         sync_row = ctk.CTkFrame(self)
         sync_row.grid(row=2, column=0, columnspan=2, sticky="ew", padx=10, pady=(0, 10))
-        for column_index in range(4):
+        for column_index in range(5):
             sync_row.grid_columnconfigure(column_index, weight=1)
         ctk.CTkButton(sync_row, text="Enable synchronization", command=self.enable_campaign_sync).grid(
             row=0, column=0, padx=6, pady=6, sticky="ew"
@@ -251,11 +251,17 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         ctk.CTkButton(sync_row, text="Publish campaign update", command=self.publish_campaign_update).grid(
             row=0, column=1, padx=6, pady=6, sticky="ew"
         )
+        self.publish_full_campaign_btn = ctk.CTkButton(
+            sync_row,
+            text="Publish full campaign to GitHub…",
+            command=self.publish_full_campaign_to_github,
+        )
+        self.publish_full_campaign_btn.grid(row=0, column=2, padx=6, pady=6, sticky="ew")
         ctk.CTkButton(sync_row, text="Check for updates", command=self.check_campaign_updates).grid(
-            row=0, column=2, padx=6, pady=6, sticky="ew"
+            row=0, column=3, padx=6, pady=6, sticky="ew"
         )
         ctk.CTkButton(sync_row, text="Unlink this local copy", command=self.unlink_campaign_sync).grid(
-            row=0, column=3, padx=6, pady=6, sticky="ew"
+            row=0, column=4, padx=6, pady=6, sticky="ew"
         )
 
         self._update_publish_button_state()
@@ -771,6 +777,13 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             messagebox.showwarning("Invalid Choice", "Enter 1, 2, or 3.")
 
     def publish_campaign_update(self):
+        self._publish_campaign_update(force_full_checkpoint=False)
+
+    def publish_full_campaign_to_github(self):
+        """Publish the next synchronized revision as a standalone checkpoint."""
+        self._publish_campaign_update(force_full_checkpoint=True)
+
+    def _publish_campaign_update(self, *, force_full_checkpoint: bool):
         if not self.selected_campaign:
             messagebox.showwarning("No Source", "Select a source campaign first.")
             return
@@ -779,18 +792,28 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             return
         campaign = self.selected_campaign
         metadata = self.campaign_publisher.enable(campaign.root, database_path=campaign.db_path)
+        expected_parent = 0 if metadata.revision == 1 and not metadata.published_at else metadata.revision
+        next_revision = expected_parent + 1
+        if force_full_checkpoint and not messagebox.askyesno(
+            "Publish Full Campaign",
+            f"Publish {campaign.name} revision {next_revision} as a complete standalone "
+            "checkpoint?\n\nThe archive will contain the campaign database and files and "
+            "will not require earlier revisions to install.",
+            parent=self,
+        ):
+            return
         coordinator = getattr(self.master, "_auto_publish_coordinator", None)
         if coordinator is not None:
-            expected_parent = 0 if metadata.revision == 1 and not metadata.published_at else metadata.revision
             coordinator.mark_dirty(
                 campaign_id=metadata.campaign_id, campaign_name=campaign.name,
                 campaign_root=campaign.root, database_path=campaign.db_path,
                 expected_parent_revision=expected_parent,
+                force_full_checkpoint=force_full_checkpoint,
             )
             coordinator.publish_now(metadata.campaign_id)
             return
 
-        title = f"{campaign.name} — Revision {metadata.revision + 1}"
+        title = f"{campaign.name} — Revision {next_revision}"
         summary = f"Saved campaign changes for {campaign.name}."
 
         def worker(callback):
@@ -800,6 +823,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 title=title.strip() or campaign.name,
                 change_summary=summary.strip() or None,
                 progress_callback=callback,
+                force_full_checkpoint=force_full_checkpoint,
             )
 
         def success(result):
@@ -1359,6 +1383,10 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
             pass
         try:
             self.publish_image_library_btn.configure(state=state)
+        except Exception:
+            pass
+        try:
+            self.publish_full_campaign_btn.configure(state=state)
         except Exception:
             pass
         try:

--- a/tests/generic/campaign_sync/test_auto_publish_coordinator.py
+++ b/tests/generic/campaign_sync/test_auto_publish_coordinator.py
@@ -1,6 +1,11 @@
 from queue import Queue
+from pathlib import Path
 
 from modules.generic.campaign_sync.auto_publish.coordinator import AutoPublishCoordinator
+from modules.generic.campaign_sync.auto_publish.models import OutboxEntry, PublicationJob
+from modules.generic.campaign_sync.auto_publish.worker import PublicationWorker
+from modules.generic.campaign_sync.change_detector import CampaignChangeResult, CampaignChangeState
+from modules.generic.campaign_sync.publisher import PublishOutcome
 
 
 class MemoryOutbox:
@@ -29,3 +34,52 @@ def test_configure_applies_saved_preferences_without_restart():
         assert coordinator.scheduler.maximum_interval == 90
     finally:
         coordinator.shutdown()
+
+
+def test_worker_preserves_forced_full_checkpoint_option():
+    calls = []
+
+    class Publisher:
+        def publish(self, *args, **kwargs):
+            calls.append(kwargs)
+            return type("Result", (), {"outcome": PublishOutcome.PUBLISHED, "revision": 8})()
+
+    worker = PublicationWorker(Publisher, Queue())
+    worker.run(PublicationJob(
+        "job", "campaign", "Campaign", Path("/campaign"), Path("/campaign/campaign.db"),
+        7, 1.0, 2.0, "Campaign — Revision 8", "summary",
+        force_full_checkpoint=True,
+    ))
+
+    assert calls[0]["force_full_checkpoint"] is True
+
+
+def test_clean_campaign_can_still_dispatch_requested_full_checkpoint():
+    jobs = []
+
+    class Outbox:
+        def remove(self, _campaign_id):
+            raise AssertionError("forced checkpoint was silently treated as a no-op")
+
+    class Detector:
+        def detect(self, *_args, **_kwargs):
+            return CampaignChangeResult(CampaignChangeState.CLEAN, "current-fingerprint")
+
+    class Worker(IdleWorker):
+        def run(self, job):
+            jobs.append(job)
+
+    coordinator = AutoPublishCoordinator(Outbox(), Worker(), detector=Detector())
+    try:
+        coordinator._prepare_and_run(
+            OutboxEntry(
+                "campaign", "Campaign", Path("/campaign"), Path("/campaign/campaign.db"),
+                7, 1.0, 2.0, force_full_checkpoint=True,
+            ),
+            force=True,
+        )
+    finally:
+        coordinator.shutdown()
+
+    assert len(jobs) == 1
+    assert jobs[0].force_full_checkpoint is True

--- a/tests/generic/campaign_sync/test_publisher.py
+++ b/tests/generic/campaign_sync/test_publisher.py
@@ -21,6 +21,7 @@ from modules.generic.campaign_sync.publisher import (
     PublishOutcome,
     StaleParentError,
 )
+from modules.generic.cross_campaign_asset_service import install_full_campaign_bundle
 
 
 class MockGallery:
@@ -91,6 +92,51 @@ def test_successful_sequential_publication(campaign, tmp_path):
     assert first.outcome is PublishOutcome.PUBLISHED and first.revision == 1
     assert second.outcome is PublishOutcome.PUBLISHED and second.revision == 2
     assert second.campaign_id == identity.campaign_id
+    with zipfile.ZipFile(io.BytesIO(second.release.archive_bytes)) as archive:
+        assert json.loads(archive.read("manifest.json"))["sync"]["snapshot_mode"] == "campaign_delta"
+
+
+def test_scheduled_checkpoint_is_full(campaign, tmp_path):
+    root, database = campaign
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery, checkpoint_interval=2)
+    publisher.enable(root, database_path=database)
+    publisher.publish(root, database_path=database)
+
+    result = publisher.publish(root, database_path=database)
+
+    with zipfile.ZipFile(io.BytesIO(result.release.archive_bytes)) as archive:
+        manifest = json.loads(archive.read("manifest.json"))
+    assert manifest["bundle_mode"] == "full_campaign"
+    assert manifest["sync"]["snapshot_mode"] == "full_campaign"
+
+
+def test_forced_checkpoint_at_incremental_revision_is_standalone(campaign, tmp_path):
+    root, database = campaign
+    (root / "gm_layouts.json").write_text('{"layout": "standalone"}', encoding="utf-8")
+    gallery = MockGallery()
+    publisher = _publisher(tmp_path, gallery, checkpoint_interval=10)
+    publisher.enable(root, database_path=database)
+    publisher.publish(root, database_path=database)
+
+    result = publisher.publish(
+        root, database_path=database, force_full_checkpoint=True
+    )
+
+    archive_path = tmp_path / "forced.zip"
+    archive_path.write_bytes(result.release.archive_bytes)
+    with zipfile.ZipFile(archive_path) as archive:
+        manifest = json.loads(archive.read("manifest.json"))
+        names = set(archive.namelist())
+    assert manifest["bundle_mode"] == "full_campaign"
+    assert manifest["sync"]["snapshot_mode"] == "full_campaign"
+    assert manifest["database"]["relative_path"] in names
+    extra = next(item for item in manifest["extra_files"] if item["relative_path"] == "gm_layouts.json")
+    assert extra["bundle_path"] in names
+
+    installed = install_full_campaign_bundle(archive_path, tmp_path / "installed")
+    assert installed.db_path.is_file()
+    assert (installed.root / "gm_layouts.json").read_text(encoding="utf-8") == '{"layout": "standalone"}'
 
 
 def test_release_digest_authenticates_archive_and_bundle_retains_uuid(campaign, tmp_path):

--- a/tests/ui/test_cross_campaign_full_publish.py
+++ b/tests/ui/test_cross_campaign_full_publish.py
@@ -1,0 +1,92 @@
+"""Unit contracts for the explicit full-campaign synchronization action."""
+
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import types
+
+if "cryptography.fernet" not in sys.modules:
+    cryptography = types.ModuleType("cryptography")
+    fernet = types.ModuleType("cryptography.fernet")
+    fernet.Fernet = object
+    fernet.InvalidToken = ValueError
+    cryptography.fernet = fernet
+    sys.modules.setdefault("cryptography", cryptography)
+    sys.modules.setdefault("cryptography.fernet", fernet)
+
+from modules.generic.campaign_sync.publisher import PublishOutcome
+import modules.generic.cross_campaign_asset_library as library
+
+
+def _window(*, can_publish=True):
+    window = object.__new__(library.CrossCampaignAssetLibraryWindow)
+    window.selected_campaign = SimpleNamespace(
+        name="Demo", root=Path("/campaign"), db_path=Path("/campaign/demo.db")
+    )
+    window.gallery_client = SimpleNamespace(can_publish=can_publish)
+    window.master = SimpleNamespace()
+    window._refresh_online_dialog = lambda: None
+    return window
+
+
+def test_full_publish_requires_campaign_and_credentials(monkeypatch):
+    messages = []
+    monkeypatch.setattr(library.messagebox, "showwarning", lambda *args, **kwargs: messages.append(args))
+    monkeypatch.setattr(library.messagebox, "showerror", lambda *args, **kwargs: messages.append(args))
+    window = _window()
+    window.selected_campaign = None
+    window.publish_full_campaign_to_github()
+    assert messages[-1][0] == "No Source"
+
+    window = _window(can_publish=False)
+    window.publish_full_campaign_to_github()
+    assert messages[-1][0] == "GitHub Token Required"
+
+
+def test_full_publish_cancellation_does_not_start_background_work(monkeypatch):
+    window = _window()
+    window.campaign_publisher = SimpleNamespace(
+        enable=lambda *_args, **_kwargs: SimpleNamespace(revision=4, published_at="yes")
+    )
+    called = []
+    window._run_progress_task = lambda *args, **kwargs: called.append((args, kwargs))
+    monkeypatch.setattr(library.messagebox, "askyesno", lambda *args, **kwargs: False)
+
+    window.publish_full_campaign_to_github()
+
+    assert called == []
+
+
+def test_full_publish_forwards_flag_and_reports_conflict_and_error(monkeypatch):
+    window = _window()
+    publish_calls = []
+    window.campaign_publisher = SimpleNamespace(
+        enable=lambda *_args, **_kwargs: SimpleNamespace(revision=4, published_at="yes"),
+        publish=lambda *args, **kwargs: publish_calls.append(kwargs) or SimpleNamespace(
+            outcome=PublishOutcome.CONFLICTED,
+            revision=5,
+            conflict_message="duplicate revision",
+        ),
+    )
+    monkeypatch.setattr(library.messagebox, "askyesno", lambda *args, **kwargs: True)
+    warnings = []
+    monkeypatch.setattr(library.messagebox, "showwarning", lambda *args, **kwargs: warnings.append(args))
+
+    def run(_title, worker, *_args, on_success, **_kwargs):
+        on_success(worker(lambda *_args: None))
+
+    window._run_progress_task = run
+    window.publish_full_campaign_to_github()
+    assert publish_calls[0]["force_full_checkpoint"] is True
+    assert warnings[-1] == ("Publication Conflict", "duplicate revision")
+
+    window.campaign_publisher.publish = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("upload failed"))
+    errors = []
+    window._run_progress_task = lambda _title, worker, *_args, **_kwargs: errors.append(worker)
+    window.publish_full_campaign_to_github()
+    try:
+        errors[0](lambda *_args: None)
+    except RuntimeError as exc:
+        assert str(exc) == "upload failed"
+    else:
+        raise AssertionError("publication error was swallowed")


### PR DESCRIPTION
### Motivation

- Provide a way to force a complete standalone campaign checkpoint on demand regardless of scheduled/checkpoint cadence. 
- Expose the capability in the UI as a clearly labelled full-campaign publish action that requires a source campaign and GitHub credentials.

### Description

- Added a keyword-only `force_full_checkpoint: bool = False` parameter to `CampaignPublisher.publish()` and used it in the existing checkpoint decision so the requested publication uses `snapshot_mode="full_campaign"` when set, while preserving campaign identity, revision increment, parent-revision validation, conflict handling, digest verification, and baseline advancement. 
- Propagated the option through the durable publication stack by adding `force_full_checkpoint` to `PublicationJob` and `OutboxEntry`, preserving it in `DurableOutbox.upsert()`, threading it through `AutoPublishCoordinator.mark_dirty()`/`_prepare_and_run()` and ensuring `PublicationWorker` calls `publish(..., force_full_checkpoint=...)`. 
- Updated the Cross-Campaign UI by renaming `Publish to GitHub…` to `Publish selected assets to GitHub…`, adding a `Publish full campaign to GitHub…` button/action that requires a selected source campaign and configured GitHub token, shows a confirmation describing the next revision as a standalone checkpoint, and either schedules coordinator work (with the flag) or invokes `CampaignPublisher.publish(..., force_full_checkpoint=True)` directly. 
- Added and updated tests to cover ordinary delta publications, scheduled full checkpoints, forced full publications at normally-incremental revisions, missing credentials and cancellation, conflict and publication error handling, and to verify that the forced archive uses `bundle_mode="full_campaign"`, `sync.snapshot_mode="full_campaign"`, contains the campaign database and files, and can be installed without earlier revisions.

### Testing

- Ran `pytest -q tests/generic/campaign_sync/test_publisher.py tests/generic/campaign_sync/test_auto_publish_coordinator.py tests/ui/test_cross_campaign_full_publish.py` and observed those test suites pass (16 tests for the combined invocation). 
- Ran `pytest -q tests/generic/campaign_sync` and observed 67 passed. 
- Performed `python -m compileall` over the modified modules and `git diff --check` to validate imports/formatting; those checks succeeded. 
- Noted wider `tests/ui` runs in the environment reported many passing tests with some unrelated pre-existing skips/failures due to test-environment stubs (Pillow/CustomTkinter), which are external to this change and did not indicate regressions in the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df6242758832bbdcef5dba31264d0)