### PR TITLE
Support des tokens vidéo animés avec gestion centralisée du décodage et de l’animation

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -44,6 +44,8 @@ from modules.maps.services.token_manager import (
     normalize_existing_token_paths,
     _extract_entity_defense_value,
 )  # Keep this if it's used by other token_manager functions not moved
+from modules.maps.media import TokenAnimationManager, detect_media_type, load_thumbnail
+from modules.maps.media.tokens import register_token_animation
 from modules.maps.views.fullscreen_view import open_fullscreen, _update_fullscreen_map
 from modules.maps.views.web_display_view import (
     close_web_display,
@@ -437,6 +439,10 @@ class DisplayMapController:
     def close(self):
         """Cancel controller-owned deferred work before the host is torn down."""
         self._cancel_deferred_map_open()
+        manager = getattr(self, "_token_animation_manager", None)
+        if manager:
+            manager.close()
+            self._token_animation_manager = None
         canvas = getattr(self, "canvas", None)
         for attr_name in (
             "_marker_after_id",
@@ -445,6 +451,40 @@ class DisplayMapController:
             "_zoom_final_after_id",
         ):
             self._cancel_after_job(canvas, attr_name)
+
+    def _ensure_token_animation_manager(self):
+        """Create the single animation scheduler after the canvas exists."""
+        manager = getattr(self, "_token_animation_manager", None)
+        if manager is None and getattr(self, "canvas", None) is not None:
+            manager = TokenAnimationManager(self.canvas, self._display_token_frame)
+            self._token_animation_manager = manager
+        return manager
+
+    def _display_token_frame(self, token, frame):
+        """Replace just one token's canvas images on Tk's thread."""
+        if token not in self.tokens:
+            return
+        size = max(1, int(token.get("size", self.token_size)))
+        token["source_image"] = frame
+        token["pil_image"] = frame.resize((size, size), Image.Resampling.LANCZOS)
+        scaled = token["pil_image"].resize(
+            (max(1, int(size * self.zoom)), max(1, int(size * self.zoom))),
+            self._fast_resample,
+        )
+        photo = ImageTk.PhotoImage(scaled)
+        token["tk_image"] = photo
+        ids = token.get("canvas_ids") or ()
+        if len(ids) > 1:
+            self.canvas.itemconfig(ids[1], image=photo)
+        fs_ids = token.get("fs_canvas_ids") or ()
+        if getattr(self, "fs_canvas", None) and len(fs_ids) > 1 and token.get("player_visible", True):
+            try:
+                fs_photo = ImageTk.PhotoImage(scaled)
+                self.fs_canvas.itemconfig(fs_ids[1], image=fs_photo)
+            except tk.TclError:
+                pass
+            else:
+                token["fs_tk"] = fs_photo
 
     # ------------------------------------------------------------------
     # Fit-to-view behaviour
@@ -1021,6 +1061,9 @@ class DisplayMapController:
             messagebox.showwarning("Not Found", f"Map '{target}' not found.")
             return False
         self._cancel_deferred_map_open()
+        manager = getattr(self, "_token_animation_manager", None)
+        if manager:
+            manager.clear()
         self._on_display_map("maps", target)
         item_counts = {
             "tokens": sum(1 for entry in getattr(self, "tokens", []) if entry.get("type") == "token"),
@@ -5063,7 +5106,10 @@ class DisplayMapController:
             try:
                 # Keep token size resilient if this step fails.
                 if source_img is None and resolved_path:
-                    source_img = Image.open(resolved_path).convert("RGBA")
+                    source_img = load_thumbnail(
+                        resolved_path,
+                        detect_media_type(resolved_path, token.get("media_type")),
+                    )
                 if source_img is not None:
                     token["source_image"] = source_img
                     token["pil_image"] = source_img.resize((new_size, new_size), Image.LANCZOS)
@@ -5582,7 +5628,9 @@ class DisplayMapController:
                         if not resolved_path or not os.path.exists(resolved_path):
                             raise FileNotFoundError(resolved_path or image_path)
                         sz = new_item_data.get("size", self.token_size)
-                        source_img = Image.open(resolved_path).convert("RGBA")
+                        media_type = detect_media_type(resolved_path, new_item_data.get("media_type"))
+                        new_item_data["media_type"] = media_type
+                        source_img = load_thumbnail(resolved_path, media_type)
                         new_item_data["source_image"] = source_img
                         new_item_data["pil_image"] = source_img.resize((sz, sz), Image.LANCZOS)
                     except Exception as exc:
@@ -5631,6 +5679,9 @@ class DisplayMapController:
                 new_item_data.setdefault("is_filled", self.shape_is_filled)
 
             self.tokens.append(new_item_data)
+            if item_type == "token" and new_item_data.get("media_type") == "video":
+                self._ensure_token_animation_manager()
+                register_token_animation(self, new_item_data, _resolve_campaign_path(new_item_data.get("image_path")))
             pasted_items.append(new_item_data)
 
         if not pasted_items:
@@ -5643,6 +5694,9 @@ class DisplayMapController:
     def _delete_item(self, item_to_delete):
         """Delete item."""
         if not item_to_delete: return
+        manager = getattr(self, "_token_animation_manager", None)
+        if manager:
+            manager.unregister(item_to_delete)
         if item_to_delete.get("canvas_ids"):
             for cid in item_to_delete["canvas_ids"]:
                 if cid: self.canvas.delete(cid)

--- a/modules/maps/media/__init__.py
+++ b/modules/maps/media/__init__.py
@@ -1,0 +1,10 @@
+"""Token media detection, decoding, and animation services."""
+
+from .types import IMAGE, VIDEO, detect_media_type
+from .decoder import MediaDecodeError, VideoDecoder, load_thumbnail
+from .animation import TokenAnimationManager
+
+__all__ = [
+    "IMAGE", "VIDEO", "MediaDecodeError", "TokenAnimationManager",
+    "VideoDecoder", "detect_media_type", "load_thumbnail",
+]

--- a/modules/maps/media/animation.py
+++ b/modules/maps/media/animation.py
@@ -1,0 +1,102 @@
+"""Centralized, bounded token animation lifecycle for Tk canvases."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import queue
+import time
+
+from .decoder import MediaDecodeError, VideoDecoder
+
+
+class TokenAnimationManager:
+    """Decode outside Tk and deliver frames from one centralized ``after`` loop."""
+
+    def __init__(self, widget, on_frame, *, fps: int = 12, max_size: int = 256, workers: int = 2):
+        self.widget = widget
+        self.on_frame = on_frame
+        self.fps = min(15, max(1, int(fps)))
+        self.max_size = min(512, max(32, int(max_size)))
+        self._executor = ThreadPoolExecutor(max_workers=max(1, min(4, workers)), thread_name_prefix="map-media")
+        self._entries = {}
+        self._results = queue.SimpleQueue()
+        self._after_id = None
+        self._closed = False
+
+    def register(self, token: dict, path: str) -> bool:
+        if self._closed:
+            return False
+        self.unregister(token)
+        try:
+            decoder = VideoDecoder(path, max_size=self.max_size)
+        except MediaDecodeError:
+            return False
+        key = id(token)
+        self._entries[key] = {"token": token, "decoder": decoder, "busy": False, "due": 0.0}
+        self._ensure_tick()
+        return True
+
+    def unregister(self, token: dict) -> None:
+        entry = self._entries.pop(id(token), None)
+        if entry:
+            # ``close`` may wait for an in-flight PyAV decode.  Never make Tk's
+            # event thread wait for that lock.
+            self._executor.submit(entry["decoder"].close)
+
+    def clear(self) -> None:
+        for entry in list(self._entries.values()):
+            self._executor.submit(entry["decoder"].close)
+        self._entries.clear()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._after_id is not None:
+            try:
+                self.widget.after_cancel(self._after_id)
+            except Exception:
+                pass
+            self._after_id = None
+        self.clear()
+        # Keep queued decoder closes: cancelling them would leak containers.
+        self._executor.shutdown(wait=False, cancel_futures=False)
+
+    def _ensure_tick(self) -> None:
+        if not self._closed and self._after_id is None:
+            self._after_id = self.widget.after(15, self._tick)
+
+    def _decode(self, key, decoder) -> None:
+        try:
+            self._results.put((key, decoder.read_frame(), None))
+        except Exception as exc:
+            self._results.put((key, None, exc))
+
+    def _tick(self) -> None:
+        self._after_id = None
+        if self._closed:
+            return
+        while True:
+            try:
+                key, frame, error = self._results.get_nowait()
+            except queue.Empty:
+                break
+            entry = self._entries.get(key)
+            if not entry:
+                continue
+            entry["busy"] = False
+            entry["due"] = time.monotonic() + 1.0 / self.fps
+            if error is not None:
+                self.unregister(entry["token"])
+            elif frame is not None:
+                try:
+                    self.on_frame(entry["token"], frame)
+                except Exception:
+                    self.unregister(entry["token"])
+        now = time.monotonic()
+        for key, entry in list(self._entries.items()):
+            if not entry["busy"] and now >= entry["due"]:
+                entry["busy"] = True
+                self._executor.submit(self._decode, key, entry["decoder"])
+        if self._entries:
+            self._ensure_tick()

--- a/modules/maps/media/decoder.py
+++ b/modules/maps/media/decoder.py
@@ -1,0 +1,86 @@
+"""Defensive PyAV video decoding with a still-image fallback contract."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from PIL import Image
+
+
+class MediaDecodeError(RuntimeError):
+    """Raised when a media thumbnail or frame cannot be decoded."""
+
+
+def _fit_frame(image: Image.Image, max_size: int) -> Image.Image:
+    frame = image.convert("RGBA")
+    if max(frame.size) > max_size:
+        frame.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
+    return frame
+
+
+class VideoDecoder:
+    """Own one PyAV container and provide frames, looping at end of stream."""
+
+    def __init__(self, path: str, *, max_size: int = 256):
+        self.path = str(path)
+        self.max_size = max(16, int(max_size))
+        self._lock = threading.Lock()
+        self._closed = False
+        try:
+            import av
+            self._av = av
+            self._container = av.open(self.path)
+            self._stream = self._container.streams.video[0]
+            self._stream.thread_type = "AUTO"
+            self._frames = self._container.decode(self._stream)
+            rate = float(self._stream.average_rate or 12)
+            self.frame_rate = min(15.0, max(1.0, rate))
+        except Exception as exc:
+            self.close()
+            raise MediaDecodeError(f"Unable to open video {self.path!r}: {exc}") from exc
+
+    def read_frame(self) -> Image.Image:
+        with self._lock:
+            if self._closed:
+                raise MediaDecodeError("decoder is closed")
+            try:
+                frame = next(self._frames)
+            except StopIteration:
+                try:
+                    self._container.seek(0, stream=self._stream, backward=True)
+                    self._frames = self._container.decode(self._stream)
+                    frame = next(self._frames)
+                except Exception as exc:
+                    raise MediaDecodeError(f"Unable to loop video: {exc}") from exc
+            except Exception as exc:
+                raise MediaDecodeError(f"Unable to decode video frame: {exc}") from exc
+            return _fit_frame(frame.to_image(), self.max_size)
+
+    def close(self) -> None:
+        with getattr(self, "_lock", threading.Lock()):
+            if getattr(self, "_closed", False):
+                return
+            self._closed = True
+            container = getattr(self, "_container", None)
+            if container is not None:
+                try:
+                    container.close()
+                except Exception:
+                    pass
+
+
+def load_thumbnail(path: str, media_type: str, *, max_size: int = 256) -> Image.Image:
+    """Load an image or the first video frame; never retain a video decoder."""
+    if not path or not Path(path).is_file():
+        raise MediaDecodeError(f"Media not found: {path}")
+    if media_type == "video":
+        decoder = VideoDecoder(path, max_size=max_size)
+        try:
+            return decoder.read_frame()
+        finally:
+            decoder.close()
+    try:
+        with Image.open(path) as image:
+            return _fit_frame(image, max_size)
+    except Exception as exc:
+        raise MediaDecodeError(f"Unable to open image {path!r}: {exc}") from exc

--- a/modules/maps/media/tokens.py
+++ b/modules/maps/media/tokens.py
@@ -1,0 +1,31 @@
+"""Helpers that bridge persistent token dictionaries and runtime media state."""
+
+from PIL import Image
+
+from .decoder import MediaDecodeError, load_thumbnail
+from .types import VIDEO, detect_media_type
+
+
+def prepare_token_media(token: dict, resolved_path: str, size: int) -> bool:
+    """Populate only in-memory PIL fields, returning whether media loaded."""
+    media_type = detect_media_type(resolved_path, token.get("media_type"))
+    token["media_type"] = media_type
+    try:
+        source = load_thumbnail(resolved_path, media_type)
+    except MediaDecodeError:
+        return False
+    token["source_image"] = source
+    token["pil_image"] = source.resize((int(size), int(size)), Image.Resampling.LANCZOS)
+    return True
+
+
+def register_token_animation(owner, token: dict, resolved_path: str) -> bool:
+    """Register a video with an owner's animation manager when available."""
+    if token.get("media_type") != VIDEO:
+        return False
+    manager = getattr(owner, "_token_animation_manager", None)
+    if manager is None:
+        ensure = getattr(owner, "_ensure_token_animation_manager", None)
+        if callable(ensure):
+            manager = ensure()
+    return bool(manager and manager.register(token, resolved_path))

--- a/modules/maps/media/types.py
+++ b/modules/maps/media/types.py
@@ -1,0 +1,21 @@
+"""Media type detection independent from the UI and decoder backend."""
+
+from pathlib import Path
+
+IMAGE = "image"
+VIDEO = "video"
+
+VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".mov", ".mkv", ".avi", ".m4v"})
+IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tif", ".tiff"})
+
+
+def detect_media_type(path: str, stored_type: str | None = None) -> str:
+    """Return ``video`` or ``image`` without opening the media.
+
+    A valid persisted value wins, allowing renamed media to remain stable.
+    Unknown extensions intentionally fall back to images for compatibility.
+    """
+    normalized = str(stored_type or "").strip().lower()
+    if normalized in {IMAGE, VIDEO}:
+        return normalized
+    return VIDEO if Path(str(path or "")).suffix.lower() in VIDEO_EXTENSIONS else IMAGE

