### PR TITLE
Add token portrait-selection submenu and unit tests

### DIFF
--- a/modules/maps/controllers/display_map_controller.py
+++ b/modules/maps/controllers/display_map_controller.py
@@ -52,6 +52,7 @@ from modules.maps.media import (
 )
 from modules.maps.media.types import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 from modules.maps.media.tokens import register_token_animation
+from modules.maps.menus.token_portrait_menu import add_token_portrait_menu
 from modules.maps.views.fullscreen_view import open_fullscreen, _update_fullscreen_map
 from modules.maps.views.web_display_view import (
     close_web_display,
@@ -5154,6 +5155,10 @@ class DisplayMapController:
         if not selected:
             return
         self._last_token_media_directory = os.path.dirname(selected)
+        self._replace_token_media(token, selected)
+
+    def _replace_token_media(self, token: dict, selected: str) -> None:
+        """Apply selected media and report the existing replacement error."""
         result = replace_token_media(self, token, selected)
         if not result.success:
             messagebox.showerror(
@@ -5161,6 +5166,12 @@ class DisplayMapController:
                 f"Unable to replace the token media.\n\n{result.error}",
                 parent=getattr(self, "canvas", None),
             )
+
+    def _replace_token_portrait(self, token: dict, selected: str) -> None:
+        """Apply a resolved portrait selected from the token context menu."""
+        resolved = resolve_portrait_candidate(selected, ConfigHelper.get_campaign_dir())
+        if resolved:
+            self._replace_token_media(token, resolved)
 
     def _load_portrait_menu_image(self, path: str) -> ImageTk.PhotoImage | None:
         """Load portrait menu image."""
@@ -5217,9 +5228,13 @@ class DisplayMapController:
             command=lambda: self._resize_tokens(valid_tokens),
         )
         if count == 1:
