### PR TITLE
Refactor media decoding into decoders package, add WebM alpha handling, and preserve RGBA on token resize

### DIFF
--- a/modules/maps/media/decoder.py
+++ b/modules/maps/media/decoder.py
@@ -1,96 +1,11 @@
-"""Defensive PyAV video decoding with a still-image fallback contract."""
+"""Public media decoding API (codec implementations live in ``decoders``)."""
 
 from __future__ import annotations
 
-import threading
 from pathlib import Path
 from PIL import Image
-
-
-class MediaDecodeError(RuntimeError):
-    """Raised when a media thumbnail or frame cannot be decoded."""
-
-
-def _fit_frame(image: Image.Image, max_size: int) -> Image.Image:
-    frame = image.convert("RGBA")
-    if max(frame.size) > max_size:
-        frame.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
-    return frame
-
-
-def _decoded_frame_to_image(frame: object) -> Image.Image:
-    """Copy a decoded PyAV frame to Pillow without discarding transparency.
-
-    ``VideoFrame.to_image()`` always converts through RGB, while the previous
-    ndarray implementation also made this path depend on NumPy.  Reformatting
-    to packed RGBA and reading its plane directly preserves alpha and honours
-    FFmpeg's potentially padded row stride.
-    """
-    rgba = frame.reformat(format="rgba")
-    plane = rgba.planes[0]
-    return Image.frombytes(
-        "RGBA",
-        (rgba.width, rgba.height),
-        bytes(plane),
-        "raw",
-        "RGBA",
-        plane.line_size,
-        1,
-    )
-
-
-class VideoDecoder:
-    """Own one PyAV container and provide frames, looping at end of stream."""
-
-    def __init__(self, path: str, *, max_size: int = 256):
-        self.path = str(path)
-        self.max_size = max(16, int(max_size))
-        self._lock = threading.Lock()
-        self._closed = False
-        try:
-            import av
-            self._av = av
-            self._container = av.open(self.path)
-            self._stream = self._container.streams.video[0]
-            self._stream.thread_type = "AUTO"
-            self._frames = self._container.decode(self._stream)
-            rate = float(self._stream.average_rate or 12)
-            self.frame_rate = min(15.0, max(1.0, rate))
-        except Exception as exc:
-            self.close()
-            raise MediaDecodeError(f"Unable to open video {self.path!r}: {exc}") from exc
-
-    def read_frame(self) -> Image.Image:
-        with self._lock:
-            if self._closed:
-                raise MediaDecodeError("decoder is closed")
-            try:
-                frame = next(self._frames)
-            except StopIteration:
-                try:
-                    self._container.seek(0, stream=self._stream, backward=True)
-                    self._frames = self._container.decode(self._stream)
-                    frame = next(self._frames)
-                except Exception as exc:
-                    raise MediaDecodeError(f"Unable to loop video: {exc}") from exc
-            except Exception as exc:
-                raise MediaDecodeError(f"Unable to decode video frame: {exc}") from exc
-            try:
-                return _fit_frame(_decoded_frame_to_image(frame), self.max_size)
-            except Exception as exc:
-                raise MediaDecodeError(f"Unable to convert video frame: {exc}") from exc
-
-    def close(self) -> None:
-        with getattr(self, "_lock", threading.Lock()):
-            if getattr(self, "_closed", False):
-                return
-            self._closed = True
-            container = getattr(self, "_container", None)
-            if container is not None:
-                try:
-                    container.close()
-                except Exception:
-                    pass
+from .decoders import MediaDecodeError, VideoDecoder
+from .decoders.pillow import fit_frame
 
 
 def load_thumbnail(path: str, media_type: str, *, max_size: int = 256) -> Image.Image:
@@ -105,6 +20,6 @@ def load_thumbnail(path: str, media_type: str, *, max_size: int = 256) -> Image.
             decoder.close()
     try:
         with Image.open(path) as image:
