### PR TITLE
Align Scenario Board title to the right

### DIFF
--- a/modules/scenarios/gm_table/workspace.py
+++ b/modules/scenarios/gm_table/workspace.py
@@ -99,6 +99,12 @@ DEFAULT_PANEL_SIZES = {
     "sticky_note": (360, 300),
 }
 
+
+def resolve_panel_title_anchor(panel_kind: str) -> str:
+    """Return the header title alignment for a GM Table panel kind."""
+    return "e" if panel_kind == "scenario_board" else "w"
+
+
 PANEL_MARGIN = 12
 PANEL_GUTTER = 12
 PANEL_SNAP_THRESHOLD = 48
@@ -872,7 +878,7 @@ class GMTablePanel(ctk.CTkFrame):
             text=self.definition.title,
             text_color=skin.title_color,
             font=ctk.CTkFont(size=13, weight="bold"),
-            anchor="w",
+            anchor=resolve_panel_title_anchor(self.definition.kind),
         )
         padx_title = (12, 4) if not self._show_eyebrow else (0, 4)
         self.title_label.pack(side="left", padx=padx_title, pady=5, fill="x", expand=True)

--- a/tests/scenarios/gm_table/test_workspace.py
+++ b/tests/scenarios/gm_table/test_workspace.py
@@ -20,7 +20,14 @@ from modules.scenarios.gm_table.workspace import (
     _resize_geometry,
     _resolve_snap_mode,
     _snap_geometry,
+    resolve_panel_title_anchor,
 )
+
+
+def test_scenario_board_header_title_is_right_aligned() -> None:
+    """Scenario titles should sit on the right without changing other panels."""
+    assert resolve_panel_title_anchor("scenario_board") == "e"
+    assert resolve_panel_title_anchor("scene_flow") == "w"
 
 
 class _FakePanel:


### PR DESCRIPTION
### Motivation

- The Scenario Board header title needs to be right-aligned to match the intended UI layout while preserving left alignment for other panel types.

### Description

- Add `resolve_panel_title_anchor(panel_kind: str) -> str` in `modules/scenarios/gm_table/workspace.py` to centralize header title alignment logic.
- Replace the hardcoded `anchor="w"` on the panel title label with `anchor=resolve_panel_title_anchor(self.definition.kind)` so `scenario_board` uses `"e"` and other panels default to `"w"`.
- Add `test_scenario_board_header_title_is_right_aligned` in `tests/scenarios/gm_table/test_workspace.py` to assert the anchor for `scenario_board` is `"e"` and for another panel (`scene_flow`) remains `"w"`.
- Preserve existing behavior for all other panels and maintain UI packing (`pack`) logic unchanged.

### Testing

- Ran `pytest -q tests/scenarios/gm_table/test_workspace.py::test_scenario_board_header_title_is_right_aligned` and the test passed.
- Ran `python -m compileall -q modules/scenarios/gm_table/workspace.py tests/scenarios/gm_table/test_workspace.py` and compilation succeeded.
- Ran `git diff --check` and no whitespace or diff issues were reported.
- Ran the full GM table test module `pytest -q tests/scenarios/gm_table/test_workspace.py` which produced 53 passed tests and 2 UI/Tk tests that could not run in this headless environment due to missing `$DISPLAY`.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f2a5d5f8c832b93e0e17c2e12f95f)