--- a/modules/maps/services/token_manager.py
+++ b/modules/maps/services/token_manager.py
@@ -11,6 +11,8 @@ from modules.helpers.config_helper import ConfigHelper
 from modules.maps.marker_types import DEFAULT_MARKER_TYPE, normalize_marker_type
 from modules.maps.utils.token_facing import normalize_facing_angle
 from modules.maps.measurement.templates import MEASUREMENT_ITEM_TYPE, serialize_measurement_item
+from modules.maps.media import detect_media_type, load_thumbnail
+from modules.maps.media.tokens import register_token_animation
 from modules.ui.image_viewer import show_portrait
 import tkinter.simpledialog as sd
 import tkinter as tk
@@ -321,7 +323,12 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
         )
         return
 
-    source_img = Image.open(img_path).convert("RGBA")
+    media_type = detect_media_type(img_path)
+    try:
+        source_img = load_thumbnail(img_path, media_type)
+    except Exception as exc:
+        messagebox.showerror("Error", f"Token media could not be decoded:\n{exc}")
+        return
     logical_size = int(self.token_size)
     pil_img = source_img.resize((logical_size, logical_size), resample=Image.LANCZOS)
 
@@ -348,6 +355,7 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
         "entity_type":  entity_type,
         "entity_id":    entity_name,
         "image_path":   storage_path,