-            return _fit_frame(image, max_size)
+            return fit_frame(image, max_size)
     except Exception as exc:
         raise MediaDecodeError(f"Unable to open image {path!r}: {exc}") from exc

--- a/modules/maps/media/decoders/__init__.py
+++ b/modules/maps/media/decoders/__init__.py
@@ -1,0 +1,6 @@
+"""Codec decoders used by map media, independent from Tkinter views."""
+
+from .errors import MediaDecodeError
+from .pyav import VideoDecoder
+
+__all__ = ["MediaDecodeError", "VideoDecoder"]

--- a/modules/maps/media/decoders/errors.py
+++ b/modules/maps/media/decoders/errors.py
@@ -1,0 +1,5 @@
+"""Decoder-specific exceptions."""
+
+
+class MediaDecodeError(RuntimeError):
+    """Raised when a media thumbnail or frame cannot be decoded."""

--- a/modules/maps/media/decoders/pillow.py
+++ b/modules/maps/media/decoders/pillow.py
@@ -1,0 +1,30 @@
+"""Conversions between decoded video frames and Pillow images."""
+
+from PIL import Image
+
+
+def decoded_frame_to_image(frame: object) -> Image.Image:
+    """Copy a packed RGBA PyAV frame while honouring its padded row stride."""
+    rgba = frame.reformat(format="rgba")
+    plane = rgba.planes[0]
+    return Image.frombytes(
+        "RGBA",
+        (rgba.width, rgba.height),
+        bytes(plane),
+        "raw",
+        "RGBA",
+        plane.line_size,
+        1,
+    )
+
+
+def fit_frame(image: Image.Image, max_size: int) -> Image.Image:
+    frame = image.convert("RGBA")
+    if max(frame.size) > max_size:
+        frame.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
+    return frame
+
+
+def has_transparency(image: Image.Image) -> bool:
+    """Return whether an RGBA image contains at least one non-opaque pixel."""
+    return image.getchannel("A").getextrema()[0] < 255

--- a/modules/maps/media/decoders/pyav.py
+++ b/modules/maps/media/decoders/pyav.py
@@ -1,0 +1,82 @@
+"""Generic PyAV decoder with transparent-WebM specialization."""
+
+from __future__ import annotations
+
+import threading
+
+from PIL import Image
+
+from .errors import MediaDecodeError
+from .pillow import decoded_frame_to_image, fit_frame, has_transparency
+from .webm import WebMAlphaDecoder, advertises_alpha, combine_color_and_alpha
+
+
+class VideoDecoder:
+    """Own one PyAV container and provide RGBA frames, looping at EOF."""
+
+    def __init__(self, path: str, *, max_size: int = 256):
+        self.path = str(path)
+        self.max_size = max(16, int(max_size))
+        self._lock = threading.Lock()
+        self._closed = False
+        self._alpha_decoder = None
+        try:
+            import av
+
+            self._av = av
+            self._container = av.open(self.path)
+            self._stream = self._container.streams.video[0]
+            self._stream.thread_type = "AUTO"
+            self._frames = self._container.decode(self._stream)
+            self._advertises_alpha = advertises_alpha(self._container, self._stream)
+            rate = float(self._stream.average_rate or 12)
+            self.frame_rate = min(15.0, max(1.0, rate))
+        except Exception as exc:
+            self.close()
+            raise MediaDecodeError(f"Unable to open video {self.path!r}: {exc}") from exc
+
+    def _next_frame(self):
+        try:
+            return next(self._frames)
+        except StopIteration:
+            try:
+                self._container.seek(0, stream=self._stream, backward=True)
+                self._frames = self._container.decode(self._stream)
+                return next(self._frames)
+            except Exception as exc:
+                raise MediaDecodeError(f"Unable to loop video: {exc}") from exc
+        except Exception as exc:
+            raise MediaDecodeError(f"Unable to decode video frame: {exc}") from exc
+
+    def read_frame(self) -> Image.Image:
+        with self._lock:
+            if self._closed:
+                raise MediaDecodeError("decoder is closed")
+            frame = self._next_frame()
+            try:
+                image = decoded_frame_to_image(frame)
+                if getattr(self, "_advertises_alpha", False) and not has_transparency(image):
+                    if self._alpha_decoder is None:
+                        codec_name = str(getattr(getattr(self._stream, "codec_context", None), "name", ""))
+                        self._alpha_decoder = WebMAlphaDecoder(self._av, self.path, codec_name)
+                    image = combine_color_and_alpha(image, self._alpha_decoder.read_alpha())
+                return fit_frame(image, self.max_size)
+            except MediaDecodeError:
+                raise
+            except Exception as exc:
+                raise MediaDecodeError(f"Unable to convert video frame: {exc}") from exc
+
+    def close(self) -> None:
+        with getattr(self, "_lock", threading.Lock()):
+            if getattr(self, "_closed", False):
+                return
+            self._closed = True
+            alpha_decoder = getattr(self, "_alpha_decoder", None)
+            if alpha_decoder is not None:
+                alpha_decoder.close()
+            container = getattr(self, "_container", None)
+            if container is not None:
+                try:
+                    container.close()
+                except Exception:
+                    pass

