### PR TITLE
Add transactional token media replacement and "Change Token Image…" action

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -44,7 +44,13 @@ from modules.maps.services.token_manager import (
     normalize_existing_token_paths,
     _extract_entity_defense_value,
 )  # Keep this if it's used by other token_manager functions not moved
-from modules.maps.media import TokenAnimationManager, detect_media_type, load_thumbnail
+from modules.maps.media import (
+    TokenAnimationManager,
+    detect_media_type,
+    load_thumbnail,
+    replace_token_media,
+)
+from modules.maps.media.types import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 from modules.maps.media.tokens import register_token_animation
 from modules.maps.views.fullscreen_view import open_fullscreen, _update_fullscreen_map
 from modules.maps.views.web_display_view import (
@@ -5126,6 +5132,36 @@ class DisplayMapController:
             return
         self._resize_tokens([token])
 
+    def _change_token_image(self, token):
+        """Select and transactionally replace the media for one token."""
+        campaign_dir = ConfigHelper.get_campaign_dir()
+        initial_dir = getattr(self, "_last_token_media_directory", "")
+        if not initial_dir or not os.path.isdir(initial_dir):
+            initial_dir = campaign_dir if os.path.isdir(campaign_dir) else os.path.expanduser("~")
+        image_patterns = " ".join(f"*{ext}" for ext in sorted(IMAGE_EXTENSIONS))
+        video_patterns = " ".join(f"*{ext}" for ext in sorted(VIDEO_EXTENSIONS))
+        selected = filedialog.askopenfilename(
+            parent=getattr(self, "canvas", None),
+            title="Change Token Image",
+            initialdir=initial_dir,
+            filetypes=[
+                ("Supported Media", f"{image_patterns} {video_patterns}"),
+                ("Image Files", image_patterns),
+                ("Video Files", video_patterns),
+                ("All Files", "*.*"),
+            ],
+        )
+        if not selected:
+            return
+        self._last_token_media_directory = os.path.dirname(selected)
+        result = replace_token_media(self, token, selected)
+        if not result.success:
+            messagebox.showerror(
+                "Change Token Image",
+                f"Unable to replace the token media.\n\n{result.error}",
+                parent=getattr(self, "canvas", None),
+            )
+
     def _load_portrait_menu_image(self, path: str) -> ImageTk.PhotoImage | None:
         """Load portrait menu image."""
         resolved = resolve_portrait_candidate(path, ConfigHelper.get_campaign_dir())
@@ -5180,6 +5216,11 @@ class DisplayMapController:
             label=f"Resize Token{plural}",
             command=lambda: self._resize_tokens(valid_tokens),
         )