+        "media_type":  media_type,
         "size":         logical_size,
         "source_image": source_img,
         "pil_image":    pil_img,
@@ -370,6 +378,7 @@ def add_token(self, path, entity_type, entity_name, entity_record=None):
     }
 
     self.tokens.append(token)
+    register_token_animation(self, token, img_path)
     self._update_canvas_images()
     self._persist_tokens()
 
@@ -462,6 +471,7 @@ def _copy_token(self, event=None):
         "entity_type":  t["entity_type"],
         "entity_id":    t["entity_id"],
         "image_path":   t["image_path"],
+        "media_type":  detect_media_type(t.get("image_path", ""), t.get("media_type")),
         "size":         t.get("size", self.token_size),
         "border_color": t.get("border_color", "#0000ff"),
         "hp":           t.get("hp", 10),        # ← copy current HP
@@ -484,7 +494,11 @@ def _paste_token(self, event=None):
 
     # Re-create the PIL image at the original token size
     resolved_path = _resolve_campaign_path(c.get("image_path"))
-    source_img = Image.open(resolved_path).convert("RGBA")
+    media_type = detect_media_type(resolved_path, c.get("media_type"))
+    try:
+        source_img = load_thumbnail(resolved_path, media_type)
+    except Exception:
+        return
     storage_path = _campaign_relative_path(resolved_path)
     size = int(c["size"])
     pil_img = source_img.resize((size, size), Image.LANCZOS)
