### PR TITLE
Improve directive readability in Scenario Board and add regression test

### DIFF
--- a/modules/scenarios/gm_table/scenario_board/page.py
+++ b/modules/scenarios/gm_table/scenario_board/page.py
@@ -221,23 +221,34 @@ class ScenarioBoardPanel(ctk.CTkFrame):
         start = 0
         for (title, value, accent), span in zip(directives, spans):
             text = f"{title}  {value or '—'}"
-            ctk.CTkLabel(
+            cell = ctk.CTkFrame(
                 parent,
-                text=text,
-                anchor="w",
-                justify="left",
-                wraplength=380,
                 fg_color=self._palette.surface,
-                text_color=self._palette.section_accents[accent],
-                font=ctk.CTkFont(size=10, weight="bold"),
-                height=34,
-            ).grid(
+                corner_radius=0,
+            )
+            cell.grid(
                 row=row,
                 column=start,
                 columnspan=span,
                 sticky="nsew",
                 pady=(0, 8),
                 padx=(0, 2),
+            )
+            directive = ctk.CTkLabel(
+                cell,
+                text=text,
+                anchor="w",
+                justify="left",
+                fg_color=self._palette.surface,
+                text_color=self._palette.section_accents[accent],
+                font=ctk.CTkFont(size=14, weight="bold"),
+                height=34,
+            )
+            directive.pack(fill="both", expand=True, padx=8, pady=4)
+            bind_full_width_wrap(
+                directive,
+                padding=16,
+                initial_wraplength=420,
             )
             start += span
         return row + 1

--- a/tests/scenarios/gm_table/test_scenario_board.py
+++ b/tests/scenarios/gm_table/test_scenario_board.py
@@ -1411,6 +1411,67 @@ def test_scenario_board_reference_content_uses_regular_weight(monkeypatch) -> No
     assert villain.options["text_color"] == "#FF5C5C"
 
 
+def test_scenario_board_directives_fill_their_cells_with_readable_text(
+    monkeypatch,
+) -> None:
+    """Secret and pressure copy should wrap to the complete half-width cell."""
+    from modules.scenarios.gm_table.scenario_board import page
+
+    widgets = []
+    wrap_calls = []
+
+    class _Widget:
+        def __init__(self, master=None, **kwargs):
+            self.master = master
+            self.options = kwargs
+            self.pack_options = None
+            widgets.append(self)
+
+        def grid(self, **_kwargs):
+            return None
+
+        def pack(self, **kwargs):
+            self.pack_options = kwargs
+
+    monkeypatch.setattr(page.ctk, "CTkFrame", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkLabel", _Widget)
+    monkeypatch.setattr(page.ctk, "CTkFont", lambda **kwargs: kwargs)
+    monkeypatch.setattr(
+        page,
+        "bind_full_width_wrap",
+        lambda label, **kwargs: wrap_calls.append((label, kwargs)),
+    )
+
+    panel = object.__new__(page.ScenarioBoardPanel)
+    panel._data = build_scenario_board_data(
+        {"Secrets": "The patron is lying.", "Stakes": "The city will fall."}
+    )
+    panel._palette = SimpleNamespace(
+        surface="#111111",
+        section_accents={"secret": "#22AA66", "pressure": "#CC5533"},
+    )
+
+    panel._add_directives(_Widget(), 0)
+
+    labels = [widget for widget in widgets if widget.options.get("anchor") == "w"]
+    assert len(labels) == 2
+    assert all(label.options["font"] == {"size": 14, "weight": "bold"} for label in labels)
+    assert all(
+        label.pack_options == {
+            "fill": "both",
+            "expand": True,
+            "padx": 8,
+            "pady": 4,
+        }
+        for label in labels
+    )
+    assert [call[0] for call in wrap_calls] == labels
+    assert all(
+        options == {"padding": 16, "initial_wraplength": 420}
+        for _label, options in wrap_calls
+    )
+
+
 def test_full_width_wrap_uses_parent_width_without_configure_feedback() -> None:
     """Wrapping must not bind to the label and continuously resize itself."""
     from modules.scenarios.gm_table.scenario_board.entity_links import (


### PR DESCRIPTION
### Motivation

- Directive text in the Secret/Pressure area was constrained to a small wrap box and used a small font, making it hard to read. The change aims to let these directives fill their available half-width cells and improve legibility.

### Description

- Replace the direct `CTkLabel(...).grid(...)` usage with a `CTkFrame` cell and an inner `CTkLabel` that is packed with `fill="both"` and `expand=True` so directive text occupies the full cell (`modules/scenarios/gm_table/scenario_board/page.py`).
- Increase directive font size from 10 to 14 and make it bold by using `CTkFont(size=14, weight="bold")` for better readability (`modules/scenarios/gm_table/scenario_board/page.py`).
- Add a call to `bind_full_width_wrap` with `padding=16` and `initial_wraplength=420` so the label dynamically wraps to the available width (`modules/scenarios/gm_table/scenario_board/page.py`).
- Add a regression unit test `test_scenario_board_directives_fill_their_cells_with_readable_text` to verify the labels are created with the new font, packing options, and that `bind_full_width_wrap` is invoked (`tests/scenarios/gm_table/test_scenario_board.py`).

### Testing

- A focused unit test was added at `tests/scenarios/gm_table/test_scenario_board.py::test_scenario_board_directives_fill_their_cells_with_readable_text` to assert font size, packing, and wrap binding for the directives.
- The code changes were committed successfully (`git commit` completed). No end-to-end GUI screenshot tests were performed because this environment has no `DISPLAY`/`xvfb-run`.
- No full test-suite `pytest -q` execution was completed in this rollout due to environment/test-harness limitations; please run `python -m pytest tests/scenarios/gm_table/test_scenario_board.py -q` locally or in CI to validate the new test and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f4d59c240832baf9731ae01810ddf)