+        if count == 1:
+            menu.add_command(
+                label="Change Token Image…",
+                command=lambda: self._change_token_image(valid_tokens[0]),
+            )
         menu.add_command(
             label=f"Change Border Color{plural}",
             command=lambda: self._prompt_change_token_border_color(valid_tokens),

--- a/modules/maps/media/__init__.py
+++ b/modules/maps/media/__init__.py
@@ -3,8 +3,10 @@
 from .types import IMAGE, VIDEO, detect_media_type
 from .decoder import MediaDecodeError, VideoDecoder, load_thumbnail
 from .animation import TokenAnimationManager
+from .replacement import MediaReplacementResult, replace_token_media
 
 __all__ = [
     "IMAGE", "VIDEO", "MediaDecodeError", "TokenAnimationManager",
     "VideoDecoder", "detect_media_type", "load_thumbnail",
+    "MediaReplacementResult", "replace_token_media",
 ]

--- a/modules/maps/media/replacement.py
+++ b/modules/maps/media/replacement.py
@@ -1,0 +1,116 @@
+"""Transactional replacement of the media displayed by one map token."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from modules.helpers.config_helper import ConfigHelper
+
+from .decoder import MediaDecodeError, load_thumbnail
+from .tokens import prepare_token_media
+from .types import IMAGE_EXTENSIONS, VIDEO, VIDEO_EXTENSIONS, detect_media_type
+
+
+@dataclass(frozen=True)
+class MediaReplacementResult:
+    """Outcome returned to the UI without displaying UI from this service."""
+
+    success: bool
+    error: str = ""
+
+
+def _campaign_relative_path(path: str) -> str:
+    """Return a portable campaign-relative path when the asset is in campaign."""
+    candidate = Path(path).resolve()
+    try:
+        return candidate.relative_to(Path(ConfigHelper.get_campaign_dir()).resolve()).as_posix()
+    except ValueError:
+        return str(candidate)
+
+
+def replace_token_media(controller, token: dict, selected_path: str) -> MediaReplacementResult:
+    """Validate then atomically replace a token's media and runtime animation.
+
+    Decoding occurs against a temporary dictionary, so an invalid selection cannot
+    alter either the token or its currently registered video decoder.
+    """
+    if not isinstance(token, dict) or token.get("type") != "token":
+        return MediaReplacementResult(False, "The selected item is not a token.")
+
+    resolved_path = str(Path(selected_path).expanduser().resolve())
+    if Path(resolved_path).suffix.lower() not in IMAGE_EXTENSIONS | VIDEO_EXTENSIONS:
+        return MediaReplacementResult(False, "The selected file is not a supported image or video.")
+    media_type = detect_media_type(resolved_path)
+    candidate = {"media_type": media_type}
+    def restore_original() -> None:
+        """Restore media fields and playback after a failed commit."""
+        if media_type == VIDEO and manager is not None:
+            manager.unregister(token)
+        for key, value in old_media.items():
+            if value is missing:
+                token.pop(key, None)
+            else:
+                token[key] = value
+        if old_type == VIDEO and manager is not None:
+            old_path = old_media.get("image_path")
+            old_path = "" if old_path is missing else (old_path or "")
+            if old_path and not Path(str(old_path)).is_absolute():
+                old_path = str(Path(ConfigHelper.get_campaign_dir()) / str(old_path))
+            if old_path:
+                manager.register(token, str(old_path))
+
+    try:
+        thumbnail = load_thumbnail(resolved_path, media_type)
+        if not prepare_token_media(
+            candidate,
+            resolved_path,
+            max(1, int(token.get("size", getattr(controller, "token_size", 48)))),
+            source_image=thumbnail,
+        ):
+            raise MediaDecodeError("The selected media could not be decoded.")
+    except Exception as exc:
+        return MediaReplacementResult(False, str(exc))
+
+    missing = object()
+    old_media = {
+        key: token.get(key, missing)
+        for key in ("image_path", "media_type", "source_image", "pil_image", "tk_image")
+    }
+    old_type = token.get("media_type")
+    manager = getattr(controller, "_token_animation_manager", None)
+    if old_type == VIDEO and manager is not None:
+        manager.unregister(token)
+
+    token.update(candidate)
+    token["image_path"] = _campaign_relative_path(resolved_path)
+    try:
+        if media_type == VIDEO:
+            ensure_manager = getattr(controller, "_ensure_token_animation_manager", None)
+            manager = ensure_manager() if callable(ensure_manager) else manager
+            if manager is None or not manager.register(token, resolved_path):
+                raise MediaDecodeError("The selected video could not be registered for playback.")
+
+        display_frame = getattr(controller, "_display_token_frame", None)
+        if callable(display_frame):
+            display_frame(token, candidate["source_image"])
+        web_update = getattr(controller, "_update_web_display_map", None)
+        if getattr(controller, "_web_server_thread", None) and callable(web_update):
+            web_update()
+        persist = getattr(controller, "_persist_tokens", None)
+        if callable(persist):
+            persist()
+    except Exception as exc:
+        restore_original()
+        # A rendering or downstream refresh may fail after the canvas was
+        # updated. Best-effort restoration keeps that item consistent too.
+        old_source = old_media.get("source_image")
+        display_frame = getattr(controller, "_display_token_frame", None)
+        if old_source is not missing and callable(display_frame):
+            try:
+                display_frame(token, old_source)
+            except Exception:
+                pass
+        return MediaReplacementResult(False, str(exc))
+
+    return MediaReplacementResult(True)

--- a/modules/maps/media/tokens.py
+++ b/modules/maps/media/tokens.py
@@ -6,12 +6,18 @@ from .decoder import MediaDecodeError, load_thumbnail
 from .types import VIDEO, detect_media_type
 
 
-def prepare_token_media(token: dict, resolved_path: str, size: int) -> bool:
+def prepare_token_media(
+    token: dict,
+    resolved_path: str,
+    size: int,
+    *,
+    source_image: Image.Image | None = None,
+) -> bool:
     """Populate only in-memory PIL fields, returning whether media loaded."""
     media_type = detect_media_type(resolved_path, token.get("media_type"))
     token["media_type"] = media_type
     try:
-        source = load_thumbnail(resolved_path, media_type)
+        source = source_image if source_image is not None else load_thumbnail(resolved_path, media_type)
     except MediaDecodeError:
         return False
     token["source_image"] = source

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -2720,7 +2720,7 @@ def build_user_manual(shots, menu_data, py_files):
 
         "<li><b>Fog of war:</b> Paint additive or subtractive fog with brush shortcuts (<code>[</code>/<code>]</code>) and reset the mask with a single click.</li>"
 
-        "<li><b>Tokens & auras:</b> Add NPC, PC, or creature tokens, colour their borders, track HP overlays, and duplicate or delete entries through the context menu.</li>"
+        "<li><b>Tokens & auras:</b> Add NPC, PC, or creature tokens, colour their borders, track HP overlays, and duplicate or delete entries through the context menu. For a single token, choose <b>Change Token Image…</b> to replace its static image or video without changing its game state.</li>"
         "<li><b>Token facing:</b> Rotate token facing where the selected token and view support it.</li>"
 
         "<li><b>Drawing tools:</b> Switch between Token, Rectangle, and Oval modes to sketch zones, spell areas, or light auras with filled/outline styles; add editable text labels and tweak drawing colours.</li>"

--- a/tests/maps/test_token_media.py
+++ b/tests/maps/test_token_media.py
@@ -7,8 +7,17 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image
 
-from modules.maps.media import IMAGE, VIDEO, MediaDecodeError, TokenAnimationManager, detect_media_type, load_thumbnail
+from modules.maps.media import (
+    IMAGE,
+    VIDEO,
+    MediaDecodeError,
+    TokenAnimationManager,
+    detect_media_type,
+    load_thumbnail,
+    replace_token_media,
+)
 from modules.maps.media import animation
+from modules.maps.media import replacement
 from modules.maps.views.web_display_view import _describe_remote_tokens
 from modules.maps.world_map_view import WorldMapPanel
 
@@ -162,3 +171,146 @@ def test_world_map_persistence_reload_keeps_only_media_metadata():
     restored = WorldMapPanel._deserialize_tokens(owner, entry)[0]
     assert restored["media_type"] == VIDEO
     assert restored["size"] == 96
+
+
+class ReplacementManager:
+    def __init__(self, *, register_result=True):
+        self.registered = []
+        self.unregistered = []
+        self.register_result = register_result
+
+    def register(self, token, path):
+        self.registered.append((token, path))
+        return self.register_result
+
+    def unregister(self, token):
+        self.unregistered.append(token)
+
+
+class ReplacementImage:
+    def __init__(self, size=(20, 30)):
+        self.size = size
+
+    def resize(self, size, _resampling):
+        return ReplacementImage(size)
+
+
+@pytest.mark.parametrize(
+    ("old_type", "new_suffix", "expected_type", "unregisters", "registers"),
+    [
+        (IMAGE, ".png", IMAGE, 0, 0),
+        (IMAGE, ".mp4", VIDEO, 0, 1),
+        (VIDEO, ".png", IMAGE, 1, 0),
+        (VIDEO, ".mp4", VIDEO, 1, 1),
+    ],
+)
+def test_replace_token_media_all_transitions_preserve_state(
+    tmp_path, monkeypatch, old_type, new_suffix, expected_type, unregisters, registers
+):
+    campaign = tmp_path / "campaign"
+    asset = campaign / "tokens" / f"replacement{new_suffix}"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"media")
+    decoded = ReplacementImage()
+    monkeypatch.setattr(replacement.ConfigHelper, "get_campaign_dir", lambda: str(campaign))
+    monkeypatch.setattr(replacement, "load_thumbnail", lambda *_args: decoded)
+    manager = ReplacementManager()
+    persisted = []
+    refreshed = []
+    token = {
+        "type": "token", "image_path": "tokens/original.mp4", "media_type": old_type,
+        "position": (12, 34), "size": 72, "border_color": "blue", "hp": 8,
+        "player_visible": False, "facing_angle": 135, "entity_id": "Hero",
+        "canvas_ids": (11, 12), "source_image": object(), "pil_image": object(),
+    }
+    controller = SimpleNamespace(
+        token_size=48, tokens=[token], _token_animation_manager=manager,
+        _ensure_token_animation_manager=lambda: manager,
+        _display_token_frame=lambda item, frame: refreshed.append((item, frame)),
+        _persist_tokens=lambda: persisted.append(True), _web_server_thread=None,
+    )
+    retained = {key: token[key] for key in (
+        "position", "size", "border_color", "hp", "player_visible", "facing_angle",
+        "entity_id", "canvas_ids",
+    )}
+
+    result = replace_token_media(controller, token, str(asset))
+
+    assert result.success
+    assert token["image_path"] == f"tokens/replacement{new_suffix}"
+    assert token["media_type"] == expected_type
+    assert token["source_image"] is decoded
+    assert token["pil_image"].size == (72, 72)
+    assert {key: token[key] for key in retained} == retained
+    assert len(manager.unregistered) == unregisters
+    assert len(manager.registered) == registers
+    assert refreshed == [(token, decoded)]
+    assert persisted == [True]
+
+
+def test_replace_token_media_decode_failure_rolls_back_media_and_animation(tmp_path, monkeypatch):
+    selected = tmp_path / "broken.png"
+    selected.write_bytes(b"broken")
+    monkeypatch.setattr(
+        replacement, "load_thumbnail", lambda *_args: (_ for _ in ()).throw(MediaDecodeError("broken"))
+    )
+    manager = ReplacementManager()
+    old_source, old_pil = object(), object()
+    token = {
+        "type": "token", "image_path": "tokens/original.mp4", "media_type": VIDEO,
+        "size": 48, "source_image": old_source, "pil_image": old_pil,
+    }
+    controller = SimpleNamespace(token_size=48, _token_animation_manager=manager)
+
+    result = replace_token_media(controller, token, str(selected))
+
+    assert not result.success
+    assert token["image_path"] == "tokens/original.mp4"
+    assert token["media_type"] == VIDEO
+    assert token["source_image"] is old_source and token["pil_image"] is old_pil
+    assert manager.unregistered == [] and manager.registered == []
+
+
+def test_replace_token_media_registration_failure_restores_old_video(tmp_path, monkeypatch):
+    campaign = tmp_path / "campaign"
+    selected = campaign / "tokens" / "new.mp4"
+    old_path = campaign / "tokens" / "old.mp4"
+    selected.parent.mkdir(parents=True)
+    selected.write_bytes(b"new")
+    old_path.write_bytes(b"old")
+    monkeypatch.setattr(replacement.ConfigHelper, "get_campaign_dir", lambda: str(campaign))
+    monkeypatch.setattr(replacement, "load_thumbnail", lambda *_args: ReplacementImage())
+    manager = ReplacementManager(register_result=False)
+    old_source, old_pil = object(), object()
+    token = {
+        "type": "token", "image_path": "tokens/old.mp4", "media_type": VIDEO,
+        "size": 48, "source_image": old_source, "pil_image": old_pil,
+    }
+    controller = SimpleNamespace(
+        token_size=48, _token_animation_manager=manager,
+        _ensure_token_animation_manager=lambda: manager,
+    )
+
+    result = replace_token_media(controller, token, str(selected))
+
+    assert not result.success
+    assert token["image_path"] == "tokens/old.mp4"
+    assert token["media_type"] == VIDEO
+    assert token["source_image"] is old_source and token["pil_image"] is old_pil
+    assert manager.unregistered == [token, token]
+    assert manager.registered == [(token, str(selected)), (token, str(old_path))]
+
+
+def test_replace_token_media_rejects_unsupported_extension_without_decoding(tmp_path, monkeypatch):
+    selected = tmp_path / "token.svg"
+    selected.write_text("<svg/>", encoding="utf-8")
+    decoded = []
+    monkeypatch.setattr(replacement, "load_thumbnail", lambda *_args: decoded.append(True))
+    token = {"type": "token", "image_path": "old.png", "media_type": IMAGE}
+
+    result = replace_token_media(SimpleNamespace(), token, str(selected))
+
+    assert not result.success
+    assert "supported" in result.error
+    assert decoded == []
+    assert token == {"type": "token", "image_path": "old.png", "media_type": IMAGE}


### PR DESCRIPTION
### Motivation
- Move media-transition logic out of the controller into a dedicated service to keep UI code focused and make media replacement transactional and testable.
- Provide a safe, explicit workflow for replacing token images/videos that validates and decodes assets before mutating runtime state and persists campaign-relative paths.
- Preserve non-media token fields (identity, position, size, border, HP, visibility, facing, entity metadata, and canvas stacking) while handling video animation registration/unregistration.
- Cover all image/video transition paths and failure cases with static unit tests and update the Map Tool docs to advertise the new action.

### Description
- Added `modules/maps/media/replacement.py` implementing `replace_token_media(controller, token, selected_path)` and the `MediaReplacementResult` return type, performing validation, decoding via `load_thumbnail`, preparing via `prepare_token_media`, managing `_token_animation_manager` unregister/register, campaign-relative `image_path`, and atomic rollback on failure.
- Exported `replace_token_media` and `MediaReplacementResult` from `modules/maps/media/__init__.py` and adjusted imports in the controller to use the new service and media `IMAGE_EXTENSIONS`/`VIDEO_EXTENSIONS` filters.
- Extended `modules/maps/media/tokens.py::prepare_token_media` to accept an optional `source_image` parameter so decoded thumbnails can be reused when rebuilding `source_image` and `pil_image`.
- Added a controller helper `DisplayMapController._change_token_image` and a single-token context-menu entry labeled `Change Token Image…` that opens a platform `filedialog.askopenfilename` filtered by the static image and video patterns, remembers the last directory in `_last_token_media_directory`, invokes `replace_token_media`, and shows an error dialog on failure.
- The replacement flow preserves non-media token properties, updates `image_path` to a campaign-relative path, refreshes the token canvas frame via `_display_token_frame` without recreating unrelated tokens, triggers `_update_web_display_map` when available, and calls `_persist_tokens` to persist the change.
- Updated documentation source in `scripts/generate_docs.py` to include the `Change Token Image…` menu item description.

### Testing
- Ran `pytest -q tests/maps/test_token_media.py` and the new/modified tests for all four transitions, rollback, registration behavior, and unsupported-extension rejection passed (`14 passed`).
- Verified video registration/unregistration behavior and rollback semantics with targeted unit tests covering `image→image`, `image→video`, `video→image`, and `video→video` transitions and registration failure restoration (all assertions succeeded in the modified test file).
- Compiled affected modules with `python -m compileall -q modules/maps tests/maps/test_token_media.py scripts/generate_docs.py` with no syntax errors.
- Ran `pytest -q tests/maps` for broader regression checks which reported `35 passed, 2 unrelated pre-existing failures` not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a873af6f95c832bb2a43d70188a6e2e)