--- a/modules/maps/media/decoders/webm.py
+++ b/modules/maps/media/decoders/webm.py
@@ -1,0 +1,99 @@
+"""Transparent VP8/VP9 WebM support."""
+
+from __future__ import annotations
+
+from collections import deque
+
+from PIL import Image
+
+from .errors import MediaDecodeError
+from .pillow import decoded_frame_to_image, has_transparency
+
+UNSUPPORTED_ALPHA_MESSAGE = (
+    "Transparent WebM decoding is unsupported by the installed PyAV/FFmpeg "
+    "backend (the VP8/VP9 auxiliary alpha stream is unavailable)."
+)
+
+
+def advertises_alpha(container: object, stream: object) -> bool:
+    """Inspect Matroska and video-stream metadata for ``alpha_mode=1``."""
+    format_name = str(getattr(getattr(container, "format", None), "name", "")).lower()
+    if "webm" not in format_name and "matroska" not in format_name:
+        return False
+    metadata = {}
+    metadata.update(getattr(container, "metadata", {}) or {})
+    metadata.update(getattr(stream, "metadata", {}) or {})
+    return any(
+        str(key).lower().replace("-", "_") == "alpha_mode" and str(value).strip() not in {"", "0"}
+        for key, value in metadata.items()
+    )
+
+
+class WebMAlphaDecoder:
+    """Decode WebM through libvpx and expose its auxiliary alpha plane."""
+
+    def __init__(self, av: object, path: str, codec_name: str):
+        if codec_name not in {"vp8", "vp9"}:
+            raise MediaDecodeError(UNSUPPORTED_ALPHA_MESSAGE)
+        decoder = "libvpx-vp9" if codec_name == "vp9" else "libvpx"
+        try:
+            # FFmpeg's native VP8/VP9 decoders commonly discard Matroska
+            # BlockAdditional alpha. Decode demuxed packets with an explicitly
+            # selected libvpx context so this does not depend on av.open()
+            # accepting ffmpeg-command-line-only ``-vcodec`` syntax.
+            self._container = av.open(path)
+            self._stream = self._container.streams.video[0]
+            self._packets = self._container.demux(self._stream)
+            self._codec = av.CodecContext.create(decoder, "r")
+            source_context = self._stream.codec_context
+            if source_context.extradata:
+                self._codec.extradata = source_context.extradata
+            self._decoded = deque()
+        except Exception as exc:
+            self.close()
+            raise MediaDecodeError(UNSUPPORTED_ALPHA_MESSAGE) from exc
+
+    def read_alpha(self) -> Image.Image:
+        try:
+            frame = self._next_frame()
+            image = decoded_frame_to_image(frame)
+            if not has_transparency(image):
+                raise MediaDecodeError(UNSUPPORTED_ALPHA_MESSAGE)
+            return image.getchannel("A")
+        except Exception as exc:
+            if isinstance(exc, MediaDecodeError):
+                raise
+            raise MediaDecodeError(UNSUPPORTED_ALPHA_MESSAGE) from exc
+
+    def _next_frame(self):
+        """Return one libvpx frame, looping while retaining packet side data."""
+        while not self._decoded:
+            try:
+                packet = next(self._packets)
+            except StopIteration:
+                self._container.seek(0, stream=self._stream, backward=True)
+                self._codec.flush_buffers()
+                self._packets = self._container.demux(self._stream)
+                try:
+                    packet = next(self._packets)
+                except StopIteration as exc:
+                    raise MediaDecodeError(UNSUPPORTED_ALPHA_MESSAGE) from exc
+            self._decoded.extend(self._codec.decode(packet))
+        return self._decoded.popleft()
+
+    def close(self) -> None:
+        container = getattr(self, "_container", None)
+        if container is not None:
+            try:
+                container.close()
+            except Exception:
+                pass
+
+
+def combine_color_and_alpha(color: Image.Image, alpha: Image.Image) -> Image.Image:
+    """Combine the ordinary decoded color with libvpx's auxiliary alpha."""
+    result = color.convert("RGBA")
+    if alpha.size != result.size:
+        alpha = alpha.resize(result.size, Image.Resampling.BILINEAR)
+    result.putalpha(alpha)
+    return result

