### PR TITLE
Preserve alpha when decoding video frames

### DIFF
--- a/modules/maps/media/decoder.py
+++ b/modules/maps/media/decoder.py
@@ -18,6 +18,12 @@ def _fit_frame(image: Image.Image, max_size: int) -> Image.Image:
     return frame
 
 
+def _decoded_frame_to_image(frame: object) -> Image.Image:
+    """Build a Pillow image after asking PyAV to retain the alpha channel."""
+    pixels = frame.to_ndarray(format="rgba")
+    return Image.fromarray(pixels, "RGBA")
+
+
 class VideoDecoder:
     """Own one PyAV container and provide frames, looping at end of stream."""
 
@@ -54,7 +60,7 @@ class VideoDecoder:
                     raise MediaDecodeError(f"Unable to loop video: {exc}") from exc
             except Exception as exc:
                 raise MediaDecodeError(f"Unable to decode video frame: {exc}") from exc
-            return _fit_frame(frame.to_image(), self.max_size)
+            return _fit_frame(_decoded_frame_to_image(frame), self.max_size)
 
     def close(self) -> None:
         with getattr(self, "_lock", threading.Lock()):

--- a/tests/maps/test_token_media.py
+++ b/tests/maps/test_token_media.py
@@ -1,5 +1,6 @@
 """Regression coverage for animated map-token media."""
 
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ from modules.maps.media import (
     VIDEO,
     MediaDecodeError,
     TokenAnimationManager,
+    VideoDecoder,
     detect_media_type,
     load_thumbnail,
     replace_token_media,
@@ -58,6 +60,36 @@ class FakeDecoder:
 
     def close(self):
         self.closed = True
+
+
+class FakeDecodedFrame:
+    def __init__(self):
+        self.requested_format = None
+
+    def to_ndarray(self, *, format):
+        self.requested_format = format
+        np = pytest.importorskip("numpy")
+        pixels = np.zeros((4, 8, 4), dtype=np.uint8)
+        pixels[:, :4] = (255, 0, 0, 0)
+        pixels[:, 4:] = (0, 255, 0, 255)
+        return pixels
+
+
+def test_video_decoder_requests_rgba_and_preserves_alpha_when_resizing():
+    decoded_frame = FakeDecodedFrame()
+    decoder = VideoDecoder.__new__(VideoDecoder)
+    decoder.max_size = 4
+    decoder._lock = threading.Lock()
+    decoder._closed = False
+    decoder._frames = iter([decoded_frame])
+
+    image = decoder.read_frame()
+
+    assert decoded_frame.requested_format == "rgba"
+    assert image.mode == "RGBA"
+    assert image.size == (4, 2)
+    assert image.getpixel((0, 0))[3] == 0
+    assert image.getpixel((3, 0)) == (0, 255, 0, 255)
 
 
 def test_mp4_selection_and_persisted_hint_detection():


### PR DESCRIPTION
### Motivation
- Prevent loss of alpha when converting decoded PyAV frames to Pillow images by explicitly requesting an alpha-capable pixel format before constructing the `Image`.
- Keep `_fit_frame` focused on RGBA normalization and bounded resizing, separate from pixel-format negotiation.
- Ensure the same decoding path is used for animated playback and first-frame thumbnail extraction so alpha handling is consistent.

### Description
- Add a helper ` _decoded_frame_to_image` which calls `frame.to_ndarray(format="rgba")` and builds a Pillow image with `Image.fromarray(..., "RGBA")` to retain alpha.
- Use the new helper from `VideoDecoder.read_frame()` so both playback and thumbnail code paths convert frames to RGBA via the helper.
- Leave `_fit_frame(image, max_size)` unchanged except to operate on already-RGBA `Image` objects and perform sizing with `thumbnail`.
- Add a regression test in `tests/maps/test_token_media.py` that injects a `FakeDecodedFrame` which records the requested pixel format and returns pixels with both zero and 255 alpha values, asserting format request, RGBA mode, alpha preservation, opaque pixel preservation, and `max_size` resizing.

### Testing
- Ran `pytest -q tests/maps/test_token_media.py` which exercised the suite and reported `14 passed, 1 skipped` where the new NumPy-backed regression test was skipped due to NumPy being unavailable.
- Ran `python -m compileall -q modules/maps/media/decoder.py tests/maps/test_token_media.py` which completed without errors.
- Ran `python -m py_compile modules/maps/media/decoder.py tests/maps/test_token_media.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8752f5ae70832b812daff8c6df4394)