### PR TITLE
Add Surface-compatible pointer pan (right-button) navigation to GM Table

### DIFF
--- a/modules/scenarios/gm_table/pointer_navigation.py
+++ b/modules/scenarios/gm_table/pointer_navigation.py
@@ -1,0 +1,40 @@
+"""Pointer gesture state for GM Table camera navigation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+RIGHT_DRAG_THRESHOLD = 8
+
+
+@dataclass(slots=True)
+class RightDragGesture:
+    """Track whether a right-button press has become a camera drag."""
+
+    threshold: int = RIGHT_DRAG_THRESHOLD
+    press_position: tuple[int, int] | None = None
+    dragging: bool = False
+
+    def begin(self, x: int, y: int) -> None:
+        """Remember a right-button press without consuming its context click."""
+        self.press_position = (int(x), int(y))
+        self.dragging = False
+
+    def update(self, x: int, y: int) -> bool:
+        """Return whether movement has crossed the camera-drag threshold."""
+        if self.press_position is None:
+            return False
+        press_x, press_y = self.press_position
+        if not self.dragging:
+            delta_x = int(x) - press_x
+            delta_y = int(y) - press_y
+            self.dragging = (delta_x * delta_x) + (delta_y * delta_y) >= self.threshold**2
+        return self.dragging
+
+    def finish(self) -> bool:
+        """Reset the gesture and return whether it became a drag."""
+        was_dragging = self.dragging
+        self.press_position = None
+        self.dragging = False
+        return was_dragging

--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -12,6 +12,7 @@ from modules.helpers import theme_manager
 from modules.helpers.logging_helper import log_warning
 from modules.scenarios.gm_table.desk_texture import InfiniteDeskTexture
 from modules.scenarios.gm_table.drag_controller import GMTableDragController
+from modules.scenarios.gm_table.pointer_navigation import RightDragGesture
 from modules.scenarios.gm_table.window_hit_testing import point_inside_map_tool
 from modules.scenarios.gm_table.layout import fit_content_minimum, fit_viewport_snap
 from modules.scenarios.gm_table.layout.window_spacing import (
@@ -1415,8 +1416,9 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._bookmarks: list[dict[str, object]] = []
         self._pan_origin: tuple[int, int, float, float] | None = None
         self._minimap_projection: dict[str, float] | None = None
-        self._surface_pan_binding_target = None
-        self._surface_pan_binding_ids: dict[str, str] = {}
+        self._pointer_pan_binding_target = None
+        self._pointer_pan_binding_ids: dict[str, str] = {}
+        self._right_drag_gesture = RightDragGesture()
         self._desk_annotation_tool: str | None = None
         self._desk_annotations: list[dict[str, object]] = []
         self._desk_draw_points: list[tuple[float, float]] = []
@@ -1815,7 +1817,7 @@ class GMTableWorkspace(ctk.CTkFrame):
             widget.bind("<Control-MouseWheel>", self._zoom_surface, add="+")
             widget.bind("<Button-1>", lambda _event: self.surface.focus_set(), add="+")
             widget.bind("<Home>", self._handle_home_shortcut, add="+")
-        self._bind_workspace_middle_pan()
+        self._bind_workspace_pointer_pan()
         try:
             self.surface.configure(cursor="fleur")
         except Exception:
@@ -1990,9 +1992,9 @@ class GMTableWorkspace(ctk.CTkFrame):
                 )
         canvas.tag_raise("desk_annotation")
 
-    def _bind_workspace_middle_pan(self) -> None:
-        """Bind middle-button camera pan to the containing window."""
-        self._unbind_workspace_middle_pan()
+    def _bind_workspace_pointer_pan(self) -> None:
+        """Bind desktop and Surface camera pan gestures to the containing window."""
+        self._unbind_workspace_pointer_pan()
         try:
             target = self.winfo_toplevel()
         except Exception:
@@ -2004,6 +2006,9 @@ class GMTableWorkspace(ctk.CTkFrame):
             ("<ButtonPress-2>", self._start_surface_pan),
             ("<B2-Motion>", self._pan_surface_to),
             ("<ButtonRelease-2>", self._stop_surface_pan),
+            ("<ButtonPress-3>", self._start_surface_pan),
+            ("<B3-Motion>", self._pan_surface_to),
+            ("<ButtonRelease-3>", self._stop_surface_pan),
         ):
             try:
                 binding_id = target.bind(sequence, handler, add="+")
@@ -2011,8 +2016,8 @@ class GMTableWorkspace(ctk.CTkFrame):
                 continue
             if binding_id:
                 binding_ids[sequence] = binding_id
-        self._surface_pan_binding_target = target
-        self._surface_pan_binding_ids = binding_ids
+        self._pointer_pan_binding_target = target
+        self._pointer_pan_binding_ids = binding_ids
 
     def _pointer_is_inside_map_tool(self, screen_x: int, screen_y: int) -> bool:
         """Return whether the screen pointer is inside an open MapTool panel."""
@@ -2029,24 +2034,24 @@ class GMTableWorkspace(ctk.CTkFrame):
             map_tool_window=map_tool_window,
         )
 
-    def _unbind_workspace_middle_pan(self) -> None:
-        """Remove any middle-button pan bindings registered on the window."""
-        target = getattr(self, "_surface_pan_binding_target", None)
-        binding_ids = dict(getattr(self, "_surface_pan_binding_ids", {}) or {})
+    def _unbind_workspace_pointer_pan(self) -> None:
+        """Remove any pointer pan bindings registered on the window."""
+        target = getattr(self, "_pointer_pan_binding_target", None)
+        binding_ids = dict(getattr(self, "_pointer_pan_binding_ids", {}) or {})
         for sequence, binding_id in binding_ids.items():
             try:
                 target.unbind(sequence, binding_id)
             except Exception:
                 pass
-        self._surface_pan_binding_target = None
-        self._surface_pan_binding_ids = {}
+        self._pointer_pan_binding_target = None
+        self._pointer_pan_binding_ids = {}
 
     def _handle_workspace_destroy(self, event=None) -> None:
         """Release toplevel pan bindings when the workspace is destroyed."""
         if event is not None and getattr(event, "widget", None) is not self:
             return
         self._stop_surface_pan()
-        self._unbind_workspace_middle_pan()
+        self._unbind_workspace_pointer_pan()
 
     def _widget_is_in_surface_subtree(self, widget) -> bool:
         """Return whether a widget belongs to this workspace surface."""
@@ -2277,20 +2282,32 @@ class GMTableWorkspace(ctk.CTkFrame):
     def _start_surface_pan(self, event) -> None:
         """Start panning the infinite desk."""
         widget = getattr(event, "widget", None)
-        is_middle_button = int(getattr(event, "num", 0) or 0) == 2
+        button = int(getattr(event, "num", 0) or 0)
+        is_navigation_button = button in {2, 3}
+        right_drag = getattr(self, "_right_drag_gesture", None)
+        if button == 3 and right_drag is not None:
+            # A fresh press must never inherit state from a release that the
+            # window did not receive (for example after focus moved away).
+            right_drag.finish()
         if widget is not self.surface and widget is not self._empty_state:
-            if not is_middle_button or not self._widget_is_in_surface_subtree(widget):
+            if not is_navigation_button or not self._widget_is_in_surface_subtree(widget):
                 return
-        if is_middle_button:
+        if is_navigation_button:
             drag_controller = getattr(self, "_drag_controller", None)
-            allows_middle_drag = (
+            allows_navigation_drag = (
                 drag_controller.allows_middle_drag_start(event)
                 if drag_controller is not None
                 else True
             )
-            if not allows_middle_drag:
+            if not allows_navigation_drag:
                 self._pan_origin = None
-                return "break"
+                return "break" if button == 2 else None
+            if button == 3:
+                if right_drag is None:
+                    right_drag = self._right_drag_gesture = RightDragGesture()
+                right_drag.begin(event.x_root, event.y_root)
+                self.surface.focus_set()
+                return None
             self._pin_snapped_panels_to_world()
         self.surface.focus_set()
         self._pan_origin = (
@@ -2302,6 +2319,19 @@ class GMTableWorkspace(ctk.CTkFrame):
 
     def _pan_surface_to(self, event) -> None:
         """Pan the camera with the active drag gesture."""
+        gesture = getattr(self, "_right_drag_gesture", None)
+        if gesture is not None and gesture.press_position is not None:
+            if not gesture.update(event.x_root, event.y_root):
+                return None
+            if self._pan_origin is None:
+                root_x, root_y = gesture.press_position
+                self._pin_snapped_panels_to_world()
+                self._pan_origin = (
+                    root_x,
+                    root_y,
+                    _coerce_float(getattr(self, "_camera_x", 0.0)),
+                    _coerce_float(getattr(self, "_camera_y", 0.0)),
+                )
         if self._pan_origin is None:
             return
         root_x, root_y, start_x, start_y = self._pan_origin
@@ -2310,10 +2340,19 @@ class GMTableWorkspace(ctk.CTkFrame):
             x=start_x - ((event.x_root - root_x) / zoom),
             y=start_y - ((event.y_root - root_y) / zoom),
         )
+        if gesture is not None and gesture.dragging:
+            return "break"
 
-    def _stop_surface_pan(self, _event=None) -> None:
+    def _stop_surface_pan(self, event=None) -> None:
         """Finish a camera pan gesture."""
         self._pan_origin = None
+        gesture = getattr(self, "_right_drag_gesture", None)
+        if gesture is not None and (
+            gesture.press_position is not None or gesture.dragging
+        ):
+            was_right_drag = gesture.finish()
+            if was_right_drag and int(getattr(event, "num", 3) or 3) == 3:
+                return "break"
 
     def _zoom_surface(self, event):
         """Zoom the desk around the cursor position."""
@@ -2649,7 +2688,7 @@ class GMTableWorkspace(ctk.CTkFrame):
         self._disposed = True
         self._layout_changed_callback = None
         self._stop_surface_pan()
-        self._unbind_workspace_middle_pan()
+        self._unbind_workspace_pointer_pan()
         self.clear_snap_preview()
         if self._save_job is not None:
             try:

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -7,6 +7,7 @@ import tkinter as tk
 from types import SimpleNamespace
 
 from modules.scenarios.gm_table.layout import fit_viewport_snap
+from modules.scenarios.gm_table.pointer_navigation import RightDragGesture
 from modules.scenarios.gm_table.workspace import (
     PANEL_GUTTER,
     PANEL_MARGIN,
@@ -1309,16 +1310,16 @@ def test_zoom_surface_updates_camera_when_pan_is_inactive() -> None:
     assert workspace._camera_zoom > 1.0
 
 
-def test_bind_surface_navigation_registers_middle_pan_on_workspace_toplevel() -> None:
-    """Middle-button pan should be scoped to this workspace via the containing toplevel."""
+def test_bind_surface_navigation_registers_pointer_pan_on_workspace_toplevel() -> None:
+    """Both navigation buttons should be scoped via the containing toplevel."""
     workspace = GMTableWorkspace.__new__(GMTableWorkspace)
     surface = _FakeWidgetNode()
     empty_state = _FakeWidgetNode(master=surface)
     toplevel = _FakeBindingTarget()
     workspace.surface = surface
     workspace._empty_state = empty_state
-    workspace._surface_pan_binding_target = None
-    workspace._surface_pan_binding_ids = {}
+    workspace._pointer_pan_binding_target = None
+    workspace._pointer_pan_binding_ids = {}
     workspace.winfo_toplevel = lambda: toplevel
 
     GMTableWorkspace._bind_surface_navigation(workspace)
@@ -1343,6 +1344,9 @@ def test_bind_surface_navigation_registers_middle_pan_on_workspace_toplevel() ->
         "<ButtonPress-2>",
         "<B2-Motion>",
         "<ButtonRelease-2>",
+        "<ButtonPress-3>",
+        "<B3-Motion>",
+        "<ButtonRelease-3>",
     }
 
     GMTableWorkspace._handle_workspace_destroy(
@@ -1353,7 +1357,104 @@ def test_bind_surface_navigation_registers_middle_pan_on_workspace_toplevel() ->
         "<ButtonPress-2>",
         "<B2-Motion>",
         "<ButtonRelease-2>",
+        "<ButtonPress-3>",
+        "<B3-Motion>",
+        "<ButtonRelease-3>",
     }
+
+
+def test_right_drag_gesture_requires_eight_pixels_of_travel() -> None:
+    """Small pointer jitter should not turn a right click into navigation."""
+    gesture = RightDragGesture()
+    gesture.begin(100, 100)
+
+    assert gesture.update(105, 105) is False
+    assert gesture.update(108, 100) is True
+    assert gesture.finish() is True
+
+
+def test_stationary_right_click_is_not_consumed() -> None:
+    """A right press/release without travel should remain available to context menus."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace.surface = _FakeWidgetNode()
+    workspace._empty_state = _FakeWidgetNode(master=workspace.surface)
+    workspace._camera_x = 40.0
+    workspace._camera_y = 24.0
+    workspace._pan_origin = None
+    workspace._panels = {}
+    workspace._right_drag_gesture = RightDragGesture()
+
+    press_result = GMTableWorkspace._start_surface_pan(
+        workspace,
+        SimpleNamespace(widget=workspace.surface, num=3, x_root=120, y_root=160),
+    )
+    release_result = GMTableWorkspace._stop_surface_pan(
+        workspace, SimpleNamespace(num=3)
+    )
+
+    assert press_result is None
+    assert release_result is None
+    assert workspace._pan_origin is None
+
+
+def test_right_drag_moves_camera_only_after_threshold_and_consumes_release() -> None:
+    """Surface-style right drag should pan only once its intentional movement is clear."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    _prepare_workspace(workspace, camera_x=100.0, camera_y=80.0)
+    workspace.surface = _FakeWidgetNode()
+    workspace.surface.winfo_width = lambda: 1400
+    workspace.surface.winfo_height = lambda: 900
+    workspace._empty_state = _FakeWidgetNode(master=workspace.surface)
+    workspace._panels = {}
+    workspace._pan_origin = None
+    workspace._right_drag_gesture = RightDragGesture()
+    workspace.clear_snap_preview = lambda: None
+    workspace.clamp_panels = lambda: None
+
+    GMTableWorkspace._start_surface_pan(
+        workspace,
+        SimpleNamespace(widget=workspace.surface, num=3, x_root=200, y_root=200),
+    )
+    small_motion = GMTableWorkspace._pan_surface_to(
+        workspace, SimpleNamespace(x_root=207, y_root=200)
+    )
+    camera_after_small_motion = (workspace._camera_x, workspace._camera_y)
+    drag_motion = GMTableWorkspace._pan_surface_to(
+        workspace, SimpleNamespace(x_root=212, y_root=200)
+    )
+    release = GMTableWorkspace._stop_surface_pan(workspace, SimpleNamespace(num=3))
+
+    assert small_motion is None
+    assert camera_after_small_motion == (100.0, 80.0)
+    assert workspace._camera_x == 88.0
+    assert workspace._camera_y == 80.0
+    assert drag_motion == "break"
+    assert release == "break"
+
+
+def test_navigation_buttons_do_not_pan_inside_map_tool() -> None:
+    """MapTool's interactive content should own both middle and right drags."""
+    workspace = GMTableWorkspace.__new__(GMTableWorkspace)
+    workspace.surface = _FakeWidgetNode()
+    nested = _FakeWidgetNode(master=workspace.surface)
+    workspace._empty_state = _FakeWidgetNode(master=workspace.surface)
+    workspace._pan_origin = None
+    workspace._right_drag_gesture = RightDragGesture()
+    workspace._drag_controller = SimpleNamespace(
+        allows_middle_drag_start=lambda _event: False
+    )
+
+    middle_result = GMTableWorkspace._start_surface_pan(
+        workspace, SimpleNamespace(widget=nested, num=2, x_root=30, y_root=40)
+    )
+    right_result = GMTableWorkspace._start_surface_pan(
+        workspace, SimpleNamespace(widget=nested, num=3, x_root=30, y_root=40)
+    )
+
+    assert middle_result == "break"
+    assert right_result is None
+    assert workspace._pan_origin is None
+    assert workspace._right_drag_gesture.press_position is None
 
 
 def test_zoom_changes_projection_but_keeps_widget_size_constant() -> None:


### PR DESCRIPTION
### Motivation
- Enable Surface-style right-button camera navigation in addition to the existing middle-button desktop navigation so pointer-based devices can pan the GM Table.
- Preserve existing middle-button behavior and MapTool drag exclusion while preventing accidental context-menu activation during intentional right-button drags.
- Keep right-click context menus working for stationary right-clicks by introducing a small movement threshold before consuming the event.

### Description
- Added `modules/scenarios/gm_table/pointer_navigation.py` with `RightDragGesture` to track right-press position and an ~8-pixel drag threshold.
- Replaced `_bind_workspace_middle_pan()` with `_bind_workspace_pointer_pan()` and registered both button-2 (`<ButtonPress-2>`, `<B2-Motion>`, `<ButtonRelease-2>`) and button-3 (`<ButtonPress-3>`, `<B3-Motion>`, `<ButtonRelease-3>`) sequences on the toplevel binding target, and renamed internal attributes to device-neutral names (`_pointer_pan_binding_*`).
- Updated `_start_surface_pan()`, `_pan_surface_to()`, and `_stop_surface_pan()` to treat `event.num` values `2` and `3` as navigation buttons, to use the new `RightDragGesture` for right-button presses, to delay camera movement until the threshold is crossed, and to return `"break"` on right-button release when a drag was performed to suppress the context menu.
- Applied the existing `GMTableDragController`/MapTool exclusion to both navigation buttons so interactive MapTool content can still capture drags, and ensured unbinding/destruction paths remove both button-2 and button-3 bindings.
- Extended `tests/scenarios/gm_table/test_workspace.py` to assert registration and removal of button-3 bindings and to add unit tests for the `RightDragGesture`, stationary right-click preservation, thresholded right-button panning, MapTool exclusion behavior, and unchanged middle-button pan behavior.

### Testing
- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py -k 'pointer_pan or right_drag or stationary_right or navigation_buttons or middle_button_pan or workspace_destroy'` which reported `7 passed, 47 deselected`.
- Ran `python -m pytest tests/scenarios/gm_table/test_workspace.py -q -k 'not mount_payload_widget'` which reported `52 passed, 2 deselected`.
- Ran `python -m pytest tests/scenarios/test_gm_table_middle_drag_hit_testing.py -q` which reported `6 passed` and `python -m compileall -q modules/scenarios/gm_table tests/scenarios/gm_table/test_workspace.py` which completed without compile errors.
- Performed `git diff --check` and static checks; note that a full run of `pytest tests/scenarios/gm_table/test_workspace.py` in the headless CI showed `52 passed` with `2` real-widget geometry tests unable to initialize due to missing `$DISPLAY`, and unrelated collection issues exist when running the entire suite with certain stubs present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f26ba1ae0832b9efae27906ce470d)