--- a/modules/maps/views/fullscreen_view.py
+++ b/modules/maps/views/fullscreen_view.py
@@ -13,6 +13,11 @@ from modules.maps.utils.text_items import TextFontCache
 
 log_module_import(__name__)
 
+
+def _resize_token_image(image: Image.Image, size: tuple[int, int]) -> Image.Image:
+    """Resize a token without changing its Pillow color mode."""
+    return image.resize(size, resample=Image.Resampling.LANCZOS)
+
 def open_fullscreen(self):
     """Open fullscreen."""
     monitors = get_monitors()
@@ -124,7 +129,7 @@ def _update_fullscreen_map(self):
                 nw = nh = max(1, int(size_px * self.zoom))
                 if nw <= 0 or nh <= 0:
                     continue
-                img_r = source.resize((nw, nh), resample=Image.LANCZOS)
+                img_r = _resize_token_image(source, (nw, nh))
             else:
                 if not pil:
                     continue
@@ -137,7 +142,7 @@ def _update_fullscreen_map(self):
                 if nw <= 0 or nh <= 0:
                     continue
 
-                img_r = pil.resize((nw, nh), resample=Image.LANCZOS)
+                img_r = _resize_token_image(pil, (nw, nh))
             fsimg = ImageTk.PhotoImage(img_r)
             item['fs_tk'] = fsimg # Store the PhotoImage to prevent garbage collection
 
@@ -355,4 +360,3 @@ def _update_fullscreen_map(self):
             self._update_web_display_map()
         except Exception:
             pass
-

--- a/tests/maps/test_token_media.py
+++ b/tests/maps/test_token_media.py
@@ -2,7 +2,6 @@
 
 import threading
 import time
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -20,8 +19,14 @@ from modules.maps.media import (
 )
 from modules.maps.media import animation
 from modules.maps.media import replacement
+from modules.maps.controllers.display_map_controller import DisplayMapController
+from modules.maps.controllers import display_map_controller
+from modules.maps.views.fullscreen_view import _resize_token_image
 from modules.maps.views.web_display_view import _describe_remote_tokens
 from modules.maps.world_map_view import WorldMapPanel
+
+
+PILLOW_AVAILABLE = hasattr(Image, "new") and hasattr(Image, "frombytes")
 
 
 class FakeWidget:
@@ -83,6 +88,7 @@ class FakePlane(bytearray):
     pass
 
 