-            menu.add_command(
-                label="Change Token Image…",
-                command=lambda: self._change_token_image(valid_tokens[0]),
+            token = valid_tokens[0]
+            add_token_portrait_menu(
+                menu,
+                self._get_token_portrait_paths(token),
+                campaign_dir=ConfigHelper.get_campaign_dir(),
+                load_image=self._load_portrait_menu_image,
+                on_select=lambda selected: self._replace_token_portrait(token, selected),
             )
         menu.add_command(
             label=f"Change Border Color{plural}",

--- a/modules/maps/menus/__init__.py
+++ b/modules/maps/menus/__init__.py
@@ -1,0 +1,1 @@
+"""Context-menu builders for map views."""

--- a/modules/maps/menus/token_portrait_menu.py
+++ b/modules/maps/menus/token_portrait_menu.py
@@ -1,0 +1,46 @@
+"""Build the portrait-selection portion of a token context menu."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from collections.abc import Callable, Iterable
+
+from modules.helpers.portrait_helper import portrait_menu_label, resolve_portrait_candidate
+
+
+def add_token_portrait_menu(
+    parent_menu,
+    portrait_paths: Iterable[str],
+    *,
+    campaign_dir: str,
+    load_image: Callable[[str], object | None],
+    on_select: Callable[[str], None],
+    menu_factory: Callable[..., object] = tk.Menu,
+) -> bool:
+    """Add a change-image submenu when multiple valid portraits are available.
+
+    Candidate paths are captured in each command's default argument to avoid
+    late-binding bugs.  The controller callback remains responsible for
+    resolving and applying the selected portrait.
+    """
+    candidates = [
+        path
+        for path in portrait_paths
+        if resolve_portrait_candidate(path, campaign_dir)
+    ]
+    if len(candidates) <= 1:
+        return False
+
+    portrait_menu = menu_factory(parent_menu, tearoff=0)
+    for index, path in enumerate(candidates, start=1):
+        options = {
+            "label": portrait_menu_label(path, index),
+            "command": lambda selected=path: on_select(selected),
+        }
+        image = load_image(path)
+        if image is not None:
+            options.update(image=image, compound="left")
+        portrait_menu.add_command(**options)
+
+    parent_menu.add_cascade(label="Change Token Image", menu=portrait_menu)
+    return True

--- a/tests/maps/test_token_portrait_menu.py
+++ b/tests/maps/test_token_portrait_menu.py
@@ -1,0 +1,133 @@
+"""Coverage for token portrait selection context menus."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from modules.maps.controllers import display_map_controller
+from modules.maps.controllers.display_map_controller import DisplayMapController
+from modules.maps.menus.token_portrait_menu import add_token_portrait_menu
+
+
+class FakeMenu:
+    def __init__(self, parent=None, **options):
+        self.parent = parent
+        self.options = options
+        self.commands = []
+        self.cascades = []
+
+    def add_command(self, **options):
+        self.commands.append(options)
+
+    def add_cascade(self, **options):
+        self.cascades.append(options)
+
+
+@pytest.mark.parametrize("candidate_count", [0, 1])
+def test_no_change_image_menu_with_fewer_than_two_portraits(tmp_path, candidate_count):
+    paths = []
+    if candidate_count:
+        portrait = tmp_path / "only.png"
+        portrait.write_bytes(b"portrait")
+        paths.append(str(portrait))
+    parent = FakeMenu()
+
+    added = add_token_portrait_menu(
+        parent,
+        paths,
+        campaign_dir=str(tmp_path),
+        load_image=lambda _path: None,
+        on_select=lambda _path: None,
+        menu_factory=FakeMenu,
+    )
+
+    assert not added
+    assert parent.cascades == []
+
+
+def test_change_image_submenu_contains_all_valid_candidates(tmp_path):
+    first = tmp_path / "hero.png"
+    second = tmp_path / "hero-alt.png"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    thumbnails = {str(first): object(), str(second): object()}
+    parent = FakeMenu()
+
+    assert add_token_portrait_menu(
+        parent,
+        [str(first), str(tmp_path / "missing.png"), str(second)],
+        campaign_dir=str(tmp_path),
+        load_image=thumbnails.get,
+        on_select=lambda _path: None,
+        menu_factory=FakeMenu,
+    )
+
+    assert [item["label"] for item in parent.cascades] == ["Change Token Image"]
+    commands = parent.cascades[0]["menu"].commands
+    assert [item["label"] for item in commands] == ["1. hero.png", "2. hero-alt.png"]
+    assert [item["image"] for item in commands] == [thumbnails[str(first)], thumbnails[str(second)]]
+
+
+def test_submenu_commands_replace_with_their_resolved_portrait(tmp_path, monkeypatch):
+    campaign = tmp_path / "campaign"
+    campaign.mkdir()
+    for name in ("first.png", "second.png"):
+        (campaign / name).write_bytes(name.encode())
+    monkeypatch.setattr(display_map_controller.ConfigHelper, "get_campaign_dir", lambda: str(campaign))
+    replacements = []
+    monkeypatch.setattr(
+        display_map_controller,
+        "replace_token_media",
+        lambda controller, token, path: replacements.append((controller, token, path))
+        or SimpleNamespace(success=True, error=""),
+    )
+    controller = DisplayMapController.__new__(DisplayMapController)
+    controller.canvas = None
+    token = {"type": "token", "image_path": "original.png"}
+    parent = FakeMenu()
+    add_token_portrait_menu(
+        parent,
+        ["first.png", "second.png"],
+        campaign_dir=str(campaign),
+        load_image=lambda _path: None,
+        on_select=lambda selected: controller._replace_token_portrait(token, selected),
+        menu_factory=FakeMenu,
+    )
+
+    commands = parent.cascades[0]["menu"].commands
+    commands[0]["command"]()
+    commands[1]["command"]()
+
+    assert [call[2] for call in replacements] == [
+        str(campaign / "first.png"),
+        str(campaign / "second.png"),
+    ]
+
+
+def test_failed_portrait_replacement_preserves_media_and_reports_error(tmp_path, monkeypatch):
+    portrait = tmp_path / "portrait.png"
+    portrait.write_bytes(b"portrait")
+    monkeypatch.setattr(display_map_controller.ConfigHelper, "get_campaign_dir", lambda: str(tmp_path))
+    errors = []
+    monkeypatch.setattr(
+        display_map_controller,
+        "replace_token_media",
+        lambda *_args: SimpleNamespace(success=False, error="decode failed"),
+    )
+    monkeypatch.setattr(
+        display_map_controller.messagebox,
+        "showerror",
+        lambda *args, **kwargs: errors.append((args, kwargs)),
+    )
+    controller = DisplayMapController.__new__(DisplayMapController)
+    controller.canvas = None
+    token = {"type": "token", "image_path": "original.png", "media_type": "image"}
+    original = token.copy()
+
+    controller._replace_token_portrait(token, str(portrait))
+
+    assert token == original
+    assert errors[0][0] == (
+        "Change Token Image",
+        "Unable to replace the token media.\n\ndecode failed",
+    )


### PR DESCRIPTION
### Motivation
- Provide a focused UI flow for selecting an associated portrait for a token when multiple portrait candidates exist. 
- Avoid adding more branching logic to the large `DisplayMapController` by extracting menu construction into a small, testable module.
- Ensure portrait candidates are resolved and applied transactionally through the existing media-replacement service.

### Description
- Added `modules/maps/menus/token_portrait_menu.py` implementing `add_token_portrait_menu(...)`, which filters valid portrait candidates with `resolve_portrait_candidate()`, builds a "Change Token Image" submenu only when two or more valid candidates exist, captures each candidate path in the command default argument to avoid late-binding, and populates entries with `portrait_menu_label()` and optional thumbnails loaded via the provided `load_image` callback.
- Imported and used `add_token_portrait_menu` from `DisplayMapController._show_token_menu()` so the controller delegates submenu construction and keeps responsibility for applying the chosen portrait via a controller callback.
- Added controller helpers: `_replace_token_media()` to centralize the call to `replace_token_media()` and error reporting, and `_replace_token_portrait()` to resolve the selected candidate with `resolve_portrait_candidate()` and call the replacement helper when resolved.
- Added `modules/maps/menus/__init__.py` to expose the new menu package.
- Added unit tests in `tests/maps/test_token_portrait_menu.py` covering zero/one candidate suppression, multi-candidate submenu content and thumbnails, that submenu commands call `replace_token_media()` with resolved paths, that candidate labels bind to the correct paths, and that a failed replacement preserves the original token media and shows the error.

### Testing
- Ran `pytest -q tests/maps/test_token_portrait_menu.py` and the new test suite passed.
- Confirmed the new menu module compiles with `python -m compileall` for the changed files.
- Verified the menu builder captures per-command candidate paths (avoids late-binding) and that the controller resolves candidates before calling `replace_token_media()` via unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a873ee86b10832b9aef169bddd7315d)