### PR TITLE
Provide feedback and event handling for full-campaign GitHub publication

### DIFF
--- a/modules/generic/cross_campaign_asset_library.py
+++ b/modules/generic/cross_campaign_asset_library.py
@@ -41,6 +41,7 @@ from modules.generic.campaign_sync.publisher import (
     CampaignSyncLinkState,
     PublishOutcome,
 )
+from modules.generic.campaign_sync.auto_publish.models import EventKind, WorkerEvent
 from modules.helpers.config_helper import ConfigHelper
 from modules.helpers.checkbox_dialog import CheckboxDialog
 from modules.helpers.logging_helper import log_exception, log_info, log_warning
@@ -86,6 +87,7 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self.source_campaigns: List[CampaignDatabase] = []
         self.selected_campaign: CampaignDatabase | None = None
         self._preview_image = None
+        self._manual_publication_campaign_ids: set[str] = set()
 
         self._build_ui()
         self.refresh_campaign_list()
@@ -810,7 +812,24 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
                 expected_parent_revision=expected_parent,
                 force_full_checkpoint=force_full_checkpoint,
             )
-            coordinator.publish_now(metadata.campaign_id)
+            if not coordinator.publish_now(metadata.campaign_id):
+                messagebox.showerror(
+                    "Publication Not Started",
+                    "The campaign could not be queued for publication. It may already be "
+                    "publishing, or campaign synchronization may be in offline mode.",
+                    parent=self,
+                )
+                return
+            pending = getattr(self, "_manual_publication_campaign_ids", None)
+            if pending is None:
+                pending = self._manual_publication_campaign_ids = set()
+            pending.add(metadata.campaign_id)
+            messagebox.showinfo(
+                "Publication Started",
+                f"{campaign.name} revision {next_revision} is being published to GitHub in "
+                "the background. You will be notified when it finishes.",
+                parent=self,
+            )
             return
 
         title = f"{campaign.name} — Revision {next_revision}"
@@ -835,6 +854,25 @@ class CrossCampaignAssetLibraryWindow(ctk.CTkToplevel):
         self._run_progress_task(
             "Publishing Campaign Update", worker, None, None, on_success=success, modal=False
         )
+
+    def handle_auto_publish_event(self, event: WorkerEvent) -> None:
+        """Report completion of a publication explicitly started from this window."""
+        pending = getattr(self, "_manual_publication_campaign_ids", set())
+        if event.campaign_id not in pending or not event.terminal:
+            return
+        pending.discard(event.campaign_id)
+        if event.kind is EventKind.SUCCESS:
+            messagebox.showinfo("Campaign Published", event.message, parent=self)
+            self._refresh_online_dialog()
+        elif event.kind is EventKind.CONFLICT:
+            messagebox.showwarning(
+                "Publication Conflict", event.message or "Remote revision conflict", parent=self
+            )
+        else:
+            messagebox.showerror(
+                "Publication Failed", event.message or "The campaign could not be published.",
+                parent=self,
+            )
 
     def check_campaign_updates(self):
         if not self.selected_campaign:

--- a/tests/ui/test_cross_campaign_full_publish.py
+++ b/tests/ui/test_cross_campaign_full_publish.py
@@ -15,6 +15,7 @@ if "cryptography.fernet" not in sys.modules:
     sys.modules.setdefault("cryptography.fernet", fernet)
 
 from modules.generic.campaign_sync.publisher import PublishOutcome
+from modules.generic.campaign_sync.auto_publish.models import EventKind, SyncState, WorkerEvent
 import modules.generic.cross_campaign_asset_library as library
 
 
@@ -90,3 +91,50 @@ def test_full_publish_forwards_flag_and_reports_conflict_and_error(monkeypatch):
         assert str(exc) == "upload failed"
     else:
         raise AssertionError("publication error was swallowed")
+
+
+def test_full_publish_with_coordinator_reports_start_and_completion(monkeypatch):
+    window = _window()
+    metadata = SimpleNamespace(campaign_id="campaign-1", revision=4, published_at="yes")
+    window.campaign_publisher = SimpleNamespace(enable=lambda *_args, **_kwargs: metadata)
+    coordinator = SimpleNamespace(mark_dirty=lambda **_kwargs: None, publish_now=lambda _id: True)
+    window.master._auto_publish_coordinator = coordinator
+    monkeypatch.setattr(library.messagebox, "askyesno", lambda *args, **kwargs: True)
+    notices = []
+    monkeypatch.setattr(
+        library.messagebox, "showinfo", lambda *args, **kwargs: notices.append(args)
+    )
+
+    window.publish_full_campaign_to_github()
+    assert notices[-1][0] == "Publication Started"
+
+    window.handle_auto_publish_event(
+        WorkerEvent(
+            "job-1",
+            "campaign-1",
+            1,
+            EventKind.SUCCESS,
+            SyncState.SYNCHRONIZED,
+            "Revision 5 published",
+            terminal=True,
+        )
+    )
+    assert notices[-1] == ("Campaign Published", "Revision 5 published")
+
+
+def test_full_publish_reports_when_coordinator_rejects_dispatch(monkeypatch):
+    window = _window()
+    metadata = SimpleNamespace(campaign_id="campaign-1", revision=4, published_at="yes")
+    window.campaign_publisher = SimpleNamespace(enable=lambda *_args, **_kwargs: metadata)
+    window.master._auto_publish_coordinator = SimpleNamespace(
+        mark_dirty=lambda **_kwargs: None, publish_now=lambda _id: False
+    )
+    monkeypatch.setattr(library.messagebox, "askyesno", lambda *args, **kwargs: True)
+    errors = []
+    monkeypatch.setattr(
+        library.messagebox, "showerror", lambda *args, **kwargs: errors.append(args)
+    )
+
+    window.publish_full_campaign_to_github()
+
+    assert errors[-1][0] == "Publication Not Started"


### PR DESCRIPTION
### Motivation
- The "Publish full campaign to GitHub" action could be silently ignored when the background auto-publish coordinator refused the request, leaving users with no feedback.
- Manually-initiated publications should not produce confusing dialogs from unrelated automatic sync events.
- The UI should notify the user when a manual background publish is started and when it completes, conflicts, or fails.

### Description
- Import `EventKind` and `WorkerEvent` and add a `self._manual_publication_campaign_ids` set to `modules/generic/cross_campaign_asset_library.py` to track manual publish requests.
- In `publish_full_campaign_to_github`, check the return value of `coordinator.publish_now(...)` and show an error dialog when the coordinator rejects the dispatch, and show an immediate "Publication Started" info dialog when the request is accepted.
- Add `handle_auto_publish_event(self, event: WorkerEvent)` to report completion for campaign IDs in the manual-pending set and display success, conflict, or error dialogs and refresh the online dialog accordingly.
- Add unit tests in `tests/ui/test_cross_campaign_full_publish.py` covering accepted dispatch + completion handling and coordinator rejection feedback.

### Testing
- Ran `pytest -q tests/ui/test_cross_campaign_full_publish.py`, which passed the new and existing tests in that file.
- Ran a combined subset `pytest -q tests/generic/campaign_sync tests/ui/test_campaign_sync_menu.py tests/ui/test_cross_campaign_full_publish.py` and observed the test subset passing (`73` tests passed in this run).
- Ran `python -m compileall` on the modified modules and tests, which succeeded.
- Running `pytest -q` for the entire repo stopped due to unrelated, suite-wide test isolation/collection errors in this environment (duplicate test-module basenames and mocked UI modules leaking between tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df935a3a8832bb756811726883598)