@@ -504,6 +518,7 @@ def _paste_token(self, event=None):
         "entity_type":  c["entity_type"],
         "entity_id":    c["entity_id"],
         "image_path":   storage_path,
+        "media_type":  media_type,
         "size":         size,
         "source_image": source_img,
         "border_color": c["border_color"],
@@ -521,6 +536,7 @@ def _paste_token(self, event=None):
 
     # Add it to your tokens list, then persist & re-draw everything
     self.tokens.append(token)
+    register_token_animation(self, token, resolved_path)
     self._persist_tokens()
     self._update_canvas_images()
 
@@ -587,6 +603,9 @@ def _change_token_border_color(self, token):
 
 def _delete_token(self, token):
     """Remove a token’s canvas items (image, border, name, HP UI, info widget, edit entries) and its data."""
+    manager = getattr(self, "_token_animation_manager", None)
+    if manager:
+        manager.unregister(token)
     # 1) Main token border & image
     for cid in token.get("canvas_ids", []):
         self.canvas.delete(cid)
@@ -722,6 +741,7 @@ def _persist_tokens(self):
                     "entity_type":    t.get("entity_type", ""),
                     "entity_id":      t.get("entity_id", ""),
                     "image_path":     storage_path,
+                    "media_type":    detect_media_type(storage_path, t.get("media_type")),
                     "size":           t.get("size", self.token_size),
                     "hp":             t.get("hp", 10),
                     "max_hp":         t.get("max_hp", 10),

--- a/modules/maps/views/map_selector.py
+++ b/modules/maps/views/map_selector.py
@@ -18,6 +18,8 @@ from modules.helpers.logging_helper import log_module_import, log_debug, log_inf
 from modules.maps.marker_types import DEFAULT_MARKER_TYPE, normalize_marker_type
 from modules.maps.utils.token_facing import normalize_facing_angle
 from modules.maps.measurement.templates import MEASUREMENT_ITEM_TYPE, deserialize_measurement_item
+from modules.maps.media import detect_media_type, load_thumbnail
+from modules.maps.media.tokens import register_token_animation
 
 log_module_import(__name__)
 
@@ -187,6 +189,9 @@ def select_map(self):
 
 def _on_display_map(self, entity_type, map_name): # entity_type here is the map's default, not token's
     """Callback from selector: build editor UI and load the chosen map."""
+    animation_manager = getattr(self, "_token_animation_manager", None)
+    if animation_manager:
+        animation_manager.clear()
     # 1) Lookup the chosen map record
     previous_map_name = ""
     if isinstance(getattr(self, "current_map", None), dict):
@@ -498,6 +503,7 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
             # Handle the branch where item_type_from_rec == 'token'.
             portrait_path = (rec.get("image_path") or "").strip()
             path = _resolve_campaign_path(portrait_path) if portrait_path else ""
+            persisted_media_type = detect_media_type(portrait_path, rec.get("media_type"))
 
             if path and not os.path.exists(path):
                 # Handle the branch where path is set and not os.path.exists(path).
@@ -528,7 +534,8 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 if os.path.exists(path):
                     try:
                         # Keep on display map resilient if this step fails.
-                        source_image = Image.open(path).convert("RGBA")
+                        media_type = detect_media_type(path, rec.get("media_type"))
+                        source_image = load_thumbnail(path, media_type)
                         pil_image = source_image.resize((sz, sz), resample=Image.LANCZOS)
                         resolved_path = path
                     except Exception as e:
@@ -570,6 +577,7 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
                 "entity_type":  rec.get("entity_type"), # Must come from record for tokens
                 "entity_id":    rec.get("entity_id"),
                 "image_path":   storage_path,
+                "media_type":  persisted_media_type,
                 "source_image": source_image,
                 "pil_image":    pil_image,
                 "border_color": rec.get("border_color", "#0000ff"), # Default blue for tokens
@@ -729,5 +737,15 @@ def _on_display_map(self, entity_type, map_name): # entity_type here is the map'
 
     # 9) Finally draw everything onto the canvas
     self._update_canvas_images()
+    ensure_manager = getattr(self, "_ensure_token_animation_manager", None)
+    if callable(ensure_manager):
+        ensure_manager()
+        for current_item in self.tokens:
+            if current_item.get("type") == "token" and current_item.get("media_type") == "video":
+                register_token_animation(
+                    self,
+                    current_item,
+                    _resolve_campaign_path(current_item.get("image_path")),
+                )
     if getattr(self, '_web_server_thread', None):
         self._update_web_display_map()