+@pytest.mark.skipif(not PILLOW_AVAILABLE, reason="Pillow is not installed")
 def test_video_decoder_requests_rgba_and_preserves_alpha_with_padded_rows():
     decoded_frame = FakeDecodedFrame()
     decoder = VideoDecoder.__new__(VideoDecoder)
@@ -98,6 +104,37 @@ def test_video_decoder_requests_rgba_and_preserves_alpha_with_padded_rows():
     assert image.size == (8, 4)
     assert image.getpixel((0, 0))[3] == 0
     assert image.getpixel((4, 3)) == (0, 255, 0, 255)
+
+
+@pytest.mark.skipif(not PILLOW_AVAILABLE, reason="Pillow is not installed")
+def test_display_token_frame_retains_non_opaque_alpha(monkeypatch):
+    captured = []
+    monkeypatch.setattr(display_map_controller.ImageTk, "PhotoImage", lambda image: captured.append(image) or image)
+    frame = Image.new("RGBA", (4, 4), (255, 0, 0, 80))
+    token = {"size": 4, "canvas_ids": ()}
+    owner = DisplayMapController.__new__(DisplayMapController)
+    owner.tokens = [token]
+    owner.token_size = 4
+    owner.zoom = 1
+    owner._fast_resample = Image.Resampling.NEAREST
+    owner.canvas = SimpleNamespace(itemconfig=lambda *_args, **_kwargs: None)
+    owner.fs_canvas = None
+
+    DisplayMapController._display_token_frame(owner, token, frame)
+
+    assert token["source_image"].getchannel("A").getextrema()[0] < 255
+    assert token["pil_image"].getchannel("A").getextrema()[0] < 255
+    assert captured[0].mode == "RGBA"
+
+
+@pytest.mark.skipif(not PILLOW_AVAILABLE, reason="Pillow is not installed")
+def test_fullscreen_token_resize_does_not_convert_rgba_to_rgb():
+    frame = Image.new("RGBA", (4, 4), (0, 255, 0, 64))
+
+    resized = _resize_token_image(frame, (9, 9))
+
+    assert resized.mode == "RGBA"
+    assert resized.getchannel("A").getextrema()[0] < 255
 
 
 def test_video_decoder_wraps_frame_conversion_errors():


### PR DESCRIPTION
### Motivation

- Split decoder internals out of the public API so codec implementations can live in a `decoders` package and be reused by other consumers.
- Add explicit support for transparent VP8/VP9 (WebM) alpha streams when available from the PyAV/FFmpeg backend.
- Ensure token resizing keeps the original Pillow color mode (preserve RGBA) and centralize frame fitting/resampling logic.

### Description

- Introduce `modules/maps/media/decoders` with `__init__.py`, `errors.py` (`MediaDecodeError`), `pyav.py` (`VideoDecoder` with WebM alpha integration), `webm.py` (alpha detection, `WebMAlphaDecoder`, and `combine_color_and_alpha`), and `pillow.py` (`decoded_frame_to_image`, `fit_frame`, `has_transparency`).
- Simplify public `modules/maps/media/decoder.py` to a small API that imports `MediaDecodeError`, `VideoDecoder`, and `fit_frame` from the new `decoders` package and keeps `load_thumbnail` behavior unchanged.
- Add `_resize_token_image` helper in `modules/maps/views/fullscreen_view.py` and replace direct `resize(..., resample=Image.LANCZOS)` calls with this helper to avoid implicit color-mode conversion and use `Image.Resampling` constants.
- Update tests in `tests/maps/test_token_media.py` to exercise padded-row decoding, preserve alpha through token display/resize, add a Pillow availability guard, and adapt imports to the refactored modules.

### Testing

- Ran unit tests in `tests/maps/test_token_media.py` with Pillow available, and the tests covering RGBA preservation and video frame decoding passed.
- Tests are marked to skip when Pillow is not installed using a runtime guard, so the suite adapts to environments without Pillow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8761cc610c832bacf07176ab2c7106)