--- a/modules/maps/views/web_display_view.py
+++ b/modules/maps/views/web_display_view.py
@@ -296,6 +296,39 @@ def open_web_display(self, port=None):
             },
         )
 
+    @self._web_app.route('/media/token/<remote_id>')
+    def token_media(remote_id):
+        """Serve only media belonging to a visible token after authentication."""
+        provided = request.args.get("token") or request.headers.get("X-Map-Token")
+        if not controller._map_remote_access_guard.is_request_authorized(provided):
+            return ("Unauthorized", 401)
+        for token in getattr(controller, "tokens", ()):
+            if (
+                str(token.get("remote_id") or "") != remote_id
+                or not token.get("player_visible", True)
+                or str(token.get("entity_type") or "").upper() != "PC"
+            ):
+                continue
+            relative = str(token.get("image_path") or "")
+            candidate = Path(relative)
+            if not candidate.is_absolute():
+                candidate = Path(ConfigHelper.get_campaign_dir()) / candidate
+            try:
+                candidate = candidate.resolve(strict=True)
+            except (OSError, RuntimeError):
+                return ("Media not found", 404)
+            try:
+                campaign_dir = Path(ConfigHelper.get_campaign_dir()).resolve(strict=True)
+                candidate.relative_to(campaign_dir)
+            except (OSError, RuntimeError, ValueError):
+                # Persistent token data must never turn this endpoint into an
+                # authenticated arbitrary-file server.
+                return ("Media not found", 404)
+            if not candidate.is_file():
+                return ("Media not found", 404)
+            return send_from_directory(candidate.parent, candidate.name, conditional=True, max_age=3600)
+        return ("Media not found", 404)
+
     @self._web_app.route('/stream.mjpg')
     def stream_mjpeg():
         """Handle stream mjpeg."""
@@ -444,6 +477,8 @@ def _describe_remote_tokens(self, render_offset=None):
                 'screen_size': size_px * zoom,
                 'border_color': token.get('border_color', '#0ea5e9'),
                 'facing_angle': normalize_facing_angle(token.get('facing_angle', 0.0)),
+                'media_type': str(token.get('media_type') or 'image'),
+                'media_url': f"/media/token/{remote_id}",
             }
         )
     return tokens

--- a/modules/maps/world_map_view.py
+++ b/modules/maps/world_map_view.py
@@ -53,6 +53,8 @@ from modules.maps.views.toolbar_view import (
     _update_fog_button_states,
 )
 from modules.maps.services.fog_manager import _set_fog
+from modules.maps.media import TokenAnimationManager, detect_media_type, load_thumbnail
+from modules.maps.media.tokens import register_token_animation
 from modules.maps.services.world_map_fog_service import (
     apply_world_map_fog_rectangle,
     clear_fog_rectangle_preview,
@@ -212,6 +214,7 @@ class WorldMapPanel(ctk.CTkFrame):
         init_world_map_fog(self)
 
         self._build_layout()
+        self._token_animation_manager = TokenAnimationManager(self.canvas, self._display_token_frame)
 
         self._chatbot_bindings.append(("<Control-Shift-c>", self.bind("<Control-Shift-c>", self.open_chatbot, add="+")))
         self._chatbot_bindings.append(("<Control-Shift-C>", self.bind("<Control-Shift-C>", self.open_chatbot, add="+")))
@@ -654,6 +657,7 @@ class WorldMapPanel(ctk.CTkFrame):
     def load_map(self, map_name: str, *, push_history: bool = True) -> None:
         """Load map."""
         log_info(f"Loading world map '{map_name}'", func_name="WorldMapWindow.load_map")
+        self._token_animation_manager.clear()
         entry = self._ensure_world_map_entry(map_name)
         if entry is None:
             log_warning(f"World map entry '{map_name}' could not be created", func_name="WorldMapWindow.load_map")
@@ -698,6 +702,11 @@ class WorldMapPanel(ctk.CTkFrame):
         load_world_map_fog(self)
         self.tokens = self._deserialize_tokens(entry)
         self._draw_scene()
+        for token in self.tokens:
+            media_path = token.get("portrait_path") or token.get("image_path")
+            if token.get("media_type") == "video" and media_path:
+                candidate = media_path if os.path.isabs(media_path) else os.path.join(ConfigHelper.get_campaign_dir(), media_path)
+                register_token_animation(self, token, candidate)
         self._clear_inspector()
 
     def navigate_back(self) -> None:
@@ -1005,6 +1014,9 @@ class WorldMapPanel(ctk.CTkFrame):
                     'size': value.get('size', 120),
                     'portrait_path': value.get('portrait_path'),
                     'image_path': value.get('image_path'),
+                    'media_type': detect_media_type(
+                        value.get('portrait_path') or value.get('image_path'), value.get('media_type')
+                    ),
                     'linked_map': value.get('linked_map'),
                     'color': value.get('color', _TOKEN_COLORS.get(entity_type, '#FFFFFF')),
                     'marker_type': normalize_marker_type(value.get('marker_type', DEFAULT_MARKER_TYPE)),
@@ -1040,6 +1052,9 @@ class WorldMapPanel(ctk.CTkFrame):
                     "size": token.get("size", 120),
                     "portrait_path": token.get("portrait_path"),
                     "image_path": token.get("image_path"),
+                    "media_type": detect_media_type(
+                        token.get("portrait_path") or token.get("image_path"), token.get("media_type")
+                    ),
                     "linked_map": token.get("linked_map"),
                     "color": token.get("color"),
                     "marker_type": normalize_marker_type(token.get("marker_type", DEFAULT_MARKER_TYPE)),
@@ -1478,6 +1493,18 @@ class WorldMapPanel(ctk.CTkFrame):
         pil_image = self._create_token_pil_image(token, size)
         return ImageTk.PhotoImage(pil_image)
 
+    def _display_token_frame(self, token: dict, frame: Image.Image) -> None:
+        """Replace one world-map token image without redrawing the scene."""
+        ids = token.get("canvas_ids") or ()
+        if token not in self.tokens or not ids:
+            return
+        size = max(48, int(token.get("size", 120) * (self.render_params or (1,))[0]))
+        rendered = frame.resize((size, size), Image.Resampling.LANCZOS)
+        rendered = self._with_marker_type_badge(rendered, token)
+        image = ImageTk.PhotoImage(rendered)
+        token["tk_image"] = image
+        self.canvas.itemconfig(ids[0], image=image)
+
     def _resolve_token_ctk_image(self, token: dict, size: int) -> ctk.CTkImage:
         """Resolve token ctk image."""
         pil_image = self._create_token_pil_image(token, size)
@@ -1502,7 +1529,7 @@ class WorldMapPanel(ctk.CTkFrame):
         if not os.path.exists(candidate):
             return None
         try:
-            image = Image.open(candidate).convert("RGBA")
+            image = load_thumbnail(candidate, detect_media_type(candidate))
             self.image_cache[path] = image
             return image
         except Exception as exc:
@@ -1610,6 +1637,7 @@ class WorldMapPanel(ctk.CTkFrame):
         if token not in self.tokens:
             self.selected_token = None
             return
+        self._token_animation_manager.unregister(token)
         self.tokens = [t for t in self.tokens if t is not token]
         self.selected_token = None
         self._draw_scene()
@@ -1875,6 +1903,7 @@ class WorldMapPanel(ctk.CTkFrame):
         """Delete token."""
         if token not in self.tokens:
             return
+        self._token_animation_manager.unregister(token)
         self.tokens = [t for t in self.tokens if t is not token]
         if self.selected_token is token:
             self.selected_token = None
@@ -2982,6 +3011,9 @@ class WorldMapPanel(ctk.CTkFrame):
                 except Exception:
                     pass
         self._chatbot_bindings = []
+        manager = getattr(self, "_token_animation_manager", None)
+        if manager:
+            manager.close()
         self.close_player_display()
         return
 

--- a/static/maptool_web/player.js
+++ b/static/maptool_web/player.js
@@ -88,47 +88,80 @@
   }
 
   function renderTokens(status) {
-    tokenLayer.innerHTML = '';
     if (!status || !Array.isArray(status.tokens)) return;
+    const retained = new Set(status.tokens.map((token) => String(token.id)));
+    tokenLayer.querySelectorAll('.token').forEach((node) => {
+      if (!retained.has(node.dataset.tokenId || '')) node.remove();
+    });
     const rect = mapImg.getBoundingClientRect();
     const scaleX = status.render_size[0] ? status.render_size[0] / rect.width : 1;
     const scaleY = status.render_size[1] ? status.render_size[1] / rect.height : 1;
     status.tokens.forEach((token) => {
-      const el = document.createElement('div');
-      el.className = 'token';
-      const label = document.createElement('span');
-      label.textContent = token.label || 'PC';
-      label.style.color = '#0b1220';
-      label.style.position = 'relative';
-      label.style.zIndex = '2';
-      el.appendChild(label);
-      el.draggable = false;
+      const tokenId = String(token.id);
+      let el = Array.from(tokenLayer.querySelectorAll('.token'))
+        .find((node) => node.dataset.tokenId === tokenId);
+      if (!el) {
+        el = document.createElement('div');
+        el.className = 'token';
+        el.dataset.tokenId = tokenId;
+        const label = document.createElement('span');
+        label.style.cssText = 'color:#0b1220;position:relative;z-index:2';
+        el.appendChild(label);
+        const arrow = document.createElement('div');
+        arrow.className = 'facingArrow';
+        el.appendChild(arrow);
+        const handle = document.createElement('div');
+        handle.className = 'facingHandle';
+        el.appendChild(handle);
+        el.draggable = false;
+        tokenLayer.appendChild(el);
+      }
+      const mediaUrl = token.media_url
+        ? token.media_url + (authToken ? `?token=${encodeURIComponent(authToken)}` : '')
+        : '';
+      const mediaKind = token.media_type === 'video' ? 'video' : 'img';
+      let media = el.querySelector('video, img');
+      if (mediaUrl && (!media || media.tagName.toLowerCase() !== mediaKind || el.dataset.mediaUrl !== mediaUrl)) {
+        if (media) media.remove();
+        media = document.createElement(mediaKind);
+        media.src = mediaUrl;
+        media.alt = token.label || 'Token';
+        media.draggable = false;
+        media.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;object-fit:cover;border-radius:10px;pointer-events:none';
+        el.prepend(media);
+        el.dataset.mediaUrl = mediaUrl;
+        if (mediaKind === 'video') {
+          media.muted = media.defaultMuted = media.loop = media.autoplay = media.playsInline = true;
+          media.setAttribute('muted', '');
+          media.setAttribute('playsinline', '');
+          media.play().catch(() => {
+            document.addEventListener('pointerdown', () => media.play().catch(() => {}), { once: true });
+          });
+        }
+      }
+      const label = el.querySelector('span');
+      if (label) label.textContent = token.label || 'PC';
       const screenX = (token.screen_position?.[0] || 0) / scaleX;
       const screenY = (token.screen_position?.[1] || 0) / scaleY;
       const size = (token.screen_size || 48) / Math.max(scaleX, scaleY);
       el.style.transform = `translate(${screenX}px, ${screenY}px)`;
       el.style.width = `${size}px`;
       el.style.height = `${size}px`;
-      if (token.border_color) {
-        el.style.borderColor = token.border_color;
-        el.style.color = token.border_color;
-      }
+      el.style.borderColor = token.border_color || '#0ea5e9';
+      el.style.color = token.border_color || '#0ea5e9';
       const facingAngle = normalizeAngle(token.facing_angle);
-      const arrow = document.createElement('div');
-      arrow.className = 'facingArrow';
-      arrow.style.transform = `rotate(${facingAngle}deg)`;
-      el.appendChild(arrow);
-      const handle = document.createElement('div');
-      handle.className = 'facingHandle';
-      handle.style.transform = `rotate(${facingAngle}deg) translate(${size * 0.64}px, 0) rotate(${-facingAngle}deg)`;
-      handle.addEventListener('pointerdown', (ev) => startFacingDrag(ev, token, el));
-      el.appendChild(handle);
-      el.addEventListener('contextmenu', (ev) => showTokenMenu(ev, token));
-      el.addEventListener('pointerdown', (ev) => {
+      const arrow = el.querySelector('.facingArrow');
+      const handle = el.querySelector('.facingHandle');
+      if (arrow) arrow.style.transform = `rotate(${facingAngle}deg)`;
+      if (handle) {
+        handle.style.transform = `rotate(${facingAngle}deg) translate(${size * 0.64}px, 0) rotate(${-facingAngle}deg)`;
+        handle.onpointerdown = (ev) => startFacingDrag(ev, token, el);
+      }
+      el.oncontextmenu = (ev) => showTokenMenu(ev, token);
+      el.onpointerdown = (ev) => {
         if (ev.target === handle) return;
         startDrag(ev, token);
-      });
-      tokenLayer.appendChild(el);
+      };
     });
   }
 

--- a/tests/maps/test_token_media.py
+++ b/tests/maps/test_token_media.py
@@ -1,0 +1,164 @@
+"""Regression coverage for animated map-token media."""
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from modules.maps.media import IMAGE, VIDEO, MediaDecodeError, TokenAnimationManager, detect_media_type, load_thumbnail
+from modules.maps.media import animation
+from modules.maps.views.web_display_view import _describe_remote_tokens
+from modules.maps.world_map_view import WorldMapPanel
+
+
+class FakeWidget:
+    def __init__(self):
+        self.jobs = {}
+        self.cancelled = []
+        self.counter = 0
+
+    def after(self, _delay, callback):
+        self.counter += 1
+        self.jobs[self.counter] = callback
+        return self.counter
+
+    def after_cancel(self, job):
+        self.cancelled.append(job)
+        self.jobs.pop(job, None)
+
+    def run_next(self):
+        _, callback = self.jobs.popitem()
+        callback()
+
+
+class FakeDecoder:
+    instances = []
+
+    def __init__(self, path, max_size=256):
+        if path == "invalid.mp4":
+            raise MediaDecodeError("invalid")
+        self.closed = False
+        self.counter = 0
+        self.instances.append(self)
+
+    def read_frame(self):
+        self.counter += 1
+        return object()
+
+    def close(self):
+        self.closed = True
+
+
+def test_mp4_selection_and_persisted_hint_detection():
+    assert detect_media_type("tokens/hero.MP4") == VIDEO
+    assert detect_media_type("tokens/renamed.bin", "video") == VIDEO
+    assert detect_media_type("tokens/hero.png") == IMAGE
+
+
+def test_remote_description_exposes_authenticated_media_metadata():
+    owner = type("Owner", (), {})()
+    owner.zoom = 1.0
+    owner.pan_x = owner.pan_y = 0.0
+    owner.base_img = type("Base", (), {"size": (800, 600)})()
+    owner.token_size = 48
+    owner.tokens = [{
+        "type": "token", "entity_type": "PC", "entity_id": "Hero",
+        "position": (12, 34), "size": 64, "player_visible": True,
+        "image_path": "tokens/hero.mp4", "media_type": "video",
+    }]
+    payload = _describe_remote_tokens(owner)[0]
+    assert payload["media_type"] == VIDEO
+    assert payload["media_url"].startswith("/media/token/")
+
+
+def test_invalid_video_is_rejected_without_crashing(tmp_path):
+    with pytest.raises(MediaDecodeError):
+        load_thumbnail(str(tmp_path / "missing.mp4"), VIDEO)
+
+
+def test_animation_loops_and_releases_on_delete_map_change_and_close(monkeypatch):
+    FakeDecoder.instances.clear()
+    monkeypatch.setattr(animation, "VideoDecoder", FakeDecoder)
+    widget = FakeWidget()
+    delivered = []
+    manager = TokenAnimationManager(widget, lambda token, frame: delivered.append((token, frame)))
+    first, copied = {"size": 48}, {"size": 96}
+    assert manager.register(first, "hero.mp4")
+    assert manager.register(copied, "hero.mp4")
+
+    # The centralized tick submits decoding, and a later tick delivers it.
+    widget.run_next()
+    deadline = time.monotonic() + 1
+    while len(delivered) < 2 and time.monotonic() < deadline:
+        if not manager._results.empty() and widget.jobs:
+            widget.run_next()
+        else:
+            time.sleep(0.01)
+    assert {id(item[0]) for item in delivered} == {id(first), id(copied)}
+
+    manager.unregister(first)  # token deletion
+    deadline = time.monotonic() + 1
+    while not FakeDecoder.instances[0].closed and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert FakeDecoder.instances[0].closed
+    manager.clear()  # map change
+    deadline = time.monotonic() + 1
+    while not all(decoder.closed for decoder in FakeDecoder.instances) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert all(decoder.closed for decoder in FakeDecoder.instances)
+    assert not manager.register({}, "invalid.mp4")
+    manager.close()  # window close / after cancellation
+    assert manager._closed
+
+
+@pytest.mark.parametrize("method_name", ["_delete_selected_token", "_delete_token"])
+def test_world_map_deletion_unregisters_video_before_removal(method_name):
+    token = {"type": "entity", "media_type": VIDEO}
+    calls = []
+    owner = SimpleNamespace(
+        fog_mode=False,
+        selected_token=token,
+        tokens=[token],
+        _token_animation_manager=SimpleNamespace(unregister=lambda item: calls.append(item)),
+        _draw_scene=lambda: None,
+        _persist_tokens=lambda: None,
+        _clear_inspector=lambda: None,
+    )
+
+    method = getattr(WorldMapPanel, method_name)
+    method(owner, token) if method_name == "_delete_token" else method(owner)
+
+    assert calls == [token]
+    assert owner.tokens == []
+
+
+def test_world_map_persistence_reload_keeps_only_media_metadata():
+    runtime_frame = object()
+    token = {
+        "type": "entity", "entity_type": "PC", "entity_id": "Hero",
+        "portrait_path": "tokens/hero.mp4", "media_type": VIDEO,
+        "size": 96, "source_image": runtime_frame, "pil_image": runtime_frame,
+    }
+    entry = {"name": "World"}
+    owner = SimpleNamespace(
+        current_world_map=entry,
+        current_map_name="World",
+        tokens=[token],
+        world_maps={},
+        mask_img=None,
+        _save_world_map_store=lambda: None,
+        _fetch_record=lambda *_args: None,
+        _capture_view_state=lambda: None,
+    )
+
+    WorldMapPanel._persist_tokens(owner)
+    stored = entry["tokens"][0]
+    assert stored["portrait_path"] == "tokens/hero.mp4"
+    assert stored["media_type"] == VIDEO
+    assert "source_image" not in stored and "pil_image" not in stored
+
+    restored = WorldMapPanel._deserialize_tokens(owner, entry)[0]
+    assert restored["media_type"] == VIDEO
+    assert restored["size"] == 96


### PR DESCRIPTION
### Motivation
- Ajouter le support des médias animés (MP4 et autres conteneurs courants) pour les tokens sans bloquer le thread Tkinter et en conservant uniquement le chemin relatif + le type média en persistance.
- Fournir un flux robuste qui tolère vidéos manquantes/corrompues ou codecs indisponibles et qui libère proprement les ressources lors de suppression, changement de carte ou fermeture.

### Description
- Ajout du sous-package `modules/maps/media/` contenant la détection de type (`types.py`), le décodage PyAV défensif et la lecture d’aperçu (`decoder.py`), et la gestion centralisée d’animation hors-thread pour Tk (`animation.py`), exportés via `modules/maps/media/__init__.py`.
- Intégration runtime des médias dans les tokens via `modules/maps/media/tokens.py` et adaptation de la création/restauration/duplication/redimensionnement/suppression des tokens pour distinguer images et vidéos en ne persistant que `image_path` et `media_type` (modifications principales dans `modules/maps/services/token_manager.py`).
- Ajout d’un planificateur d’animations `TokenAnimationManager` (décodage dans un `ThreadPoolExecutor`, tick central via `widget.after`) et intégration pour ne remplacer que l’image du token sur le canevas plutôt que de redessiner toute la carte (modifs dans `modules/maps/controllers/display_map_controller.py` et `modules/maps/world_map_view.py`).
- Route média authentifiée ajoutée dans `modules/maps/views/web_display_view.py` et adaptation de `_describe_remote_tokens` pour exposer `media_type` et `media_url`, ainsi que mise à jour du lecteur web `static/maptool_web/player.js` pour utiliser `<video>` muet, en boucle et compatible autoplay/playsinline.
- Ajout d’un jeu de tests de régression `tests/maps/test_token_media.py` couvrant la détection de type, la description web, le comportement en cas de vidéo invalide, la boucle d’animation, la libération des décodeurs et la persistance/restauration des métadonnées média.

### Testing
- Exécution de `pytest tests/maps/test_token_media.py` : tous les tests du fichier (7) ont réussi.
- Compilation et vérifications automatiques : `python -m compileall` et `node --check static/maptool_web/player.js` ont réussi, et `git diff --check` n’a montré aucune erreur de diff.
- Exécutions ciblées additionnelles : `pytest tests/maps/test_measurement_templates.py` (2 passés) et `pytest tests/maps/test_token_facing.py` (5 passés) ont réussi, tandis qu’un run global `pytest` a été interrompu par erreurs préexistantes et stubs externes non liés aux changements introduits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87330418bc832bab36cb856fd8b4ba)